### PR TITLE
Follow-up fixes to the 'derive ports from config' feature

### DIFF
--- a/pkg/adapters/config_to_ports.go
+++ b/pkg/adapters/config_to_ports.go
@@ -51,8 +51,8 @@ func ConfigToReceiverPorts(ctx context.Context, config map[interface{}]interface
 	for key, val := range receivers {
 		receiver, ok := val.(map[interface{}]interface{})
 		if !ok {
-			logger.Info("receiver doesn't seem to be a map of properties")
-			continue
+			logger.Info("receiver doesn't seem to be a map of properties", "receiver", key)
+			receiver = map[interface{}]interface{}{}
 		}
 
 		rcvrName := key.(string)

--- a/pkg/adapters/config_to_ports_test.go
+++ b/pkg/adapters/config_to_ports_test.go
@@ -34,13 +34,15 @@ func TestExtractPortsFromConfig(t *testing.T) {
   examplereceiver/without-endpoint:
     notendpoint: "0.0.0.0:12347"
   jaeger:
-    grpc:
-    thrift_compact:
-    thrift_binary:
-      endpoint: 0.0.0.0:6833
+    protocols:
+      grpc:
+      thrift_compact:
+      thrift_binary:
+        endpoint: 0.0.0.0:6833
   jaeger/custom:
-    thrift_http:
-      endpoint: 0.0.0.0:15268
+    protocols:
+      thrift_http:
+        endpoint: 0.0.0.0:15268
 `
 
 	// test

--- a/pkg/parser/receiver.go
+++ b/pkg/parser/receiver.go
@@ -59,7 +59,7 @@ func singlePortFromConfigEndpoint(ctx context.Context, name string, config map[i
 	logger := ctx.Value(opentelemetry.ContextLogger).(logr.Logger)
 	endpoint, ok := config["endpoint"]
 	if !ok {
-		logger.Info("receiver doesn't have an endpoint")
+		logger.V(2).Info("receiver doesn't have an endpoint")
 		return nil
 	}
 

--- a/pkg/parser/receiver_jaeger.go
+++ b/pkg/parser/receiver_jaeger.go
@@ -26,9 +26,16 @@ type JaegerReceiverParser struct {
 
 // NewJaegerReceiverParser builds a new parser for Jaeger receivers
 func NewJaegerReceiverParser(name string, config map[interface{}]interface{}) ReceiverParser {
+	if protocols, ok := config["protocols"].(map[interface{}]interface{}); ok {
+		return &JaegerReceiverParser{
+			name:   name,
+			config: protocols,
+		}
+	}
+
 	return &JaegerReceiverParser{
 		name:   name,
-		config: config,
+		config: map[interface{}]interface{}{},
 	}
 }
 

--- a/pkg/parser/receiver_jaeger_test.go
+++ b/pkg/parser/receiver_jaeger_test.go
@@ -13,7 +13,9 @@ func TestJaegerParserRegistration(t *testing.T) {
 
 func TestJaegerMinimalReceiverConfiguration(t *testing.T) {
 	builder := NewJaegerReceiverParser("jaeger", map[interface{}]interface{}{
-		"grpc": map[interface{}]interface{}{},
+		"protocols": map[interface{}]interface{}{
+			"grpc": map[interface{}]interface{}{},
+		},
 	})
 
 	// test
@@ -27,8 +29,10 @@ func TestJaegerMinimalReceiverConfiguration(t *testing.T) {
 
 func TestJaegerOverrideReceiverProtocolPort(t *testing.T) {
 	builder := NewJaegerReceiverParser("jaeger", map[interface{}]interface{}{
-		"grpc": map[interface{}]interface{}{
-			"endpoint": "0.0.0.0:1234",
+		"protocols": map[interface{}]interface{}{
+			"grpc": map[interface{}]interface{}{
+				"endpoint": "0.0.0.0:1234",
+			},
 		},
 	})
 
@@ -43,10 +47,12 @@ func TestJaegerOverrideReceiverProtocolPort(t *testing.T) {
 
 func TestJaegerDefaultPorts(t *testing.T) {
 	builder := NewJaegerReceiverParser("jaeger", map[interface{}]interface{}{
-		"grpc":           map[interface{}]interface{}{},
-		"thrift_http":    map[interface{}]interface{}{},
-		"thrift_compact": map[interface{}]interface{}{},
-		"thrift_binary":  map[interface{}]interface{}{},
+		"protocols": map[interface{}]interface{}{
+			"grpc":           map[interface{}]interface{}{},
+			"thrift_http":    map[interface{}]interface{}{},
+			"thrift_compact": map[interface{}]interface{}{},
+			"thrift_binary":  map[interface{}]interface{}{},
+		},
 	})
 
 	expectedResults := map[string]struct {


### PR DESCRIPTION
A couple of fixes and improvements to the 'derive ports from config' based on real usage in a business application.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>