### PR TITLE
Parse flags before using them in config

### DIFF
--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/spf13/pflag"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/version"
@@ -83,18 +82,6 @@ func New(opts ...Option) Config {
 		autoInstrumentationNodeJSImage: o.autoInstrumentationNodeJSImage,
 		autoInstrumentationPythonImage: o.autoInstrumentationPythonImage,
 	}
-}
-
-// FlagSet binds the flags to the user-modifiable values of the operator's configuration.
-func (c *Config) FlagSet() *pflag.FlagSet {
-	fs := pflag.NewFlagSet("opentelemetry-operator", pflag.ExitOnError)
-	pflag.StringVar(&c.collectorImage,
-		"otelcol-image",
-		c.collectorImage,
-		"The default image to use for OpenTelemetry Collector when not specified in the individual custom resource (CR)",
-	)
-
-	return fs
 }
 
 // StartAutoDetect attempts to automatically detect relevant information for this operator. This will block until the first

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func main() {
 	pflag.StringVar(&autoInstrumentationJava, "auto-instrumentation-java-image", fmt.Sprintf("ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:%s", v.AutoInstrumentationJava), "The default OpenTelemetry Java instrumentation image. This image is used when no image is specified in the CustomResource.")
 	pflag.StringVar(&autoInstrumentationNodeJS, "auto-instrumentation-nodejs-image", fmt.Sprintf("ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:%s", v.AutoInstrumentationNodeJS), "The default OpenTelemetry NodeJS instrumentation image. This image is used when no image is specified in the CustomResource.")
 	pflag.StringVar(&autoInstrumentationPython, "auto-instrumentation-python-image", fmt.Sprintf("ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:%s", v.AutoInstrumentationPython), "The default OpenTelemetry Python instrumentation image. This image is used when no image is specified in the CustomResource.")
+	pflag.Parse()
 
 	logger := zap.New(zap.UseFlagOptions(&opts))
 	ctrl.SetLogger(logger)
@@ -125,10 +126,6 @@ func main() {
 		config.WithAutoInstrumentationPythonImage(autoInstrumentationPython),
 		config.WithAutoDetect(ad),
 	)
-
-	pflag.CommandLine.AddFlagSet(cfg.FlagSet())
-
-	pflag.Parse()
 
 	watchNamespace, found := os.LookupEnv("WATCH_NAMESPACE")
 	if found {


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

`pflag.Parse()` Should be called before we use the arguments to initialize the config structure. If not, the variables won't contain the argument values, and the operator won't honor the argument values.

Also, removed the config flags, as this is not used anymore since this PR https://github.com/open-telemetry/opentelemetry-operator/pull/449 migrated the flags to `main.go`