### PR TITLE
Add aws xray receiver

### DIFF
--- a/pkg/collector/parser/receiver_aws-xray.go
+++ b/pkg/collector/parser/receiver_aws-xray.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import "github.com/go-logr/logr"
+
+const parserNameAWSXRAY = "__awsxray"
+
+// NewAWSXrayReceiverParser builds a new parser for AWS xray receivers, from the contrib repository.
+func NewAWSXrayReceiverParser(logger logr.Logger, name string, config map[interface{}]interface{}) ReceiverParser {
+	return &GenericReceiver{
+		logger:      logger,
+		name:        name,
+		config:      config,
+		defaultPort: 2000,
+		parserName:  parserNameAWSXRAY,
+	}
+}
+
+func init() {
+	Register("awsxray", NewAWSXrayReceiverParser)
+}

--- a/pkg/collector/parser/receiver_aws-xray_test.go
+++ b/pkg/collector/parser/receiver_aws-xray_test.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+// all tests for the AWS XRAY parser are currently part of the test TestDownstreamParsers

--- a/pkg/collector/parser/receiver_generic_test.go
+++ b/pkg/collector/parser/receiver_generic_test.go
@@ -79,6 +79,7 @@ func TestDownstreamParsers(t *testing.T) {
 		{"statsd", "statsd", "__statsd", 8125, parser.NewStatsdReceiverParser},
 		{"influxdb", "influxdb", "__influxdb", 8086, parser.NewInfluxdbReceiverParser},
 		{"splunk-hec", "splunk-hec", "__splunk_hec", 8088, parser.NewSplunkHecReceiverParser},
+		{"awsxray", "awsxray", "__awsxray", 2000, parser.NewAWSXrayReceiverParser},
 	} {
 		t.Run(tt.receiverName, func(t *testing.T) {
 			t.Run("builds successfully", func(t *testing.T) {


### PR DESCRIPTION
Syncing AWS XRAY receiver from [collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsxrayreceiver#aws-x-ray-receiver). Added the default port as `2000` as mentioned in `README.md`.

Just to be clear I am not adding any other default config parameters such as `transport` as `udp`  and other fields as we expect this to be taken care by users right?. We are only concerned with default port that needs to be exposed for this particular receiver.

WDYT @jpkrohling ?

Part of #128 