### PR TITLE
Add resource attributes to collector sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,9 +164,7 @@ spec:
 EOF
 ```
 
-When using sidecar mode the opentelemetry container will have the environment variable `OTEL_RESOURCE_ATTRIBUTES` set with some pod kubernetes attributes in the format `key=value,key2=value`, ready for be consumed by the resourcedetection processor.
-
-
+When using sidecar mode the OpenTelemetry collector container will have the environment variable `OTEL_RESOURCE_ATTRIBUTES`set with Kubernetes resource attributes, ready to be consumed by the [resourcedetection](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor) processor.
 
 ### OpenTelemetry auto-instrumentation injection
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ spec:
 EOF
 ```
 
+When using sidecar mode the opentelemetry container will have the environment variable `OTEL_RESOURCE_ATTRIBUTES` set with some pod kubernetes attributes in the format `key=value,key2=value`, ready for be consumed by the resourcedetection processor.
+
+
+
 ### OpenTelemetry auto-instrumentation injection
 
 The operator can inject and configure OpenTelemetry auto-instrumentation libraries. Currently Java, NodeJS and Python are supported.

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+const (
+	EnvOTELServiceName          = "OTEL_SERVICE_NAME"
+	EnvOTELExporterOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	EnvOTELResourceAttrs        = "OTEL_RESOURCE_ATTRIBUTES"
+	EnvOTELPropagators          = "OTEL_PROPAGATORS"
+	EnvOTELTracesSampler        = "OTEL_TRACES_SAMPLER"
+	EnvOTELTracesSamplerArg     = "OTEL_TRACES_SAMPLER_ARG"
+
+	EnvPodName  = "OTEL_RESOURCE_ATTRIBUTES_POD_NAME"
+	EnvPodUID   = "OTEL_RESOURCE_ATTRIBUTES_POD_UID"
+	EnvNodeName = "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME"
+)

