### PR TITLE
[Part 1]Add unit tests for reconcile methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ bin
 # Release artifacts
 dist
 bundle.tar.gz
+vendor
 
 # editor and IDE paraphernalia
 .idea

--- a/pkg/collector/reconcile/configmap.go
+++ b/pkg/collector/reconcile/configmap.go
@@ -120,7 +120,7 @@ func expectedConfigMaps(ctx context.Context, params Params, expected []corev1.Co
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		patch := client.MergeFrom(&params.Instance)
+		patch := client.MergeFrom(existing)
 
 		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)

--- a/pkg/collector/reconcile/configmap_test.go
+++ b/pkg/collector/reconcile/configmap_test.go
@@ -16,31 +16,62 @@ package reconcile
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 )
 
 func TestDesiredConfigMap(t *testing.T) {
 	t.Run("should return expected config map", func(t *testing.T) {
-		expected := configMap("test-collector")
+		expectedLables := map[string]string{
+			"app.kubernetes.io/managed-by": "opentelemetry-operator",
+			"app.kubernetes.io/instance":   "default.test",
+			"app.kubernetes.io/part-of":    "opentelemetry",
+			"app.kubernetes.io/component":  "opentelemetry-collector",
+			"app.kubernetes.io/name":       "test-collector",
+		}
+
+		expectedData := map[string]string{
+			"collector.yaml": `
+    receivers:
+      jaeger:
+        protocols:
+          grpc:
+    processors:
+
+    exporters:
+      logging:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [jaeger]
+          processors: []
+          exporters: [logging]
+
+`,
+		}
+
 		actual := desiredConfigMap(context.Background(), params())
-		assert.Equal(t, expected, actual)
+
+		assert.Equal(t, "test-collector", actual.Name)
+		assert.Equal(t, expectedLables, actual.Labels)
+		assert.Equal(t, expectedData, actual.Data)
+
 	})
 
 }
 
 func TestExpectedConfigMap(t *testing.T) {
-
-	cm := configMap("test-collector")
-	deletecm := configMap("test")
-
 	t.Run("should create config map", func(t *testing.T) {
-		err := expectedConfigMaps(context.Background(), params(), []v1.ConfigMap{cm}, true)
+		err := expectedConfigMaps(context.Background(), params(), []v1.ConfigMap{desiredConfigMap(context.Background(), params())}, true)
 		assert.NoError(t, err)
 
 		exists, err := populateObjectIfExists(t, &v1.ConfigMap{}, types.NamespacedName{Namespace: "default", Name: "test-collector"})
@@ -51,6 +82,25 @@ func TestExpectedConfigMap(t *testing.T) {
 
 	t.Run("should update config map", func(t *testing.T) {
 
+		param := Params{
+			Config: config.New(),
+			Client: k8sClient,
+			Instance: v1alpha1.OpenTelemetryCollector{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "opentelemetry.io",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					UID:       instanceUID,
+				},
+			},
+			Scheme:   testScheme,
+			Log:      logger,
+			Recorder: record.NewFakeRecorder(10),
+		}
+		cm := desiredConfigMap(context.Background(), param)
 		createObjectIfNotExists(t, "test-collector", &cm)
 
 		err := expectedConfigMaps(context.Background(), params(), []v1.ConfigMap{desiredConfigMap(context.Background(), params())}, true)
@@ -62,34 +112,30 @@ func TestExpectedConfigMap(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, exists)
 		assert.Equal(t, instanceUID, actual.OwnerReferences[0].UID)
+		assert.Equal(t, params().Instance.Spec.Config, actual.Data["collector.yaml"])
 	})
 
 	t.Run("should delete config map", func(t *testing.T) {
-		createObjectIfNotExists(t, "test", &deletecm)
-		err := deleteConfigMaps(context.Background(), params(), []v1.ConfigMap{configMap("test-collector")})
+
+		deletecm := v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-delete-collector",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app.kubernetes.io/instance":   "default.test",
+					"app.kubernetes.io/managed-by": "opentelemetry-operator",
+				},
+			},
+		}
+		createObjectIfNotExists(t, "test-delete-collector", &deletecm)
+
+		exists, _ := populateObjectIfExists(t, &v1.ConfigMap{}, types.NamespacedName{Namespace: "default", Name: "test-delete-collector"})
+		assert.True(t, exists)
+
+		err := deleteConfigMaps(context.Background(), params(), []v1.ConfigMap{desiredConfigMap(context.Background(), params())})
 		assert.NoError(t, err)
 
-		exists, _ := populateObjectIfExists(t, &v1.ConfigMap{}, types.NamespacedName{Namespace: "default", Name: "test"})
-
+		exists, _ = populateObjectIfExists(t, &v1.ConfigMap{}, types.NamespacedName{Namespace: "default", Name: "test-delete-collector"})
 		assert.False(t, exists)
 	})
