### PR TITLE
Cross namespace instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ instrumentation.opentelemetry.io/inject-python: "true"
 
 The possible values for the annotation can be
 * `"true"` - inject and `Instrumentation` resource from the namespace.
-* `"my-instrumentation"` - name of `Instrumentation` CR instance.
+* `"my-instrumentation"` - name of `Instrumentation` CR instance in the current namespace.
+* `"my-other-namespace/my-instrumentation"` - name and namespace of `Instrumentation` CR instance in another namespace.
 * `"false"` - do not inject
 
 #### Multi-container pods

--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -118,8 +118,15 @@ func (pm *instPodMutator) getInstrumentationInstance(ctx context.Context, ns cor
 		return pm.selectInstrumentationInstanceFromNamespace(ctx, ns)
 	}
 
+	var instNamespacedName types.NamespacedName
+	if instNamespace, instName, namespaced := strings.Cut(instValue, "/"); namespaced {
+		instNamespacedName = types.NamespacedName{Name: instName, Namespace: instNamespace}
+	} else {
+		instNamespacedName = types.NamespacedName{Name: instValue, Namespace: ns.Name}
+	}
+
 	otelInst := &v1alpha1.Instrumentation{}
-	err := pm.Client.Get(ctx, types.NamespacedName{Name: instValue, Namespace: ns.Name}, otelInst)
+	err := pm.Client.Get(ctx, instNamespacedName, otelInst)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/instrumentation-java-other-ns/00-cleanup-other-ns.yaml
+++ b/tests/e2e/instrumentation-java-other-ns/00-cleanup-other-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Namespace
+  name: my-other-ns

--- a/tests/e2e/instrumentation-java-other-ns/00-install-collector.yaml
+++ b/tests/e2e/instrumentation-java-other-ns/00-install-collector.yaml
@@ -1,0 +1,23 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: sidecar
+spec:
+  mode: sidecar
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+
+    exporters:
+      logging:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [logging]

--- a/tests/e2e/instrumentation-java-other-ns/00-install-instrumentation.yaml
+++ b/tests/e2e/instrumentation-java-other-ns/00-install-instrumentation.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-other-ns
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: java
+  namespace: my-other-ns
+spec:
+  env:
+    - name: OTEL_TRACES_EXPORTER
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4317
+    - name: OTEL_EXPORTER_OTLP_TIMEOUT
+      value: "20"
+    - name: OTEL_TRACES_SAMPLER
+      value: parentbased_traceidratio
+    - name: OTEL_TRACES_SAMPLER_ARG
+      value: "0.85"
+    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
+      value: "true"
+  exporter:
+    endpoint: http://localhost:4317
+  propagators:
+    - jaeger
+    - b3
+  sampler:
+    type: parentbased_traceidratio
+    argument: "0.25"
+  java:
+    env:
+    - name: OTEL_JAVAAGENT_DEBUG
+      value: "true"
+    - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
+      value: "false"
+    - name: SPLUNK_PROFILER_ENABLED
+      value: "false"

--- a/tests/e2e/instrumentation-java-other-ns/01-assert.yaml
+++ b/tests/e2e/instrumentation-java-other-ns/01-assert.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    sidecar.opentelemetry.io/inject: "true"
+    instrumentation.opentelemetry.io/inject-java: "my-other-ns/java"
+  labels:
+    app: my-pod-with-sidecar
+spec:
+  containers:
+  - name: myapp
+    env:
+    - name: OTEL_JAVAAGENT_DEBUG
+      value: "true"
+    - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
+      value: "false"
+    - name: SPLUNK_PROFILER_ENABLED
+      value: "false"
+    - name: JAVA_TOOL_OPTIONS
+      value: " -javaagent:/otel-auto-instrumentation/javaagent.jar"
+    - name: OTEL_TRACES_EXPORTER
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4317
+    - name: OTEL_EXPORTER_OTLP_TIMEOUT
+      value: "20"
+    - name: OTEL_TRACES_SAMPLER
+      value: parentbased_traceidratio
+    - name: OTEL_TRACES_SAMPLER_ARG
+      value: "0.85"
+    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
+      value: "true"
+    - name: OTEL_SERVICE_NAME
+      value: my-deployment-with-sidecar
+    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+    - name: OTEL_PROPAGATORS
+      value: jaeger,b3
+    - name: OTEL_RESOURCE_ATTRIBUTES
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+    - mountPath: /otel-auto-instrumentation
+      name: opentelemetry-auto-instrumentation
+  - name: otc-container
+  initContainers:
+  - name: opentelemetry-auto-instrumentation
+status:
+  phase: Running

--- a/tests/e2e/instrumentation-java-other-ns/01-install-app.yaml
+++ b/tests/e2e/instrumentation-java-other-ns/01-install-app.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment-with-sidecar
+spec:
+  selector:
+    matchLabels:
+      app: my-pod-with-sidecar
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: my-pod-with-sidecar
+      annotations:
+        sidecar.opentelemetry.io/inject: "true"
+        instrumentation.opentelemetry.io/inject-java: "my-other-ns/java"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+      containers:
+      - name: myapp
+        image: ghcr.io/pavolloffay/spring-petclinic:latest


### PR DESCRIPTION
This PR adds support for specifying the namespace of an instrumentation instance in the `inject-*` annotations.

closes #886 