### PR TITLE
Remove fmt.Println from test

### DIFF
--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -365,8 +365,8 @@ func TestSDKInjection(t *testing.T) {
 				client: k8sClient,
 			}
 			pod := inj.injectCommonSDKConfig(context.Background(), test.inst, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: test.pod.Namespace}}, test.pod)
-			b, _ := json.MarshalIndent(pod, "", "  ")
-			fmt.Println(string(b))
+			_, err = json.MarshalIndent(pod, "", "  ")
+			assert.NoError(t, err)
 			assert.Equal(t, test.expected, pod)
 		})
 	}


### PR DESCRIPTION
The PR #464 introduced a test that is printing debugging information to the console even when the test is passing. This PR fixes that.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
