### PR TITLE
Match pod `dnsPolicy` to `hostNetwork` config

### DIFF
--- a/pkg/collector/daemonset.go
+++ b/pkg/collector/daemonset.go
@@ -32,10 +32,6 @@ func DaemonSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 
 	annotations := Annotations(otelcol)
 	podAnnotations := PodAnnotations(otelcol)
-	dnsPolicy := corev1.DNSClusterFirst
-	if otelcol.Spec.HostNetwork {
-		dnsPolicy = corev1.DNSClusterFirstWithHostNet
-	}
 	return appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        naming.Collector(otelcol),
@@ -58,7 +54,7 @@ func DaemonSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 					Volumes:            Volumes(cfg, otelcol),
 					Tolerations:        otelcol.Spec.Tolerations,
 					HostNetwork:        otelcol.Spec.HostNetwork,
-					DNSPolicy:          dnsPolicy,
+					DNSPolicy:          getDnsPolicy(otelcol),
 					SecurityContext:    otelcol.Spec.PodSecurityContext,
 				},
 			},

--- a/pkg/collector/daemonset.go
+++ b/pkg/collector/daemonset.go
@@ -32,7 +32,10 @@ func DaemonSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 
 	annotations := Annotations(otelcol)
 	podAnnotations := PodAnnotations(otelcol)
-
+	dnsPolicy := corev1.DNSClusterFirst
+	if otelcol.Spec.HostNetwork {
+		dnsPolicy = corev1.DNSClusterFirstWithHostNet
+	}
 	return appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        naming.Collector(otelcol),
@@ -55,6 +58,7 @@ func DaemonSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 					Volumes:            Volumes(cfg, otelcol),
 					Tolerations:        otelcol.Spec.Tolerations,
 					HostNetwork:        otelcol.Spec.HostNetwork,
+					DNSPolicy:          dnsPolicy,
 					SecurityContext:    otelcol.Spec.PodSecurityContext,
 				},
 			},

--- a/pkg/collector/daemonset_test.go
+++ b/pkg/collector/daemonset_test.go
@@ -67,6 +67,7 @@ func TestDaemonsetHostNetwork(t *testing.T) {
 		Spec: v1alpha1.OpenTelemetryCollectorSpec{},
 	})
 	assert.False(t, d1.Spec.Template.Spec.HostNetwork)
+	assert.Equal(t, d1.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirst)
 
 	// verify custom
 	d2 := DaemonSet(config.New(), logger, v1alpha1.OpenTelemetryCollector{
@@ -75,6 +76,7 @@ func TestDaemonsetHostNetwork(t *testing.T) {
 		},
 	})
 	assert.True(t, d2.Spec.Template.Spec.HostNetwork)
+	assert.Equal(t, d2.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirstWithHostNet)
 }
 
 func TestDaemonsetPodAnnotations(t *testing.T) {

--- a/pkg/collector/deployment.go
+++ b/pkg/collector/deployment.go
@@ -55,6 +55,7 @@ func Deployment(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTele
 					Containers:         []corev1.Container{Container(cfg, logger, otelcol)},
 					Volumes:            Volumes(cfg, otelcol),
 					DNSPolicy:          getDnsPolicy(otelcol),
+					HostNetwork:        otelcol.Spec.HostNetwork,
 					Tolerations:        otelcol.Spec.Tolerations,
 					SecurityContext:    otelcol.Spec.PodSecurityContext,
 				},

--- a/pkg/collector/deployment.go
+++ b/pkg/collector/deployment.go
@@ -54,6 +54,7 @@ func Deployment(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTele
 					ServiceAccountName: ServiceAccountName(otelcol),
 					Containers:         []corev1.Container{Container(cfg, logger, otelcol)},
 					Volumes:            Volumes(cfg, otelcol),
+					DNSPolicy:          getDnsPolicy(otelcol),
 					Tolerations:        otelcol.Spec.Tolerations,
 					SecurityContext:    otelcol.Spec.PodSecurityContext,
 				},

--- a/pkg/collector/deployment_test.go
+++ b/pkg/collector/deployment_test.go
@@ -119,3 +119,35 @@ func TestDeploymenttPodSecurityContext(t *testing.T) {
 	assert.Equal(t, &runAsUser, d.Spec.Template.Spec.SecurityContext.RunAsUser)
 	assert.Equal(t, &runasGroup, d.Spec.Template.Spec.SecurityContext.RunAsGroup)
 }
+
+func TestDeploymentHostNetwork(t *testing.T) {
+	// Test default
+	otelcol_1 := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-instance",
+		},
+	}
+
+	cfg := config.New()
+
+	d1 := Deployment(cfg, logger, otelcol_1)
+
+	assert.Equal(t, d1.Spec.Template.Spec.HostNetwork, false)
+	assert.Equal(t, d1.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirst)
+
+	// Test hostNetwork=true
+	otelcol_2 := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-instance-hostnetwork",
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			HostNetwork: true,
+		},
+	}
+
+	cfg = config.New()
+
+	d2 := Deployment(cfg, logger, otelcol_2)
+	assert.Equal(t, d2.Spec.Template.Spec.HostNetwork, true)
+	assert.Equal(t, d2.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirstWithHostNet)
+}

