### PR TITLE
updated module name and imports

### DIFF
--- a/cmd/otel-allocator/discovery/discovery.go
+++ b/cmd/otel-allocator/discovery/discovery.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-logr/logr"
-	"github.com/otel-allocator/allocation"
-	allocatorWatcher "github.com/otel-allocator/watcher"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
+	allocatorWatcher "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"

--- a/cmd/otel-allocator/discovery/discovery_test.go
+++ b/cmd/otel-allocator/discovery/discovery_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	gokitlog "github.com/go-kit/log"
-	"github.com/otel-allocator/allocation"
-	"github.com/otel-allocator/config"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery"
 	"github.com/stretchr/testify/assert"

--- a/cmd/otel-allocator/go.mod
+++ b/cmd/otel-allocator/go.mod
@@ -1,4 +1,4 @@
-module github.com/otel-allocator
+module github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator
 
 go 1.18
 

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -12,11 +12,11 @@ import (
 	gokitlog "github.com/go-kit/log"
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
-	"github.com/otel-allocator/allocation"
-	"github.com/otel-allocator/collector"
-	"github.com/otel-allocator/config"
-	lbdiscovery "github.com/otel-allocator/discovery"
-	allocatorWatcher "github.com/otel-allocator/watcher"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/collector"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
+	lbdiscovery "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/discovery"
+	allocatorWatcher "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 

--- a/cmd/otel-allocator/watcher/file.go
+++ b/cmd/otel-allocator/watcher/file.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/go-logr/logr"
-	"github.com/otel-allocator/config"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
 )
 
 type FileWatcher struct {

--- a/cmd/otel-allocator/watcher/main.go
+++ b/cmd/otel-allocator/watcher/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/otel-allocator/allocation"
-	"github.com/otel-allocator/config"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
 )
 
 type Manager struct {

--- a/cmd/otel-allocator/watcher/promOperator.go
+++ b/cmd/otel-allocator/watcher/promOperator.go
@@ -3,7 +3,7 @@ package watcher
 import (
 	"fmt"
 
-	allocatorconfig "github.com/otel-allocator/config"
+	allocatorconfig "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
 
 	"github.com/go-kit/log"
 	"github.com/go-logr/logr"


### PR DESCRIPTION
Updated the module name and imports for multiple files within otel-allocator from github.com/otel-allocator to github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator
This closes #907 