### PR TITLE
bump operator-sdk version to 1.8.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: jpkrohling/setup-operator-sdk@v1.1.0
       with:
-        operator-sdk-version: v1.6.1
+        operator-sdk-version: v1.8.0
 
     - name: "generate release resources"
       run: make release-artifacts IMG_PREFIX="quay.io/opentelemetry"


### PR DESCRIPTION
bump operator-sdk version to 1.8.0

closes #298