### PR TITLE
Fix rollout when the collector config changes

### DIFF
--- a/pkg/collector/annotations.go
+++ b/pkg/collector/annotations.go
@@ -37,6 +37,18 @@ func Annotations(instance v1alpha1.OpenTelemetryCollector) map[string]string {
 			annotations[k] = v
 		}
 	}
+	return annotations
+}
+
+func PodAnnotations(instance v1alpha1.OpenTelemetryCollector) map[string]string {
+	// new map every time, so that we don't touch the instance's annotations
+	annotations := map[string]string{}
+
+	if nil != instance.Spec.PodAnnotations {
+		for k, v := range instance.Spec.PodAnnotations {
+			annotations[k] = v
+		}
+	}
 	// make sure sha256 for configMap is always calculated
 	annotations["opentelemetry-operator-config/sha256"] = getConfigMapSHA(instance.Spec.Config)
 
@@ -44,6 +56,9 @@ func Annotations(instance v1alpha1.OpenTelemetryCollector) map[string]string {
 }
 
 func getConfigMapSHA(config string) string {
-	h := sha256.Sum256([]byte(config))
-	return fmt.Sprintf("%x", h)
+	if config != "" {
+		h := sha256.Sum256([]byte(config))
+		return fmt.Sprintf("%x", h)
+	}
+	return ""
 }

--- a/pkg/collector/annotations_test.go
+++ b/pkg/collector/annotations_test.go
@@ -42,7 +42,6 @@ func TestDefaultAnnotations(t *testing.T) {
 	assert.Equal(t, "true", annotations["prometheus.io/scrape"])
 	assert.Equal(t, "8888", annotations["prometheus.io/port"])
 	assert.Equal(t, "/metrics", annotations["prometheus.io/path"])
-	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", annotations["opentelemetry-operator-config/sha256"])
 }
 
 func TestUserAnnotations(t *testing.T) {
@@ -69,7 +68,6 @@ func TestUserAnnotations(t *testing.T) {
 	assert.Equal(t, "false", annotations["prometheus.io/scrape"])
 	assert.Equal(t, "1234", annotations["prometheus.io/port"])
 	assert.Equal(t, "/test", annotations["prometheus.io/path"])
-	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", annotations["opentelemetry-operator-config/sha256"])
 }
 
 func TestAnnotationsPropagateDown(t *testing.T) {
@@ -84,6 +82,43 @@ func TestAnnotationsPropagateDown(t *testing.T) {
 	annotations := Annotations(otelcol)
 
 	// verify
-	assert.Len(t, annotations, 5)
+	assert.Len(t, annotations, 4)
 	assert.Equal(t, "mycomponent", annotations["myapp"])
+}
+
+func TestPodAnnotations(t *testing.T) {
+	// prepare
+	config := `
+    receivers:
+      jaeger:
+        protocols:
+          grpc:
+    processors:
+
+    exporters:
+      logging:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [jaeger]
+          processors: []
+          exporters: [logging]`
+
+	otelcol := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-instance",
+			Namespace: "my-ns",
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Config: config,
+		},
+	}
+
+	// test
+	annotations := PodAnnotations(otelcol)
+
+	//verify
+	assert.Equal(t, "56607aa3ab98db3ab60233d83ad62337167b63d83699dc6408b4f0381428e2ae", annotations["opentelemetry-operator-config/sha256"])
+
 }

--- a/pkg/collector/daemonset.go
+++ b/pkg/collector/daemonset.go
@@ -31,6 +31,7 @@ func DaemonSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 	labels["app.kubernetes.io/name"] = naming.Collector(otelcol)
 
 	annotations := Annotations(otelcol)
+	podAnnotations := PodAnnotations(otelcol)
 
 	return appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -46,7 +47,7 @@ func DaemonSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: otelcol.Spec.PodAnnotations,
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: ServiceAccountName(otelcol),

--- a/pkg/collector/daemonset_test.go
+++ b/pkg/collector/daemonset_test.go
@@ -33,6 +33,7 @@ func TestDaemonSetNewDefault(t *testing.T) {
 		},
 		Spec: v1alpha1.OpenTelemetryCollectorSpec{
 			Tolerations: testTolerationValues,
+			Config:      "test",
 		},
 	}
 	cfg := config.New()
