### PR TITLE
Sort order of ports returned to fix flaky tests

### DIFF
--- a/pkg/collector/adapters/config_to_ports.go
+++ b/pkg/collector/adapters/config_to_ports.go
@@ -62,8 +62,13 @@ func ConfigToReceiverPorts(logger logr.Logger, config map[interface{}]interface{
 	}
 
 	sortedNames := make([]string, 0, len(receivers))
-	for name := range receivers {
-		sortedNames = append(sortedNames, name.(string))
+	for receiverName := range receivers {
+		name, ok := receiverName.(string)
+		if !ok {
+			logger.V(2).Info("receiver does not match type, want: %s, got: %T", "string", receiverName)
+			continue
+		}
+		sortedNames = append(sortedNames, name)
 	}
 	sort.Strings(sortedNames)
 

--- a/pkg/collector/adapters/config_to_ports.go
+++ b/pkg/collector/adapters/config_to_ports.go
@@ -98,6 +98,9 @@ func ConfigToReceiverPorts(logger logr.Logger, config map[interface{}]interface{
 		}
 
 		if len(rcvrPorts) > 0 {
+			sort.Slice(ports, func(i, j int) bool {
+				return ports[i].Name < ports[j].Name
+			})
 			ports = append(ports, rcvrPorts...)
 		}
 	}

--- a/pkg/collector/adapters/config_to_ports.go
+++ b/pkg/collector/adapters/config_to_ports.go
@@ -91,11 +91,9 @@ func ConfigToReceiverPorts(logger logr.Logger, config map[interface{}]interface{
 		}
 	}
 
-	if len(ports) > 0 {
-		sort.Slice(ports, func(i, j int) bool {
-			return ports[i].Name < ports[j].Name
-		})
-	}
+	sort.Slice(ports, func(i, j int) bool {
+		return ports[i].Name < ports[j].Name
+	})
 
 	return ports, nil
 }

--- a/pkg/collector/adapters/config_to_ports_test.go
+++ b/pkg/collector/adapters/config_to_ports_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
@@ -87,94 +88,24 @@ service:
 	assert.Len(t, ports, 11)
 
 	// verify
-	expectedPorts := map[int32]bool{}
-	expectedPorts[int32(12345)] = false
-	expectedPorts[int32(12346)] = false
-	expectedPorts[int32(14250)] = false
-	expectedPorts[int32(6831)] = false
-	expectedPorts[int32(6833)] = false
-	expectedPorts[int32(15268)] = false
-	expectedPorts[int32(4318)] = false
-	expectedPorts[int32(55681)] = false
-	expectedPorts[int32(55555)] = false
-	expectedPorts[int32(9411)] = false
+	httpAppProtocol := "http"
+	grpcAppProtocol := "grpc"
+	targetPortZero := intstr.IntOrString{Type: 0, IntVal: 0, StrVal: ""}
+	targetPort4317 := intstr.IntOrString{Type: 0, IntVal: 4317, StrVal: ""}
+	targetPort4318 := intstr.IntOrString{Type: 0, IntVal: 4318, StrVal: ""}
 
-	expectedNames := map[string]bool{}
-	expectedNames["examplereceiver"] = false
-	expectedNames["examplereceiver-settings"] = false
-	expectedNames["jaeger-grpc"] = false
-	expectedNames["jaeger-thrift-compact"] = false
-	expectedNames["jaeger-thrift-binary"] = false
-	expectedNames["jaeger-custom-thrift-http"] = false
-	expectedNames["otlp-grpc"] = false
-	expectedNames["otlp-http"] = false
-	expectedNames["otlp-http-legacy"] = false
-	expectedNames["otlp-2-grpc"] = false
-	expectedNames["zipkin"] = false
-
-	expectedAppProtocols := map[string]string{}
-	expectedAppProtocols["otlp-grpc"] = "grpc"
-	expectedAppProtocols["otlp-http"] = "http"
-	expectedAppProtocols["otlp-http-legacy"] = "http"
-	expectedAppProtocols["jaeger-custom-thrift-http"] = "http"
-	expectedAppProtocols["jaeger-grpc"] = "grpc"
-	expectedAppProtocols["otlp-2-grpc"] = "grpc"
-	expectedAppProtocols["zipkin"] = "http"
-
-	// make sure we only have the ports in the set
-	for _, port := range ports {
-		assert.NotNil(t, expectedPorts[port.Port])
-		assert.NotNil(t, expectedNames[port.Name])
-		expectedPorts[port.Port] = true
-		expectedNames[port.Name] = true
-
-		if appProtocol, ok := expectedAppProtocols[port.Name]; ok {
-			assert.Equal(t, appProtocol, *port.AppProtocol)
-		}
-	}
-
-	// and make sure all the ports from the set are there
-	for _, val := range expectedPorts {
-		assert.True(t, val)
-	}
-
-	// make sure we only have the ports names in the set
-	for _, val := range expectedNames {
-		assert.True(t, val)
-	}
-}
-
-func TestReceiverPortsSortedCorrectly(t *testing.T) {
-	configurationString := `receivers:
-  otlp:
-    protocols:
-      grpc:
-      http:  
-  jaeger:
-    protocols:
-      grpc:
-service:
-  pipelines:
-    traces:
-      receivers: [otlp, jaeger]
-      exporters: [logging]
-`
-	configuration, err := adapters.ConfigFromString(configurationString)
-	require.NoError(t, err)
-	require.NotEmpty(t, configuration)
-
-	ports, err := adapters.ConfigToReceiverPorts(logger, configuration)
-	assert.NoError(t, err)
-	assert.Len(t, ports, 4)
-
-	// Ports should be ordered by receiver (alphabetically) and by port number within receiver
-	assert.Equal(t, "jaeger-grpc", ports[0].Name)
-	assert.Equal(t, int32(14250), ports[0].Port)
-
-	assert.Equal(t, "otlp-grpc", ports[1].Name)
-	assert.Equal(t, int32(4317), ports[1].Port)
-	assert.Equal(t, int32(4318), ports[2].Port)
-	assert.Equal(t, int32(55681), ports[3].Port)
+	assert.Len(t, ports, 11)
+	assert.Equal(t, corev1.ServicePort{Name: "examplereceiver", Port: int32(12345)}, ports[0])
+	assert.Equal(t, corev1.ServicePort{Name: "examplereceiver-settings", Port: int32(12346)}, ports[1])
+	assert.Equal(t, corev1.ServicePort{Name: "jaeger-custom-thrift-http", AppProtocol: &httpAppProtocol, Protocol: "TCP", Port: int32(15268), TargetPort: targetPortZero}, ports[2])
+	assert.Equal(t, corev1.ServicePort{Name: "jaeger-grpc", AppProtocol: &grpcAppProtocol, Protocol: "TCP", Port: int32(14250)}, ports[3])
+	assert.Equal(t, corev1.ServicePort{Name: "jaeger-thrift-binary", Protocol: "UDP", Port: int32(6833)}, ports[4])
+	assert.Equal(t, corev1.ServicePort{Name: "jaeger-thrift-compact", Protocol: "UDP", Port: int32(6831)}, ports[5])
+	assert.Equal(t, corev1.ServicePort{Name: "otlp-2-grpc", AppProtocol: &grpcAppProtocol, Protocol: "TCP", Port: int32(55555)}, ports[6])
+	assert.Equal(t, corev1.ServicePort{Name: "otlp-grpc", AppProtocol: &grpcAppProtocol, Port: int32(4317), TargetPort: targetPort4317}, ports[7])
+	assert.Equal(t, corev1.ServicePort{Name: "otlp-http", AppProtocol: &httpAppProtocol, Port: int32(4318), TargetPort: targetPort4318}, ports[8])
+	assert.Equal(t, corev1.ServicePort{Name: "otlp-http-legacy", AppProtocol: &httpAppProtocol, Port: int32(55681), TargetPort: targetPort4318}, ports[9])
+	assert.Equal(t, corev1.ServicePort{Name: "zipkin", AppProtocol: &httpAppProtocol, Protocol: "TCP", Port: int32(9411)}, ports[10])
 }
 
 func TestNoPortsParsed(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This should fix #969.  If there is more than one receiver defined, ports may be returned in a different order than that in which they were created.  Ideally they would always be in the same order as they are defined, but because Go does not guarantee order when iterating over keys from a map, we cannot guarantee this.