### PR TITLE
Deprecate otelcol status messages

### DIFF
--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -138,6 +138,7 @@ type OpenTelemetryCollectorStatus struct {
 	// Messages about actions performed by the operator on this resource.
 	// +optional
 	// +listType=atomic
+	// Deprecated: use Kubernetes events instead.
 	Messages []string `json:"messages,omitempty"`
 }
 

--- a/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -2555,8 +2555,8 @@ spec:
               OpenTelemetryCollector.
             properties:
               messages:
-                description: Messages about actions performed by the operator on this
-                  resource.
+                description: 'Messages about actions performed by the operator on
+                  this resource. Deprecated: use Kubernetes events instead.'
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -2553,8 +2553,8 @@ spec:
               OpenTelemetryCollector.
             properties:
               messages:
-                description: Messages about actions performed by the operator on this
-                  resource.
+                description: 'Messages about actions performed by the operator on
+                  this resource. Deprecated: use Kubernetes events instead.'
                 items:
                   type: string
                 type: array

--- a/docs/api.md
+++ b/docs/api.md
@@ -6099,7 +6099,7 @@ OpenTelemetryCollectorStatus defines the observed state of OpenTelemetryCollecto
         <td><b>messages</b></td>
         <td>[]string</td>
         <td>
-          Messages about actions performed by the operator on this resource.<br/>
+          Messages about actions performed by the operator on this resource. Deprecated: use Kubernetes events instead.<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

This is follow-up after #707. It's better to inform users that status messages are not used anymore.