### PR TITLE
Increase memory resource requests and limits

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,8 +32,8 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 128Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 64Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This is a change to fix the OOMKilled issue reported in #279 when running operator manager on Openshift 4.7. 

Closes #279 