### PR TITLE
Update sidecar example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,7 @@ spec:
     receivers:
       jaeger:
         protocols:
-          grpc:
-      otlp:
-        protocols:
-          grpc:
-          http:
+          thrift_compact:
     processors:
 
     exporters:
@@ -102,7 +98,7 @@ spec:
     service:
       pipelines:
         traces:
-          receivers: [otlp, jaeger]
+          receivers: [jaeger]
           processors: []
           exporters: [logging]
 EOF


### PR DESCRIPTION
This PR updates the sidecar example in the README, as it does not work. It removes the unnecessary  `otlpreceiver` and changes the `jaegerreceiver` protocol to `thrift_compact` instead of `grpc`. This is also reflected in a PR on the `opentelemetry-helm-charts` repository, [183](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/183).