### PR TITLE
Added global timeout

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -11,3 +11,4 @@ commands:
   - command: sleep 5s
 testDirs:
   - ./tests/e2e/
+timeout: 150

--- a/tests/e2e/smoke-statefulset/00-assert.yaml
+++ b/tests/e2e/smoke-statefulset/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 150
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/tests/e2e/smoke-targetallocator/02-assert.yaml
+++ b/tests/e2e/smoke-targetallocator/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 150
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/tests/e2e/statefulset-features/00-assert.yaml
+++ b/tests/e2e/statefulset-features/00-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 150
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/tests/e2e/targetallocator-features/02-assert.yaml
+++ b/tests/e2e/targetallocator-features/02-assert.yaml
@@ -1,7 +1,3 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 150
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:


### PR DESCRIPTION
Replaces the test specific timeout introduced for StatefulSet KUTTL tests with a global timeout for all the tests.