### PR TITLE
Remove tigrannajaryan as a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,14 +267,22 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Approvers ([@open-telemetry/operator-approvers](https://github.com/orgs/open-telemetry/teams/operator-approvers)):
 
-- [@open-telemetry/collector-approvers](https://github.com/orgs/open-telemetry/teams/collector-approvers)
+- [Anthony Mirabella](https://github.com/Aneurysm9), AWS
+- [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
+- [Jay Camp](https://github.com/jrcamp), Splunk
+- [James Bebbington](https://github.com/james-bebbington), Google
+- [Owais Lone](https://github.com/owais), Splunk
+- [Pablo Baeyens](https://github.com/mx-psi), DataDog
 
 Maintainers ([@open-telemetry/operator-maintainers](https://github.com/orgs/open-telemetry/teams/operator-maintainers)):
 
-- [@open-telemetry/collector-maintainers](https://github.com/orgs/open-telemetry/teams/collector-maintainers)
+- [Alex Boten](https://github.com/codeboten), Lightstep
 - [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs
 - [Pavol Loffay](https://github.com/pavolloffay), Red Hat
 - [Vineeth Pothulapati](https://github.com/VineethReddy02), Timescale
+
+Emeritus Maintainers
+- [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
 
 Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Approvers ([@open-telemetry/operator-approvers](https://github.com/orgs/open-tel
 Maintainers ([@open-telemetry/operator-maintainers](https://github.com/orgs/open-telemetry/teams/operator-maintainers)):
 
 - [Alex Boten](https://github.com/codeboten), Lightstep
+- [Bogdan Drutu](https://github.com/BogdanDrutu), Splunk
 - [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs
 - [Pavol Loffay](https://github.com/pavolloffay), Red Hat
 - [Vineeth Pothulapati](https://github.com/VineethReddy02), Timescale


### PR DESCRIPTION
I am no longer able to allocate time to be a maintainer of the operator
due to focusing on other parts of OpenTelemetry.

I am moving myself to the Emeritus section according to the rules introduced in
https://github.com/open-telemetry/community/pull/961

I have also listed approvers and maintainers directly in the README, like we
do in the Collector repos. I will also remove Collector github teams' permissions
from this repo since we have github teams for operator to avoid confusion as to
who has what permissions.