### PR TITLE
Bump operator-sdk to v1.9.0, change v0.27.0 tags to v0.28.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: jpkrohling/setup-operator-sdk@v1.1.0
       with:
-        operator-sdk-version: v1.8.0
+        operator-sdk-version: v1.9.0
 
     - name: "generate release resources"
       run: make release-artifacts IMG_PREFIX="quay.io/opentelemetry"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,7 +5,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=opentelemetry-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.8.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.9.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go
 COPY bundle/manifests /manifests/

--- a/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -21,11 +21,11 @@ metadata:
     containerImage: quay.io/opentelemetry/opentelemetry-operator
     createdAt: "2020-12-16T13:37:00+00:00"
     description: Provides the OpenTelemetry components, including the Collector
-    operators.operatorframework.io/builder: operator-sdk-v1.8.0
+    operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: github.com/open-telemetry/opentelemetry-operator
     support: OpenTelemetry Community
-  name: opentelemetry-operator.v0.27.0
+  name: opentelemetry-operator.v0.28.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -206,7 +206,7 @@ spec:
                 - --enable-leader-election
                 command:
                 - /manager
-                image: quay.io/opentelemetry/opentelemetry-operator:v0.27.0
+                image: quay.io/opentelemetry/opentelemetry-operator:v0.28.0
                 name: manager
                 ports:
                 - containerPort: 9443
@@ -297,7 +297,7 @@ spec:
   maturity: alpha
   provider:
     name: OpenTelemetry Community
-  version: 0.27.0
+  version: 0.28.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1
@@ -305,7 +305,7 @@ spec:
     containerPort: 443
     deploymentName: opentelemetry-operator-controller-manager
     failurePolicy: Fail
-    generateName: vopentelemetrycollector.kb.io
+    generateName: vopentelemetrycollectorcreateupdate.kb.io
     rules:
     - apiGroups:
       - opentelemetry.io
@@ -314,6 +314,25 @@ spec:
       operations:
       - CREATE
       - UPDATE
+      resources:
+      - opentelemetrycollectors
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-opentelemetry-io-v1alpha1-opentelemetrycollector
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    containerPort: 443
+    deploymentName: opentelemetry-operator-controller-manager
+    failurePolicy: Ignore
+    generateName: vopentelemetrycollectordelete.kb.io
+    rules:
+    - apiGroups:
+      - opentelemetry.io
+      apiVersions:
+      - v1alpha1
+      operations:
       - DELETE
       resources:
       - opentelemetrycollectors

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,7 +4,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: opentelemetry-operator
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.8.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.9.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go
   operators.operatorframework.io.bundle.channel.default.v1: alpha

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/opentelemetry/opentelemetry-operator
-  newTag: v0.27.0
+  newTag: v0.28.0


### PR DESCRIPTION
FIxes: #322 

Note: I tested the operator-sdk version bump by running the operator locally & created a sample CR. 