### PR TITLE
Enable instrumentation injecting only core SDK config

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ DotNet:
 instrumentation.opentelemetry.io/inject-dotnet: "true"
 ```
 
+OpenTelemetry SDK environment variables only:
+```bash
+instrumentation.opentelemetry.io/inject-sdk: "true"
+```
+
 The possible values for the annotation can be
 * `"true"` - inject and `Instrumentation` resource from the namespace.
 * `"my-instrumentation"` - name of `Instrumentation` CR instance in the current namespace.
@@ -222,7 +227,7 @@ The possible values for the annotation can be
 * `"false"` - do not inject
 
 
->**Note:** For `DotNet` auto-instrumentation, by default, operator sets the `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS` environment variable which specifies the list of traces source instrumentations you want to enable. The value that is set by default by the operator is all available instrumentations supported by the `openTelemery-dotnet-instrumentation` release consumed in the image, i.e. `AspNet,HttpClient,SqlClient`. This value can be overriden by configuring the environment variable explicitely. 
+>**Note:** For `DotNet` auto-instrumentation, by default, operator sets the `OTEL_DOTNET_AUTO_TRACES_ENABLED_INSTRUMENTATIONS` environment variable which specifies the list of traces source instrumentations you want to enable. The value that is set by default by the operator is all available instrumentations supported by the `openTelemery-dotnet-instrumentation` release consumed in the image, i.e. `AspNet,HttpClient,SqlClient`. This value can be overriden by configuring the environment variable explicitely.
 
 #### Multi-container pods
 
@@ -283,8 +288,16 @@ spec:
     image: your-customized-auto-instrumentation-image:dotnet
 ```
 
-The Dockerfiles for auto-instrumentation can be found in [autoinstrumentation directory](./autoinstrumentation). 
+The Dockerfiles for auto-instrumentation can be found in [autoinstrumentation directory](./autoinstrumentation).
 Follow the instructions in the Dockerfiles on how to build a custom container image.
+
+#### Inject OpenTelemetry SDK environment variables only
+
+You can configure the OpenTelemetry SDK for applications which can't currently be autoinstrumented by using `inject-sdk` in place of (e.g.) `inject-python` or `inject-java`. This will inject environment variables like `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_TRACES_SAMPLER`, and `OTEL_EXPORTER_OTLP_ENDPOINT`, that you can configure in the `Instrumentation`, but will not actually provide the SDK.
+
+```bash
+instrumentation.opentelemetry.io/inject-sdk: "true"
+```
 
 ## Compatibility matrix
 

--- a/pkg/instrumentation/annotation.go
+++ b/pkg/instrumentation/annotation.go
@@ -27,6 +27,7 @@ const (
 	annotationInjectNodeJS        = "instrumentation.opentelemetry.io/inject-nodejs"
 	annotationInjectPython        = "instrumentation.opentelemetry.io/inject-python"
 	annotationInjectDotNet        = "instrumentation.opentelemetry.io/inject-dotnet"
+	annotationInjectSdk           = "instrumentation.opentelemetry.io/inject-sdk"
 	annotationInjectContainerName = "instrumentation.opentelemetry.io/container-names"
 )
 

--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -44,6 +44,7 @@ type languageInstrumentations struct {
 	NodeJS *v1alpha1.Instrumentation
 	Python *v1alpha1.Instrumentation
 	DotNet *v1alpha1.Instrumentation
+	Sdk    *v1alpha1.Instrumentation
 }
 
 var _ webhookhandler.PodMutator = (*instPodMutator)(nil)
@@ -103,7 +104,14 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 	}
 	insts.DotNet = inst
 
-	if insts.Java == nil && insts.NodeJS == nil && insts.Python == nil && insts.DotNet == nil {
+	if inst, err = pm.getInstrumentationInstance(ctx, ns, pod, annotationInjectSdk); err != nil {
+		// we still allow the pod to be created, but we log a message to the operator's logs
+		logger.Error(err, "failed to select an OpenTelemetry Instrumentation instance for this pod")
+		return pod, err
+	}
+	insts.Sdk = inst
+
+	if insts.Java == nil && insts.NodeJS == nil && insts.Python == nil && insts.DotNet == nil && insts.Sdk == nil {
 		logger.V(1).Info("annotation not present in deployment, skipping instrumentation injection")
 		return pod, nil
 	}

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -90,6 +90,13 @@ func (i *sdkInjector) inject(ctx context.Context, insts languageInstrumentations
 		pod = i.injectCommonEnvVar(otelinst, pod, index)
 		pod = i.injectCommonSDKConfig(ctx, otelinst, ns, pod, index)
 	}
+	if insts.Sdk != nil {
+		otelinst := *insts.Sdk
+		i.logger.V(1).Info("injecting sdk-only instrumentation into pod", "otelinst-namespace", otelinst.Namespace, "otelinst-name", otelinst.Name)
+		pod = i.injectCommonEnvVar(otelinst, pod, index)
+		pod = i.injectCommonSDKConfig(ctx, otelinst, ns, pod, index)
+	}
+
 	return pod
 }
 

--- a/tests/e2e/instrumentation-sdk/00-install-collector.yaml
+++ b/tests/e2e/instrumentation-sdk/00-install-collector.yaml
@@ -1,0 +1,23 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: sidecar
+spec:
+  mode: sidecar
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+
+    exporters:
+      logging:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [logging]

--- a/tests/e2e/instrumentation-sdk/00-install-instrumentation.yaml
+++ b/tests/e2e/instrumentation-sdk/00-install-instrumentation.yaml
@@ -1,0 +1,24 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: sdk-only
+spec:
+  env:
+    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
+      value: "true"
+  exporter:
+    endpoint: http://localhost:4317
+  propagators:
+    - jaeger
+    - b3
+  sampler:
+    type: parentbased_traceidratio
+    argument: "0.25"
+  nodejs:
+    env:
+      - name: OTEL_NODEJS_DEBUG
+        value: "true"
+  python:
+    env:
+      - name: OTEL_ENV_VAR
+        value: "true"

--- a/tests/e2e/instrumentation-sdk/01-assert.yaml
+++ b/tests/e2e/instrumentation-sdk/01-assert.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    sidecar.opentelemetry.io/inject: "true"
+    instrumentation.opentelemetry.io/inject-sdk: "true"
+  labels:
+    app: my-pod-with-sidecar
+spec:
+  containers:
+  - name: myapp
+    env:
+    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
+      value: "true"
+    - name: OTEL_SERVICE_NAME
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4317
+    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+    - name: OTEL_PROPAGATORS
+      value: jaeger,b3
+    - name: OTEL_TRACES_SAMPLER
+    - name: OTEL_TRACES_SAMPLER_ARG
+    - name: OTEL_RESOURCE_ATTRIBUTES
+  - name: otc-container
+status:
+  phase: Running

--- a/tests/e2e/instrumentation-sdk/01-install-app.yaml
+++ b/tests/e2e/instrumentation-sdk/01-install-app.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment-with-sidecar
+spec:
+  selector:
+    matchLabels:
+      app: my-pod-with-sidecar
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: my-pod-with-sidecar
+      annotations:
+        sidecar.opentelemetry.io/inject: "true"
+        instrumentation.opentelemetry.io/inject-sdk: "true"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+      containers:
+      - name: myapp
+        image: ghcr.io/anuraaga/express-hello-world:latest


### PR DESCRIPTION
Closes #990.

Adds support for injecting SDK environment variables only,
without injecting language-specific libraries or config.

Usage:

```bash
instrumentation.opentelemetry.io/inject-sdk: "true"
```