### PR TITLE
Force a dummy subject for the self-signed Issuer

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -24,3 +24,6 @@ spec:
     kind: Issuer
     name: selfsigned-issuer
   secretName: opentelemetry-operator-controller-manager-service-cert # this secret will not be prefixed, since it's not managed by kustomize
+  subject:
+    organizationalUnits:
+      - "opentelemetry-operator"


### PR DESCRIPTION
This prevents cert-manager from creating a certificate with an empty DN, which is invalid according to RFC 5280. See: https://github.com/jetstack/cert-manager/issues/3634#issuecomment-773894638

Fixes #255