### PR TITLE
Fix the issue that the number of target-allocator replicas 

### DIFF
--- a/pkg/collector/reconcile/deployment.go
+++ b/pkg/collector/reconcile/deployment.go
@@ -99,7 +99,7 @@ func expectedDeployments(ctx context.Context, params Params, expected []appsv1.D
 			updated.ObjectMeta.Labels[k] = v
 		}
 
-		if params.Instance.Spec.MaxReplicas != nil {
+		if params.Instance.Spec.MaxReplicas != nil && desired.Labels["app.kubernetes.io/component"] == "opentelemetry-collector" {
 			currentReplicas := currentReplicasWithHPA(params.Instance.Spec, existing.Status.Replicas)
 			updated.Spec.Replicas = &currentReplicas
 		}

--- a/pkg/collector/reconcile/deployment_test.go
+++ b/pkg/collector/reconcile/deployment_test.go
@@ -102,6 +102,58 @@ func TestExpectedDeployments(t *testing.T) {
 		assert.Len(t, expected, 0)
 	})
 
+	t.Run("should not update target allocator deployment replicas when collector max replicas is set", func(t *testing.T) {
+		replicas, maxReplicas := int32(2), int32(10)
+		param := Params{
+			Client: k8sClient,
+			Instance: v1alpha1.OpenTelemetryCollector{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "opentelemetry.io",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					UID:       instanceUID,
+				},
+				Spec: v1alpha1.OpenTelemetryCollectorSpec{
+					MaxReplicas: &maxReplicas,
+					Replicas:    &replicas,
+					Mode:        v1alpha1.ModeStatefulSet,
+					TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
+						Enabled: true,
+					},
+					Config: `
+				receivers:
+				jaeger:
+					protocols:
+					grpc:
+				processors:
+			
+				exporters:
+				logging:
+			
+				service:
+				pipelines:
+					traces:
+					receivers: [jaeger]
+					processors: []
+					exporters: [logging]
+			
+			`,
+				},
+			},
+			Scheme: testScheme,
+			Log:    logger,
+		}
+		expected := []v1.Deployment{}
+		allocator := targetallocator.Deployment(param.Config, param.Log, param.Instance)
+		expected = append(expected, allocator)
+
+		assert.Len(t, expected, 1)
+		assert.Equal(t, *allocator.Spec.Replicas, int32(1))
+	})
+
 	t.Run("should update deployment", func(t *testing.T) {
 		createObjectIfNotExists(t, "test-collector", &expectedDeploy)
 		err := expectedDeployments(context.Background(), param, []v1.Deployment{expectedDeploy})


### PR DESCRIPTION
Fix the issue that the number of target-allocator replicas 

- [x] Add a judgment that there is no need to modify replicas when dealing with target-allocators