### PR TITLE
Restart collector pod when config is updated

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - list

--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func main() {
 		Log:      ctrl.Log.WithName("controllers").WithName("OpenTelemetryCollector"),
 		Scheme:   mgr.GetScheme(),
 		Config:   cfg,
-		Recorder: mgr.GetEventRecorderFor("otel-controller"),
+		Recorder: mgr.GetEventRecorderFor("opentelemetry-operator"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenTelemetryCollector")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -145,10 +145,11 @@ func main() {
 	}
 
 	if err = controllers.NewReconciler(controllers.Params{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("OpenTelemetryCollector"),
-		Scheme: mgr.GetScheme(),
-		Config: cfg,
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("OpenTelemetryCollector"),
+		Scheme:   mgr.GetScheme(),
+		Config:   cfg,
+		Recorder: mgr.GetEventRecorderFor("otel-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OpenTelemetryCollector")
 		os.Exit(1)

--- a/pkg/collector/annotations.go
+++ b/pkg/collector/annotations.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package collector
 
 import (

--- a/pkg/collector/annotations.go
+++ b/pkg/collector/annotations.go
@@ -1,0 +1,31 @@
+package collector
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
+)
+
+// Annotations return the annotations for OpenTelemetryCollector pod.
+func Annotations(instance v1alpha1.OpenTelemetryCollector) map[string]string {
+	// new map every time, so that we don't touch the instance's annotations
+	annotations := map[string]string{}
+	if nil != instance.Annotations {
+		for k, v := range instance.Annotations {
+			annotations[k] = v
+		}
+	}
+
+	annotations["prometheus.io/scrape"] = "true"
+	annotations["prometheus.io/port"] = "8888"
+	annotations["prometheus.io/path"] = "/metrics"
+	annotations["opentelemetry-operator-config/sha256"] = getConfigMapSHA(instance.Spec.Config)
+
+	return annotations
+}
+
+func getConfigMapSHA(config string) string {
+	h := sha256.Sum256([]byte(config))
+	return fmt.Sprintf("%x", h)
+}

--- a/pkg/collector/annotations.go
+++ b/pkg/collector/annotations.go
@@ -25,15 +25,19 @@ import (
 func Annotations(instance v1alpha1.OpenTelemetryCollector) map[string]string {
 	// new map every time, so that we don't touch the instance's annotations
 	annotations := map[string]string{}
+
+	// set default prometheus annotations
+	annotations["prometheus.io/scrape"] = "true"
+	annotations["prometheus.io/port"] = "8888"
+	annotations["prometheus.io/path"] = "/metrics"
+
+	// allow override of prometheus annotations
 	if nil != instance.Annotations {
 		for k, v := range instance.Annotations {
 			annotations[k] = v
 		}
 	}
-
-	annotations["prometheus.io/scrape"] = "true"
-	annotations["prometheus.io/port"] = "8888"
-	annotations["prometheus.io/path"] = "/metrics"
+	// make sure sha256 for configMap is always calculated
 	annotations["opentelemetry-operator-config/sha256"] = getConfigMapSHA(instance.Spec.Config)
 
 	return annotations

--- a/pkg/collector/annotations_test.go
+++ b/pkg/collector/annotations_test.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
+	. "github.com/open-telemetry/opentelemetry-operator/pkg/collector"
+)
+
+func TestAnnotations(t *testing.T) {
+	// prepare
+	otelcol := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-instance",
+			Namespace: "my-ns",
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Config: "test",
+		},
+	}
+
+	// test
+	annotations := Annotations(otelcol)
+	assert.Equal(t, "true", annotations["prometheus.io/scrape"])
+	assert.Equal(t, "8888", annotations["prometheus.io/port"])
+	assert.Equal(t, "/metrics", annotations["prometheus.io/path"])
+	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", annotations["opentelemetry-operator-config/sha256"])
+}
+
+func TestAnnotationsPropagateDown(t *testing.T) {
+	// prepare
+	otelcol := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{"myapp": "mycomponent"},
+		},
+	}
+
+	// test
+	annotations := Annotations(otelcol)
+
+	// verify
+	assert.Len(t, annotations, 5)
+	assert.Equal(t, "mycomponent", annotations["myapp"])
+}