--- a/pkg/sidecar/attributes.go
+++ b/pkg/sidecar/attributes.go
@@ -1,0 +1,105 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sidecar contains operations related to sidecar manipulation (Add, update, remove).
+package sidecar
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const resourceAttributesEnvName = "OTEL_RESOURCE_ATTRIBUTES"
+
+type podReferences struct {
+	replicaset *appsv1.ReplicaSet
+	deployment *appsv1.Deployment
+}
+
+// add resource attributes environment variables. and OTEL_RESOURCE_ATTRIBUTES if not exists.
+func getAttributesEnv(ns corev1.Namespace, podReferences podReferences) []corev1.EnvVar {
+
+	var envvars []corev1.EnvVar
+
+	attributes := map[string]string{
+		"k8s.pod.name":       "$(POD_NAME)",
+		"k8s.pod.uid":        "$(POD_UID)",
+		"k8s.node.name":      "$(NODE_NAME)",
+		"k8s.namespace.name": ns.Name,
+	}
+
+	if podReferences.deployment != nil {
+		attributes["k8s.deployment.uid"] = string(podReferences.deployment.UID)
+		attributes["k8s.deployment.name"] = string(podReferences.deployment.Name)
+	}
+
+	if podReferences.replicaset != nil {
+		attributes["k8s.replicaset.uid"] = string(podReferences.replicaset.UID)
+		attributes["k8s.replicaset.name"] = string(podReferences.replicaset.Name)
+	}
+
+	envvars = append(envvars, corev1.EnvVar{
+		Name: "NODE_NAME",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "spec.nodeName",
+			},
+		},
+	})
+
+	envvars = append(envvars, corev1.EnvVar{
+		Name: "POD_UID",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.uid",
+			},
+		},
+	})
+	envvars = append(envvars, corev1.EnvVar{
+		Name:  resourceAttributesEnvName,
+		Value: mapToValue(attributes),
+	})
+
+	return envvars
+}
+
+func mapToValue(attribues map[string]string) string {
+	var parts []string
+
+	// Sort it to make it predictable
+	keys := make([]string, 0, len(attribues))
+	for k := range attribues {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, attribues[key]))
+	}
+	return strings.Join(parts, ",")
+}
+
+// check if container doesn't have already the OTEL_RESOURCE_ATTRIBUTES, we don't want to override it if it's already specified.
+func hasResourceAttributeEnvVar(envvars []corev1.EnvVar) bool {
+	for _, env := range envvars {
+		if env.Name == resourceAttributesEnvName {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sidecar/attributes.go
+++ b/pkg/sidecar/attributes.go
@@ -20,11 +20,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 )
 
 const resourceAttributesEnvName = "OTEL_RESOURCE_ATTRIBUTES"

--- a/pkg/sidecar/attributes.go
+++ b/pkg/sidecar/attributes.go
@@ -34,9 +34,9 @@ type podReferences struct {
 	deployment *appsv1.Deployment
 }
 
-// getAttributesEnv returns a list of environment variables. The list contains OTEL_RESOURCE_ATTRIBUTES and additional environment variables that use Kubernetes downward API to read pod specification.
+// getResourceAttributesEnv returns a list of environment variables. The list contains OTEL_RESOURCE_ATTRIBUTES and additional environment variables that use Kubernetes downward API to read pod specification.
 // see: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-func getAttributesEnv(ns corev1.Namespace, podReferences podReferences) []corev1.EnvVar {
+func getResourceAttributesEnv(ns corev1.Namespace, podReferences podReferences) []corev1.EnvVar {
 
 	var envvars []corev1.EnvVar
 

--- a/pkg/sidecar/attributes.go
+++ b/pkg/sidecar/attributes.go
@@ -34,7 +34,7 @@ type podReferences struct {
 	deployment *appsv1.Deployment
 }
 
-// getAttributesEnv returns a list of environment variables. This consists of some pod fields and an environment variable OTEL_RESOURCE_ATTRIBUTES which contains a set of different pod references.
+// getAttributesEnv returns a list of environment variables. The list contains OTEL_RESOURCE_ATTRIBUTES and additional environment variables that use Kubernetes downward API to read pod specification.
 // see: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
 func getAttributesEnv(ns corev1.Namespace, podReferences podReferences) []corev1.EnvVar {
 

--- a/pkg/sidecar/attributes.go
+++ b/pkg/sidecar/attributes.go
@@ -31,7 +31,8 @@ type podReferences struct {
 	deployment *appsv1.Deployment
 }
 
-// add resource attributes environment variables. and OTEL_RESOURCE_ATTRIBUTES if not exists.
+// getAttributesEnv returns a list of environment variables. This consists of some pod fields and an environment variable OTEL_RESOURCE_ATTRIBUTES which contains a set of different pod references.
+// see: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
 func getAttributesEnv(ns corev1.Namespace, podReferences podReferences) []corev1.EnvVar {
 
 	var envvars []corev1.EnvVar

--- a/pkg/sidecar/attributes_test.go
+++ b/pkg/sidecar/attributes_test.go
@@ -1,0 +1,137 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sidecar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetAttributesEnvNoPodReferences(t *testing.T) {
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-ns",
+		},
+	}
+	references := podReferences{}
+	envs := getAttributesEnv(ns, references)
+
+	expectedEnv := []corev1.EnvVar{
+		{
+			Name: "NODE_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
+		{
+			Name: "POD_UID",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.uid",
+				},
+			},
+		},
+		{
+			Name:  resourceAttributesEnvName,
+			Value: "k8s.namespace.name=my-ns,k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID)",
+		},
+	}
+
+	assert.Equal(t, expectedEnv, envs)
+}
+
+func TestGetAttributesEnvWithPodReferences(t *testing.T) {
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-ns",
+		},
+	}
+	references := podReferences{
+		deployment: &appv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-deployment",
+				UID:  "uuid-dep",
+			},
+		},
+		replicaset: &appv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-replicaset",
+				UID:  "uuid-replicaset",
+			},
+		},
+	}
+	envs := getAttributesEnv(ns, references)
+
+	expectedEnv := []corev1.EnvVar{
+		{
+			Name: "NODE_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
+		{
+			Name: "POD_UID",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.uid",
+				},
+			},
+		},
+		{
+			Name:  resourceAttributesEnvName,
+			Value: "k8s.deployment.name=my-deployment,k8s.deployment.uid=uuid-dep,k8s.namespace.name=my-ns,k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),k8s.replicaset.name=my-replicaset,k8s.replicaset.uid=uuid-replicaset",
+		},
+	}
+
+	assert.Equal(t, expectedEnv, envs)
+}
+
+func TestHasResourceAttributeEnvVar(t *testing.T) {
+	for _, tt := range []struct {
+		desc     string
+		expected bool
+		env      []corev1.EnvVar
+	}{
+		{
+			"has-attributes", true, []corev1.EnvVar{
+				{
+					Name:  resourceAttributesEnvName,
+					Value: "k8s.namespace.name=my-ns,k8s.deployment.uid=uuid-dep,k8s.deployment.name=my-deployment,k8s.replicaset.uid=uuid-replicaset,k8s.replicaset.name=my-replicaset,k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),k8s.node.name=$(NODE_NAME)",
+				},
+			},
+		},
+
+		{
+			"does-not-have-attributes", false, []corev1.EnvVar{
+				{
+					Name:  "other_env",
+					Value: "other_value",
+				},
+			},
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			assert.Equal(t, tt.expected, hasResourceAttributeEnvVar(tt.env))
+		})
+	}
+}

