### PR TITLE
Use cmctl to test if cert-manager is ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,11 +144,23 @@ start-kind:
 	kind create cluster --config $(KIND_CONFIG)
 	kind load docker-image local/opentelemetry-operator:e2e
 
-cert-manager:
+cert-manager: cmctl
+	# Consider using cmctl to install the cert-manager once install comment is not experimental
 	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v${CERTMANAGER_VERSION}/cert-manager.yaml
-	kubectl wait --timeout=5m --for=condition=available deployment cert-manager -n cert-manager
-	kubectl wait --timeout=5m --for=condition=available deployment cert-manager-cainjector -n cert-manager
-	kubectl wait --timeout=5m --for=condition=available deployment cert-manager-webhook -n cert-manager
+	cmctl check api --wait=5m
+
+cmctl:
+ifeq (, $(shell which cmctl))
+	@{ \
+	curl -L -o /tmp/cmctl.tar.gz https://github.com/jetstack/cert-manager/releases/download/v$(CERTMANAGER_VERSION)/cmctl-`go env GOOS`-`go env GOARCH`.tar.gz ;\
+	cd /tmp ;\
+	tar xzf cmctl.tar.gz ;\
+	mv cmctl $(GOBIN) ;\
+	}
+CTL=$(GOBIN)/cmctl
+else
+CTL=$(shell which cmctl)
+endif
 
 # find or download controller-gen
 # download controller-gen if necessary

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ start-kind:
 	kind load docker-image local/opentelemetry-operator:e2e
 
 cert-manager: cmctl
-	# Consider using cmctl to install the cert-manager once install comment is not experimental
+	# Consider using cmctl to install the cert-manager once install command is not experimental
 	kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v${CERTMANAGER_VERSION}/cert-manager.yaml
 	cmctl check api --wait=5m
 


### PR DESCRIPTION
The current approach is flaky and cert-manager
docs suggests to use cmctl to test if the cert-manager is
ready.


This should fix flaky CI e2e jobs:
* https://github.com/open-telemetry/opentelemetry-operator/runs/4331745148?check_suite_focus=true



Signed-off-by: Pavol Loffay <p.loffay@gmail.com>