### PR TITLE
chore(nodejs): bump auto-instrumentations

### DIFF
--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "1.0.4",
-    "@opentelemetry/auto-instrumentations-node": "0.27.2",
+    "@opentelemetry/auto-instrumentations-node": "0.27.4",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.27.0",
     "@opentelemetry/sdk-node": "0.27.0"
   }


### PR DESCRIPTION
Bump NodeJS auto-instrumentation packages - [changes](https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-node-v0.27.4)