### PR TITLE
Add v0.31.0 upgrade routine

### DIFF
--- a/pkg/collector/upgrade/v0_31_0.go
+++ b/pkg/collector/upgrade/v0_31_0.go
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
+)
+
+func upgrade0_31_0(cl client.Client, otelcol *v1alpha1.OpenTelemetryCollector) (*v1alpha1.OpenTelemetryCollector, error) {
+	if len(otelcol.Spec.Config) == 0 {
+		return otelcol, nil
+	}
+
+	cfg, err := adapters.ConfigFromString(otelcol.Spec.Config)
+	if err != nil {
+		return otelcol, fmt.Errorf("couldn't upgrade to v0.31.0, failed to parse configuration: %w", err)
+	}
+
+	receivers, ok := cfg["receivers"].(map[interface{}]interface{})
+	if !ok {
+		// no receivers? no need to fail because of that
+		return otelcol, nil
+	}
+
+	for k, v := range receivers {
+		// from the changelog https://github.com/open-telemetry/opentelemetry-collector/blob/main/CHANGELOG.md#v0310-beta
+		// Here is the upstream PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/4277
+
+		// Remove deprecated field metrics_schema from influxdb receiver
+		if strings.HasPrefix(k.(string), "influxdb") {
+			influxdbConfig, ok := v.(map[interface{}]interface{})
+			if !ok {
+				// no influxdbConfig? no need to fail because of that
+				return otelcol, nil
+			}
+			for fieldKey := range influxdbConfig {
+				if strings.HasPrefix(fieldKey.(string), "metrics_schema") {
+					delete(influxdbConfig, fieldKey)
+					otelcol.Status.Messages = append(otelcol.Status.Messages, fmt.Sprintf("upgrade to v0.31.0 dropped the 'metrics_schema' field from %q receiver", k))
+					continue
+				}
+			}
+		}
+	}
+
+	cfg["receivers"] = receivers
+	res, err := yaml.Marshal(cfg)
+	if err != nil {
+		return otelcol, fmt.Errorf("couldn't upgrade to v0.31.0, failed to marshall back configuration: %w", err)
+	}
+
+	otelcol.Spec.Config = string(res)
+	return otelcol, nil
+}

--- a/pkg/collector/upgrade/v0_31_0_test.go
+++ b/pkg/collector/upgrade/v0_31_0_test.go
@@ -1,0 +1,82 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/open-telemetry/opentelemetry-operator/api/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/version"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
+)
+
+func TestInfluxdbReceiverPropertyDrop(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{Name: "my-instance", Namespace: "default"}
+	existing := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nsn.Name,
+			Namespace: nsn.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "opentelemetry-operator",
+			},
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Config: `
+receivers:
+  influxdb:
+    endpoint: 0.0.0.0:8080
+    metrics_schema: telegraf-prometheus-v1
+
+exporters:
+  prometheusremotewrite:
+    endpoint: "http:hello:4555/hii"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [influxdb]
+      exporters: [prometheusremotewrite]
+`,
+		},
+	}
+	existing.Status.Version = "0.30.0"
+
+	// test
+	res, err := upgrade.ManagedInstance(context.Background(), logger, version.Get(), nil, existing)
+	assert.NoError(t, err)
+
+	// verify
+	assert.Equal(t, `exporters:
+  prometheusremotewrite:
+    endpoint: http:hello:4555/hii
+receivers:
+  influxdb:
+    endpoint: 0.0.0.0:8080
+service:
+  pipelines:
+    metrics:
+      exporters:
+      - prometheusremotewrite
+      receivers:
+      - influxdb
+`, res.Spec.Config)
+	assert.Equal(t, "upgrade to v0.31.0 dropped the 'metrics_schema' field from \"influxdb\" receiver", res.Status.Messages[0])
+}

--- a/pkg/collector/upgrade/versions.go
+++ b/pkg/collector/upgrade/versions.go
@@ -50,6 +50,10 @@ var (
 			Version: *semver.MustParse("0.24.0"),
 			upgrade: upgrade0_24_0,
 		},
+		{
+			Version: *semver.MustParse("0.31.0"),
+			upgrade: upgrade0_31_0,
+		},
 	}
 
 	// Latest represents the latest version that we need to upgrade. This is not necessarily the latest known version.


### PR DESCRIPTION
Upgrade routine to fix `influxdb` receiver breaking change in upstream otelcol-contrib repo.

Fixes: #350 