-}
-
-func configMap(name string) v1.ConfigMap {
-	return v1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "opentelemetry-operator",
-				"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params().Instance.Namespace, params().Instance.Name),
-				"app.kubernetes.io/part-of":    "opentelemetry",
-				"app.kubernetes.io/component":  "opentelemetry-collector",
-				"app.kubernetes.io/name":       name,
-			},
-		},
-		Data: map[string]string{
-			"collector.yaml": params().Instance.Spec.Config,
-		},
-	}
 }

--- a/pkg/collector/reconcile/configmap_test.go
+++ b/pkg/collector/reconcile/configmap_test.go
@@ -53,13 +53,15 @@ func TestExpectedConfigMap(t *testing.T) {
 
 		createObjectIfNotExists(t, "test-collector", &cm)
 
-		_ = expectedConfigMaps(context.Background(), params(), []v1.ConfigMap{configMap("test-collector")}, true)
+		//err := expectedConfigMaps(context.Background(), params(), []v1.ConfigMap{desiredConfigMap(context.Background(), params())}, true)
 		//assert.NoError(t, err)
 		//
-		//actual, err := getCM(t)
+		//actual := v1.ConfigMap{}
+		//exists, err := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "test-collector"})
 		//
 		//assert.NoError(t, err)
-		//assert.Equal(t, actual.Data, configMap().Data)
+		//assert.True(t, exists)
+		//assert.Equal(t, actual.Data, cm.Data)
 	})
 
 	t.Run("should delete config map", func(t *testing.T) {

--- a/pkg/collector/reconcile/configmap_test.go
+++ b/pkg/collector/reconcile/configmap_test.go
@@ -1,0 +1,125 @@
+package reconcile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var logger = logf.Log.WithName("unit-tests")
+
+func TestDesiredConfigMap(t *testing.T) {
+	t.Run("should return expected config map", func(t *testing.T) {
+		expected := configMap()
+		actual := desiredConfigMap(context.Background(), params())
+		assert.Equal(t, expected, actual)
+	})
+
+}
+
+func TestExpectedConfigMap(t *testing.T) {
+	t.Run("should create config map", func(t *testing.T) {
+		err := expectedConfigMaps(context.Background(), params(), []v1.ConfigMap{configMap()}, true)
+		assert.NoError(t, err)
+
+		actual := v1.ConfigMap{}
+		err = k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "test-collector"}, &actual)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, actual)
+	})
+
+	t.Run("should update config map", func(t *testing.T) {
+		err := k8sClient.Create(context.Background(),
+			&v1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-collector",
+					Namespace: "default",
+				}})
+		assert.NoError(t, err)
+
+		//err = expectedConfigMaps(context.Background(), params(), []v1.ConfigMap{configMap()}, true)
+		//assert.NoError(t, err)
+		//
+		//actual := v1.ConfigMap{}
+		//err = k8sClient.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "test-collector"}, &actual)
+		//assert.NoError(t, err)
+		//assert.Equal(t, actual.Data, configMap().Data)
+	})
+}
+
+func configMap() v1.ConfigMap {
+	return v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-collector",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "opentelemetry-operator",
+				"app.kubernetes.io/instance":   "default.test",
+				"app.kubernetes.io/part-of":    "opentelemetry",
+				"app.kubernetes.io/component":  "opentelemetry-collector",
+				"app.kubernetes.io/name":       "test-collector",
+			},
+		},
+		Data: map[string]string{
+			"collector.yaml": params().Instance.Spec.Config,
+		},
+	}
+}
+
+func params() Params {
+	return Params{
+		Config: config.New(),
+		Client: k8sClient,
+		Instance: v1alpha1.OpenTelemetryCollector{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "opentelemetry.io",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+				UID:       "testuid1234",
+			},
+			Spec: v1alpha1.OpenTelemetryCollectorSpec{
+				Config: `
+    receivers:
+      jaeger:
+        protocols:
+          grpc:
+    processors:
+
+    exporters:
+      logging:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [jaeger]
+          processors: []
+          exporters: [logging]
+
+`,
+			},
+		},
+		Scheme:   testScheme,
+		Log:      logger,
+		Recorder: record.NewFakeRecorder(10),
+	}
+}

