### PR TITLE
Add cert manager 1.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ KIND_CONFIG ?= kind-$(KUBE_VERSION).yaml
 
 OPERATOR_SDK_VERSION ?= 1.17.0
 
-CERTMANAGER_VERSION ?= 1.6.1
+CERTMANAGER_VERSION ?= 1.8.0
 
 ifndef ignore-not-found
   ignore-not-found = false

--- a/README.md
+++ b/README.md
@@ -297,27 +297,27 @@ The OpenTelemetry Operator *might* work on versions outside of the given range, 
 
 | OpenTelemetry Operator | Kubernetes           | Cert-Manager         |
 |------------------------|----------------------|----------------------|
-| v0.51.0                | v1.19 to v1.23       | 1.8.0                |
-| v0.50.0                | v1.19 to v1.23       | 1.6.1                |
-| v0.49.0                | v1.19 to v1.23       | 1.6.1                |
-| v0.48.0                | v1.19 to v1.23       | 1.6.1                |
-| v0.47.0                | v1.19 to v1.23       | 1.6.1                |
-| v0.46.0                | v1.19 to v1.23       | 1.6.1                |
-| v0.45.0                | v1.21 to v1.23       | 1.6.1                |
-| v0.44.0                | v1.21 to v1.23       | 1.6.1                |
-| v0.43.0                | v1.21 to v1.23       | 1.6.1                |
-| v0.42.0                | v1.21 to v1.23       | 1.6.1                |
-| v0.41.1                | v1.21 to v1.23       | 1.6.1                |
-| v0.41.0                | v1.20 to v1.22       | 1.6.1                |
-| v0.40.0                | v1.20 to v1.22       | 1.6.1                |
-| v0.39.0                | v1.20 to v1.22       | 1.6.1                |
-| v0.38.0                | v1.20 to v1.22       | 1.6.1                |
-| v0.37.1                | v1.20 to v1.22       | v1.4.0 to v1.6.1     |
-| v0.37.0                | v1.20 to v1.22       | v1.4.0 to v1.5.4     |
-| v0.36.0                | v1.20 to v1.22       | v1.4.0 to v1.5.4     |
-| v0.35.0                | v1.20 to v1.22       | v1.4.0 to v1.5.4     |
-| v0.34.0                | v1.20 to v1.22       | v1.4.0 to v1.5.4     |
-| v0.33.0                | v1.20 to v1.22       | v1.4.0 to v1.5.4     |
+| v0.51.0                | v1.19 to v1.23       | v1alpha2             |
+| v0.50.0                | v1.19 to v1.23       | v1alpha2             |
+| v0.49.0                | v1.19 to v1.23       | v1alpha2             |
+| v0.48.0                | v1.19 to v1.23       | v1alpha2             |
+| v0.47.0                | v1.19 to v1.23       | v1alpha2             |
+| v0.46.0                | v1.19 to v1.23       | v1alpha2             |
+| v0.45.0                | v1.21 to v1.23       | v1alpha2             |
+| v0.44.0                | v1.21 to v1.23       | v1alpha2             |
+| v0.43.0                | v1.21 to v1.23       | v1alpha2             |
+| v0.42.0                | v1.21 to v1.23       | v1alpha2             |
+| v0.41.1                | v1.21 to v1.23       | v1alpha2             |
+| v0.41.0                | v1.20 to v1.22       | v1alpha2             |
+| v0.40.0                | v1.20 to v1.22       | v1alpha2             |
+| v0.39.0                | v1.20 to v1.22       | v1alpha2             |
+| v0.38.0                | v1.20 to v1.22       | v1alpha2             |
+| v0.37.1                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
+| v0.37.0                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
+| v0.36.0                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
+| v0.35.0                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
+| v0.34.0                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
+| v0.33.0                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
 
 ## Contributing and Developing
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ The OpenTelemetry Operator *might* work on versions outside of the given range, 
 
 | OpenTelemetry Operator | Kubernetes           | Cert-Manager         |
 |------------------------|----------------------|----------------------|
-| v0.51.0                | v1.19 to v1.23       | 1.6.1                |
+| v0.51.0                | v1.19 to v1.23       | 1.8.0                |
 | v0.50.0                | v1.19 to v1.23       | 1.6.1                |
 | v0.49.0                | v1.19 to v1.23       | 1.6.1                |
 | v0.48.0                | v1.19 to v1.23       | 1.6.1                |

--- a/README.md
+++ b/README.md
@@ -312,12 +312,12 @@ The OpenTelemetry Operator *might* work on versions outside of the given range, 
 | v0.40.0                | v1.20 to v1.22       | v1alpha2             |
 | v0.39.0                | v1.20 to v1.22       | v1alpha2             |
 | v0.38.0                | v1.20 to v1.22       | v1alpha2             |
-| v0.37.1                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
-| v0.37.0                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
-| v0.36.0                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
-| v0.35.0                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
-| v0.34.0                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
-| v0.33.0                | v1.20 to v1.22       | v1alpha2, v1alpha3   |
+| v0.37.1                | v1.20 to v1.22       | v1alpha2             |
+| v0.37.0                | v1.20 to v1.22       | v1alpha2             |
+| v0.36.0                | v1.20 to v1.22       | v1alpha2             |
+| v0.35.0                | v1.20 to v1.22       | v1alpha2             |
+| v0.34.0                | v1.20 to v1.22       | v1alpha2             |
+| v0.33.0                | v1.20 to v1.22       | v1alpha2             |
 
 ## Contributing and Developing
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 Approvers ([@open-telemetry/operator-approvers](https://github.com/orgs/open-telemetry/teams/operator-approvers)):
 
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
+- [Yuri Oliveira Sa](https://github.com/yuriolisa), Red Hat
 
 Emeritus Approvers:
 


### PR DESCRIPTION
Signed-off-by: Yuri Sa [yurimsa@gmail.com]

- Modifying makefile to install cert-manager 1.8.0.
- Adding on Compatibility Matrix this cert-manager version for the last release. 