### PR TITLE
Fail CI if bundle.Dockerfile is not the same as generated one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ ensure-generate-is-noop: set-image-controller generate bundle
 	@git restore config/manager/kustomization.yaml
 	@git diff -s --exit-code api/v1alpha1/zz_generated.*.go || (echo "Build failed: a model has been changed but the generated resources aren't up to date. Run 'make generate' and update your PR." && exit 1)
 	@git diff -s --exit-code bundle config || (echo "Build failed: the bundle, config files has been changed but the generated bundle, config files aren't up to date. Run 'make bundle' and update your PR." && git diff && exit 1)
+	@git diff -s --exit-code bundle.Dockerfile || (echo "Build failed: the bundle.Dockerfile file has been changed. The file should be the same as generated one. Run 'make bundle' and update your PR." && git diff && exit 1)
 	@git diff -s --exit-code docs/api.md || (echo "Build failed: the api.md file has been changed but the generated api.md file isn't up to date. Run 'make api-docs' and update your PR." && git diff && exit 1)
 
 .PHONY: all


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Avoid issues like https://github.com/open-telemetry/opentelemetry-operator/pull/719#discussion_r812638158