### PR TITLE
Bump operator-sdk to v1.10.1

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - uses: jpkrohling/setup-operator-sdk@v1.1.0
       with:
-        operator-sdk-version: v1.10.0
+        operator-sdk-version: v1.10.1
 
     - name: "basic checks"
       run: make ci

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: jpkrohling/setup-operator-sdk@v1.1.0
       with:
-        operator-sdk-version: v1.10.0
+        operator-sdk-version: v1.10.1
 
     - name: "generate release resources"
       run: make release-artifacts IMG_PREFIX="quay.io/opentelemetry"

--- a/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
     containerImage: quay.io/opentelemetry/opentelemetry-operator
     createdAt: "2020-12-16T13:37:00+00:00"
     description: Provides the OpenTelemetry components, including the Collector
-    operators.operatorframework.io/builder: operator-sdk-v1.9.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.10.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: github.com/open-telemetry/opentelemetry-operator
     support: OpenTelemetry Community


### PR DESCRIPTION
Closes #386 by bumping the operator SDK version to v1.10.1 and re-generating the bundles with this version.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
