### PR TITLE
Bump default java auto-instrumentation version to 1.11.1

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -12,7 +12,7 @@ targetallocator=0.1.0
 
 # Represents the current release of Java instrumentation.
 # Should match autoinstrumentation/java/version.txt
-autoinstrumentation-java=1.10.1
+autoinstrumentation-java=1.11.1
 
 # Represents the current release of NodeJS instrumentation.
 # Should match value in autoinstrumentation/nodejs/package.json


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>