### PR TITLE
Fix port in Instrumentation exporter to 4317 to use grpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ metadata:
   name: java-instrumentation
 spec:
   exporter:
-    endpoint: http://otel-collector:4318
+    endpoint: http://otel-collector:4317
   java:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest # <1>
 EOF

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -37,7 +37,7 @@ func TestSDKInjection(t *testing.T) {
 			inst: v1alpha1.Instrumentation{
 				Spec: v1alpha1.InstrumentationSpec{
 					Exporter: v1alpha1.Exporter{
-						Endpoint: "https://collector:4318",
+						Endpoint: "https://collector:4317",
 					},
 				},
 			},
@@ -70,7 +70,7 @@ func TestSDKInjection(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
-									Value: "https://collector:4318",
+									Value: "https://collector:4317",
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
@@ -87,7 +87,7 @@ func TestSDKInjection(t *testing.T) {
 			inst: v1alpha1.Instrumentation{
 				Spec: v1alpha1.InstrumentationSpec{
 					Exporter: v1alpha1.Exporter{
-						Endpoint: "https://collector:4318",
+						Endpoint: "https://collector:4317",
 					},
 					ResourceAttributes: map[string]string{
 						"fromcr": "val",
@@ -164,7 +164,7 @@ func TestInjection(t *testing.T) {
 				Image: "img:1",
 			},
 			Exporter: v1alpha1.Exporter{
-				Endpoint: "https://collector:4318",
+				Endpoint: "https://collector:4317",
 			},
 		},
 	}
@@ -216,7 +216,7 @@ func TestInjection(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
-							Value: "https://collector:4318",
+							Value: "https://collector:4317",
 						},
 						{
 							Name:  "OTEL_RESOURCE_ATTRIBUTES",

--- a/tests/e2e/instrumentation-java/00-install-instrumentation.yaml
+++ b/tests/e2e/instrumentation-java/00-install-instrumentation.yaml
@@ -4,6 +4,6 @@ metadata:
   name: java
 spec:
   exporter:
-    endpoint: http://localhost:4318
+    endpoint: http://localhost:4317
   java:
     image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest

--- a/tests/e2e/instrumentation-java/01-assert.yaml
+++ b/tests/e2e/instrumentation-java/01-assert.yaml
@@ -13,7 +13,7 @@ spec:
     - name: OTEL_SERVICE_NAME
       value: myapp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4318
+      value: http://localhost:4317
     - name: OTEL_RESOURCE_ATTRIBUTES
     - name: JAVA_TOOL_OPTIONS
       value: " -javaagent:/otel-auto-instrumentation/javaagent.jar"


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

The GRPC exporter uses 4317 port not 4318.