### PR TITLE
Create serving certs for headless services on OpenShift (#818)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The `config` node holds the `YAML` that should be passed down as-is to the under
 
 At this point, the Operator does *not* validate the contents of the configuration file: if the configuration is invalid, the instance will still be created but the underlying OpenTelemetry Collector might crash.
 
+The Operator does examine the configuration file to discover configured receivers and their ports. If it finds receivers with ports, it creates a pair of kubernetes services, one headless, exposing those ports within the cluster. The headless service contains a `service.beta.openshift.io/serving-cert-secret-name` annotation that will cause OpenShift to create a secret containing a certificate and key. This secret can be mounted as a volume and the certificate and key used in those receivers' TLS configurations.
+
 
 ### Upgrades
 

--- a/pkg/collector/reconcile/service.go
+++ b/pkg/collector/reconcile/service.go
@@ -158,6 +158,16 @@ func headless(ctx context.Context, params Params) *corev1.Service {
 	}
 
 	h.Name = naming.HeadlessService(params.Instance)
+
+	// copy to avoid modifying params.Instance.Annotations
+	annotations := map[string]string{
+		"service.beta.openshift.io/serving-cert-secret-name": fmt.Sprintf("%s-tls", h.Name),
+	}
+	for k, v := range h.Annotations {
+		annotations[k] = v
+	}
+	h.Annotations = annotations
+
 	h.Spec.ClusterIP = "None"
 	return h
 }

--- a/pkg/collector/reconcile/service_test.go
+++ b/pkg/collector/reconcile/service_test.go
@@ -196,6 +196,7 @@ func TestDeleteServices(t *testing.T) {
 func TestHeadlessService(t *testing.T) {
 	t.Run("should return headless service", func(t *testing.T) {
 		actual := headless(context.Background(), params())
+		assert.Equal(t, actual.Annotations["service.beta.openshift.io/serving-cert-secret-name"], "test-collector-headless-tls")
 		assert.Equal(t, actual.Spec.ClusterIP, "None")
 	})
 }


### PR DESCRIPTION
resolves #818 

Signed-off-by: Robert Kukura <rkukura@redhat.com>