### PR TITLE
Added support for service accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ container:
 
 .PHONY: run
 run: crd
-	@OPERATOR_NAME=${OPERATOR_NAME} operator-sdk run --local --operator-flags "--zap-devel" --go-ldflags ${LD_FLAGS}
+	@OPERATOR_NAME=${OPERATOR_NAME} operator-sdk run --local --namespace="${WATCH_NAMESPACE}" --operator-flags "--zap-devel" --go-ldflags ${LD_FLAGS}
 
 .PHONY: clean
 clean:

--- a/deploy/crds/opentelemetry.io_opentelemetrycollectors_crd.yaml
+++ b/deploy/crds/opentelemetry.io_opentelemetrycollectors_crd.yaml
@@ -64,6 +64,10 @@ spec:
                 OpenTelemetry Collector
               format: int32
               type: integer
+            serviceAccount:
+              description: ServiceAccount indicates the name of an existing service
+                account to use with this instance.
+              type: string
           type: object
         status:
           description: OpenTelemetryCollectorStatus defines the observed state of

--- a/pkg/apis/opentelemetry/v1alpha1/opentelemetrycollector_types.go
+++ b/pkg/apis/opentelemetry/v1alpha1/opentelemetrycollector_types.go
@@ -34,6 +34,11 @@ type OpenTelemetryCollectorSpec struct {
 	// +kubebuilder:validation:Enum=daemonset;deployment
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Mode opentelemetry.Mode `json:"mode,omitempty"`
+
+	// ServiceAccount indicates the name of an existing service account to use with this instance.
+	// +optional
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	ServiceAccount string `json:"serviceAccount,omitempty"`
 }
 
 // OpenTelemetryCollectorStatus defines the observed state of OpenTelemetryCollector

--- a/pkg/apis/opentelemetry/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/opentelemetry/v1alpha1/zz_generated.openapi.go
@@ -113,6 +113,13 @@ func schema_pkg_apis_opentelemetry_v1alpha1_OpenTelemetryCollectorSpec(ref commo
 							Format:      "",
 						},
 					},
