### PR TITLE
Add permissions for opentelemetry finalizer resource

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -97,6 +97,14 @@ rules:
 - apiGroups:
   - opentelemetry.io
   resources:
+  - opentelemetrycollectors/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - opentelemetry.io
+  resources:
   - opentelemetrycollectors/status
   verbs:
   - get

--- a/controllers/opentelemetrycollector_controller.go
+++ b/controllers/opentelemetrycollector_controller.go
@@ -105,6 +105,7 @@ func NewReconciler(p Params) *OpenTelemetryCollectorReconciler {
 
 // +kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 
 // Reconcile the current state of an OpenTelemetry collector resource with the desired state.


### PR DESCRIPTION
Still need to test this changes on an OCP cluster, but this should be enough for fix https://github.com/open-telemetry/opentelemetry-operator/issues/211

See other similar issues here:
https://github.com/operator-framework/operator-sdk/issues/1736
https://github.com/spotahome/redis-operator/issues/98

Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>