### PR TITLE
Create Docker image for Python auto-instrumentation.

### DIFF
--- a/.github/workflows/publish-autoinstrumentation-python.yaml
+++ b/.github/workflows/publish-autoinstrumentation-python.yaml
@@ -1,0 +1,44 @@
+name: "Publish Python Auto-Instrumentation"
+
+on:
+  push:
+    paths:
+      - 'autoinstrumentation/python/**'
+      - '.github/workflows/publish-autoinstrumentation-python.yaml'
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2.3.5
+
+      - name: Read version
+        run: echo VERSION=$(head -n 1 autoinstrumentation/python/requirements.txt | cut -d '=' -f3) >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3.6.0
+        with:
+          images: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python
+          tags: |
+            type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
+
+      - name: Login to GitHub Package Registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: autoinstrumentation/python
+          push: true
+          build-args: version=${{ env.VERSION }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/autoinstrumentation/python/Dockerfile
+++ b/autoinstrumentation/python/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10-alpine AS build
+
+WORKDIR /operator-build
+
+ADD requirements.txt .
+
+RUN mkdir workspace && pip install --target workspace -r requirements.txt
+
+FROM busybox
+
+COPY --from=build /operator-build/workspace /autoinstrumentation

--- a/autoinstrumentation/python/requirements.txt
+++ b/autoinstrumentation/python/requirements.txt
@@ -1,0 +1,43 @@
+opentelemetry-distro==0.25b2
+# We don't use the distro[otlp] option which automatically includes exporters since gRPC is not appropriate for
+# injected auto-instrumentation, where it has a strict dependency on the OS / Python version the artifact is built for.
+opentelemetry-exporter-otlp-proto-http==1.6.2
+
+opentelemetry-instrumentation==0.25b2
+
+# Copied in from https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation
+# except for aws-lambda
+opentelemetry-instrumentation-aiohttp-client==0.25b2
+opentelemetry-instrumentation-aiopg==0.25b2
+opentelemetry-instrumentation-asgi==0.25b2
+opentelemetry-instrumentation-asyncpg==0.25b2
+opentelemetry-instrumentation-boto==0.25b2
+opentelemetry-instrumentation-botocore==0.25b2
+opentelemetry-instrumentation-celery==0.25b2
+opentelemetry-instrumentation-dbapi==0.25b2
+opentelemetry-instrumentation-django==0.25b2
+opentelemetry-instrumentation-elasticsearch==0.25b2
+opentelemetry-instrumentation-falcon==0.25b2
+opentelemetry-instrumentation-fastapi==0.25b2
+opentelemetry-instrumentation-flask==0.25b2
+opentelemetry-instrumentation-grpc==0.25b2
+opentelemetry-instrumentation-httpx==0.25b2
+opentelemetry-instrumentation-jinja2==0.25b2
+opentelemetry-instrumentation-logging==0.25b2
+opentelemetry-instrumentation-mysql==0.25b2
+opentelemetry-instrumentation-pika==0.25b2
+opentelemetry-instrumentation-psycopg2==0.25b2
+opentelemetry-instrumentation-pymemcache==0.25b2
+opentelemetry-instrumentation-pymongo==0.25b2
+opentelemetry-instrumentation-pymysql==0.25b2
+opentelemetry-instrumentation-pyramid==0.25b2
+opentelemetry-instrumentation-redis==0.25b2
+opentelemetry-instrumentation-requests==0.25b2
+opentelemetry-instrumentation-sklearn==0.25b2
+opentelemetry-instrumentation-sqlalchemy==0.25b2
+opentelemetry-instrumentation-sqlite3==0.25b2
+opentelemetry-instrumentation-starlette==0.25b2
+opentelemetry-instrumentation-tornado==0.25b2
+opentelemetry-instrumentation-urllib==0.25b2
+opentelemetry-instrumentation-urllib3==0.25b2
+opentelemetry-instrumentation-wsgi==0.25b2

--- a/versions.txt
+++ b/versions.txt
@@ -17,3 +17,7 @@ autoinstrumentation-java=1.7.0
 # Represents the current release of NodeJS instrumentation.
 # Should match value in autoinstrumentation/nodejs/package.json
 autoinstrumentation-nodejs=0.26.0
+
+# Represents the current release of Python instrumentation.
+# Should match value in autoinstrumentation/python/requirements.txt
+autoinstrumentation-python=0.25b2


### PR DESCRIPTION
Created https://github.com/anuraaga/opentelemetry-operator/pkgs/container/opentelemetry-operator%2Fautoinstrumentation-python with it

I will write up the PR for the operator change after #507 is in. The mechanism, which I verified locally, is

`PYTHONPATH=/otel-autoinstrumentation/opentelemetry/instrumentation/auto_instrumentation:$PYTHONPATH:/otel-autoinstrumentation`

The trick is that the first entry is pointing to the folder with OTel's `sitecustomize.py` which gets automatically executed.

This is the same as what the `opentelemetry-instrument` script does I think except also appends the opentelemetry libraries to pythonpath, which otherwise is usually pip installed.

https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/opentelemetry-instrumentation/src/opentelemetry/instrumentation/auto_instrumentation/__init__.py#L105

