### PR TITLE
Fix K8s attributes values in OTEL_RESOURCE_ATTRIBUTES env var

### DIFF
--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -186,6 +186,13 @@ func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alph
 		}
 	}
 
+	// Move OTEL_RESOURCE_ATTRIBUTES to last position.
+	// All used env vars as value have to be configured before
+	// to avoid incorrect attributes values.
+	idx = getIndexOfEnv(container.Env, constants.EnvOTELResourceAttrs)
+	envs := moveEnvToListEnd(container.Env, idx)
+	container.Env = envs
+
 	return pod
 }
 
@@ -320,4 +327,11 @@ func getIndexOfEnv(envs []corev1.EnvVar, name string) int {
 		}
 	}
 	return -1
+}
+
+func moveEnvToListEnd(envs []corev1.EnvVar, idx int) []corev1.EnvVar {
+	envToMove := envs[idx]
+	envs = append(envs[:idx], envs[idx+1:]...)
+	envs = append(envs, envToMove)
+	return envs
 }

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -172,10 +172,6 @@ func TestSDKInjection(t *testing.T) {
 									},
 								},
 								{
-									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.deployment.uid=depuid,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,k8s.replicaset.uid=rsuid",
-								},
-								{
 									Name:  "OTEL_PROPAGATORS",
 									Value: "b3,jaeger",
 								},
@@ -186,6 +182,10 @@ func TestSDKInjection(t *testing.T) {
 								{
 									Name:  "OTEL_TRACES_SAMPLER_ARG",
 									Value: "0.25",
+								},
+								{
+									Name:  "OTEL_RESOURCE_ATTRIBUTES",
+									Value: "k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.deployment.uid=depuid,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,k8s.replicaset.uid=rsuid",
 								},
 							},
 						},
@@ -230,16 +230,16 @@ func TestSDKInjection(t *testing.T) {
 									Value: "explicitly_set",
 								},
 								{
-									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "foo=bar,k8s.container.name=other,",
-								},
-								{
 									Name:  "OTEL_PROPAGATORS",
 									Value: "b3",
 								},
 								{
 									Name:  "OTEL_TRACES_SAMPLER",
 									Value: "always_on",
+								},
+								{
+									Name:  "OTEL_RESOURCE_ATTRIBUTES",
+									Value: "foo=bar,k8s.container.name=other,",
 								},
 							},
 						},
@@ -264,10 +264,6 @@ func TestSDKInjection(t *testing.T) {
 									Value: "explicitly_set",
 								},
 								{
-									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "foo=bar,k8s.container.name=other,fromcr=val,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app",
-								},
-								{
 									Name:  "OTEL_PROPAGATORS",
 									Value: "b3",
 								},
@@ -282,6 +278,10 @@ func TestSDKInjection(t *testing.T) {
 											FieldPath: "spec.nodeName",
 										},
 									},
+								},
+								{
+									Name:  "OTEL_RESOURCE_ATTRIBUTES",
+									Value: "foo=bar,k8s.container.name=other,fromcr=val,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app",
 								},
 							},
 						},

--- a/tests/e2e/instrumentation-java/01-assert.yaml
+++ b/tests/e2e/instrumentation-java/01-assert.yaml
@@ -34,9 +34,9 @@ spec:
       value: my-deployment-with-sidecar
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
     - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
-    - name: OTEL_RESOURCE_ATTRIBUTES
     - name: OTEL_PROPAGATORS
       value: jaeger,b3
+    - name: OTEL_RESOURCE_ATTRIBUTES
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
     - mountPath: /otel-auto-instrumentation

--- a/tests/e2e/instrumentation-nodejs/01-assert.yaml
+++ b/tests/e2e/instrumentation-nodejs/01-assert.yaml
@@ -30,9 +30,9 @@ spec:
       value: my-deployment-with-sidecar
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
     - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
-    - name: OTEL_RESOURCE_ATTRIBUTES
     - name: OTEL_PROPAGATORS
       value: jaeger,b3
+    - name: OTEL_RESOURCE_ATTRIBUTES
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
     - mountPath: /otel-auto-instrumentation

--- a/tests/e2e/instrumentation-python/01-assert.yaml
+++ b/tests/e2e/instrumentation-python/01-assert.yaml
@@ -30,9 +30,9 @@ spec:
       value: my-deployment-with-sidecar
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
     - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
-    - name: OTEL_RESOURCE_ATTRIBUTES
     - name: OTEL_PROPAGATORS
       value: jaeger,b3
+    - name: OTEL_RESOURCE_ATTRIBUTES
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
     - mountPath: /otel-auto-instrumentation


### PR DESCRIPTION
Move OTEL_RESOURCE_ATTRIBUTES to last position on env list.
When `OTEL_RESOURCE_ATTRIBUTES` environment variable uses other env vars as attributes value they have to be configured before. It is mandatory to set right order to avoid attributes with value pointing to the name of used environment variable instead of its value.

**Correct order of env vars**
```
env:
 - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
   valueFrom:
     fieldRef:
       fieldPath: spec.nodeName
 - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
   valueFrom:
     fieldRef:
       fieldPath: metadata.name
 - name: OTEL_RESOURCE_ATTRIBUTES
   value: k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)
```

This PR fixes: https://github.com/open-telemetry/opentelemetry-operator/issues/793