### PR TITLE
Bump scorecard version to 1.17.0 to align with operator-sdk version

### DIFF
--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -8,7 +8,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.17.0
     labels:
       suite: basic
       test: basic-check-spec-test
@@ -18,7 +18,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.17.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -28,7 +28,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.17.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -38,7 +38,7 @@ stages:
   - entrypoint:
     - scorecard-test
     - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.17.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.17.0
     labels:
       suite: basic
       test: basic-check-spec-test

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -4,7 +4,7 @@
     entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.17.0
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -14,7 +14,7 @@
     entrypoint:
     - scorecard-test
     - olm-crds-have-validation
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.17.0
     labels:
       suite: olm
       test: olm-crds-have-validation-test
@@ -24,7 +24,7 @@
     entrypoint:
       - scorecard-test
       - olm-crds-have-resources
-    image: quay.io/operator-framework/scorecard-test:v1.13.1
+    image: quay.io/operator-framework/scorecard-test:v1.17.0
     labels:
       suite: olm
       test: olm-crds-have-resources-test


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

This should have been done as part of the bump operator-sdk version. 