### PR TITLE
Remove v prefix from the container image version/tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LD_FLAGS ?= "-X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.buildDate=${
 # Image URL to use all building/pushing image targets
 IMG_PREFIX ?= ghcr.io/${USER}/opentelemetry-operator
 IMG_REPO ?= opentelemetry-operator
-IMG ?= ${IMG_PREFIX}/${IMG_REPO}:$(addprefix v,${VERSION})
+IMG ?= ${IMG_PREFIX}/${IMG_REPO}:${VERSION}
 BUNDLE_IMG ?= ${IMG_PREFIX}/${IMG_REPO}-bundle:${VERSION}
 
 # Options for 'bundle-build'

--- a/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -297,7 +297,7 @@ spec:
               - args:
                 - --metrics-addr=127.0.0.1:8080
                 - --enable-leader-election
-                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:v0.46.0
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.46.0
                 livenessProbe:
                   httpGet:
                     path: /healthz


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

All other OTEL images are published as `X.Y.Z` (without `v` prefix).  

The operator image is already published without prefix - https://github.com/open-telemetry/opentelemetry-operator/pkgs/container/opentelemetry-operator%2Fopentelemetry-operator 


@jpkrohling is there any reason why the operator image has `v` prefix? 