### PR TITLE
Publish images to GHCR

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -32,7 +32,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v3.6.0
         with:
-          images: quay.io/opentelemetry/opentelemetry-operator
+          images: quay.io/opentelemetry/opentelemetry-operator,ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
           tag-semver: |
             {{raw}}
             {{version}}
@@ -58,6 +58,13 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Login to GitHub Package Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Operator image
         uses: docker/build-push-action@v2.6.1


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Updates #492 

Now just publish to both registries and after the following release we can switch to GHCR in CSV, makefile and other places.