### PR TITLE
Add delete webhook

### DIFF
--- a/api/v1alpha1/opentelemetrycollector_webhook.go
+++ b/api/v1alpha1/opentelemetrycollector_webhook.go
@@ -52,7 +52,8 @@ func (r *OpenTelemetryCollector) Default() {
 	opentelemetrycollectorlog.Info("default", "name", r.Name)
 }
 
-// +kubebuilder:webhook:verbs=create;update;delete,path=/validate-opentelemetry-io-v1alpha1-opentelemetrycollector,mutating=false,failurePolicy=fail,groups=opentelemetry.io,resources=opentelemetrycollectors,versions=v1alpha1,name=vopentelemetrycollector.kb.io,sideEffects=none,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=create;update,path=/validate-opentelemetry-io-v1alpha1-opentelemetrycollector,mutating=false,failurePolicy=fail,groups=opentelemetry.io,resources=opentelemetrycollectors,versions=v1alpha1,name=vopentelemetrycollectorcreateupdate.kb.io,sideEffects=none,admissionReviewVersions=v1;v1beta1
+// +kubebuilder:webhook:verbs=delete,path=/validate-opentelemetry-io-v1alpha1-opentelemetrycollector,mutating=false,failurePolicy=ignore,groups=opentelemetry.io,resources=opentelemetrycollectors,versions=v1alpha1,name=vopentelemetrycollectordelete.kb.io,sideEffects=none,admissionReviewVersions=v1;v1beta1
 
 var _ webhook.Validator = &OpenTelemetryCollector{}
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -65,7 +65,7 @@ webhooks:
       namespace: system
       path: /validate-opentelemetry-io-v1alpha1-opentelemetrycollector
   failurePolicy: Fail
-  name: vopentelemetrycollector.kb.io
+  name: vopentelemetrycollectorcreateupdate.kb.io
   rules:
   - apiGroups:
     - opentelemetry.io
@@ -74,6 +74,25 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    resources:
+    - opentelemetrycollectors
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-opentelemetry-io-v1alpha1-opentelemetrycollector
+  failurePolicy: Ignore
+  name: vopentelemetrycollectordelete.kb.io
+  rules:
+  - apiGroups:
+    - opentelemetry.io
+    apiVersions:
+    - v1alpha1
+    operations:
     - DELETE
     resources:
     - opentelemetrycollectors


### PR DESCRIPTION
The delete webhook configures the `failurePolicy: Ignore` to delete otelcol successfully when the Otel operator isn't available
fixes: #56 