--- a/pkg/collector/statefulset.go
+++ b/pkg/collector/statefulset.go
@@ -54,6 +54,7 @@ func StatefulSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTel
 					ServiceAccountName: ServiceAccountName(otelcol),
 					Containers:         []corev1.Container{Container(cfg, logger, otelcol)},
 					Volumes:            Volumes(cfg, otelcol),
+					DNSPolicy:          getDnsPolicy(otelcol),
 					Tolerations:        otelcol.Spec.Tolerations,
 					SecurityContext:    otelcol.Spec.PodSecurityContext,
 				},

--- a/pkg/collector/statefulset.go
+++ b/pkg/collector/statefulset.go
@@ -55,6 +55,7 @@ func StatefulSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTel
 					Containers:         []corev1.Container{Container(cfg, logger, otelcol)},
 					Volumes:            Volumes(cfg, otelcol),
 					DNSPolicy:          getDnsPolicy(otelcol),
+					HostNetwork:        otelcol.Spec.HostNetwork,
 					Tolerations:        otelcol.Spec.Tolerations,
 					SecurityContext:    otelcol.Spec.PodSecurityContext,
 				},

--- a/pkg/collector/statefulset_test.go
+++ b/pkg/collector/statefulset_test.go
@@ -178,3 +178,35 @@ func TestStatefulSetPodSecurityContext(t *testing.T) {
 	assert.Equal(t, &runAsUser, d.Spec.Template.Spec.SecurityContext.RunAsUser)
 	assert.Equal(t, &runasGroup, d.Spec.Template.Spec.SecurityContext.RunAsGroup)
 }
+
+func TestStatefulSetHostNetwork(t *testing.T) {
+	// Test default
+	otelcol_1 := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-instance",
+		},
+	}
+
+	cfg := config.New()
+
+	d1 := StatefulSet(cfg, logger, otelcol_1)
+
+	assert.Equal(t, d1.Spec.Template.Spec.HostNetwork, false)
+	assert.Equal(t, d1.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirst)
+
+	// Test hostNetwork=true
+	otelcol_2 := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-instance-hostnetwork",
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			HostNetwork: true,
+		},
+	}
+
+	cfg = config.New()
+
+	d2 := StatefulSet(cfg, logger, otelcol_2)
+	assert.Equal(t, d2.Spec.Template.Spec.HostNetwork, true)
+	assert.Equal(t, d2.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirstWithHostNet)
+}

--- a/pkg/collector/utils.go
+++ b/pkg/collector/utils.go
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+)
+
+func getDnsPolicy(otelcol v1alpha1.OpenTelemetryCollector) corev1.DNSPolicy {
+	dnsPolicy := corev1.DNSClusterFirst
+	if otelcol.Spec.HostNetwork {
+		dnsPolicy = corev1.DNSClusterFirstWithHostNet
+	}
+	return dnsPolicy
+}


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-operator/issues/690

I added a simple check to make the pods' DNSPolicy matching the `hostNetwork` option