### PR TITLE
Add docker image containing nodejs auto instrumentation

### DIFF
--- a/.github/workflows/publish-autoinstrumentation-nodejs.yaml
+++ b/.github/workflows/publish-autoinstrumentation-nodejs.yaml
@@ -1,0 +1,44 @@
+name: "Publish NodeJS Auto-Instrumentation"
+
+on:
+  push:
+    paths:
+      - 'autoinstrumentation/nodejs/**'
+      - '.github/workflows/publish-autoinstrumentation-nodejs.yaml'
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2.3.5
+
+      - name: Read version
+        run: echo VERSION=$(cat autoinstrumentation/nodejs/package.json | jq -r '.dependencies."@opentelemetry/sdk-node"') >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3.6.0
+        with:
+          images: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs
+          tags: |
+            type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
+
+      - name: Login to GitHub Package Registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: autoinstrumentation/nodejs
+          push: true
+          build-args: version=${{ env.VERSION }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ local
 # test resources
 kubeconfig
 tests/_build/
+
+# autoinstrumentation artifacts
+build
+node_modules
+package-lock.json

--- a/autoinstrumentation/nodejs/.dockerignore
+++ b/autoinstrumentation/nodejs/.dockerignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/autoinstrumentation/nodejs/Dockerfile
+++ b/autoinstrumentation/nodejs/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:16 AS build
+
+WORKDIR /operator-build
+COPY . .
+
+RUN npm install
+
+FROM busybox
+
+COPY --from=build /operator-build/build/workspace /autoinstrumentation

--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@opentelemetry/k8s-autoinstrumentation",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "clean": "rimraf build/*",
+    "prepare": "npm run compile",
+    "compile": "tsc -p .",
+    "postcompile": "copyfiles -f 'build/src/**' build/workspace/ && copyfiles 'node_modules/**' build/workspace/"
+  },
+  "devDependencies": {
+    "copyfiles": "^2.4.1",
+    "rimraf": "^3.0.2",
+    "typescript": "^4.4.4"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "1.0.3",
+    "@opentelemetry/auto-instrumentations-node": "0.26.0",
+    "@opentelemetry/exporter-otlp-grpc": "0.26.0",
+    "@opentelemetry/sdk-node": "0.26.0"
+  }
+}

--- a/autoinstrumentation/nodejs/src/autoinstrumentation.ts
+++ b/autoinstrumentation/nodejs/src/autoinstrumentation.ts
@@ -1,0 +1,12 @@
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-otlp-grpc';
+
+import { NodeSDK } from '@opentelemetry/sdk-node';
+
+const sdk = new NodeSDK({
+    autoDetectResources: true,
+    instrumentations: [getNodeAutoInstrumentations()],
+    traceExporter: new OTLPTraceExporter(),
+});
+
+sdk.start();

--- a/autoinstrumentation/nodejs/tsconfig.json
+++ b/autoinstrumentation/nodejs/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
+    "inlineSources": true,
+    "module": "commonjs",
+    "newLine": "LF",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "pretty": true,
+    "sourceMap": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "target": "es2017"
+  },
+  "include": [
+    "src/**/*.ts",
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/versions.txt
+++ b/versions.txt
@@ -13,3 +13,7 @@ targetallocator=0.1.0
 # Represents the current release of Java instrumentation.
 # Should match autoinstrumentation/java/version.txt
 autoinstrumentation-java=1.7.0
+
+# Represents the current release of NodeJS instrumentation.
+# Should match value in autoinstrumentation/nodejs/package.json
+autoinstrumentation-nodejs=0.26.0


### PR DESCRIPTION
Created image: https://github.com/anuraaga/opentelemetry-operator/pkgs/container/opentelemetry-operator%2Fautoinstrumentation-nodejs

I think the autoinstrumentation wrapper could be pushed to js-contrib though we'll still need to package something with Docker. Hopefully it's OK to include it here for now to try out the autoinstrumentation experience.

@pavolloffay @jpkrohling 

/cc @dyladan 

Would be used by https://github.com/open-telemetry/opentelemetry-operator/pull/507