### PR TITLE
fix panic when spec.replicas is nil

### DIFF
--- a/pkg/collector/reconcile/deployment.go
+++ b/pkg/collector/reconcile/deployment.go
@@ -103,7 +103,7 @@ func expectedDeployments(ctx context.Context, params Params, expected []appsv1.D
 			currentReplicas := existing.Status.Replicas
 			// if replicas (minReplicas from HPA perspective) is bigger than
 			// current status use it.
-			if *params.Instance.Spec.Replicas > currentReplicas {
+			if params.Instance.Spec.Replicas != nil && *params.Instance.Spec.Replicas > currentReplicas {
 				currentReplicas = *params.Instance.Spec.Replicas
 			}
 			updated.Spec.Replicas = &currentReplicas


### PR DESCRIPTION
Resolves #803 


Since the spec.replicas in [docs](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollectorspec) is not required, so it may be nil.
Need check whether replicas is nil before get value of it.
![image](https://user-images.githubusercontent.com/17737823/160126594-085837f5-b287-483e-b5df-690fba1f11e8.png)
