### PR TITLE
[WIP] auto-instrumentation: Allow per container control

### DIFF
--- a/pkg/instrumentation/javaagent.go
+++ b/pkg/instrumentation/javaagent.go
@@ -15,6 +15,9 @@
 package instrumentation
 
 import (
+	"path"
+	"strings"
+
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
@@ -22,13 +25,58 @@ import (
 )
 
 const (
-	envJavaToolsOptions = "JAVA_TOOL_OPTIONS"
-	javaJVMArgument     = " -javaagent:/otel-auto-instrumentation/javaagent.jar"
+	envJavaToolsOptions          = "JAVA_TOOL_OPTIONS"
+	annotationJavaContainerNames = "instrumentation.opentelemetry.io/inject-java-container-names"
+	javaInitContainerName        = initContainerName + "-java"
+	javaVolumeName               = volumeName + "-java"
+	javaMountPath                = "/" + javaVolumeName
 )
 
+var javaJVMArgument = " -javaagent:" + path.Join(javaMountPath, "javaagent.jar")
+
 func injectJavaagent(logger logr.Logger, javaSpec v1alpha1.Java, pod corev1.Pod) corev1.Pod {
-	// caller checks if there is at least one container
-	container := &pod.Spec.Containers[0]
+
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: javaVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		}})
+
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
+		Name:    javaInitContainerName,
+		Image:   javaSpec.Image,
+		Command: []string{"cp", "/javaagent.jar", path.Join(javaMountPath, "javaagent.jar")},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      javaVolumeName,
+			MountPath: javaMountPath,
+		}},
+	})
+
+	filter := make(map[string]bool)
+	if val, ok := pod.Annotations[annotationJavaContainerNames]; ok {
+		names := strings.Split(val, ",")
+		//Go has no sets, but this structure helps avoid quadratic filter time
+		for _, name := range names {
+			name = strings.TrimSpace(name)
+			filter[name] = true
+		}
+	} else {
+		//Default to injecting into the first container
+		filter[pod.Spec.Containers[0].Name] = true
+	}
+
+	for idx, container := range pod.Spec.Containers {
+		if _, ok := filter[container.Name]; ok {
+			pod.Spec.Containers[idx] = injectJavaagentIntoContainer(logger, javaSpec, container)
+		} else {
+			_ = idx
+		}
+	}
+
+	return pod
+}
+
+func injectJavaagentIntoContainer(logger logr.Logger, javaSpec v1alpha1.Java, container corev1.Container) corev1.Container {
 
 	// inject env vars
 	for _, env := range javaSpec.Env {
@@ -48,30 +96,14 @@ func injectJavaagent(logger logr.Logger, javaSpec v1alpha1.Java, pod corev1.Pod)
 		if container.Env[idx].ValueFrom != nil {
 			// TODO add to status object or submit it as an event
 			logger.Info("Skipping javaagent injection, the container defines JAVA_TOOL_OPTIONS env var value via ValueFrom", "container", container.Name)
-			return pod
+			return container
 		}
 		container.Env[idx].Value = container.Env[idx].Value + javaJVMArgument
 	}
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name:      volumeName,
-		MountPath: "/otel-auto-instrumentation",
+		Name:      javaVolumeName,
+		MountPath: javaMountPath,
 	})
 
-	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-		Name: volumeName,
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		}})
-
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
-		Name:    initContainerName,
-		Image:   javaSpec.Image,
-		Command: []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation/javaagent.jar"},
-		VolumeMounts: []corev1.VolumeMount{{
-			Name:      volumeName,
-			MountPath: "/otel-auto-instrumentation",
-		}},
-	})
-
-	return pod
+	return container
 }

--- a/pkg/instrumentation/javaagent_test.go
+++ b/pkg/instrumentation/javaagent_test.go
@@ -15,6 +15,7 @@
 package instrumentation
 
 import (
+	"path"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -45,7 +46,7 @@ func TestInjectJavaagent(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: volumeName,
+							Name: javaVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
@@ -53,12 +54,12 @@ func TestInjectJavaagent(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:    initContainerName,
+							Name:    javaInitContainerName,
 							Image:   "foo/bar:1",
-							Command: []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation/javaagent.jar"},
+							Command: []string{"cp", "/javaagent.jar", path.Join(javaMountPath, "javaagent.jar")},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      volumeName,
-								MountPath: "/otel-auto-instrumentation",
+								Name:      javaVolumeName,
+								MountPath: javaMountPath,
 							}},
 						},
 					},
