### PR TITLE
Fix Default Image Annotations

### DIFF
--- a/main.go
+++ b/main.go
@@ -258,7 +258,8 @@ func addDependencies(_ context.Context, mgr ctrl.Manager, cfg config.Config, v v
 		u := &instrumentationupgrade.InstrumentationUpgrade{
 			Logger:                ctrl.Log.WithName("instrumentation-upgrade"),
 			DefaultAutoInstJava:   cfg.AutoInstrumentationJavaImage(),
-			DefaultAutoInstNodeJS: cfg.AutoInstrumentationJavaImage(),
+			DefaultAutoInstNodeJS: cfg.AutoInstrumentationNodeJSImage(),
+			DefaultAutoInstPython: cfg.AutoInstrumentationPythonImage(),
 			Client:                mgr.GetClient(),
 		}
 		return u.ManagedInstances(c)


### PR DESCRIPTION
This addresses issue #841

The PR corrects the default instrumentation image names if no annotation is provided.  The previous behavior was that nodejs image would default to Java but now it should correctly fill in the Java, Nodejs, and Python images, if no annotation is provided.