### PR TITLE
[FIX]: adds case to handle kubeletstats reciever to ignore endpoint

### DIFF
--- a/pkg/collector/parser/receiver.go
+++ b/pkg/collector/parser/receiver.go
@@ -100,6 +100,11 @@ func singlePortFromConfigEndpoint(logger logr.Logger, name string, config map[in
 	case name == "tcplog" || name == "udplog":
 		endpoint = getAddressFromConfig(logger, name, listenAddressKey, config)
 
+	// in case of kubeletstats reciever, the endpoint is ignored
+	case name == "kubeletstats":
+		endpoint = nil
+		return nil
+
 	default:
 		endpoint = getAddressFromConfig(logger, name, endpointKey, config)
 	}

--- a/pkg/collector/parser/receiver.go
+++ b/pkg/collector/parser/receiver.go
@@ -100,9 +100,10 @@ func singlePortFromConfigEndpoint(logger logr.Logger, name string, config map[in
 	case name == "tcplog" || name == "udplog":
 		endpoint = getAddressFromConfig(logger, name, listenAddressKey, config)
 
-	// in case of kubeletstats reciever, the endpoint is ignored
+	// ignore kubeletstats receiver as it holds the field key endpoint, and it
+	// is a scraper, we only expose endpoint through k8s service objects for
+	// receivers that aren't scrapers.
 	case name == "kubeletstats":
-		endpoint = nil
 		return nil
 
 	default:

--- a/pkg/collector/parser/receiver_test.go
+++ b/pkg/collector/parser/receiver_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/parser"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -97,20 +98,20 @@ func TestReceiverFailsWhenPortIsntString(t *testing.T) {
 	// verify
 	assert.Nil(t, p)
 }
-
-func TestReceiverFailsWhenNameIsKubeletStats(t *testing.T) {
-	// prepare
-	config := map[interface{}]interface{}{
-		"name": "kubeletstats",
-	}
+func TestIgnorekubeletstatsEndpoint(t *testing.T) {
+	// ignore "kubeletstats" receiver endpoint field, this is special case
+	// as this receiver gets parsed by generic receiver parser
+	builder := parser.NewGenericReceiverParser(logger, "kubeletstats", map[interface{}]interface{}{
+		"endpoint": "0.0.0.0:9000",
+	})
 
 	// test
-	p := singlePortFromConfigEndpoint(logger, "myreceiver", config)
+	ports, err := builder.Ports()
 
 	// verify
-	assert.Nil(t, p)
+	assert.NoError(t, err)
+	assert.Len(t, ports, 0)
 }
-
 func TestReceiverFallbackWhenNotRegistered(t *testing.T) {
 	// test
 	p := For(logger, "myreceiver", map[interface{}]interface{}{})

--- a/pkg/collector/parser/receiver_test.go
+++ b/pkg/collector/parser/receiver_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/parser"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -98,10 +97,11 @@ func TestReceiverFailsWhenPortIsntString(t *testing.T) {
 	// verify
 	assert.Nil(t, p)
 }
+
 func TestIgnorekubeletstatsEndpoint(t *testing.T) {
 	// ignore "kubeletstats" receiver endpoint field, this is special case
 	// as this receiver gets parsed by generic receiver parser
-	builder := parser.NewGenericReceiverParser(logger, "kubeletstats", map[interface{}]interface{}{
+	builder := NewGenericReceiverParser(logger, "kubeletstats", map[interface{}]interface{}{
 		"endpoint": "0.0.0.0:9000",
 	})
 
@@ -112,6 +112,7 @@ func TestIgnorekubeletstatsEndpoint(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, ports, 0)
 }
+
 func TestReceiverFallbackWhenNotRegistered(t *testing.T) {
 	// test
 	p := For(logger, "myreceiver", map[interface{}]interface{}{})

--- a/pkg/collector/parser/receiver_test.go
+++ b/pkg/collector/parser/receiver_test.go
@@ -98,6 +98,19 @@ func TestReceiverFailsWhenPortIsntString(t *testing.T) {
 	assert.Nil(t, p)
 }
 
+func TestReceiverFailsWhenNameIsKubeletStats(t *testing.T) {
+	// prepare
+	config := map[interface{}]interface{}{
+		"name": "kubeletstats",
+	}
+
+	// test
+	p := singlePortFromConfigEndpoint(logger, "myreceiver", config)
+
+	// verify
+	assert.Nil(t, p)
+}
+
 func TestReceiverFallbackWhenNotRegistered(t *testing.T) {
 	// test
 	p := For(logger, "myreceiver", map[interface{}]interface{}{})


### PR DESCRIPTION
This PR is an attempt  to fix #527 to ignore certain kubeletstats receivers when deriving service from config 
Signed-off-by: Mritunjay Sharma <mritunjaysharma394@gmail.com>