### PR TITLE
Documentation for container-names annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,16 +228,16 @@ For this, we will use the `instrumentation.opentelemetry.io/container-names` ann
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: my-deployment-with-sidecar
+  name: my-deployment-with-multiple-containers
 spec:
   selector:
     matchLabels:
-      app: my-pod-with-sidecar
+      app: my-pod-with-multiple-containers
   replicas: 1
   template:
     metadata:
       labels:
-        app: my-pod-with-sidecar
+        app: my-pod-with-multiple-containers
       annotations:
         instrumentation.opentelemetry.io/inject-java: "true"
         instrumentation.opentelemetry.io/container-names: "myapp,myapp2"

--- a/README.md
+++ b/README.md
@@ -222,15 +222,23 @@ In some cases (for example in the case of the injection of an Istio sidecar) it 
 
 For this, it is possible to fine-tune the pod(s) on which the injection will be carried out.
 
-For this, we will use the "instrumentation.opentelemetry.io/container-names" annotation for which we will indicate one or more pod names (.spec.containers.name) on which the injection must be made:
+For this, we will use the `instrumentation.opentelemetry.io/container-names` annotation for which we will indicate one or more pod names (`.spec.containers.name`) on which the injection must be made:
 
 ```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment-with-sidecar
+spec:
+  selector:
+    matchLabels:
+      app: my-pod-with-sidecar
+  replicas: 1
   template:
     metadata:
       labels:
         app: my-pod-with-sidecar
       annotations:
-        sidecar.opentelemetry.io/inject: "true"
         instrumentation.opentelemetry.io/inject-java: "true"
         instrumentation.opentelemetry.io/container-names: "myapp,myapp2"
     spec:
@@ -243,7 +251,7 @@ For this, we will use the "instrumentation.opentelemetry.io/container-names" ann
         image: myImage3
 ```
 
-In the above case, myapp and myapp2 containers will be instrumented, myapp3 will not.
+In the above case, `myapp` and `myapp2` containers will be instrumented, `myapp3` will not.
 
 #### Use customized or vendor instrumentation
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,36 @@ The possible values for the annotation can be
 * `"my-instrumentation"` - name of `Instrumentation` CR instance.
 * `"false"` - do not inject
 
+#### Multi-container pods
+
+If nothing else is specified, instrumentation is performed on the first container available in the pod spec.
+In some cases (for example in the case of the injection of an Istio sidecar) it becomes necessary to specify on which container(s) this injection must be performed.
+
+For this, it is possible to fine-tune the pod(s) on which the injection will be carried out.
+
+For this, we will use the "instrumentation.opentelemetry.io/container-names" annotation for which we will indicate one or more pod names (.spec.containers.name) on which the injection must be made:
+
+```yaml
+  template:
+    metadata:
+      labels:
+        app: my-pod-with-sidecar
+      annotations:
+        sidecar.opentelemetry.io/inject: "true"
+        instrumentation.opentelemetry.io/inject-java: "true"
+        instrumentation.opentelemetry.io/container-names: "myapp,myapp2"
+    spec:
+      containers:
+      - name: myapp
+        image: myImage1
+      - name: myapp2
+        image: myImage2
+      - name: myapp3
+        image: myImage3
+```
+
+In the above case, myapp and myapp2 containers will be instrumented, myapp3 will not.
+
 #### Use customized or vendor instrumentation
 
 By default, the operator uses upstream auto-instrumentation libraries. Custom auto-instrumentation can be configured by


### PR DESCRIPTION
@pavolloffay : missing documentation for multiple injection based on "instrumentation.opentelemetry.io/container-names"  #689