### PR TITLE
Support k8s 1.19 and higher

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       matrix:
        kube-version:
-       - "1.19" # long term support for OpenShift 4.6 based on k8s 1.19
-       - "1.21"
+       - "1.19"
        - "1.23"
 
     steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
        kube-version:
-       - "1.19"
+       - "1.19" # long term support for OpenShift 4.9 based on k8s 1.19
        - "1.21"
        - "1.23"
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
        kube-version:
-       - "1.19" # long term support for OpenShift 4.9 based on k8s 1.19
+       - "1.19" # long term support for OpenShift 4.6 based on k8s 1.19
        - "1.21"
        - "1.23"
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
+       # The e2e tests are run on the lowest and highest supported k8s version.
+       # All Kubernetes version in between expose the same APIs, hence the operator
+       # should be compatible with them.
        kube-version:
        - "1.19"
        - "1.23"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
        kube-version:
+       - "1.19"
        - "1.21"
-       - "1.22"
        - "1.23"
 
     steps:

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -14,9 +14,8 @@ jobs:
       matrix:
         kube-version:
           - "1.19"
-          - "1.20"
           - "1.21"
-          - "1.22"
+          - "1.23"
 
     steps:
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         kube-version:
-          - "1.19"
+          - "1.19" # long term support for OpenShift 4.9 based on k8s 1.19
           - "1.21"
           - "1.23"
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         kube-version:
-          - "1.19" # long term support for OpenShift 4.9 based on k8s 1.19
+          - "1.19" # long term support for OpenShift 4.6 based on k8s 1.19
           - "1.21"
           - "1.23"
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       matrix:
         kube-version:
-          - "1.19" # long term support for OpenShift 4.6 based on k8s 1.19
-          - "1.21"
+          - "1.19"
           - "1.23"
 
     steps:

--- a/README.md
+++ b/README.md
@@ -230,10 +230,6 @@ When a custom `Spec.Image` is used with an `OpenTelemetryCollector` resource, th
 
 We strive to be compatible with the widest range of Kubernetes versions as possible, but some changes to Kubernetes itself require us to break compatibility with older Kubernetes versions, be it because of code incompatibilities, or in the name of maintainability.
 
-Our promise is that we'll follow what's common practice in the Kubernetes world and support N-2 versions, based on the release date of the OpenTelemetry Operator.
-
-For instance, when we released v0.27.0, the latest Kubernetes version was v1.21.1. As such, the minimum version of Kubernetes we support for OpenTelemetry Operator v0.27.0 is v1.19 and we tested it with up to 1.21.
-
 We use `cert-manager` for some features of this operator and the third column shows the versions of the `cert-manager` that are known to work with this operator's versions.
 
 The OpenTelemetry Operator *might* work on versions outside of the given range, but when opening new issues, please make sure to test your scenario on a supported version.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ When a custom `Spec.Image` is used with an `OpenTelemetryCollector` resource, th
 
 ### OpenTelemetry Operator vs. Kubernetes vs. Cert Manager
 
-We strive to be compatible with the widest range of Kubernetes versions as possible, but some changes to Kubernetes itself require us to break compatibility with older Kubernetes versions, be it because of code incompatibilities, or in the name of maintainability.
+We strive to be compatible with the widest range of Kubernetes versions as possible, but some changes to Kubernetes itself require us to break compatibility with older Kubernetes versions, be it because of code incompatibilities, or in the name of maintainability. Every released operator will support a specific range of Kubernetes versions, to be determined at the latest during the release.
 
 We use `cert-manager` for some features of this operator and the third column shows the versions of the `cert-manager` that are known to work with this operator's versions.
 


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Resolves #734 


This PR changes CI to run tests on the lowest supported k8s version 1.19 and highest 1.23 

The PR essentially ensures that the operator is supported on a broader range of Kubernetes versions. We are committed to resource the support on k8s 1.19 and higher. 


The tests are run on 1.19 and the highest version, the versions in between does not have to be tested as there is no breaking change "in between". We are taking the same approach in other k8s operators. 