### PR TITLE
Revert "Upgrade nodejs auto instrumentation to 1.27.0"

### DIFF
--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@opentelemetry/api": "1.0.3",
-    "@opentelemetry/auto-instrumentations-node": "0.27.0",
-    "@opentelemetry/exporter-otlp-grpc": "0.27.0",
-    "@opentelemetry/sdk-node": "0.27.0"
+    "@opentelemetry/auto-instrumentations-node": "0.26.0",
+    "@opentelemetry/exporter-otlp-grpc": "0.26.0",
+    "@opentelemetry/sdk-node": "0.26.0"
   }
 }

--- a/versions.txt
+++ b/versions.txt
@@ -16,7 +16,7 @@ autoinstrumentation-java=1.7.0
 
 # Represents the current release of NodeJS instrumentation.
 # Should match value in autoinstrumentation/nodejs/package.json
-autoinstrumentation-nodejs=0.27.0
+autoinstrumentation-nodejs=0.26.0
 
 # Represents the current release of Python instrumentation.
 # Should match value in autoinstrumentation/python/requirements.txt


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-operator#546

Fixes #550 

@pavolloffay Oops sorry for not noticing when reviewing. It looks like `js` has released 0.27.0 but not `js-contrib` yet from what I can tell, which has the instrumentations.

https://github.com/open-telemetry/opentelemetry-js-contrib/releases