### PR TITLE
Remove unused operator-sdk annotations from kinds

### DIFF
--- a/apis/v1alpha1/instrumentation_types.go
+++ b/apis/v1alpha1/instrumentation_types.go
@@ -22,37 +22,30 @@ import (
 type InstrumentationSpec struct {
 	// Exporter defines exporter configuration.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Exporter `json:"exporter,omitempty"`
 
 	// ResourceAttributes defines attributes that are added to resource.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	ResourceAttributes map[string]string `json:"resourceAttributes,omitempty"`
 
 	// Propagators defines inter-process context propagation configuration.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Propagators []Propagator `json:"propagators,omitempty"`
 
 	// Sampler defines sampling configuration.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Sampler `json:"sampler,omitempty"`
 
 	// Java defines configuration for java auto-instrumentation.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Java JavaSpec `json:"java,omitempty"`
 
 	// NodeJS defines configuration for nodejs auto-instrumentation.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	NodeJS NodeJSSpec `json:"nodejs,omitempty"`
 
 	// Python defines configuration for python auto-instrumentation.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Python PythonSpec `json:"python,omitempty"`
 }
 
@@ -60,7 +53,6 @@ type InstrumentationSpec struct {
 type JavaSpec struct {
 	// Image is a container image with javaagent JAR.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Image string `json:"image,omitempty"`
 }
 
@@ -68,7 +60,6 @@ type JavaSpec struct {
 type NodeJSSpec struct {
 	// Image is a container image with NodeJS SDK and autoinstrumentation.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Image string `json:"image,omitempty"`
 }
 
@@ -76,7 +67,6 @@ type NodeJSSpec struct {
 type PythonSpec struct {
 	// Image is a container image with Python SDK and autoinstrumentation.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Image string `json:"image,omitempty"`
 }
 
@@ -84,7 +74,6 @@ type PythonSpec struct {
 type Exporter struct {
 	// Endpoint is address of the collector with OTLP endpoint.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Endpoint string `json:"endpoint,omitempty"`
 }
 
@@ -93,14 +82,12 @@ type Sampler struct {
 	// Type defines sampler type.
 	// The value can be for instance parentbased_always_on, parentbased_always_off, parentbased_traceidratio...
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Type SamplerType `json:"type,omitempty"`
 
 	// Argument defines sampler argument.
 	// The value depends on the sampler type.
 	// For instance for parentbased_traceidratio sampler type it is a number in range [0..1] e.g. 0.25.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Argument string `json:"argument,omitempty"`
 }
 

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -23,72 +23,59 @@ import (
 type OpenTelemetryCollectorSpec struct {
 	// Config is the raw JSON to be used as the collector's configuration. Refer to the OpenTelemetry Collector documentation for details.
 	// +required
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Config string `json:"config,omitempty"`
 
 	// Args is the set of arguments to pass to the OpenTelemetry Collector binary
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Args map[string]string `json:"args,omitempty"`
 
 	// Replicas is the number of pod instances for the underlying OpenTelemetry Collector
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// ImagePullPolicy indicates the pull policy to be used for retrieving the container image (Always, Never, IfNotPresent)
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 
 	// Image indicates the container image to use for the OpenTelemetry Collector.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Image string `json:"image,omitempty"`
 
 	// TargetAllocator indicates a value which determines whether to spawn a target allocation resource or not.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	TargetAllocator OpenTelemetryTargetAllocatorSpec `json:"targetAllocator,omitempty"`
 
 	// Mode represents how the collector should be deployed (deployment, daemonset, statefulset or sidecar)
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Mode Mode `json:"mode,omitempty"`
 
 	// ServiceAccount indicates the name of an existing service account to use with this instance.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 
 	// SecurityContext will be set as the container security context.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	SecurityContext *v1.SecurityContext `json:"securityContext,omitempty"`
 
 	PodSecurityContext *v1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 
 	// HostNetwork indicates if the pod should run in the host networking namespace.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	HostNetwork bool `json:"hostNetwork,omitempty"`
 
 	// VolumeClaimTemplates will provide stable storage using PersistentVolumes. Only available when the mode=statefulset.
 	// +optional
 	// +listType=atomic
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	VolumeClaimTemplates []v1.PersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
 
 	// VolumeMounts represents the mount points to use in the underlying collector deployment(s)
 	// +optional
 	// +listType=atomic
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
 
 	// Volumes represents which volumes to use in the underlying collector deployment(s).
 	// +optional
 	// +listType=atomic
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Volumes []v1.Volume `json:"volumes,omitempty"`
 
 	// Ports allows a set of ports to be exposed by the underlying v1.Service. By default, the operator
@@ -96,36 +83,30 @@ type OpenTelemetryCollectorSpec struct {
 	// used to open aditional ports that can't be inferred by the operator, like for custom receivers.
 	// +optional
 	// +listType=atomic
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Ports []v1.ServicePort `json:"ports,omitempty"`
 
 	// ENV vars to set on the OpenTelemetry Collector's Pods. These can then in certain cases be
 	// consumed in the config file for the Collector.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Env []v1.EnvVar `json:"env,omitempty"`
 
 	// List of sources to populate environment variables on the OpenTelemetry Collector's Pods.
 	// These can then in certain cases be consumed in the config file for the Collector.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
 
 	// Resources to set on the OpenTelemetry Collector pods.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Toleration to schedule OpenTelemetry Collector pods.
 	// This is only relevant to daemonsets, statefulsets and deployments
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 
 	// PodAnnotations is the set of annotations that will be attached to
 	// Collector and Target Allocator pods.
 	// +optional
-	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
 }
 


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

The removed annotations seem to be noop. The CSV/CRD does not change after removal.