### PR TITLE
Use Patch instead of Update in the reconciliation

### DIFF
--- a/pkg/collector/reconcile/configmap.go
+++ b/pkg/collector/reconcile/configmap.go
@@ -117,18 +117,11 @@ func expectedConfigMaps(ctx context.Context, params Params, expected []corev1.Co
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		// editting Update with Patch
 		patch := client.MergeFrom(&params.Instance)
 
-		// if err := params.Client.Patch(ctx, &changed, patch); err != nil {
 		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
-
-		
-		// if err := params.Client.Update(ctx, updated); err != nil {
-		// 	return fmt.Errorf("failed to apply changes: %w", err)
-		// }
 
 		params.Log.V(2).Info("applied", "configmap.name", desired.Name, "configmap.namespace", desired.Namespace)
 	}

--- a/pkg/collector/reconcile/configmap.go
+++ b/pkg/collector/reconcile/configmap.go
@@ -120,7 +120,8 @@ func expectedConfigMaps(ctx context.Context, params Params, expected []corev1.Co
 		// editting Update with Patch
 		patch := client.MergeFrom(&params.Instance)
 
-		if err := params.Client.Patch(ctx, &changed, patch); err != nil {
+		// if err := params.Client.Patch(ctx, &changed, patch); err != nil {
+		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
 

--- a/pkg/collector/reconcile/configmap.go
+++ b/pkg/collector/reconcile/configmap.go
@@ -117,9 +117,17 @@ func expectedConfigMaps(ctx context.Context, params Params, expected []corev1.Co
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		if err := params.Client.Update(ctx, updated); err != nil {
+		// editting Update with Patch
+		patch := client.MergeFrom(&params.Instance)
+
+		if err := params.Client.Patch(ctx, &changed, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
+
+		
+		// if err := params.Client.Update(ctx, updated); err != nil {
+		// 	return fmt.Errorf("failed to apply changes: %w", err)
+		// }
 
 		params.Log.V(2).Info("applied", "configmap.name", desired.Name, "configmap.namespace", desired.Namespace)
 	}

--- a/pkg/collector/reconcile/daemonset.go
+++ b/pkg/collector/reconcile/daemonset.go
@@ -87,9 +87,16 @@ func expectedDaemonSets(ctx context.Context, params Params, expected []appsv1.Da
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		if err := params.Client.Update(ctx, updated); err != nil {
+		// editting Update with Patch
+		patch := client.MergeFrom(&params.Instance)
+
+		if err := params.Client.Patch(ctx, &changed, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
+		
+		// if err := params.Client.Update(ctx, updated); err != nil {
+		// 	return fmt.Errorf("failed to apply changes: %w", err)
+		// }
 
 		params.Log.V(2).Info("applied", "daemonset.name", desired.Name, "daemonset.namespace", desired.Namespace)
 	}

--- a/pkg/collector/reconcile/daemonset.go
+++ b/pkg/collector/reconcile/daemonset.go
@@ -87,17 +87,10 @@ func expectedDaemonSets(ctx context.Context, params Params, expected []appsv1.Da
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		// editting Update with Patch
 		patch := client.MergeFrom(&params.Instance)
-
-		// if err := params.Client.Patch(ctx, &changed, patch); err != nil {
 		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
-		
-		// if err := params.Client.Update(ctx, updated); err != nil {
-		// 	return fmt.Errorf("failed to apply changes: %w", err)
-		// }
 
 		params.Log.V(2).Info("applied", "daemonset.name", desired.Name, "daemonset.namespace", desired.Namespace)
 	}

--- a/pkg/collector/reconcile/daemonset.go
+++ b/pkg/collector/reconcile/daemonset.go
@@ -90,7 +90,8 @@ func expectedDaemonSets(ctx context.Context, params Params, expected []appsv1.Da
 		// editting Update with Patch
 		patch := client.MergeFrom(&params.Instance)
 
-		if err := params.Client.Patch(ctx, &changed, patch); err != nil {
+		// if err := params.Client.Patch(ctx, &changed, patch); err != nil {
+		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
 		

--- a/pkg/collector/reconcile/deployment.go
+++ b/pkg/collector/reconcile/deployment.go
@@ -87,19 +87,12 @@ func expectedDeployments(ctx context.Context, params Params, expected []appsv1.D
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		
-		// editting Update with Patch
 		patch := client.MergeFrom(&params.Instance)
 
 		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
-
-
-		// if err := params.Client.Update(ctx, updated); err != nil {
-		// 	return fmt.Errorf("failed to apply changes: %w", err)
-		// }
-
+		
 		params.Log.V(2).Info("applied", "deployment.name", desired.Name, "deployment.namespace", desired.Namespace)
 	}
 

--- a/pkg/collector/reconcile/deployment.go
+++ b/pkg/collector/reconcile/deployment.go
@@ -87,10 +87,12 @@ func expectedDeployments(ctx context.Context, params Params, expected []appsv1.D
 			updated.ObjectMeta.Labels[k] = v
 		}
 
+		
 		// editting Update with Patch
 		patch := client.MergeFrom(&params.Instance)
 
-		if err := params.Client.Patch(ctx, &changed, patch); err != nil {
+		// if err := params.Client.Patch(ctx, &changed, patch); err != nil {
+		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
 

--- a/pkg/collector/reconcile/deployment.go
+++ b/pkg/collector/reconcile/deployment.go
@@ -87,9 +87,17 @@ func expectedDeployments(ctx context.Context, params Params, expected []appsv1.D
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		if err := params.Client.Update(ctx, updated); err != nil {
+		// editting Update with Patch
+		patch := client.MergeFrom(&params.Instance)
+
+		if err := params.Client.Patch(ctx, &changed, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
+
+
+		// if err := params.Client.Update(ctx, updated); err != nil {
+		// 	return fmt.Errorf("failed to apply changes: %w", err)
+		// }
 
 		params.Log.V(2).Info("applied", "deployment.name", desired.Name, "deployment.namespace", desired.Namespace)
 	}

--- a/pkg/collector/reconcile/service.go
+++ b/pkg/collector/reconcile/service.go
@@ -193,17 +193,11 @@ func expectedServices(ctx context.Context, params Params, expected []corev1.Serv
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		// editting Update with Patch
 		patch := client.MergeFrom(&params.Instance)
 
-		// if err := params.Client.Patch(ctx, &changed, patch); err != nil {
 		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
-
-		// if err := params.Client.Update(ctx, updated); err != nil {
-		// 	return fmt.Errorf("failed to apply changes: %w", err)
-		// }
 
 		params.Log.V(2).Info("applied", "service.name", desired.Name, "service.namespace", desired.Namespace)
 	}

--- a/pkg/collector/reconcile/service.go
+++ b/pkg/collector/reconcile/service.go
@@ -196,7 +196,8 @@ func expectedServices(ctx context.Context, params Params, expected []corev1.Serv
 		// editting Update with Patch
 		patch := client.MergeFrom(&params.Instance)
 
-		if err := params.Client.Patch(ctx, &changed, patch); err != nil {
+		// if err := params.Client.Patch(ctx, &changed, patch); err != nil {
+		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
 

--- a/pkg/collector/reconcile/service.go
+++ b/pkg/collector/reconcile/service.go
@@ -193,9 +193,16 @@ func expectedServices(ctx context.Context, params Params, expected []corev1.Serv
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		if err := params.Client.Update(ctx, updated); err != nil {
+		// editting Update with Patch
+		patch := client.MergeFrom(&params.Instance)
+
+		if err := params.Client.Patch(ctx, &changed, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
+
+		// if err := params.Client.Update(ctx, updated); err != nil {
+		// 	return fmt.Errorf("failed to apply changes: %w", err)
+		// }
 
 		params.Log.V(2).Info("applied", "service.name", desired.Name, "service.namespace", desired.Namespace)
 	}

--- a/pkg/collector/reconcile/serviceaccount.go
+++ b/pkg/collector/reconcile/serviceaccount.go
@@ -86,9 +86,17 @@ func expectedServiceAccounts(ctx context.Context, params Params, expected []core
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		if err := params.Client.Update(ctx, updated); err != nil {
+		// editting Update with Patch
+		patch := client.MergeFrom(&params.Instance)
+
+		if err := params.Client.Patch(ctx, &changed, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
+
+
+		// if err := params.Client.Update(ctx, updated); err != nil {
+		// 	return fmt.Errorf("failed to apply changes: %w", err)
+		// }
 
 		params.Log.V(2).Info("applied", "serviceaccount.name", desired.Name, "serviceaccount.namespace", desired.Namespace)
 	}

--- a/pkg/collector/reconcile/serviceaccount.go
+++ b/pkg/collector/reconcile/serviceaccount.go
@@ -86,18 +86,11 @@ func expectedServiceAccounts(ctx context.Context, params Params, expected []core
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		// editting Update with Patch
 		patch := client.MergeFrom(&params.Instance)
 
-		// if err := params.Client.Patch(ctx, &changed, patch); err != nil {
 		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
-
-
-		// if err := params.Client.Update(ctx, updated); err != nil {
-		// 	return fmt.Errorf("failed to apply changes: %w", err)
-		// }
 
 		params.Log.V(2).Info("applied", "serviceaccount.name", desired.Name, "serviceaccount.namespace", desired.Namespace)
 	}

--- a/pkg/collector/reconcile/serviceaccount.go
+++ b/pkg/collector/reconcile/serviceaccount.go
@@ -89,7 +89,8 @@ func expectedServiceAccounts(ctx context.Context, params Params, expected []core
 		// editting Update with Patch
 		patch := client.MergeFrom(&params.Instance)
 
-		if err := params.Client.Patch(ctx, &changed, patch); err != nil {
+		// if err := params.Client.Patch(ctx, &changed, patch); err != nil {
+		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}
 


### PR DESCRIPTION
Fixes #54 by changing the reconciliation calls to use Patch instead of Update.