### PR TITLE
Delete namespaces created in tests.

### DIFF
--- a/internal/webhookhandler/webhookhandler_test.go
+++ b/internal/webhookhandler/webhookhandler_test.go
@@ -126,6 +126,7 @@ func TestShouldInjectSidecar(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := k8sClient.Create(context.Background(), &tt.ns)
 			require.NoError(t, err)
+			defer k8sClient.Delete(context.Background(), &tt.ns)
 
 			for i := range tt.otelcols {
 				err := k8sClient.Create(context.Background(), &tt.otelcols[i])
@@ -347,6 +348,7 @@ func TestPodShouldNotBeChanged(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := k8sClient.Create(context.Background(), &tt.ns)
 			require.NoError(t, err)
+			defer k8sClient.Delete(context.Background(), &tt.ns)
 
 			for i := range tt.otelcols {
 				err := k8sClient.Create(context.Background(), &tt.otelcols[i])

--- a/internal/webhookhandler/webhookhandler_test.go
+++ b/internal/webhookhandler/webhookhandler_test.go
@@ -126,7 +126,9 @@ func TestShouldInjectSidecar(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := k8sClient.Create(context.Background(), &tt.ns)
 			require.NoError(t, err)
-			defer k8sClient.Delete(context.Background(), &tt.ns)
+			defer func() {
+				_ = k8sClient.Delete(context.Background(), &tt.ns)
+			}()
 
 			for i := range tt.otelcols {
 				err := k8sClient.Create(context.Background(), &tt.otelcols[i])
@@ -186,7 +188,6 @@ func TestShouldInjectSidecar(t *testing.T) {
 			for i := range tt.otelcols {
 				require.NoError(t, k8sClient.Delete(context.Background(), &tt.otelcols[i]))
 			}
-			require.NoError(t, k8sClient.Delete(context.Background(), &tt.ns))
 		})
 	}
 }
@@ -348,7 +349,9 @@ func TestPodShouldNotBeChanged(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := k8sClient.Create(context.Background(), &tt.ns)
 			require.NoError(t, err)
-			defer k8sClient.Delete(context.Background(), &tt.ns)
+			defer func() {
+				_ = k8sClient.Delete(context.Background(), &tt.ns)
+			}()
 
 			for i := range tt.otelcols {
 				err := k8sClient.Create(context.Background(), &tt.otelcols[i])
@@ -389,7 +392,6 @@ func TestPodShouldNotBeChanged(t *testing.T) {
 			for i := range tt.otelcols {
 				require.NoError(t, k8sClient.Delete(context.Background(), &tt.otelcols[i]))
 			}
-			require.NoError(t, k8sClient.Delete(context.Background(), &tt.ns))
 		})
 	}
 }

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -401,6 +401,7 @@ func TestMutatePod(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := k8sClient.Create(context.Background(), &test.ns)
 			require.NoError(t, err)
+			defer k8sClient.Delete(context.Background(), &test.ns)
 			err = k8sClient.Create(context.Background(), &test.inst)
 			require.NoError(t, err)
 

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -401,7 +401,9 @@ func TestMutatePod(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := k8sClient.Create(context.Background(), &test.ns)
 			require.NoError(t, err)
-			defer k8sClient.Delete(context.Background(), &test.ns)
+			defer func() {
+				_ = k8sClient.Delete(context.Background(), &test.ns)
+			}()
 			err = k8sClient.Create(context.Background(), &test.inst)
 			require.NoError(t, err)
 


### PR DESCRIPTION
This allows tests to be run multiple times without needing to manually delete the namespaces, or recreate the cluster, between runs.

Fixes #523