--- a/pkg/sidecar/attributes_test.go
+++ b/pkg/sidecar/attributes_test.go
@@ -33,7 +33,7 @@ func TestGetAttributesEnvNoPodReferences(t *testing.T) {
 		},
 	}
 	references := podReferences{}
-	envs := getAttributesEnv(ns, references)
+	envs := getResourceAttributesEnv(ns, references)
 
 	expectedEnv := []corev1.EnvVar{
 		{
@@ -97,7 +97,7 @@ func TestGetAttributesEnvWithPodReferences(t *testing.T) {
 			},
 		},
 	}
-	envs := getAttributesEnv(ns, references)
+	envs := getResourceAttributesEnv(ns, references)
 
 	expectedEnv := []corev1.EnvVar{
 		{

--- a/pkg/sidecar/attributes_test.go
+++ b/pkg/sidecar/attributes_test.go
@@ -18,12 +18,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 )
 
 func TestGetAttributesEnvNoPodReferences(t *testing.T) {

--- a/pkg/sidecar/attributes_test.go
+++ b/pkg/sidecar/attributes_test.go
@@ -15,9 +15,11 @@
 package sidecar
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,8 +52,9 @@ func TestGetAttributesEnvNoPodReferences(t *testing.T) {
 			},
 		},
 		{
-			Name:  resourceAttributesEnvName,
-			Value: "k8s.namespace.name=my-ns,k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID)",
+			Name: resourceAttributesEnvName,
+			Value: fmt.Sprintf("%s=my-ns,%s=$(NODE_NAME),%s=$(POD_NAME),%s=$(POD_UID)",
+				semconv.K8SNamespaceNameKey, semconv.K8SNodeNameKey, semconv.K8SPodNameKey, semconv.K8SPodUIDKey),
 		},
 	}
 
@@ -98,8 +101,17 @@ func TestGetAttributesEnvWithPodReferences(t *testing.T) {
 			},
 		},
 		{
-			Name:  resourceAttributesEnvName,
-			Value: "k8s.deployment.name=my-deployment,k8s.deployment.uid=uuid-dep,k8s.namespace.name=my-ns,k8s.node.name=$(NODE_NAME),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),k8s.replicaset.name=my-replicaset,k8s.replicaset.uid=uuid-replicaset",
+			Name: resourceAttributesEnvName,
+			Value: fmt.Sprintf("%s=my-deployment,%s=uuid-dep,%s=my-ns,%s=$(NODE_NAME),%s=$(POD_NAME),%s=$(POD_UID),%s=my-replicaset,%s=uuid-replicaset",
+				semconv.K8SDeploymentNameKey,
+				semconv.K8SDeploymentUIDKey,
+				semconv.K8SNamespaceNameKey,
+				semconv.K8SNodeNameKey,
+				semconv.K8SPodNameKey,
+				semconv.K8SPodUIDKey,
+				semconv.K8SReplicaSetNameKey,
+				semconv.K8SReplicaSetUIDKey,
+			),
 		},
 	}
 
