### PR TITLE
Use default github token to publish the release

### DIFF
--- a/.ci/create-release-github.sh
+++ b/.ci/create-release-github.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 OPERATOR_VERSION=$(git describe --tags)
-echo "${GH_WRITE_TOKEN}" | gh auth login --with-token
 
 gh config set prompt disabled
 gh release create \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
 
     - name: "create the release in GitHub"
       env:
-        GH_WRITE_TOKEN: ${{ secrets.GH_WRITE_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ./.ci/create-release-github.sh
 
     - name: "refresh go proxy module info on release"


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Right now the release process is using @jpkrohling personal token (https://github.com/open-telemetry/opentelemetry-operator/releases). It works but it confused me that he actually explicitly created the release I was working on.

Using standard token should be preferred as we don't care about e.g. expiration. 