### PR TITLE
add go lint rule in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,10 @@ fmt:
 vet:
 	go vet ./...
 
+# Run go lint against code
+lint:
+	golangci-lint run
+
 # Generate code
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -282,6 +282,7 @@ spec:
                 type: string
               tolerations:
                 description: Toleration to schedule OpenTelemetry Collector pods.
+                  This is only relevant to daemonsets, statefulsets and deployments
                 items:
                   description: The pod this Toleration is attached to tolerates any
                     taint that matches the triple <key,value,effect> using the matching

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -282,7 +282,6 @@ spec:
                 type: string
               tolerations:
                 description: Toleration to schedule OpenTelemetry Collector pods.
-                  This is only relevant to daemonsets, statefulsets and deployments
                 items:
                   description: The pod this Toleration is attached to tolerates any
                     taint that matches the triple <key,value,effect> using the matching


### PR DESCRIPTION
We have the go-lint checks in place in CI. But we do not have it in Makefile to test the linting locally before committing. So added it into Makefile for a better development experience.  