### PR TITLE
Update used apiVersion of cert-manager components from v1alpha2 to v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ start-kind:
 	kind load docker-image local/opentelemetry-operator:e2e
 
 cert-manager:
-	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.2/cert-manager.yaml
+	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.6.0/cert-manager.yaml
 	kubectl wait --timeout=5m --for=condition=available deployment cert-manager -n cert-manager
 	kubectl wait --timeout=5m --for=condition=available deployment cert-manager-cainjector -n cert-manager
 	kubectl wait --timeout=5m --for=condition=available deployment cert-manager-webhook -n cert-manager

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -2,7 +2,7 @@
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for 
 # breaking changes
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -10,7 +10,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -36,7 +36,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1alpha2
+    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
   fieldref:
     fieldpath: metadata.namespace
@@ -44,7 +44,7 @@ vars:
   objref:
     kind: Certificate
     group: cert-manager.io
-    version: v1alpha2
+    version: v1
     name: serving-cert # this name should match the one in certificate.yaml
 - name: SERVICE_NAMESPACE # namespace of the service
   objref:


### PR DESCRIPTION
Fixes #477 

[cert-manager 1.6.0](https://github.com/jetstack/cert-manager/releases/tag/v1.6.0) was released recently which stops serving the api `cert-manager.io/v1alpha2`

This CR updates to use the apiVersion `cert-manager.io/v1` with the cert-manager objects in the manifest.