### PR TITLE
Change apiVersion for webhook manifests & patches

### DIFF
--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,13 +1,13 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   creationTimestamp: null
@@ -24,6 +24,8 @@ webhooks:
     - UPDATE
     resources:
     - opentelemetrycollectors
+  admissionReviewVersions: ["v1","v1beta1"]
+  sideEffects: None
 - clientConfig:
     caBundle: Cg==
     service:
@@ -42,9 +44,11 @@ webhooks:
     - UPDATE
     resources:
     - pods
+  admissionReviewVersions: ["v1","v1beta1"]
+  sideEffects: None
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
@@ -69,3 +73,5 @@ webhooks:
     - DELETE
     resources:
     - opentelemetrycollectors
+  admissionReviewVersions: ["v1","v1beta1"]
+  sideEffects: None


### PR DESCRIPTION
Update apiVersion for metrics-reader clusterRole to rbac.authorization.k8s.io/v1

Signed-off-by: santosh <bsantosh@thoughtworks.com>