+					"serviceAccount": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServiceAccount indicates the name of an existing service account to use with this instance.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/opentelemetrycollector/reconcile.go
+++ b/pkg/controller/opentelemetrycollector/reconcile.go
@@ -50,6 +50,7 @@ func New(scheme *runtime.Scheme, clientset *client.Clientset) *ReconcileOpenTele
 		clientset: clientset,
 	}
 	r.reconcileFuncs = []func(context.Context) error{
+		r.reconcileServiceAccount,
 		r.reconcileConfigMap,
 		r.reconcileService,
 		r.reconcileDeployment,

--- a/pkg/controller/opentelemetrycollector/reconcile_deployment.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_deployment.go
@@ -101,6 +101,7 @@ func deployment(ctx context.Context) *appsv1.Deployment {
 					Annotations: specAnnotations,
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: ServiceAccountNameFor(ctx),
 					Containers: []corev1.Container{{
 						Name:  "opentelemetry-collector",
 						Image: image,

--- a/pkg/controller/opentelemetrycollector/reconcile_deployment_test.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_deployment_test.go
@@ -28,6 +28,7 @@ func TestProperDeployment(t *testing.T) {
 	assert.Equal(t, d.Annotations["custom-annotation"], "custom-annotation-value")
 	assert.Equal(t, d.Labels["custom-label"], "custom-value")
 	assert.Equal(t, d.Labels["app.kubernetes.io/name"], d.Name)
+	assert.Equal(t, ServiceAccountNameFor(ctx), d.Spec.Template.Spec.ServiceAccountName)
 }
 
 func TestProperDeployments(t *testing.T) {

--- a/pkg/controller/opentelemetrycollector/reconcile_serviceaccount.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_serviceaccount.go
@@ -1,0 +1,148 @@
+package opentelemetrycollector
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/open-telemetry/opentelemetry-operator/pkg/apis/opentelemetry"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/apis/opentelemetry/v1alpha1"
+)
+
+// reconcileServiceAccount reconciles the service(s) required for the instance in the current context
+func (r *ReconcileOpenTelemetryCollector) reconcileServiceAccount(ctx context.Context) error {
+	instance := ctx.Value(opentelemetry.ContextInstance).(*v1alpha1.OpenTelemetryCollector)
+
+	svcs := []*corev1.ServiceAccount{}
+	if len(instance.Spec.ServiceAccount) == 0 {
+		// if this has been specified and is not empty, we manage the service account
+		svcs = append(svcs, serviceAccount(ctx))
+	}
+
+	// first, handle the create/update parts
+	if err := r.reconcileExpectedServiceAccounts(ctx, svcs); err != nil {
+		return fmt.Errorf("failed to reconcile the expected service accounts: %v", err)
+	}
+
+	// then, delete the extra objects
+	if err := r.deleteServiceAccounts(ctx, svcs); err != nil {
+		return fmt.Errorf("failed to reconcile the service accounts to be deleted: %v", err)
+	}
+
+	return nil
+}
+
+func serviceAccount(ctx context.Context) *corev1.ServiceAccount {
+	instance := ctx.Value(opentelemetry.ContextInstance).(*v1alpha1.OpenTelemetryCollector)
+	name := resourceName(instance.Name)
+
+	labels := commonLabels(ctx)
+	labels["app.kubernetes.io/name"] = name
+
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   instance.Namespace,
+			Labels:      labels,
+			Annotations: instance.Annotations,
+		},
+	}
+}
+
+func (r *ReconcileOpenTelemetryCollector) reconcileExpectedServiceAccounts(ctx context.Context, expected []*corev1.ServiceAccount) error {
+	logger := ctx.Value(opentelemetry.ContextLogger).(logr.Logger)
+	for _, obj := range expected {
+		desired := obj
+
+		// #nosec G104 (CWE-703): Errors unhandled.
+		r.setControllerReference(ctx, desired)
+
+		svcs := r.clientset.Kubernetes.CoreV1().ServiceAccounts(desired.Namespace)
+
+		existing, err := svcs.Get(desired.Name, metav1.GetOptions{})
+		if err != nil && errors.IsNotFound(err) {
+			if desired, err = svcs.Create(desired); err != nil {
+				return fmt.Errorf("failed to create: %v", err)
+			}
+
+			logger.WithValues("serviceAccount.name", desired.Name, "serviceAccount.namespace", desired.Namespace).V(2).Info("created")
+			continue
+		} else if err != nil {
+			return fmt.Errorf("failed to retrieve: %v", err)
+		}
+
+		// it exists already, merge the two if the end result isn't identical to the existing one
+		updated := existing.DeepCopy()
+		if updated.Annotations == nil {
+			updated.Annotations = map[string]string{}
+		}
+		if updated.Labels == nil {
+			updated.Labels = map[string]string{}
+		}
+		updated.ObjectMeta.OwnerReferences = desired.ObjectMeta.OwnerReferences
+
+		for k, v := range desired.ObjectMeta.Annotations {
+			updated.ObjectMeta.Annotations[k] = v
+		}
+		for k, v := range desired.ObjectMeta.Labels {
+			updated.ObjectMeta.Labels[k] = v
+		}
+
+		if updated, err = svcs.Update(updated); err != nil {
+			return fmt.Errorf("failed to apply changes to service account: %v", err)
+		}
+		logger.V(2).Info("applied", "serviceAccount.name", desired.Name, "serviceAccount.namespace", desired.Namespace)
+	}
+
+	return nil
+}
+
+func (r *ReconcileOpenTelemetryCollector) deleteServiceAccounts(ctx context.Context, expected []*corev1.ServiceAccount) error {
+	instance := ctx.Value(opentelemetry.ContextInstance).(*v1alpha1.OpenTelemetryCollector)
+	logger := ctx.Value(opentelemetry.ContextLogger).(logr.Logger)
+	svcs := r.clientset.Kubernetes.CoreV1().ServiceAccounts(instance.Namespace)
+
+	opts := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", instance.Namespace, instance.Name),
+			"app.kubernetes.io/managed-by": "opentelemetry-operator",
+		}).String(),
+	}
+	list, err := svcs.List(opts)
+	if err != nil {
+		return fmt.Errorf("failed to list: %v", err)
+	}
+
+	for _, existing := range list.Items {
+		del := true
+		for _, keep := range expected {
+			if keep.Name == existing.Name && keep.Namespace == existing.Namespace {
+				del = false
+			}
+		}
+
+		if del {
+			if err := svcs.Delete(existing.Name, &metav1.DeleteOptions{}); err != nil {
+				return fmt.Errorf("failed to delete: %v", err)
+			}
+			logger.V(2).Info("deleted", "serviceAccount.name", existing.Name, "serviceAccount.namespace", existing.Namespace)
+		}
+	}
+
+	return nil
+}
+
+// ServiceAccountNameFor returns the name of the service account for the given context
+func ServiceAccountNameFor(ctx context.Context) string {
+	instance := ctx.Value(opentelemetry.ContextInstance).(*v1alpha1.OpenTelemetryCollector)
+	if len(instance.Spec.ServiceAccount) == 0 {
+		return serviceAccount(ctx).Name
+	}
+
+	return instance.Spec.ServiceAccount
+}

