### PR TITLE
Fix publishing main docker tag for operator image

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -39,6 +39,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1.2.0


### PR DESCRIPTION
Latest publish builds are failing  https://github.com/open-telemetry/opentelemetry-operator/runs/5388522267?check_suite_focus=true#step:6:28

This PR should fix it and publish the `main` tag

Signed-off-by: Pavol Loffay <p.loffay@gmail.com>