### PR TITLE
Change container image USER to UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-X $
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+USER 1002:1002
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Kubernetes requires USER to be UID in order to verify running as non root.
ref https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/security_context_others.go#L49[](https://github.com/kraman)