### PR TITLE
Set instrumentation versions when building official image

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -25,6 +25,9 @@ jobs:
         run: |
           grep -v '\#' versions.txt | grep opentelemetry-collector | awk -F= '{print "OTELCOL_VERSION="$2}' >> $GITHUB_ENV
           grep -v '\#' versions.txt | grep targetallocator | awk -F= '{print "TARGETALLOCATOR_VERSION="$2}' >> $GITHUB_ENV
+          grep -v '\#' versions.txt | grep autoinstrumentation-java | awk -F= '{print "AUTO_INSTRUMENTATION_JAVA_VERSION="$2}' >> $GITHUB_ENV
+          grep -v '\#' versions.txt | grep autoinstrumentation-nodejs | awk -F= '{print "AUTO_INSTRUMENTATION_NODEJS_VERSION="$2}' >> $GITHUB_ENV
+          grep -v '\#' versions.txt | grep autoinstrumentation-python | awk -F= '{print "AUTO_INSTRUMENTATION_PYTHON_VERSION="$2}' >> $GITHUB_ENV
           echo "VERSION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
           echo "VERSION=$(git describe --tags | sed 's/^v//')" >> $GITHUB_ENV
 
@@ -81,5 +84,8 @@ jobs:
             VERSION_DATE=${{ env.VERSION_DATE }}
             OTELCOL_VERSION=${{ env.OTELCOL_VERSION }}
             TARGETALLOCATOR_VERSION=${{ env.TARGETALLOCATOR_VERSION }}
+            AUTO_INSTRUMENTATION_JAVA_VERSION=${{ env.AUTO_INSTRUMENTATION_JAVA_VERSION }}
+            AUTO_INSTRUMENTATION_NODEJS_VERSION=${{ env.AUTO_INSTRUMENTATION_NODEJS_VERSION }}
+            AUTO_INSTRUMENTATION_PYTHON_VERSION=${{ env. AUTO_INSTRUMENTATION_PYTHON_VERSION }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Fixes:

```
docker run --rm -it  ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.41.0                                                                                         ploffay@fedora
{"level":"info","ts":1640160584.5407813,"msg":"Starting the OpenTelemetry Operator","opentelemetry-operator":"0.41.0","opentelemetry-collector":"otel/opentelemetry-collector:0.41.0","opentelemetry-targetallocator":"quay.io/opentelemetry/target-allocator:0.1.0","auto-instrumentation-java":"ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:0.0.0","build-date":"2021-12-10T16:30:10Z","go-version":"go1.17.5","go-arch":"amd64","go-os":"linux"}
{"level":"error","ts":1640160584.5411556,"logger":"controller-runtime.client.config","msg":"unable to get kubeconfig","error":"invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable","errorCauses":[{"error":"no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}],"stacktrace":"sigs.k8s.io/controller-runtime/pkg/client/config.GetConfigOrDie\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.6/pkg/client/config/config.go:153\nmain.main\n\t/workspace/main.go:103\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:255"}
```

mind:` "auto-instrumentation-java":"ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:0.0.0`

The CI works on the main branch because it is building images via `make` not via the GHA.