### PR TITLE
Remove cmd from CSV

### DIFF
--- a/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -204,8 +204,6 @@ spec:
               - args:
                 - --metrics-addr=127.0.0.1:8080
                 - --enable-leader-election
-                command:
-                - /manager
                 image: quay.io/opentelemetry/opentelemetry-operator:v0.35.0
                 name: manager
                 ports:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -23,9 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - command:
-        - /manager
-        args:
+      - args:
         - --enable-leader-election
         image: controller
         name: manager


### PR DESCRIPTION
The command in CSV is not needed because the dockerfile uses entrypoint.

It is useful to rely on the default conventions to allow easy override
of the operator image - e.g. a productized version with vendor specific
functionality.

Signed-off-by: Pavol Loffay <p.loffay@gmail.com>