### PR TITLE
Add liveness probe to created container if otelcol configuration supports a health_check.

### DIFF
--- a/pkg/collector/adapters/config_to_probe.go
+++ b/pkg/collector/adapters/config_to_probe.go
@@ -1,0 +1,171 @@
+package adapters
+
+import (
+	"errors"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"strings"
+)
+
+var (
+	// ErrNoService indicates that there is no service in the configuration.
+	ErrNoService = errors.New("no service available as part of the configuration")
+	// ErrNoExtensions indicates that there are no extensions in the configuration
+	ErrNoExtensions = errors.New("no extensions available as part of the configuration")
+
+	// ErrServiceNotAMap indicates that the service property isn't a map of values.
+	ErrServiceNotAMap = errors.New("service property in the configuration doesn't contain valid services")
+	// ErrExtensionsNotAMap indicates that the extensions property isn't a map of values.
+	ErrExtensionsNotAMap = errors.New("extensions property in the configuration doesn't contain valid extensions")
+
+	// ErrNoExtensionHealthCheck indicates no health_check extension was found for the
+	ErrNoExtensionHealthCheck = errors.New("extensions property in the configuration does not contain the expected health_check extension")
+
+	// ErrNoServiceExtensions indicates the service configuration does not contain any extensions
+	ErrNoServiceExtensions = errors.New("service property in the configuration doesn't contain extensions")
+
+	// ErrServiceExtensionsNotSlice indicates the service extensions property isn't a slice as expected
+	ErrServiceExtensionsNotSlice = errors.New("service extensions property in the configuration does not contain valid extensions")
+
+	// ErrNoServiceExtensionHealthCheck indicates no health_check
+	ErrNoServiceExtensionHealthCheck = errors.New("no healthcheck extension available in service extension configuration")
+)
+
+// ConfigToContainerProbe converts the incoming configuration object into a container probe or returns an error
+func ConfigToContainerProbe(logger logr.Logger, config map[interface{}]interface{}) (*corev1.Probe, error) {
+	serviceProperty, ok := config["service"]
+	if !ok {
+		return nil, ErrNoService
+	}
+	service, ok := serviceProperty.(map[interface{}]interface{})
+	if !ok {
+		return nil, ErrServiceNotAMap
+	}
+
+	serviceExtensionsProperty, ok := service["extensions"]
+	if !ok {
+		return nil, ErrNoServiceExtensions
+	}
+
+	healthcheckForProbe := ""
+
+	serviceExtensions, ok := serviceExtensionsProperty.([]interface{})
+	if !ok {
+		return nil, ErrServiceExtensionsNotSlice
+	}
+	// in the event of multiple health_check extensions defined, we arbitrarily take the first one found
+	for _, ext := range serviceExtensions {
+		parsedExt, ok := ext.(string)
+		if ok && strings.HasPrefix(parsedExt, "health_check") {
+			healthcheckForProbe = parsedExt
+			break
+		}
+	}
+
+	if healthcheckForProbe == "" {
+		return nil, ErrNoServiceExtensionHealthCheck
+	}
+
+	extensionsProperty, ok := config["extensions"]
+	if !ok {
+		return nil, ErrNoExtensions
+	}
+	extensions, ok := extensionsProperty.(map[interface{}]interface{})
+	if !ok {
+		return nil, ErrExtensionsNotAMap
+	}
+	healthcheckExtension, ok := extensions[healthcheckForProbe]
+	if !ok {
+		return nil, ErrNoExtensionHealthCheck
+	}
+
+	return createProbeFromExtension(healthcheckExtension)
+}
+
+func createProbeFromExtension(extension interface{}) (*corev1.Probe, error) {
+	probeCfg := extractProbeConfigurationFromExtension(extension)
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: probeCfg.path,
+				Port: probeCfg.port,
+				Host: probeCfg.host,
+			},
+		},
+	}, nil
+}
+
+type probeConfiguration struct {
+	path string
+	port intstr.IntOrString
+	host string
+}
+
+const (
+	defaultHealthCheckPath = "/"
+	defaultHealthCheckPort = 13133
+	defaultHealthCheckHost = "0.0.0.0"
+)
+
+func extractProbeConfigurationFromExtension(ext interface{}) probeConfiguration {
+	extensionCfg, ok := ext.(map[interface{}]interface{})
+	if !ok {
+		return defaultProbeConfiguration()
+	}
+	endpoint := extractEndpointFromExtensionConfig(extensionCfg)
+	return probeConfiguration{
+		path: extractPathFromExtensionConfig(extensionCfg),
+		port: endpoint.port,
+		host: endpoint.host,
+	}
+}
+
+func defaultProbeConfiguration() probeConfiguration {
+	return probeConfiguration{
+		path: defaultHealthCheckPath,
+		port: intstr.FromInt(defaultHealthCheckPort),
+		host: defaultHealthCheckHost,
+	}
+}
+
+type healthCheckEndpoint struct {
+	port intstr.IntOrString
+	host string
+}
+
+func defaultHealthCheckEndpoint() healthCheckEndpoint {
+	defaultProbe := defaultProbeConfiguration()
+	return healthCheckEndpoint{
+		port: defaultProbe.port,
+		host: defaultProbe.host,
+	}
+}
+
+func extractEndpointFromExtensionConfig(cfg map[interface{}]interface{}) healthCheckEndpoint {
+	endpoint, ok := cfg["endpoint"]
+	if !ok {
+		return defaultHealthCheckEndpoint()
+	}
+	parsedEndpoint, ok := endpoint.(string)
+	if !ok {
+		return defaultHealthCheckEndpoint()
+	}
+	endpointComponents := strings.Split(parsedEndpoint, ":")
+	if len(endpointComponents) != 2 {
+		return defaultHealthCheckEndpoint()
+	}
+	return healthCheckEndpoint{
+		port: intstr.Parse(endpointComponents[1]),
+		host: endpointComponents[0],
+	}
+}
+
+func extractPathFromExtensionConfig(cfg map[interface{}]interface{}) string {
+	if path, ok := cfg["path"]; ok {
+		if parsedPath, ok := path.(string); ok {
+			return parsedPath
+		}
+	}
+	return defaultHealthCheckPath
+}

