### PR TITLE
Add read permission to 'group' for java autoinstrumentation JAR

### DIFF
--- a/autoinstrumentation/java/Dockerfile
+++ b/autoinstrumentation/java/Dockerfile
@@ -4,4 +4,4 @@ ARG version
 
 ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /javaagent.jar
 
-RUN chmod -R o+r /javaagent.jar
+RUN chmod -R go+r /javaagent.jar

--- a/autoinstrumentation/nodejs/Dockerfile
+++ b/autoinstrumentation/nodejs/Dockerfile
@@ -9,4 +9,4 @@ FROM busybox
 
 COPY --from=build /operator-build/build/workspace /autoinstrumentation
 
-RUN chmod -R o+r /autoinstrumentation
+RUN chmod -R go+r /autoinstrumentation

--- a/autoinstrumentation/python/Dockerfile
+++ b/autoinstrumentation/python/Dockerfile
@@ -10,4 +10,4 @@ FROM busybox
 
 COPY --from=build /operator-build/workspace /autoinstrumentation
 
-RUN chmod -R o+r /autoinstrumentation
+RUN chmod -R go+r /autoinstrumentation


### PR DESCRIPTION
Fixes Java auto-instrumentation permissions when fsGroup is in use in the container. 

Fixes #636