--- a/pkg/controller/opentelemetrycollector/reconcile_serviceaccount.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_serviceaccount.go
@@ -20,7 +20,7 @@ func (r *ReconcileOpenTelemetryCollector) reconcileServiceAccount(ctx context.Co
 
 	svcs := []*corev1.ServiceAccount{}
 	if len(instance.Spec.ServiceAccount) == 0 {
-		// if this has been specified and is not empty, we manage the service account
+		// if there's no Service Account specified we create one and manage it ourselves
 		svcs = append(svcs, serviceAccount(ctx))
 	}
 

--- a/pkg/controller/opentelemetrycollector/reconcile_serviceaccount_test.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_serviceaccount_test.go
@@ -1,0 +1,168 @@
+package opentelemetrycollector
+
+import (
+	"context"
+	"testing"
+
+	fakemon "github.com/coreos/prometheus-operator/pkg/client/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/open-telemetry/opentelemetry-operator/pkg/apis/opentelemetry"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/client"
+	fakeotclient "github.com/open-telemetry/opentelemetry-operator/pkg/client/versioned/fake"
+)
+
+func TestProperServiceAccount(t *testing.T) {
+	// test
+	s := serviceAccount(ctx)
+
+	// verify
+	assert.Equal(t, s.Name, "my-otelcol-collector")
+	assert.Equal(t, s.Annotations["custom-annotation"], "custom-annotation-value")
+	assert.Equal(t, s.Labels["custom-label"], "custom-value")
+	assert.Equal(t, s.Labels["app.kubernetes.io/name"], s.Name)
+}
+
+func TestOverrideServiceAccountName(t *testing.T) {
+	// test
+	overridden := *instance
+	overridden.Spec.ServiceAccount = "custom-sa"
+
+	ctx := context.WithValue(context.Background(), opentelemetry.ContextInstance, &overridden)
+	ctx = context.WithValue(ctx, opentelemetry.ContextLogger, logf.Log.WithName("unit-tests"))
+
+	s := ServiceAccountNameFor(ctx)
+
+	// verify
+	assert.Equal(t, "custom-sa", s)
+}
+
+func TestUnmanagedServiceAccount(t *testing.T) {
+	// customize the CR, to override the service account name
+	overridden := *instance
+	overridden.Spec.ServiceAccount = "custom-sa"
+
+	// build a context with an instance of our custom CR
+	ctx := context.WithValue(context.Background(), opentelemetry.ContextInstance, &overridden)
+	ctx = context.WithValue(ctx, opentelemetry.ContextLogger, logf.Log.WithName("unit-tests"))
+
+	c := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        overridden.Spec.ServiceAccount,
+			Namespace:   instance.Namespace,
+			Annotations: instance.Annotations,
+		},
+	}
+
+	clients := &client.Clientset{
+		Kubernetes:    fake.NewSimpleClientset(c),
+		Monitoring:    fakemon.NewSimpleClientset(),
+		OpenTelemetry: fakeotclient.NewSimpleClientset(instance),
+	}
+	reconciler := New(schem, clients)
+
+	// sanity check
+	persisted, err := clients.Kubernetes.CoreV1().ServiceAccounts(instance.Namespace).Get(c.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, persisted)
+
+	// test
+	reconciler.reconcileServiceAccount(ctx)
+
+	// verify that the service account still exists and is not with the operator's labels
+	existing, err := clients.Kubernetes.CoreV1().ServiceAccounts(instance.Namespace).Get(c.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Nil(t, existing.Labels)
+
+	// verify that a service account with the name that the operator would create does *not* exist
+	managed := serviceAccount(ctx)
+	managed, err = clients.Kubernetes.CoreV1().ServiceAccounts(instance.Namespace).Get(managed.Name, metav1.GetOptions{})
+	assert.Error(t, err) // not found
+	assert.Nil(t, managed)
+}
+
+func TestProperReconcileServiceAccount(t *testing.T) {
+	// prepare
+	clients := &client.Clientset{
+		Kubernetes:    fake.NewSimpleClientset(),
+		Monitoring:    fakemon.NewSimpleClientset(),
+		OpenTelemetry: fakeotclient.NewSimpleClientset(instance),
+	}
+	reconciler := New(schem, clients)
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: instance.Namespace}}
+
+	// test
+	reconciler.Reconcile(req)
+
+	// verify
+	list, err := clients.Kubernetes.CoreV1().ServiceAccounts(instance.Namespace).List(metav1.ListOptions{})
+	assert.NoError(t, err)
+
+	// we assert the correctness of the service in another test
+	assert.Len(t, list.Items, 1)
+
+	// we assert the correctness of the reference in another test
+	for _, item := range list.Items {
+		assert.Len(t, item.OwnerReferences, 1)
+	}
+}
+
+func TestUpdateServiceAccount(t *testing.T) {
+	// prepare
+	c := serviceAccount(ctx)
+	c.Namespace = instance.Namespace
+	c.Labels = map[string]string{"some-key": "some-value"}
+
+	clients := &client.Clientset{
+		Kubernetes:    fake.NewSimpleClientset(c),
+		Monitoring:    fakemon.NewSimpleClientset(),
+		OpenTelemetry: fakeotclient.NewSimpleClientset(instance),
+	}
+	reconciler := New(schem, clients)
+
+	// sanity check
+	persisted, err := clients.Kubernetes.CoreV1().ServiceAccounts(instance.Namespace).Get(c.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	// test
+	reconciler.reconcileServiceAccount(ctx)
+
+	// verify
+	persisted, err = clients.Kubernetes.CoreV1().ServiceAccounts(instance.Namespace).Get(c.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.Contains(t, persisted.Labels, "some-key")
+	assert.Equal(t, persisted.Name, persisted.Labels["app.kubernetes.io/name"])
+}
+
+func TestDeleteExtraServiceAccount(t *testing.T) {
+	// prepare
+	c := serviceAccount(ctx)
+	c.Name = "extra-service"
+	c.Namespace = instance.Namespace
+
+	clients := &client.Clientset{
+		Kubernetes:    fake.NewSimpleClientset(c),
+		Monitoring:    fakemon.NewSimpleClientset(),
+		OpenTelemetry: fakeotclient.NewSimpleClientset(instance),
+	}
+	reconciler := New(schem, clients)
+
+	// sanity check
+	persisted, err := clients.Kubernetes.CoreV1().ServiceAccounts(c.Namespace).Get(c.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	// test
+	err = reconciler.reconcileServiceAccount(ctx)
+	assert.NoError(t, err)
+
+	// verify
+	persisted, err = clients.Kubernetes.CoreV1().ServiceAccounts(c.Namespace).Get(c.Name, metav1.GetOptions{})
+	assert.Error(t, err) // not found
+	assert.Nil(t, persisted)
+}

--- a/pkg/controller/opentelemetrycollector/reconcile_serviceaccount_test.go
+++ b/pkg/controller/opentelemetrycollector/reconcile_serviceaccount_test.go
@@ -104,10 +104,10 @@ func TestProperReconcileServiceAccount(t *testing.T) {
 	list, err := clients.Kubernetes.CoreV1().ServiceAccounts(instance.Namespace).List(metav1.ListOptions{})
 	assert.NoError(t, err)
 
-	// we assert the correctness of the service in another test
+	// we assert the correctness of the service account in another test
 	assert.Len(t, list.Items, 1)
 
-	// we assert the correctness of the reference in another test
+	// we assert the correctness of the reference in another test (TestSetControllerReference)
 	for _, item := range list.Items {
 		assert.Len(t, item.OwnerReferences, 1)
 	}
@@ -129,6 +129,8 @@ func TestUpdateServiceAccount(t *testing.T) {
 	// sanity check
 	persisted, err := clients.Kubernetes.CoreV1().ServiceAccounts(instance.Namespace).Get(c.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
+	assert.Contains(t, persisted.Labels, "some-key")
+	assert.NotContains(t, persisted.Labels, "app.kubernetes.io/name")
 
 	// test
 	reconciler.reconcileServiceAccount(ctx)


### PR DESCRIPTION
- Creates a new service account to be used with the Collector instance
- Allows users to specify an existing service account, managed externally to the operator

Closes #14

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>