### PR TITLE
Update to collector v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes by Version
 ==================
 
+0.25.0 (2021-05-12)
+-------------------
+* Bumped OpenTelemetry Collector to v0.26.0
+
 0.25.0 (2021-05-06)
 -------------------
 * Bumped OpenTelemetry Collector to v0.25.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changes by Version
 ==================
 
-0.25.0 (2021-05-12)
+0.26.0 (2021-05-12)
 -------------------
 * Bumped OpenTelemetry Collector to v0.26.0
 

--- a/versions.txt
+++ b/versions.txt
@@ -2,7 +2,7 @@
 # by default with the OpenTelemetry Operator. This would usually be the latest
 # stable OpenTelemetry version. When you update this file, make sure to update the
 # the docs as well.
-opentelemetry-collector=0.25.0
+opentelemetry-collector=0.26.0
 
 # Represents the next release of the OpenTelemetry Operator.
-operator=0.25.0
+operator=0.26.0


### PR DESCRIPTION
This PR bumps the operator to work with the latest stable version of the collector (0.26.0).

Fixes [Issue #264](https://github.com/open-telemetry/opentelemetry-operator/issues/264)