### PR TITLE
Copy desired Service ports when reconciling

### DIFF
--- a/pkg/collector/reconcile/service.go
+++ b/pkg/collector/reconcile/service.go
@@ -194,6 +194,7 @@ func expectedServices(ctx context.Context, params Params, expected []corev1.Serv
 		for k, v := range desired.ObjectMeta.Labels {
 			updated.ObjectMeta.Labels[k] = v
 		}
+		updated.Spec.Ports = desired.Spec.Ports
 
 		patch := client.MergeFrom(existing)
 

--- a/pkg/collector/reconcile/service_test.go
+++ b/pkg/collector/reconcile/service_test.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
@@ -145,9 +146,10 @@ func TestExpectedServices(t *testing.T) {
 		createObjectIfNotExists(t, "test-collector", &serviceInstance)
 
 		extraPorts := v1.ServicePort{
-			Name:     "port-web",
-			Protocol: "TCP",
-			Port:     8080,
+			Name:       "port-web",
+			Protocol:   "TCP",
+			Port:       8080,
+			TargetPort: intstr.FromInt(8080),
 		}
 
 		ports := append(params().Instance.Spec.Ports, extraPorts)

--- a/pkg/collector/reconcile/service_test.go
+++ b/pkg/collector/reconcile/service_test.go
@@ -160,9 +160,7 @@ func TestExpectedServices(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, exists)
 		assert.Equal(t, instanceUID, actual.OwnerReferences[0].UID)
-		// issue# https://github.com/open-telemetry/opentelemetry-operator/issues/256
-		// Would uncomment once above issue is resolved
-		//assert.Contains(t, actual.Spec.Ports, extraPorts)
+		assert.Contains(t, actual.Spec.Ports, extraPorts)
 
 	})
 }


### PR DESCRIPTION
Copy services from the desired service when reconciling.

For now it only copies the `ports` attribute. We might need to copy additional fields as well. Let me know!

Fixes #256 
Fixes #295 