### PR TITLE
Remove the OTLP receiver legacy gRPC port(55680) references

### DIFF
--- a/pkg/collector/parser/receiver_otlp.go
+++ b/pkg/collector/parser/receiver_otlp.go
@@ -27,9 +27,8 @@ var _ ReceiverParser = &OTLPReceiverParser{}
 const (
 	parserNameOTLP = "__otlp"
 
-	defaultOTLPGRPCPort       int32 = 4317
-	defaultOTLPGRPCLegacyPort int32 = 55680
-	defaultOTLPHTTPPort       int32 = 55681
+	defaultOTLPGRPCPort int32 = 4317
+	defaultOTLPHTTPPort int32 = 55681
 )
 
 // OTLPReceiverParser parses the configuration for OTLP receivers.
@@ -70,11 +69,6 @@ func (o *OTLPReceiverParser) Ports() ([]corev1.ServicePort, error) {
 					Name:       portName(fmt.Sprintf("%s-grpc", o.name), defaultOTLPGRPCPort),
 					Port:       defaultOTLPGRPCPort,
 					TargetPort: intstr.FromInt(int(defaultOTLPGRPCPort)),
-				},
-				{
-					Name:       portName(fmt.Sprintf("%s-grpc-legacy", o.name), defaultOTLPGRPCLegacyPort),
-					Port:       defaultOTLPGRPCLegacyPort,
-					TargetPort: intstr.FromInt(int(defaultOTLPGRPCPort)), // we target the official port, not the legacy
 				},
 			},
 		},

--- a/pkg/collector/parser/receiver_otlp_test.go
+++ b/pkg/collector/parser/receiver_otlp_test.go
@@ -64,8 +64,7 @@ func TestOTLPExposeDefaultPorts(t *testing.T) {
 		portNumber int32
 		seen       bool
 	}{
-		"otlp-grpc":        {portNumber: 4317},
-		"otlp-grpc-legacy": {portNumber: 55680},
+		"otlp-grpc": {portNumber: 4317},
 	}
 
 	// test
@@ -73,7 +72,7 @@ func TestOTLPExposeDefaultPorts(t *testing.T) {
 
 	// verify
 	assert.NoError(t, err)
-	assert.Len(t, ports, 2)
+	assert.Len(t, ports, 1)
 
 	for _, port := range ports {
 		r := expectedResults[port.Name]


### PR DESCRIPTION
**Description:**
The legacy gRPC port(55680) in OTLP Receiver will be disabled in OTel Collector before the collector GA.

This CR replaced all gRPC port occurrences from `55680` to `4317` in this repo. The same PRs have been posted to the rest of OTel repos. 

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2565