### PR TITLE
feat: add `envFrom` to collector spec

### DIFF
--- a/api/v1alpha1/opentelemetrycollector_types.go
+++ b/api/v1alpha1/opentelemetrycollector_types.go
@@ -103,6 +103,12 @@ type OpenTelemetryCollectorSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Env []v1.EnvVar `json:"env,omitempty"`
 
+	// List of sources to populate environment variables on the OpenTelemetry Collector's Pods.
+	// These can then in certain cases be consumed in the config file for the Collector.
+	// +optional
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
+
 	// Resources to set on the OpenTelemetry Collector pods.
 	// +optional
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -139,6 +139,13 @@ func (in *OpenTelemetryCollectorSpec) DeepCopyInto(out *OpenTelemetryCollectorSp
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.EnvFrom != nil {
+		in, out := &in.EnvFrom, &out.EnvFrom
+		*out = make([]v1.EnvFromSource, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations

--- a/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -182,6 +182,41 @@ spec:
                   - name
                   type: object
                 type: array
+              envFrom:
+                description: List of sources to populate environment variables on
+                  the OpenTelemetry Collector's Pods. These can then in certain cases
+                  be consumed in the config file for the Collector.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                    prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                  type: object
+                type: array
               hostNetwork:
                 description: HostNetwork indicates if the pod should run in the host
                   networking namespace.

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -170,6 +170,41 @@ spec:
                   - name
                   type: object
                 type: array
+              envFrom:
+                description: List of sources to populate environment variables on
+                  the OpenTelemetry Collector's Pods. These can then in certain cases
+                  be consumed in the config file for the Collector.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                    prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                  type: object
+                type: array
               hostNetwork:
                 description: HostNetwork indicates if the pod should run in the host
                   networking namespace.

--- a/docs/otelcol_cr_spec.md
+++ b/docs/otelcol_cr_spec.md
@@ -62,6 +62,10 @@ spec:
   // consumed in the config file for the Collector.
   env: []
   
+  // +optional List of sources to populate environment variables on the OpenTelemetry Collector's Pods.
+	// These can then in certain cases be consumed in the config file for the Collector.
+  envFrom: []
+
   // +optional Resources to set on the OpenTelemetry Collector pods.
   resources: {}
 

--- a/pkg/collector/container.go
+++ b/pkg/collector/container.go
@@ -77,5 +77,6 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 		Env:             envVars,
 		Resources:       otelcol.Spec.Resources,
 		SecurityContext: otelcol.Spec.SecurityContext,
+		EnvFrom:         otelcol.Spec.EnvFrom,
 	}
 }

--- a/pkg/collector/container.go
+++ b/pkg/collector/container.go
@@ -75,8 +75,8 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 		VolumeMounts:    volumeMounts,
 		Args:            args,
 		Env:             envVars,
+		EnvFrom:         otelcol.Spec.EnvFrom,
 		Resources:       otelcol.Spec.Resources,
 		SecurityContext: otelcol.Spec.SecurityContext,
-		EnvFrom:         otelcol.Spec.EnvFrom,
 	}
 }

--- a/pkg/collector/container_test.go
+++ b/pkg/collector/container_test.go
@@ -238,3 +238,37 @@ func TestContainerImagePullPolicy(t *testing.T) {
 	// verify
 	assert.Equal(t, c.ImagePullPolicy, corev1.PullIfNotPresent)
 }
+
+func TestContainerEnvFrom(t *testing.T) {
+	//prepare
+	envFrom1 := corev1.EnvFromSource{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: "env-as-secret",
+			},
+		},
+	}
+	envFrom2 := corev1.EnvFromSource{
+		ConfigMapRef: &corev1.ConfigMapEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: "env-as-configmap",
+			},
+		},
+	}
+	otelcol := v1alpha1.OpenTelemetryCollector{
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			EnvFrom: []corev1.EnvFromSource{
+				envFrom1,
+				envFrom2,
+			},
+		},
+	}
+	cfg := config.New()
+
+	// test
+	c := Container(cfg, logger, otelcol)
+
+	// verify
+	assert.Contains(t, c.EnvFrom, envFrom1)
+	assert.Contains(t, c.EnvFrom, envFrom2)
+}


### PR DESCRIPTION
### Summary

Add support for passing `envFrom` values into Collector's pods.