### PR TITLE
chore(e2e): use public target-allocator img

### DIFF
--- a/tests/e2e/smoke-targetallocator/02-install.yaml
+++ b/tests/e2e/smoke-targetallocator/02-install.yaml
@@ -6,7 +6,7 @@ spec:
   mode: statefulset
   targetAllocator:
     enabled: true
-    image: "local/opentelemetry-operator-targetallocator:e2e"
+    image: "ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.1.0"
   config: |
     receivers:
       jaeger:

--- a/tests/e2e/targetallocator-features/02-install.yaml
+++ b/tests/e2e/targetallocator-features/02-install.yaml
@@ -19,7 +19,7 @@ spec:
           storage: 1Gi
   targetAllocator:
     enabled: true
-    image: "local/opentelemetry-operator-targetallocator:e2e"
+    image: "ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:0.1.0"
     prometheusCR:
       enabled: true
   config: |


### PR DESCRIPTION
It fixes failing tests in the `opentelemetry-helm-charts` repository [gh-action](https://github.com/open-telemetry/opentelemetry-helm-charts/runs/6555387039?check_suite_focus=true#step:6:995)