--- a/pkg/collector/annotations_test.go
+++ b/pkg/collector/annotations_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
 )
 
-func TestAnnotations(t *testing.T) {
+func TestDefaultAnnotations(t *testing.T) {
 	// prepare
 	otelcol := v1alpha1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
@@ -37,9 +37,38 @@ func TestAnnotations(t *testing.T) {
 
 	// test
 	annotations := Annotations(otelcol)
+
+	//verify
 	assert.Equal(t, "true", annotations["prometheus.io/scrape"])
 	assert.Equal(t, "8888", annotations["prometheus.io/port"])
 	assert.Equal(t, "/metrics", annotations["prometheus.io/path"])
+	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", annotations["opentelemetry-operator-config/sha256"])
+}
+
+func TestUserAnnotations(t *testing.T) {
+	// prepare
+	otelcol := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-instance",
+			Namespace: "my-ns",
+			Annotations: map[string]string{"prometheus.io/scrape": "false",
+				"prometheus.io/port":                   "1234",
+				"prometheus.io/path":                   "/test",
+				"opentelemetry-operator-config/sha256": "shouldBeOverwritten",
+			},
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Config: "test",
+		},
+	}
+
+	// test
+	annotations := Annotations(otelcol)
+
+	//verify
+	assert.Equal(t, "false", annotations["prometheus.io/scrape"])
+	assert.Equal(t, "1234", annotations["prometheus.io/port"])
+	assert.Equal(t, "/test", annotations["prometheus.io/path"])
 	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", annotations["opentelemetry-operator-config/sha256"])
 }
 

--- a/pkg/collector/annotations_test.go
+++ b/pkg/collector/annotations_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package collector_test
+package collector
 
 import (
 	"testing"
@@ -21,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
-	. "github.com/open-telemetry/opentelemetry-operator/pkg/collector"
 )
 
 func TestAnnotations(t *testing.T) {

--- a/pkg/collector/daemonset.go
+++ b/pkg/collector/daemonset.go
@@ -30,14 +30,7 @@ func DaemonSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 	labels := Labels(otelcol)
 	labels["app.kubernetes.io/name"] = naming.Collector(otelcol)
 
-	annotations := otelcol.Annotations
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-
-	annotations["prometheus.io/scrape"] = "true"
-	annotations["prometheus.io/port"] = "8888"
-	annotations["prometheus.io/path"] = "/metrics"
+	annotations := Annotations(otelcol)
 
 	return appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/collector/deployment.go
+++ b/pkg/collector/deployment.go
@@ -30,14 +30,7 @@ func Deployment(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTele
 	labels := Labels(otelcol)
 	labels["app.kubernetes.io/name"] = naming.Collector(otelcol)
 
-	annotations := otelcol.Annotations
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-
-	annotations["prometheus.io/scrape"] = "true"
-	annotations["prometheus.io/port"] = "8888"
-	annotations["prometheus.io/path"] = "/metrics"
+	annotations := Annotations(otelcol)
 
 	return appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/collector/reconcile/params.go
+++ b/pkg/collector/reconcile/params.go
@@ -17,6 +17,7 @@ package reconcile
 import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
@@ -30,4 +31,5 @@ type Params struct {
 	Instance v1alpha1.OpenTelemetryCollector
 	Log      logr.Logger
 	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }


### PR DESCRIPTION
Signed-off-by: santosh <bsantosh@thoughtworks.com>

Resolves #197 

**Change Description**
Annotate deployment/daemonset with SHA256 of the config data. Publish an event for configmap, whenever config changes. On the reconcile loop triggered by configmap event - deployment/daemonset would be updated leading to rolling restart of the pod.