--- a/pkg/collector/reconcile/configmap_test.go
+++ b/pkg/collector/reconcile/configmap_test.go
@@ -53,15 +53,15 @@ func TestExpectedConfigMap(t *testing.T) {
 
 		createObjectIfNotExists(t, "test-collector", &cm)
 
-		//err := expectedConfigMaps(context.Background(), params(), []v1.ConfigMap{desiredConfigMap(context.Background(), params())}, true)
-		//assert.NoError(t, err)
-		//
-		//actual := v1.ConfigMap{}
-		//exists, err := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "test-collector"})
-		//
-		//assert.NoError(t, err)
-		//assert.True(t, exists)
-		//assert.Equal(t, actual.Data, cm.Data)
+		err := expectedConfigMaps(context.Background(), params(), []v1.ConfigMap{desiredConfigMap(context.Background(), params())}, true)
+		assert.NoError(t, err)
+
+		actual := v1.ConfigMap{}
+		exists, err := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "test-collector"})
+
+		assert.NoError(t, err)
+		assert.True(t, exists)
+		assert.Equal(t, instanceUID, actual.OwnerReferences[0].UID)
 	})
 
 	t.Run("should delete config map", func(t *testing.T) {

--- a/pkg/collector/reconcile/configmap_test.go
+++ b/pkg/collector/reconcile/configmap_test.go
@@ -67,7 +67,7 @@ func TestExpectedConfigMap(t *testing.T) {
 		err := deleteConfigMaps(context.Background(), params(), []v1.ConfigMap{configMap("test-collector")})
 		assert.NoError(t, err)
 
-		exists, err := populateObjectIfExists(t, &v1.ConfigMap{}, types.NamespacedName{Namespace: "default", Name: "test"})
+		exists, _ := populateObjectIfExists(t, &v1.ConfigMap{}, types.NamespacedName{Namespace: "default", Name: "test"})
 
 		assert.False(t, exists)
 	})
@@ -91,4 +91,3 @@ func configMap(name string) v1.ConfigMap {
 		},
 	}
 }
-

--- a/pkg/collector/reconcile/daemonset.go
+++ b/pkg/collector/reconcile/daemonset.go
@@ -89,7 +89,7 @@ func expectedDaemonSets(ctx context.Context, params Params, expected []appsv1.Da
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		patch := client.MergeFrom(&params.Instance)
+		patch := client.MergeFrom(existing)
 		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)
 		}

--- a/pkg/collector/reconcile/daemonset_test.go
+++ b/pkg/collector/reconcile/daemonset_test.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package reconcile
 
 import (
@@ -27,7 +41,6 @@ func TestExpectedDaemonsets(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, exists)
 
-
 	})
 	t.Run("should update Daemonset", func(t *testing.T) {
 		ds := daemonset("test-collector")
@@ -53,7 +66,7 @@ func TestExpectedDaemonsets(t *testing.T) {
 		assert.NoError(t, err)
 
 		actual := v1.DaemonSet{}
-		exists, err := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "dummy"})
+		exists, _ := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "dummy"})
 
 		assert.False(t, exists)
 
@@ -63,8 +76,8 @@ func TestExpectedDaemonsets(t *testing.T) {
 func daemonset(name string) v1.DaemonSet {
 	return v1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   "default",
+			Name:      name,
+			Namespace: "default",
 			Labels: map[string]string{
 				"app.kubernetes.io/managed-by": "opentelemetry-operator",
 				"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params().Instance.Namespace, params().Instance.Name),
@@ -76,16 +89,15 @@ func daemonset(name string) v1.DaemonSet {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"app.kubernetes.io/name": name},
+					Labels: map[string]string{"app.kubernetes.io/name": name},
 				},
 				Spec: corev1.PodSpec{
-					Containers:         []corev1.Container{{
-						Name:        "dummy",
-						Image:       "busybox",
-										}},
+					Containers: []corev1.Container{{
+						Name:  "dummy",
+						Image: "busybox",
+					}},
 				},
 			},
 		},
 	}
 }
