### PR TITLE
Fix issue in name trimming not adding all values

### DIFF
--- a/pkg/naming/triming.go
+++ b/pkg/naming/triming.go
@@ -35,11 +35,11 @@ func init() {
 func Truncate(format string, max int, values ...interface{}) string {
 	var truncated []interface{}
 	result := fmt.Sprintf(format, values...)
-
 	if excess := len(result) - max; excess > 0 {
 		// we try to reduce the first string we find
 		for _, value := range values {
 			if excess == 0 {
+				truncated = append(truncated, value)
 				continue
 			}
 
@@ -55,7 +55,6 @@ func Truncate(format string, max int, values ...interface{}) string {
 
 			truncated = append(truncated, value)
 		}
-
 		result = fmt.Sprintf(format, truncated...)
 	}
 

--- a/pkg/naming/triming_test.go
+++ b/pkg/naming/triming_test.go
@@ -60,6 +60,13 @@ func TestTruncate(t *testing.T) {
 			cap:      "first value gets dropped, second truncated",
 		},
 		{
+			format:   "%s-%s-collector",
+			max:      63,
+			values:   []interface{}{"4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174-c85b7644b6b5", "d0c1e62"},
+			expected: "4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11e-d0c1e62-collector",
+			cap:      "first value gets truncated, second added",
+		},
+		{
 			format:   "%d-%s-collector",
 			max:      63,
 			values:   []interface{}{42, "d0c1e62-4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174-c85b7644b6b5"},
@@ -67,7 +74,9 @@ func TestTruncate(t *testing.T) {
 			cap:      "first value gets passed, second truncated",
 		},
 	} {
-		assert.Equal(t, tt.expected, Truncate(tt.format, tt.max, tt.values...))
+		t.Run(tt.cap, func(t *testing.T) {
+			assert.Equal(t, tt.expected, Truncate(tt.format, tt.max, tt.values...))
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #596

In the previous PR for this issue a case was missed when submitting the name trimming code.
This issue caused, in certain cases, an error where `fmt.Sprintf()` would receive less values that the format expected and would therefore have a missing parameter. 
The result of this are formatted texts that look like this:
```bash
--- FAIL: TestTruncate (0.00s)
    --- FAIL: TestTruncate/first_value_gets_truncated,_second_added (0.00s)
        /home/mihai/projects/open-telemetry/opentelemetry-operator/pkg/naming/triming_test.go:78: 
            	Error Trace:	triming_test.go:78
            	Error:      	Not equal: 
            	            	expected: "4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174--collector"
            	            	actual  : "4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11e-%!s(MISSING)-coll"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174--collector
            	            	+4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11e-%!s(MISSING)-coll
            	Test:       	TestTruncate/first_value_gets_truncated,_second_added
FAIL
FAIL	github.com/open-telemetry/opentelemetry-operator/pkg/naming	0.015s
FAIL
```

Notice the `%!s(MISSING)`. This would also cause the labels to fail when such a case was encountered during execution.