### PR TITLE
Make sure correct version of operator-sdk is always used

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -25,10 +25,6 @@ jobs:
     - name: "install kustomize"
       run: ./hack/install-kustomize.sh
 
-    - uses: jpkrohling/setup-operator-sdk@v1.1.0
-      with:
-        operator-sdk-version: v1.17.0
-
     - name: "basic checks"
       run: make ci
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,10 +21,6 @@ jobs:
     - name: "install kustomize"
       run: ./hack/install-kustomize.sh
 
-    - uses: jpkrohling/setup-operator-sdk@v1.1.0
-      with:
-        operator-sdk-version: v1.17.0
-
     - name: "generate release resources"
       run: make release-artifacts IMG_PREFIX="ghcr.io/open-telemetry/opentelemetry-operator"
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -39,9 +39,5 @@ jobs:
       - name: "wait until cluster is ready"
         run:  kubectl wait --timeout=5m --for=condition=available deployment/coredns -n kube-system
 
-      - uses: jpkrohling/setup-operator-sdk@v1.1.0
-        with:
-          operator-sdk-version: v1.17.0
-
       - name: "run scorecard test"
         run: make scorecard-tests

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ endif
 KUBE_VERSION ?= 1.21
 KIND_CONFIG ?= kind-$(KUBE_VERSION).yaml
 
+OPERATOR_SDK_VERSION ?= 1.17.0
+
 CERTMANAGER_VERSION ?= 1.6.1
 
 ifndef ignore-not-found
@@ -263,20 +265,14 @@ else
 KIND=$(shell which kind)
 endif
 
+OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
 .PHONY: operator-sdk
 operator-sdk:
-ifeq (, $(shell which operator-sdk))
 	@{ \
 	set -e ;\
-	echo "" ;\
-	echo "ERROR: operator-sdk not found." ;\
-	echo "Please check https://sdk.operatorframework.io for installation instructions and try again." ;\
-	echo "" ;\
-	exit 1 ;\
+	curl -L -o $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_`go env GOOS`_`go env GOARCH`;\
+	chmod +x $(OPERATOR_SDK) ;\
 	}
-else
-OPERATOR_SDK=$(shell which operator-sdk)
-endif
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ prepare-e2e: kuttl set-test-image-vars set-image-controller container start-kind
 	$(KUSTOMIZE) build config/crd -o tests/_build/crds/
 
 .PHONY: scorecard-tests
-scorecard-tests:
+scorecard-tests: operator-sdk
 	$(OPERATOR_SDK) scorecard -w=5m bundle || (echo "scorecard test failed" && exit 1)
 
 .PHONY: set-test-image-vars

--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,7 @@ OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
 operator-sdk:
 	@{ \
 	set -e ;\
+	[ -d bin ] || mkdir bin ;\
 	curl -L -o $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_`go env GOOS`_`go env GOARCH`;\
 	chmod +x $(OPERATOR_SDK) ;\
 	}


### PR DESCRIPTION
This PR installs operator-sdk to ./bin which makes sure
that always correct version of operator-sdk is used.


This should solve issues like https://github.com/open-telemetry/opentelemetry-operator/pull/719#discussion_r810917431


Signed-off-by: Pavol Loffay <p.loffay@gmail.com>