-

--- a/pkg/collector/reconcile/daemonset_test.go
+++ b/pkg/collector/reconcile/daemonset_test.go
@@ -1,0 +1,91 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/open-telemetry/opentelemetry-operator/pkg/collector"
+)
+
+func TestExpectedDaemonsets(t *testing.T) {
+	param := params()
+	expectedDs := collector.DaemonSet(param.Config, logger, param.Instance)
+
+	t.Run("should create Daemonset", func(t *testing.T) {
+		err := expectedDaemonSets(context.Background(), param, []v1.DaemonSet{expectedDs})
+		assert.NoError(t, err)
+
+		exists, err := populateObjectIfExists(t, &v1.DaemonSet{}, types.NamespacedName{Namespace: "default", Name: "test-collector"})
+
+		assert.NoError(t, err)
+		assert.True(t, exists)
+
+
+	})
+	t.Run("should update Daemonset", func(t *testing.T) {
+		ds := daemonset("test-collector")
+		createObjectIfNotExists(t, "test-collector", &ds)
+		//err := expectedDaemonSets(context.Background(), param, []v1.DaemonSet{expectedDs})
+		//assert.NoError(t, err)
+		//
+		//actual := v1.DaemonSet{}
+		//exists, err := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "test-collector"})
+		//
+		//assert.NoError(t, err)
+		//assert.True(t, exists)
+		//assert.Equal(t, expectedDs, actual)
+
+	})
+
+	t.Run("should cleanup daemonsets", func(t *testing.T) {
+
+		ds := daemonset("dummy")
+		createObjectIfNotExists(t, "dummy", &ds)
+
+		err := deleteDaemonSets(context.Background(), param, []v1.DaemonSet{expectedDs})
+		assert.NoError(t, err)
+
+		actual := v1.DaemonSet{}
+		exists, err := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "dummy"})
+
+		assert.False(t, exists)
+
+	})
+}
+
+func daemonset(name string) v1.DaemonSet {
+	return v1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "opentelemetry-operator",
+				"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params().Instance.Namespace, params().Instance.Name),
+			},
+		},
+		Spec: v1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/name": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{"app.kubernetes.io/name": name},
+				},
+				Spec: corev1.PodSpec{
+					Containers:         []corev1.Container{{
+						Name:        "dummy",
+						Image:       "busybox",
+										}},
+				},
+			},
+		},
+	}
+}
+