@@ -115,8 +127,17 @@ func TestHasResourceAttributeEnvVar(t *testing.T) {
 		{
 			"has-attributes", true, []corev1.EnvVar{
 				{
-					Name:  resourceAttributesEnvName,
-					Value: "k8s.namespace.name=my-ns,k8s.deployment.uid=uuid-dep,k8s.deployment.name=my-deployment,k8s.replicaset.uid=uuid-replicaset,k8s.replicaset.name=my-replicaset,k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID),k8s.node.name=$(NODE_NAME)",
+					Name: resourceAttributesEnvName,
+					Value: fmt.Sprintf("%s=my-deployment,%s=uuid-dep,%s=my-ns,%s=$(NODE_NAME),%s=$(POD_NAME),%s=$(POD_UID),%s=my-replicaset,%s=uuid-replicaset",
+						semconv.K8SDeploymentNameKey,
+						semconv.K8SDeploymentUIDKey,
+						semconv.K8SNamespaceNameKey,
+						semconv.K8SNodeNameKey,
+						semconv.K8SPodNameKey,
+						semconv.K8SPodUIDKey,
+						semconv.K8SReplicaSetNameKey,
+						semconv.K8SReplicaSetUIDKey,
+					),
 				},
 			},
 		},

--- a/pkg/sidecar/attributes_test.go
+++ b/pkg/sidecar/attributes_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 	"github.com/stretchr/testify/assert"
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	appv1 "k8s.io/api/apps/v1"
@@ -36,15 +37,15 @@ func TestGetAttributesEnvNoPodReferences(t *testing.T) {
 
 	expectedEnv := []corev1.EnvVar{
 		{
-			Name: "NODE_NAME",
+			Name: constants.EnvPodName,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "spec.nodeName",
+					FieldPath: "metadata.name",
 				},
 			},
 		},
 		{
-			Name: "POD_UID",
+			Name: constants.EnvPodUID,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "metadata.uid",
@@ -52,9 +53,24 @@ func TestGetAttributesEnvNoPodReferences(t *testing.T) {
 			},
 		},
 		{
+			Name: constants.EnvNodeName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
+		{
 			Name: resourceAttributesEnvName,
-			Value: fmt.Sprintf("%s=my-ns,%s=$(NODE_NAME),%s=$(POD_NAME),%s=$(POD_UID)",
-				semconv.K8SNamespaceNameKey, semconv.K8SNodeNameKey, semconv.K8SPodNameKey, semconv.K8SPodUIDKey),
+			Value: fmt.Sprintf("%s=my-ns,%s=$(%s),%s=$(%s),%s=$(%s)",
+				semconv.K8SNamespaceNameKey,
+				semconv.K8SNodeNameKey,
+				constants.EnvNodeName,
+				semconv.K8SPodNameKey,
+				constants.EnvPodName,
+				semconv.K8SPodUIDKey,
+				constants.EnvPodUID,
+			),
 		},
 	}
 
@@ -85,15 +101,15 @@ func TestGetAttributesEnvWithPodReferences(t *testing.T) {
 
 	expectedEnv := []corev1.EnvVar{
 		{
-			Name: "NODE_NAME",
+			Name: constants.EnvPodName,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
-					FieldPath: "spec.nodeName",
+					FieldPath: "metadata.name",
 				},
 			},
 		},
 		{
-			Name: "POD_UID",
+			Name: constants.EnvPodUID,
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "metadata.uid",
@@ -101,14 +117,25 @@ func TestGetAttributesEnvWithPodReferences(t *testing.T) {
 			},
 		},
 		{
+			Name: constants.EnvNodeName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
+		{
 			Name: resourceAttributesEnvName,
-			Value: fmt.Sprintf("%s=my-deployment,%s=uuid-dep,%s=my-ns,%s=$(NODE_NAME),%s=$(POD_NAME),%s=$(POD_UID),%s=my-replicaset,%s=uuid-replicaset",
+			Value: fmt.Sprintf("%s=my-deployment,%s=uuid-dep,%s=my-ns,%s=$(%s),%s=$(%s),%s=$(%s),%s=my-replicaset,%s=uuid-replicaset",
 				semconv.K8SDeploymentNameKey,
 				semconv.K8SDeploymentUIDKey,
 				semconv.K8SNamespaceNameKey,
 				semconv.K8SNodeNameKey,
+				constants.EnvNodeName,
 				semconv.K8SPodNameKey,
+				constants.EnvPodName,
 				semconv.K8SPodUIDKey,
+				constants.EnvPodUID,
 				semconv.K8SReplicaSetNameKey,
 				semconv.K8SReplicaSetUIDKey,
 			),
@@ -128,13 +155,16 @@ func TestHasResourceAttributeEnvVar(t *testing.T) {
 			"has-attributes", true, []corev1.EnvVar{
 				{
 					Name: resourceAttributesEnvName,
-					Value: fmt.Sprintf("%s=my-deployment,%s=uuid-dep,%s=my-ns,%s=$(NODE_NAME),%s=$(POD_NAME),%s=$(POD_UID),%s=my-replicaset,%s=uuid-replicaset",
+					Value: fmt.Sprintf("%s=my-deployment,%s=uuid-dep,%s=my-ns,%s=$(%s),%s=$(%s),%s=$(%s),%s=my-replicaset,%s=uuid-replicaset",
 						semconv.K8SDeploymentNameKey,
 						semconv.K8SDeploymentUIDKey,
 						semconv.K8SNamespaceNameKey,
 						semconv.K8SNodeNameKey,
+						constants.EnvNodeName,
 						semconv.K8SPodNameKey,
+						constants.EnvPodName,
 						semconv.K8SPodUIDKey,
+						constants.EnvPodUID,
 						semconv.K8SReplicaSetNameKey,
 						semconv.K8SReplicaSetUIDKey,
 					),

--- a/pkg/sidecar/pod.go
+++ b/pkg/sidecar/pod.go
@@ -32,10 +32,13 @@ const (
 )
 
 // add a new sidecar container to the given pod, based on the given OpenTelemetryCollector.
-func add(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector, pod corev1.Pod) (corev1.Pod, error) {
+func add(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector, pod corev1.Pod, attributes []corev1.EnvVar) (corev1.Pod, error) {
 	// add the container
 	volumes := collector.Volumes(cfg, otelcol)
 	container := collector.Container(cfg, logger, otelcol)
+	if !hasResourceAttributeEnvVar(container.Env) {
+		container.Env = append(container.Env, attributes...)
+	}
 	pod.Spec.Containers = append(pod.Spec.Containers, container)
 	pod.Spec.Volumes = append(pod.Spec.Volumes, volumes...)
 

--- a/pkg/sidecar/podmutator.go
+++ b/pkg/sidecar/podmutator.go
@@ -20,7 +20,9 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -68,7 +70,6 @@ func (p *sidecarPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod
 	}
 
 	// from this point and on, a sidecar is wanted
-
 	// check whether there's a sidecar already -- return the same pod if that's the case.
 	if existsIn(pod) {
 		logger.V(1).Info("pod already has sidecar in it, skipping injection")
@@ -88,10 +89,15 @@ func (p *sidecarPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod
 		return pod, err
 	}
 
+	// getting pod references, if any
+	references := p.podReferences(ctx, pod.OwnerReferences, ns)
+	attributes := getAttributesEnv(ns, references)
+
 	// once it's been determined that a sidecar is desired, none exists yet, and we know which instance it should talk to,
 	// we should add the sidecar.
 	logger.V(1).Info("injecting sidecar into pod", "otelcol-namespace", otelcol.Namespace, "otelcol-name", otelcol.Name)
-	return add(p.config, p.logger, otelcol, pod)
+
+	return add(p.config, p.logger, otelcol, pod, attributes)
 }
 
 func (p *sidecarPodMutator) getCollectorInstance(ctx context.Context, ns corev1.Namespace, ann string) (v1alpha1.OpenTelemetryCollector, error) {
@@ -137,4 +143,50 @@ func (p *sidecarPodMutator) selectCollectorInstance(ctx context.Context, ns core
 	default:
 		return sidecars[0], nil
 	}
+}
+
+func (p *sidecarPodMutator) podReferences(ctx context.Context, ownerReferences []metav1.OwnerReference, ns corev1.Namespace) podReferences {
+	references := &podReferences{}
+	replicaSet := p.getReplicaSetReference(ctx, ownerReferences, ns)
+	if replicaSet != nil {
+		references.replicaset = replicaSet
+		deployment := p.getDeploymentReference(ctx, replicaSet)
+		if deployment != nil {
+			references.deployment = deployment
+		}
+	}
+	return *references
+}
+
+func (p *sidecarPodMutator) getReplicaSetReference(ctx context.Context, ownerReferences []metav1.OwnerReference, ns corev1.Namespace) *appsv1.ReplicaSet {
+	replicaSetName := findOwnerReferenceKind(ownerReferences, "ReplicaSet")
+	if replicaSetName != "" {
+		replicaSet := &appsv1.ReplicaSet{}
+		err := p.client.Get(ctx, types.NamespacedName{Name: replicaSetName, Namespace: ns.Name}, replicaSet)
+		if err == nil {
+			return replicaSet
+		}
+	}
+	return nil
+}
+
+func (p *sidecarPodMutator) getDeploymentReference(ctx context.Context, replicaSet *appsv1.ReplicaSet) *appsv1.Deployment {
+	deploymentName := findOwnerReferenceKind(replicaSet.OwnerReferences, "Deployment")
+	if deploymentName != "" {
+		deployment := &appsv1.Deployment{}
+		err := p.client.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: replicaSet.Namespace}, deployment)
+		if err == nil {
+			return deployment
+		}
+	}
+	return nil
+}
+
+func findOwnerReferenceKind(references []metav1.OwnerReference, kind string) string {
+	for _, reference := range references {
+		if reference.Kind == kind {
+			return reference.Name
+		}
+	}
+	return ""
 }

--- a/pkg/sidecar/podmutator.go
+++ b/pkg/sidecar/podmutator.go
@@ -91,7 +91,7 @@ func (p *sidecarPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod
 
 	// getting pod references, if any
 	references := p.podReferences(ctx, pod.OwnerReferences, ns)
-	attributes := getAttributesEnv(ns, references)
+	attributes := getResourceAttributesEnv(ns, references)
 
 	// once it's been determined that a sidecar is desired, none exists yet, and we know which instance it should talk to,
 	// we should add the sidecar.

--- a/tests/e2e/smoke-sidecar/01-assert.yaml
+++ b/tests/e2e/smoke-sidecar/01-assert.yaml
@@ -9,5 +9,11 @@ spec:
   containers:
   - name: myapp
   - name: otc-container
+    env:
+    - name: POD_NAME
+    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+    - name: OTEL_RESOURCE_ATTRIBUTES_POD_UID
+    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+    - name: OTEL_RESOURCE_ATTRIBUTES
 status:
   phase: Running


### PR DESCRIPTION
This PR adds an env var `OTEL_RESOURCE_ATTRIBUTES` to the sidecar pod, this envvar contains the k8s attributes of the pod, this is to be used for example with the resource detector processor to attach k8s attributes to spans,logs and metrics.


Updates #573 

Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>