@@ -66,8 +67,8 @@ func TestInjectJavaagent(t *testing.T) {
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      volumeName,
-									MountPath: "/otel-auto-instrumentation",
+									Name:      javaVolumeName,
+									MountPath: javaMountPath,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -102,7 +103,7 @@ func TestInjectJavaagent(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: volumeName,
+							Name: javaVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
@@ -110,12 +111,12 @@ func TestInjectJavaagent(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:    initContainerName,
+							Name:    javaInitContainerName,
 							Image:   "foo/bar:1",
-							Command: []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation/javaagent.jar"},
+							Command: []string{"cp", "/javaagent.jar", path.Join(javaMountPath, "javaagent.jar")},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      volumeName,
-								MountPath: "/otel-auto-instrumentation",
+								Name:      javaVolumeName,
+								MountPath: javaMountPath,
 							}},
 						},
 					},
@@ -123,8 +124,8 @@ func TestInjectJavaagent(t *testing.T) {
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      volumeName,
-									MountPath: "/otel-auto-instrumentation",
+									Name:      javaVolumeName,
+									MountPath: javaMountPath,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -157,6 +158,25 @@ func TestInjectJavaagent(t *testing.T) {
 			},
 			expected: corev1.Pod{
 				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: javaVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:    javaInitContainerName,
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "/javaagent.jar", path.Join(javaMountPath, "javaagent.jar")},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      javaVolumeName,
+								MountPath: javaMountPath,
+							}},
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Env: []corev1.EnvVar{

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -17,6 +17,7 @@ package instrumentation
 import (
 	"context"
 	"fmt"
+	"path"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -115,7 +116,7 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "opentelemetry-auto-instrumentation",
+							Name: javaVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
@@ -123,11 +124,11 @@ func TestMutatePod(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name:    initContainerName,
-							Command: []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation/javaagent.jar"},
+							Name:    javaInitContainerName,
+							Command: []string{"cp", "/javaagent.jar", path.Join(javaMountPath, "javaagent.jar")},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      volumeName,
-								MountPath: "/otel-auto-instrumentation",
+								Name:      javaVolumeName,
+								MountPath: javaMountPath,
 							}},
 						},
 					},
@@ -194,8 +195,8 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "opentelemetry-auto-instrumentation",
-									MountPath: "/otel-auto-instrumentation",
+									Name:      javaVolumeName,
+									MountPath: javaMountPath,
 								},
 							},
 						},

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -404,7 +405,7 @@ func TestInjectJava(t *testing.T) {
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
 				{
-					Name: volumeName,
+					Name: javaVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
@@ -412,12 +413,12 @@ func TestInjectJava(t *testing.T) {
 			},
 			InitContainers: []corev1.Container{
 				{
-					Name:    initContainerName,
+					Name:    javaInitContainerName,
 					Image:   "img:1",
-					Command: []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation/javaagent.jar"},
+					Command: []string{"cp", "/javaagent.jar", path.Join(javaMountPath, "javaagent.jar")},
 					VolumeMounts: []corev1.VolumeMount{{
-						Name:      volumeName,
-						MountPath: "/otel-auto-instrumentation",
+						Name:      javaVolumeName,
+						MountPath: javaMountPath,
 					}},
 				},
 			},
@@ -426,8 +427,8 @@ func TestInjectJava(t *testing.T) {
 					Name: "app",
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      volumeName,
-							MountPath: "/otel-auto-instrumentation",
+							Name:      javaVolumeName,
+							MountPath: javaMountPath,
 						},
 					},
 					Env: []corev1.EnvVar{


### PR DESCRIPTION
NOTE:  Due to the changes in injection behaviour I have only included the javaagent changes for early review. If the java changes are greenlit, I will add python and nodejs accordingly

fixes #618
fixes #529

Currently, it is only possible to inject a single autoinstrumentation
per pod and it will always be injected into the first container and
first container only. This is especially troublesome if a mutating
webhook will be injecting additional sidecars (e.g. Istio) which will
often receive the instrumentation instead of the main container.
Furthermore, for multi-container, multi-language pods only one container
can currently be auto-instrumented.

This commit introduces a new set of annotations of the form
`instrumentation.opentelemetry.io/inject-<language>-container-names`,
which tells the operator which containers should receive which language
instrumentation. The value of the annotation should be a comma-delimited
list of container-names to inject into. If the annotation is not
present, injection will use the default container-selection (currently
first container). The annotation will be ignored if the corresponding
language annotation `instrumentation.opentelemetry.io/inject-<language>`
is not present or set to enable instrumentation for `<language>`.

Note: It is now possible that instrumentation for multiple languages
needs to be prepared for the same pod. To avoid clashes, the volumes,
volume mount paths and initContainers for each language have been
postfixed with `-<language>`. Furthermore, to avoid ballooning the
injection logic complexity, the initContainer and volume for a language
will always be added to the Pod as long as injection for that language
is enabled, even if the injection into every container fails.
Previously, with only one language and one container to inject the
operator would only inject the volume and initContainer if the container
could successfully be modified.

Signed-off-by: Joel Pepper <pepper@bronze-deer.de>