### PR TITLE
[925] Fix parameter encoding issue

### DIFF
--- a/cmd/otel-allocator/Dockerfile
+++ b/cmd/otel-allocator/Dockerfile
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . .
 
 # Build the Go app
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
+RUN CGO_ENABLED=0 GOOS=linux go build -x -a -installsuffix cgo -o main .
 
 ######## Start a new stage from scratch #######
 FROM alpine:latest  

--- a/cmd/otel-allocator/allocation/allocator_test.go
+++ b/cmd/otel-allocator/allocation/allocator_test.go
@@ -2,17 +2,18 @@ package allocation
 
 import (
 	"math"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 )
 
+var logger = logf.Log.WithName("unit-tests")
+
 // Tests least connection - The expected collector after running findNextCollector should be the collector with the least amount of workload
 func TestFindNextCollector(t *testing.T) {
-	var log logr.Logger
-	s := NewAllocator(log)
+	s := NewAllocator(logger)
 
 	defaultCol := collector{Name: "default-col", NumTargets: 1}
 	maxCol := collector{Name: "max-col", NumTargets: 2}
@@ -25,9 +26,7 @@ func TestFindNextCollector(t *testing.T) {
 }
 
 func TestSetCollectors(t *testing.T) {
-
-	var log logr.Logger
-	s := NewAllocator(log)
+	s := NewAllocator(logger)
 
 	cols := []string{"col-1", "col-2", "col-3"}
 	s.SetCollectors(cols)
@@ -42,8 +41,7 @@ func TestSetCollectors(t *testing.T) {
 
 func TestAddingAndRemovingTargets(t *testing.T) {
 	// prepare allocator with initial targets and collectors
-	var log logr.Logger
-	s := NewAllocator(log)
+	s := NewAllocator(logger)
 
 	cols := []string{"col-1", "col-2", "col-3"}
 	s.SetCollectors(cols)
@@ -88,8 +86,7 @@ func TestAddingAndRemovingTargets(t *testing.T) {
 func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 
 	// prepare allocator with 3 collectors and 'random' amount of targets
-	var log logr.Logger
-	s := NewAllocator(log)
+	s := NewAllocator(logger)
 
 	cols := []string{"col-1", "col-2", "col-3"}
 	s.SetCollectors(cols)

--- a/cmd/otel-allocator/allocation/http_test.go
+++ b/cmd/otel-allocator/allocation/http_test.go
@@ -1,0 +1,118 @@
+package allocation
+
+import (
+	"github.com/prometheus/common/model"
+	"reflect"
+	"testing"
+)
+
+func TestGetAllTargetsByCollectorAndJob(t *testing.T) {
+	baseAllocator := NewAllocator(logger)
+	baseAllocator.SetCollectors([]string{"test-collector"})
+	statefulAllocator := NewAllocator(logger)
+	statefulAllocator.SetCollectors([]string{"test-collector-0"})
+	type args struct {
+		collector string
+		job       string
+		cMap      map[string][]TargetItem
+		allocator *Allocator
+	}
+	var tests = []struct {
+		name string
+		args args
+		want []targetGroupJSON
+	}{
+		{
+			name: "Empty target map",
+			args: args{
+				collector: "test-collector",
+				job:       "test-job",
+				cMap:      map[string][]TargetItem{},
+				allocator: baseAllocator,
+			},
+			want: nil,
+		},
+		{
+			name: "Single entry target map",
+			args: args{
+				collector: "test-collector",
+				job:       "test-job",
+				cMap: map[string][]TargetItem{
+					"test-collectortest-job": {
+						TargetItem{
+							JobName: "test-job",
+							Label:   model.LabelSet{
+								"test-label": "test-value",
+							},
+							TargetURL: "test-url",
+							Collector: &collector{
+								Name:       "test-collector",
+								NumTargets: 1,
+							},
+						},
+					},
+				},
+				allocator: baseAllocator,
+			},
+			want: []targetGroupJSON{
+				{
+					Targets: []string{"test-url"},
+					Labels: map[model.LabelName]model.LabelValue{
+						"test-label": "test-value",
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple entry target map",
+			args: args{
+				collector: "test-collector",
+				job:       "test-job",
+				cMap: map[string][]TargetItem{
+					"test-collectortest-job": {
+						TargetItem{
+							JobName: "test-job",
+							Label:   model.LabelSet{
+								"test-label": "test-value",
+							},
+							TargetURL: "test-url",
+							Collector: &collector{
+								Name:       "test-collector",
+								NumTargets: 1,
+							},
+						},
+					},
+					"test-collectortest-job2": {
+						TargetItem{
+							JobName: "test-job2",
+							Label:   model.LabelSet{
+								"test-label": "test-value",
+							},
+							TargetURL: "test-url",
+							Collector: &collector{
+								Name:       "test-collector",
+								NumTargets: 1,
+							},
+						},
+					},
+				},
+				allocator: baseAllocator,
+			},
+			want: []targetGroupJSON{
+				{
+					Targets: []string{"test-url"},
+					Labels: map[model.LabelName]model.LabelValue{
+						"test-label": "test-value",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetAllTargetsByCollectorAndJob(tt.args.collector, tt.args.job, tt.args.cMap, tt.args.allocator); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAllTargetsByCollectorAndJob() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -185,6 +185,11 @@ func (s *server) TargetsHandler(w http.ResponseWriter, r *http.Request) {
 		compareMap[v.Collector.Name+v.JobName] = append(compareMap[v.Collector.Name+v.JobName], *v)
 	}
 	params := mux.Vars(r)
+	s.logger.Info("------------")
+	s.logger.Info("query params", q)
+	s.logger.Info("params", params)
+	s.logger.Info("compareMap", compareMap)
+	s.logger.Info("------------")
 
 	if len(q) == 0 {
 		jobId, err := url.QueryUnescape(params["job_id"])

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -185,23 +185,18 @@ func (s *server) TargetsHandler(w http.ResponseWriter, r *http.Request) {
 		compareMap[v.Collector.Name+v.JobName] = append(compareMap[v.Collector.Name+v.JobName], *v)
 	}
 	params := mux.Vars(r)
-	s.logger.Info("------------")
-	s.logger.Info("query params", q)
-	s.logger.Info("params", params)
-	s.logger.Info("compareMap", compareMap)
-	s.logger.Info("------------")
+	jobId, err := url.QueryUnescape(params["job_id"])
+	if err != nil {
+		errorHandler(err, w, r)
+		return
+	}
 
 	if len(q) == 0 {
-		jobId, err := url.QueryUnescape(params["job_id"])
-		if err != nil {
-			errorHandler(err, w, r)
-			return
-		}
 		displayData := allocation.GetAllTargetsByJob(jobId, compareMap, s.allocator)
 		jsonHandler(w, r, displayData)
 
 	} else {
-		tgs := allocation.GetAllTargetsByCollectorAndJob(q[0], params["job_id"], compareMap, s.allocator)
+		tgs := allocation.GetAllTargetsByCollectorAndJob(q[0], jobId, compareMap, s.allocator)
 		// Displays empty list if nothing matches
 		if len(tgs) == 0 {
 			jsonHandler(w, r, []interface{}{})


### PR DESCRIPTION
The target allocator was only unencoding when a collector_id wasn't provided which made it so that the target for the collector was never returned. This also fixes the issue where the encoded URL wasn't provided correctly to the collectors

Closes #925 