--- a/pkg/collector/reconcile/daemonset_test.go
+++ b/pkg/collector/reconcile/daemonset_test.go
@@ -43,8 +43,7 @@ func TestExpectedDaemonsets(t *testing.T) {
 
 	})
 	t.Run("should update Daemonset", func(t *testing.T) {
-		ds := daemonset("test-collector")
-		createObjectIfNotExists(t, "test-collector", &ds)
+		createObjectIfNotExists(t, "test-collector", &expectedDs)
 		err := expectedDaemonSets(context.Background(), param, []v1.DaemonSet{expectedDs})
 		assert.NoError(t, err)
 

--- a/pkg/collector/reconcile/deployment.go
+++ b/pkg/collector/reconcile/deployment.go
@@ -89,7 +89,7 @@ func expectedDeployments(ctx context.Context, params Params, expected []appsv1.D
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		patch := client.MergeFrom(&params.Instance)
+		patch := client.MergeFrom(existing)
 
 		if err := params.Client.Patch(ctx, updated, patch); err != nil {
 			return fmt.Errorf("failed to apply changes: %w", err)

--- a/pkg/collector/reconcile/deployment_test.go
+++ b/pkg/collector/reconcile/deployment_test.go
@@ -45,15 +45,15 @@ func TestExpectedDeployments(t *testing.T) {
 	t.Run("should update deployment", func(t *testing.T) {
 		deploy := deployment("test-collector")
 		createObjectIfNotExists(t, "test-collector", &deploy)
-		//err := expectedDeployments(context.Background(), param, []v1.Deployment{expectedDeploy})
-		//assert.NoError(t, err)
-		//
-		//actual := v1.Deployment{}
-		//exists, err := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "test-collector"})
-		//
-		//assert.NoError(t, err)
-		//assert.True(t, exists)
-		//assert.Equal(t, expectedDeploy.Labels, actual.Labels)
+		err := expectedDeployments(context.Background(), param, []v1.Deployment{expectedDeploy})
+		assert.NoError(t, err)
+
+		actual := v1.Deployment{}
+		exists, err := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "test-collector"})
+
+		assert.NoError(t, err)
+		assert.True(t, exists)
+		assert.Equal(t, instanceUID, actual.OwnerReferences[0].UID)
 
 	})
 
@@ -74,6 +74,8 @@ func TestExpectedDeployments(t *testing.T) {
 }
 
 func deployment(name string) v1.Deployment {
+	labels := collector.Labels(params().Instance)
+	labels["app.kubernetes.io/name"] = name
 	return v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -85,11 +87,11 @@ func deployment(name string) v1.Deployment {
 		},
 		Spec: v1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app.kubernetes.io/name": name},
+				MatchLabels: labels,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app.kubernetes.io/name": name},
+					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{

--- a/pkg/collector/reconcile/deployment_test.go
+++ b/pkg/collector/reconcile/deployment_test.go
@@ -28,44 +28,44 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector"
 )
 
-func TestExpectedDaemonsets(t *testing.T) {
+func TestExpectedDeployments(t *testing.T) {
 	param := params()
-	expectedDs := collector.DaemonSet(param.Config, logger, param.Instance)
+	expectedDeploy := collector.Deployment(param.Config, logger, param.Instance)
 
-	t.Run("should create Daemonset", func(t *testing.T) {
-		err := expectedDaemonSets(context.Background(), param, []v1.DaemonSet{expectedDs})
+	t.Run("should create deployment", func(t *testing.T) {
+		err := expectedDeployments(context.Background(), param, []v1.Deployment{expectedDeploy})
 		assert.NoError(t, err)
 
-		exists, err := populateObjectIfExists(t, &v1.DaemonSet{}, types.NamespacedName{Namespace: "default", Name: "test-collector"})
+		exists, err := populateObjectIfExists(t, &v1.Deployment{}, types.NamespacedName{Namespace: "default", Name: "test-collector"})
 
 		assert.NoError(t, err)
 		assert.True(t, exists)
 
 	})
-	t.Run("should update Daemonset", func(t *testing.T) {
-		ds := daemonset("test-collector")
-		createObjectIfNotExists(t, "test-collector", &ds)
-		//err := expectedDaemonSets(context.Background(), param, []v1.DaemonSet{expectedDs})
+	t.Run("should update deployment", func(t *testing.T) {
+		deploy := deployment("test-collector")
+		createObjectIfNotExists(t, "test-collector", &deploy)
+		//err := expectedDeployments(context.Background(), param, []v1.Deployment{expectedDeploy})
 		//assert.NoError(t, err)
 		//
-		//actual := v1.DaemonSet{}
+		//actual := v1.Deployment{}
 		//exists, err := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "test-collector"})
 		//
 		//assert.NoError(t, err)
 		//assert.True(t, exists)
-		//assert.Equal(t, expectedDs.Labels, actual.Labels)
+		//assert.Equal(t, expectedDeploy.Labels, actual.Labels)
 
 	})
 
-	t.Run("should cleanup daemonsets", func(t *testing.T) {
+	t.Run("should cleanup deployments", func(t *testing.T) {
 
-		ds := daemonset("dummy")
-		createObjectIfNotExists(t, "dummy", &ds)
+		deploy := deployment("dummy")
+		createObjectIfNotExists(t, "dummy", &deploy)
 
-		err := deleteDaemonSets(context.Background(), param, []v1.DaemonSet{expectedDs})
+		err := deleteDeployments(context.Background(), param, []v1.Deployment{expectedDeploy})
 		assert.NoError(t, err)
 
-		actual := v1.DaemonSet{}
+		actual := v1.Deployment{}
 		exists, _ := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "dummy"})
 
 		assert.False(t, exists)
@@ -73,8 +73,8 @@ func TestExpectedDaemonsets(t *testing.T) {
 	})
 }
 
-func daemonset(name string) v1.DaemonSet {
-	return v1.DaemonSet{
+func deployment(name string) v1.Deployment {
+	return v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "default",
@@ -83,7 +83,7 @@ func daemonset(name string) v1.DaemonSet {
 				"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params().Instance.Namespace, params().Instance.Name),
 			},
 		},
-		Spec: v1.DaemonSetSpec{
+		Spec: v1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app.kubernetes.io/name": name},
 			},

--- a/pkg/collector/reconcile/deployment_test.go
+++ b/pkg/collector/reconcile/deployment_test.go
@@ -54,7 +54,7 @@ func TestExpectedDeployments(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, exists)
 		assert.Equal(t, instanceUID, actual.OwnerReferences[0].UID)
-
+		assert.Equal(t, int32(2), *actual.Spec.Replicas)
 	})
 
 	t.Run("should cleanup deployments", func(t *testing.T) {

--- a/pkg/collector/reconcile/opentelemetry_test.go
+++ b/pkg/collector/reconcile/opentelemetry_test.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
+)
+
+func TestSelf(t *testing.T) {
+	t.Run("should add version to the status", func(t *testing.T) {
+		instance := params().Instance
+		createObjectIfNotExists(t, "test", &instance)
+		err := Self(context.Background(), params())
+		assert.NoError(t, err)
+
+		actual := v1alpha1.OpenTelemetryCollector{}
+		exists, err := populateObjectIfExists(t, &actual, types.NamespacedName{Namespace: "default", Name: "test"})
+		assert.NoError(t, err)
+		assert.True(t, exists)
+
+		assert.Equal(t, actual.Status.Version, "0.0.0")
+
+	})
+}

--- a/pkg/collector/reconcile/suite_test.go
+++ b/pkg/collector/reconcile/suite_test.go
@@ -34,8 +34,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
-
-	// +kubebuilder:scaffold:imports
 )
 
 var k8sClient client.Client

--- a/pkg/collector/reconcile/suite_test.go
+++ b/pkg/collector/reconcile/suite_test.go
@@ -42,9 +42,11 @@ var testEnv *envtest.Environment
 var testScheme *runtime.Scheme = scheme.Scheme
 var logger = logf.Log.WithName("unit-tests")
 
+var instanceUID = uuid.NewUUID()
+
 func TestMain(m *testing.M) {
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 	}
 
 	cfg, err := testEnv.Start()
@@ -88,7 +90,7 @@ func params() Params {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "default",
-				UID:       uuid.NewUUID(),
+				UID:       instanceUID,
 			},
 			Spec: v1alpha1.OpenTelemetryCollectorSpec{
 				Config: `

--- a/pkg/collector/reconcile/suite_test.go
+++ b/pkg/collector/reconcile/suite_test.go
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
+	// +kubebuilder:scaffold:imports
+)
+
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var testScheme *runtime.Scheme = scheme.Scheme
+
+func TestMain(m *testing.M) {
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "config", "crd", "bases")},
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		fmt.Printf("failed to start testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	if err := v1alpha1.AddToScheme(testScheme); err != nil {
+		fmt.Printf("failed to register scheme: %v", err)
+		os.Exit(1)
+	}
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+	if err != nil {
+		fmt.Printf("failed to setup a Kubernetes client: %v", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	err = testEnv.Stop()
+	if err != nil {
+		fmt.Printf("failed to stop testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}

--- a/pkg/collector/reconcile/suite_test.go
+++ b/pkg/collector/reconcile/suite_test.go
@@ -79,6 +79,7 @@ func TestMain(m *testing.M) {
 }
 
 func params() Params {
+	replicas := int32(2)
 	return Params{
 		Config: config.New(),
 		Client: k8sClient,
@@ -93,6 +94,7 @@ func params() Params {
 				UID:       instanceUID,
 			},
 			Spec: v1alpha1.OpenTelemetryCollectorSpec{
+				Replicas: &replicas,
 				Config: `
     receivers:
       jaeger:

--- a/pkg/collector/reconcile/suite_test.go
+++ b/pkg/collector/reconcile/suite_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -87,7 +88,7 @@ func params() Params {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test",
 				Namespace: "default",
-				UID:       "testuid1234",
+				UID:       uuid.NewUUID(),
 			},
 			Spec: v1alpha1.OpenTelemetryCollectorSpec{
 				Config: `


### PR DESCRIPTION
Signed-off-by: santosh <bsantosh@thoughtworks.com>

Resolves #35 
* Add unit tests for configmap, daemonset, deployment reconcilers
* Fix Patch calls for  configmap, daemonset, deployment reconcilers


Raised https://github.com/open-telemetry/opentelemetry-operator/pull/261 for service and service account reconcilers