### PR TITLE
Added extra cli flag webhook-port

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	)
 
 	pflag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-addr", ":8081", "The address the probe endpoint binds to.")
+	pflag.StringVar(&probeAddr, "health-probe-addr", ":8081", "The address the probe endpoint binds to.")
 	pflag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 		autoInstrumentationNodeJS string
 		autoInstrumentationPython string
 		labelsFilter              []string
+		webhookPort               int
 	)
 
 	pflag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -94,6 +95,7 @@ func main() {
 	pflag.StringVar(&autoInstrumentationNodeJS, "auto-instrumentation-nodejs-image", fmt.Sprintf("ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs:%s", v.AutoInstrumentationNodeJS), "The default OpenTelemetry NodeJS instrumentation image. This image is used when no image is specified in the CustomResource.")
 	pflag.StringVar(&autoInstrumentationPython, "auto-instrumentation-python-image", fmt.Sprintf("ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:%s", v.AutoInstrumentationPython), "The default OpenTelemetry Python instrumentation image. This image is used when no image is specified in the CustomResource.")
 	pflag.StringArrayVar(&labelsFilter, "labels", []string{}, "Labels to filter away from propagating onto deploys")
+	pflag.IntVar(&webhookPort, "webhook-port", 9443, "The port the webhook endpoint binds to.")
 	pflag.Parse()
 
 	logger := zap.New(zap.UseFlagOptions(&opts))
@@ -148,7 +150,7 @@ func main() {
 	mgrOptions := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
-		Port:                   9443,
+		Port:                   webhookPort,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "9f7554c3.opentelemetry.io",


### PR DESCRIPTION
This PR is related to the following issues: 

* https://github.com/open-telemetry/opentelemetry-helm-charts/issues/214
* https://github.com/open-telemetry/opentelemetry-operator/issues/896

It includes a new CLI flag `webhook-port` to allow the user to select a different port in case the default `9443` is already in use by another cluster add-on. 

The second commit fixes a typo in the code that prevented the correct use of the CLI flag `health-probe-addr`, before the change, you'll get the following error if you attempt to pass the flag. 

```
unknown flag: --health-probe-addr
```