--- a/pkg/collector/adapters/config_to_probe.go
+++ b/pkg/collector/adapters/config_to_probe.go
@@ -1,10 +1,25 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package adapters
 
 import (
 	"errors"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"strings"
 )
 
 var (
@@ -32,7 +47,7 @@ const (
 	defaultHealthCheckPort = 13133
 )
 
-// ConfigToContainerProbe converts the incoming configuration object into a container probe or returns an error
+// ConfigToContainerProbe converts the incoming configuration object into a container probe or returns an error.
 func ConfigToContainerProbe(config map[interface{}]interface{}) (*corev1.Probe, error) {
 	serviceProperty, ok := config["service"]
 	if !ok {

--- a/pkg/collector/adapters/config_to_probe.go
+++ b/pkg/collector/adapters/config_to_probe.go
@@ -8,18 +8,18 @@ import (
 )
 
 var (
-	ErrNoService    = errors.New("no service available as part of the configuration")
-	ErrNoExtensions = errors.New("no extensions available as part of the configuration")
+	errNoService    = errors.New("no service available as part of the configuration")
+	errNoExtensions = errors.New("no extensions available as part of the configuration")
 
-	ErrServiceNotAMap    = errors.New("service property in the configuration doesn't contain valid services")
-	ErrExtensionsNotAMap = errors.New("extensions property in the configuration doesn't contain valid extensions")
+	errServiceNotAMap    = errors.New("service property in the configuration doesn't contain valid services")
+	errExtensionsNotAMap = errors.New("extensions property in the configuration doesn't contain valid extensions")
 
-	ErrNoExtensionHealthCheck = errors.New("extensions property in the configuration does not contain the expected health_check extension")
+	errNoExtensionHealthCheck = errors.New("extensions property in the configuration does not contain the expected health_check extension")
 
-	ErrNoServiceExtensions = errors.New("service property in the configuration doesn't contain extensions")
+	errNoServiceExtensions = errors.New("service property in the configuration doesn't contain extensions")
 
-	ErrServiceExtensionsNotSlice     = errors.New("service extensions property in the configuration does not contain valid extensions")
-	ErrNoServiceExtensionHealthCheck = errors.New("no healthcheck extension available in service extension configuration")
+	errServiceExtensionsNotSlice     = errors.New("service extensions property in the configuration does not contain valid extensions")
+	errNoServiceExtensionHealthCheck = errors.New("no healthcheck extension available in service extension configuration")
 )
 
 type probeConfiguration struct {
@@ -36,21 +36,21 @@ const (
 func ConfigToContainerProbe(config map[interface{}]interface{}) (*corev1.Probe, error) {
 	serviceProperty, ok := config["service"]
 	if !ok {
-		return nil, ErrNoService
+		return nil, errNoService
 	}
 	service, ok := serviceProperty.(map[interface{}]interface{})
 	if !ok {
-		return nil, ErrServiceNotAMap
+		return nil, errServiceNotAMap
 	}
 
 	serviceExtensionsProperty, ok := service["extensions"]
 	if !ok {
-		return nil, ErrNoServiceExtensions
+		return nil, errNoServiceExtensions
 	}
 
 	serviceExtensions, ok := serviceExtensionsProperty.([]interface{})
 	if !ok {
-		return nil, ErrServiceExtensionsNotSlice
+		return nil, errServiceExtensionsNotSlice
 	}
 	healthCheckServiceExtensions := make([]string, 0)
 	for _, ext := range serviceExtensions {
@@ -61,16 +61,16 @@ func ConfigToContainerProbe(config map[interface{}]interface{}) (*corev1.Probe, 
 	}
 
 	if len(healthCheckServiceExtensions) == 0 {
-		return nil, ErrNoServiceExtensionHealthCheck
+		return nil, errNoServiceExtensionHealthCheck
 	}
 
 	extensionsProperty, ok := config["extensions"]
 	if !ok {
-		return nil, ErrNoExtensions
+		return nil, errNoExtensions
 	}
 	extensions, ok := extensionsProperty.(map[interface{}]interface{})
 	if !ok {
-		return nil, ErrExtensionsNotAMap
+		return nil, errExtensionsNotAMap
 	}
 	// in the event of multiple health_check service extensions defined, we arbitrarily take the first one found
 	for _, healthCheckForProbe := range healthCheckServiceExtensions {
@@ -80,7 +80,7 @@ func ConfigToContainerProbe(config map[interface{}]interface{}) (*corev1.Probe, 
 		}
 	}
 
-	return nil, ErrNoExtensionHealthCheck
+	return nil, errNoExtensionHealthCheck
 }
 
 func createProbeFromExtension(extension interface{}) (*corev1.Probe, error) {

--- a/pkg/collector/adapters/config_to_probe_test.go
+++ b/pkg/collector/adapters/config_to_probe_test.go
@@ -1,7 +1,6 @@
-package adapters_test
+package adapters
 
 import (
-	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -91,12 +90,12 @@ service:
 
 	for _, test := range tests {
 		// prepare
-		config, err := adapters.ConfigFromString(test.config)
+		config, err := ConfigFromString(test.config)
 		require.NoError(t, err, test.desc)
 		require.NotEmpty(t, config, test.desc)
 
 		// test
-		actualProbe, err := adapters.ConfigToContainerProbe(config)
+		actualProbe, err := ConfigToContainerProbe(config)
 		assert.NoError(t, err)
 		assert.Equal(t, test.expectedPath, actualProbe.HTTPGet.Path, test.desc)
 		assert.Equal(t, test.expectedPort, actualProbe.HTTPGet.Port.IntVal, test.desc)
@@ -116,58 +115,58 @@ func TestConfigToProbeShouldErrorIf(t *testing.T) {
   pprof:
 service:
   extensions: [health_check]`,
-			expectedErr: adapters.ErrNoExtensionHealthCheck,
+			expectedErr: errNoExtensionHealthCheck,
 		}, {
 			desc: "BadlyFormattedExtensions",
 			config: `extensions: [hi]
 service:
   extensions: [health_check]`,
-			expectedErr: adapters.ErrExtensionsNotAMap,
+			expectedErr: errExtensionsNotAMap,
 		}, {
 			desc: "NoExtensions",
 			config: `service:
   extensions: [health_check]`,
-			expectedErr: adapters.ErrNoExtensions,
+			expectedErr: errNoExtensions,
 		}, {
 			desc: "NoHealthCheckInServiceExtensions",
 			config: `service:
   extensions: [pprof]`,
-			expectedErr: adapters.ErrNoServiceExtensionHealthCheck,
+			expectedErr: errNoServiceExtensionHealthCheck,
 		}, {
 			desc: "BadlyFormattedServiceExtensions",
 			config: `service:
   extensions:
     this: should-not-be-a-map`,
-			expectedErr: adapters.ErrServiceExtensionsNotSlice,
+			expectedErr: errServiceExtensionsNotSlice,
 		}, {
 			desc: "NoServiceExtensions",
 			config: `service:
   pipelines:
     traces:
       receivers: [otlp]`,
-			expectedErr: adapters.ErrNoServiceExtensions,
+			expectedErr: errNoServiceExtensions,
 		}, {
 			desc: "BadlyFormattedService",
 			config: `extensions:
   health_check:
 service: [hi]`,
-			expectedErr: adapters.ErrServiceNotAMap,
+			expectedErr: errServiceNotAMap,
 		}, {
 			desc: "NoService",
 			config: `extensions:
   health_check:`,
-			expectedErr: adapters.ErrNoService,
+			expectedErr: errNoService,
 		},
 	}
 
 	for _, test := range tests {
 		// prepare
-		config, err := adapters.ConfigFromString(test.config)
+		config, err := ConfigFromString(test.config)
 		require.NoError(t, err, test.desc)
 		require.NotEmpty(t, config, test.desc)
 
 		// test
-		_, err = adapters.ConfigToContainerProbe(config)
+		_, err = ConfigToContainerProbe(config)
 		assert.Equal(t, test.expectedErr, err, test.desc)
 	}
 }

--- a/pkg/collector/adapters/config_to_probe_test.go
+++ b/pkg/collector/adapters/config_to_probe_test.go
@@ -1,9 +1,24 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package adapters
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestConfigToProbeShouldCreateProbeFor(t *testing.T) {

--- a/pkg/collector/adapters/config_to_probe_test.go
+++ b/pkg/collector/adapters/config_to_probe_test.go
@@ -1,0 +1,243 @@
+package adapters_test
+
+import (
+	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSimpleCase(t *testing.T) {
+	configStr := `extensions:
+  health_check:
+service:
+  extensions: [health_check]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	actualProbe, err := adapters.ConfigToContainerProbe(logger, config)
+	assert.NoError(t, err)
+	assert.Equal(t, "/", actualProbe.HTTPGet.Path)
+	assert.Equal(t, int32(13133), actualProbe.HTTPGet.Port.IntVal)
+	assert.Equal(t, "0.0.0.0", actualProbe.HTTPGet.Host)
+}
+
+func TestShouldUseCustomEndpointAndPath(t *testing.T) {
+	configStr := `extensions:
+  health_check:
+    endpoint: localhost:1234
+    path: /checkit
+service:
+  extensions: [health_check]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	actualProbe, err := adapters.ConfigToContainerProbe(logger, config)
+	assert.NoError(t, err)
+	assert.Equal(t, "/checkit", actualProbe.HTTPGet.Path)
+	assert.Equal(t, int32(1234), actualProbe.HTTPGet.Port.IntVal)
+	assert.Equal(t, "localhost", actualProbe.HTTPGet.Host)
+}
+
+func TestShouldUseCustomEndpointAndDefaultPath(t *testing.T) {
+	configStr := `extensions:
+  health_check:
+    endpoint: localhost:1234
+service:
+  extensions: [health_check]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	actualProbe, err := adapters.ConfigToContainerProbe(logger, config)
+	assert.NoError(t, err)
+	assert.Equal(t, "/", actualProbe.HTTPGet.Path)
+	assert.Equal(t, int32(1234), actualProbe.HTTPGet.Port.IntVal)
+	assert.Equal(t, "localhost", actualProbe.HTTPGet.Host)
+}
+
+func TestShouldUseDefaultEndpointAndCustomPath(t *testing.T) {
+	configStr := `extensions:
+  health_check:
+    path: /checkit
+service:
+  extensions: [health_check]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	actualProbe, err := adapters.ConfigToContainerProbe(logger, config)
+	assert.NoError(t, err)
+	assert.Equal(t, "/checkit", actualProbe.HTTPGet.Path)
+	assert.Equal(t, int32(13133), actualProbe.HTTPGet.Port.IntVal)
+	assert.Equal(t, "0.0.0.0", actualProbe.HTTPGet.Host)
+}
+
+func TestShouldUseDefaultEndpointForUnexpectedEndpoint(t *testing.T) {
+	configStr := `extensions:
+  health_check:
+    endpoint: 0:0:0"
+service:
+  extensions: [health_check]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	actualProbe, err := adapters.ConfigToContainerProbe(logger, config)
+	assert.NoError(t, err)
+	assert.Equal(t, "/", actualProbe.HTTPGet.Path)
+	assert.Equal(t, int32(13133), actualProbe.HTTPGet.Port.IntVal)
+	assert.Equal(t, "0.0.0.0", actualProbe.HTTPGet.Host)
+}
+
+func TestShouldErrorIfNoService(t *testing.T) {
+	configStr := `extensions:
+  health_check:`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	_, err = adapters.ConfigToContainerProbe(logger, config)
+	assert.Equal(t, adapters.ErrNoService, err)
+}
+
+func TestShouldErrorIfBadlyFormattedService(t *testing.T) {
+	configStr := `extensions:
+  health_check:
+service: [hi]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	_, err = adapters.ConfigToContainerProbe(logger, config)
+	assert.Equal(t, adapters.ErrServiceNotAMap, err)
+}
+
+func TestShouldErrorIfNoServiceExtensions(t *testing.T) {
+	configStr := `service:
+  pipelines:
+    traces:
+      receivers: [otlp]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	_, err = adapters.ConfigToContainerProbe(logger, config)
+	assert.Equal(t, adapters.ErrNoServiceExtensions, err)
+}
+
+func TestShouldErrorIfBadlyFormattedServiceExtensions(t *testing.T) {
+	configStr := `service:
+  extensions:
+    this: should-not-be-a-map`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	_, err = adapters.ConfigToContainerProbe(logger, config)
+	assert.Equal(t, adapters.ErrServiceExtensionsNotSlice, err)
+}
+
+func TestShouldErrorIfNoHealthCheckInServiceExtensions(t *testing.T) {
+	configStr := `service:
+  extensions: [pprof]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	_, err = adapters.ConfigToContainerProbe(logger, config)
+	assert.Equal(t, adapters.ErrNoServiceExtensionHealthCheck, err)
+}
+
+func TestShouldErrorIfNoExtensions(t *testing.T) {
+	configStr := `service:
+  extensions: [health_check]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	_, err = adapters.ConfigToContainerProbe(logger, config)
+	assert.Equal(t, adapters.ErrNoExtensions, err)
+}
+
+func TestShouldErrorIfBadlyFormattedExtensions(t *testing.T) {
+	configStr := `extensions: [hi]
+service:
+  extensions: [health_check]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	_, err = adapters.ConfigToContainerProbe(logger, config)
+	assert.Equal(t, adapters.ErrExtensionsNotAMap, err)
+}
+
+func TestShouldErrorIfNoHealthCheckExtension(t *testing.T) {
+	configStr := `extensions:
+  pprof:
+service:
+  extensions: [health_check]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	_, err = adapters.ConfigToContainerProbe(logger, config)
+	assert.Equal(t, adapters.ErrNoExtensionHealthCheck, err)
+}
+
+func TestShouldErrorIfNoHealthCheckExtension_mustMatchFirstHealthCheck(t *testing.T) {
+	configStr := `extensions:
+  health_check:
+service:
+  extensions: [health_check/1, health_check]`
+
+	// prepare
+	config, err := adapters.ConfigFromString(configStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, config)
+
+	// test
+	_, err = adapters.ConfigToContainerProbe(logger, config)
+	assert.Equal(t, adapters.ErrNoExtensionHealthCheck, err)
+}

--- a/pkg/collector/adapters/config_to_probe_test.go
+++ b/pkg/collector/adapters/config_to_probe_test.go
@@ -42,6 +42,15 @@ service:
 service:
   extensions: [health_check]`,
 		}, {
+			desc:         "CustomEndpointWithJustPortAndDefaultPath",
+			expectedPort: int32(1234),
+			expectedPath: "/",
+			config: `extensions:
+  health_check:
+    endpoint: :1234
+service:
+  extensions: [health_check]`,
+		}, {
 			desc:         "DefaultEndpointAndCustomPath",
 			expectedPort: int32(13133),
 			expectedPath: "/checkit",

--- a/pkg/collector/container.go
+++ b/pkg/collector/container.go
@@ -79,7 +79,7 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 
 	var livenessProbe *corev1.Probe
 	if config, err := adapters.ConfigFromString(otelcol.Spec.Config); err == nil {
-		if probe, err := adapters.ConfigToContainerProbe(logger, config); err == nil {
+		if probe, err := adapters.ConfigToContainerProbe(config); err == nil {
 			livenessProbe = probe
 		}
 	}

--- a/pkg/collector/container.go
+++ b/pkg/collector/container.go
@@ -20,10 +20,9 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
-
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/naming"
 )
 

--- a/pkg/collector/container.go
+++ b/pkg/collector/container.go
@@ -16,9 +16,11 @@ package collector
 
 import (
 	"fmt"
+
 	"github.com/go-logr/logr"
-	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"

--- a/pkg/collector/container.go
+++ b/pkg/collector/container.go
@@ -16,8 +16,8 @@ package collector
 
 import (
 	"fmt"
-
 	"github.com/go-logr/logr"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
@@ -77,6 +77,13 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 		},
 	})
 
+	var livenessProbe *corev1.Probe
+	if config, err := adapters.ConfigFromString(otelcol.Spec.Config); err == nil {
+		if probe, err := adapters.ConfigToContainerProbe(logger, config); err == nil {
+			livenessProbe = probe
+		}
+	}
+
 	return corev1.Container{
 		Name:            naming.Container(),
 		Image:           image,
@@ -87,5 +94,6 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 		EnvFrom:         otelcol.Spec.EnvFrom,
 		Resources:       otelcol.Spec.Resources,
 		SecurityContext: otelcol.Spec.SecurityContext,
+		LivenessProbe:   livenessProbe,
 	}
 }

--- a/pkg/collector/container_test.go
+++ b/pkg/collector/container_test.go
@@ -290,7 +290,7 @@ service:
 	c := Container(cfg, logger, otelcol)
 
 	// verify
-	assert.Equal(t, "0.0.0.0", c.LivenessProbe.HTTPGet.Host)
 	assert.Equal(t, "/", c.LivenessProbe.HTTPGet.Path)
 	assert.Equal(t, int32(13133), c.LivenessProbe.HTTPGet.Port.IntVal)
+	assert.Equal(t, "", c.LivenessProbe.HTTPGet.Host)
 }

--- a/pkg/collector/container_test.go
+++ b/pkg/collector/container_test.go
@@ -273,3 +273,24 @@ func TestContainerEnvFrom(t *testing.T) {
 	assert.Contains(t, c.EnvFrom, envFrom1)
 	assert.Contains(t, c.EnvFrom, envFrom2)
 }
+
+func TestContainerProbe(t *testing.T) {
+	// prepare
+	otelcol := v1alpha1.OpenTelemetryCollector{
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Config: `extensions:
+  health_check:
+service:
+  extensions: [health_check]`,
+		},
+	}
+	cfg := config.New()
+
+	// test
+	c := Container(cfg, logger, otelcol)
+
+	// verify
+	assert.Equal(t, "0.0.0.0", c.LivenessProbe.HTTPGet.Host)
+	assert.Equal(t, "/", c.LivenessProbe.HTTPGet.Path)
+	assert.Equal(t, int32(13133), c.LivenessProbe.HTTPGet.Port.IntVal)
+}


### PR DESCRIPTION
Add liveness probe to created container if otelcol configuration supports a health_check.

Fixes #571

Signed-off-by: Adrian Kostrubiak <adrian.kostrubiak@tomtom.com>