@@ -50,8 +51,9 @@ func TestDaemonSetNewDefault(t *testing.T) {
 
 	assert.Len(t, d.Spec.Template.Spec.Containers, 1)
 
-	// none of the default annotations should propagate down to the pod
-	assert.Empty(t, d.Spec.Template.Annotations)
+	// should have a pod annotation for config SHA
+	assert.Len(t, d.Spec.Template.Annotations, 1)
+	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", d.Spec.Template.Annotations["opentelemetry-operator-config/sha256"])
 
 	// the pod selector should match the pod spec's labels
 	assert.Equal(t, d.Spec.Selector.MatchLabels, d.Spec.Template.Labels)
@@ -88,8 +90,11 @@ func TestDaemonsetPodAnnotations(t *testing.T) {
 
 	// test
 	ds := DaemonSet(cfg, logger, otelcol)
+	expectedAnnotations := testPodAnnotationValues
+
+	expectedAnnotations["opentelemetry-operator-config/sha256"] = ""
 
 	// verify
 	assert.Equal(t, "my-instance-collector", ds.Name)
-	assert.Equal(t, testPodAnnotationValues, ds.Spec.Template.Annotations)
+	assert.Equal(t, expectedAnnotations, ds.Spec.Template.Annotations)
 }

--- a/pkg/collector/deployment.go
+++ b/pkg/collector/deployment.go
@@ -31,6 +31,7 @@ func Deployment(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTele
 	labels["app.kubernetes.io/name"] = naming.Collector(otelcol)
 
 	annotations := Annotations(otelcol)
+	podAnnotations := PodAnnotations(otelcol)
 
 	return appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -47,7 +48,7 @@ func Deployment(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTele
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: otelcol.Spec.PodAnnotations,
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: ServiceAccountName(otelcol),

--- a/pkg/collector/deployment_test.go
+++ b/pkg/collector/deployment_test.go
@@ -42,6 +42,7 @@ func TestDeploymentNewDefault(t *testing.T) {
 		},
 		Spec: v1alpha1.OpenTelemetryCollectorSpec{
 			Tolerations: testTolerationValues,
+			Config:      "test",
 		},
 	}
 	cfg := config.New()
@@ -59,8 +60,9 @@ func TestDeploymentNewDefault(t *testing.T) {
 
 	assert.Len(t, d.Spec.Template.Spec.Containers, 1)
 
-	// none of the default annotations should propagate down to the pod
-	assert.Empty(t, d.Spec.Template.Annotations)
+	// should have a pod annotation for config SHA
+	assert.Len(t, d.Spec.Template.Annotations, 1)
+	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", d.Spec.Template.Annotations["opentelemetry-operator-config/sha256"])
 
 	// the pod selector should match the pod spec's labels
 	assert.Equal(t, d.Spec.Template.Labels, d.Spec.Selector.MatchLabels)
@@ -81,8 +83,11 @@ func TestDeploymentPodAnnotations(t *testing.T) {
 
 	// test
 	d := Deployment(cfg, logger, otelcol)
+	expectedAnnotations := testPodAnnotationValues
+
+	expectedAnnotations["opentelemetry-operator-config/sha256"] = ""
 
 	// verify
 	assert.Equal(t, "my-instance-collector", d.Name)
-	assert.Equal(t, testPodAnnotationValues, d.Spec.Template.Annotations)
+	assert.Equal(t, expectedAnnotations, d.Spec.Template.Annotations)
 }

--- a/pkg/collector/statefulset.go
+++ b/pkg/collector/statefulset.go
@@ -31,6 +31,7 @@ func StatefulSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTel
 	labels["app.kubernetes.io/name"] = naming.Collector(otelcol)
 
 	annotations := Annotations(otelcol)
+	podAnnotations := PodAnnotations(otelcol)
 
 	return appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -47,7 +48,7 @@ func StatefulSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTel
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: otelcol.Spec.PodAnnotations,
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: ServiceAccountName(otelcol),

--- a/tests/e2e/smoke-pod-annotations/00-assert.yaml
+++ b/tests/e2e/smoke-pod-annotations/00-assert.yaml
@@ -10,5 +10,6 @@ spec:
       annotations:
         pod-annotation1: value1
         pod-annotation2: value2
+        opentelemetry-operator-config/sha256: 56607aa3ab98db3ab60233d83ad62337167b63d83699dc6408b4f0381428e2ae
 status:
   readyReplicas: 1

--- a/tests/e2e/smoke-pod-annotations/00-assert.yaml
+++ b/tests/e2e/smoke-pod-annotations/00-assert.yaml
@@ -10,6 +10,6 @@ spec:
       annotations:
         pod-annotation1: value1
         pod-annotation2: value2
-        opentelemetry-operator-config/sha256: 56607aa3ab98db3ab60233d83ad62337167b63d83699dc6408b4f0381428e2ae
+        opentelemetry-operator-config/sha256: dad2b0c2baaeed3a4d75d654900786da3721e6976b3a37eb25a9eaaba87d7b1e
 status:
   readyReplicas: 1


### PR DESCRIPTION
Signed-off-by: santosh <bsantosh@thoughtworks.com>

Use pod annotations instead of deployment annotations to store SHA256 for config. This would help restart opentelemetry collector whenever config is updated.

Fixes https://github.com/open-telemetry/opentelemetry-operator/issues/460