### PR TITLE
Increase StatefulSet timeout for KUTTL tests

### DIFF
--- a/tests/e2e/smoke-statefulset/00-assert.yaml
+++ b/tests/e2e/smoke-statefulset/00-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 150
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/tests/e2e/smoke-targetallocator/02-assert.yaml
+++ b/tests/e2e/smoke-targetallocator/02-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 150
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/tests/e2e/statefulset-features/00-assert.yaml
+++ b/tests/e2e/statefulset-features/00-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 150
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/tests/e2e/targetallocator-features/02-assert.yaml
+++ b/tests/e2e/targetallocator-features/02-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 150
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
Closes #396

This increases the timeout for the KUTTL StatefulSet assert steps ensuring that the StatefulSet has enough time for completely rolling out. Hopefully this fixes the flaky tests.