### PR TITLE
BUG FIX: Version Label not properly splitting for Otel Images

### DIFF
--- a/pkg/collector/labels.go
+++ b/pkg/collector/labels.go
@@ -47,7 +47,9 @@ func Labels(instance v1alpha1.OpenTelemetryCollector, filterLabels []string) map
 		base[k] = v
 	}
 
-	version := strings.Split(instance.Spec.Image, ":")
+	version := strings.Split(instance.Spec.Image, "otel/opentelemetry-collector-contrib")
+	version = strings.Split(instance.Spec.Image, "otel/opentelemetry-collector")
+	version = strings.Split(instance.Spec.Image, ":")
 	if len(version) > 1 {
 		base["app.kubernetes.io/version"] = version[len(version)-1]
 	} else {

--- a/pkg/collector/labels_test.go
+++ b/pkg/collector/labels_test.go
@@ -116,3 +116,25 @@ func TestSelectorLabels(t *testing.T) {
 	// verify
 	assert.Equal(t, expected, result)
 }
+
+func TestVersionLabelImage(t *testing.T) {
+	otelcol := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-opentelemetry-collector", 
+			Namespace: "my-namespace",
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Image: "otel/opentelemetry-collector-contrib:0.56.0",
+		},
+	}
+
+	// test
+	labels := Labels(otelcol, []string{})
+
+	// verify
+	assert.Equal(t, "opentelemetry-operator", labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "my-namespace.my-opentelemetry-collector", labels["app.kubernetes.io/instance"])
+	assert.Equal(t, "0.56.0", labels["app.kubernetes.io/version"])
+	assert.Equal(t, "opentelemetry", labels["app.kubernetes.io/part-of"])
+	assert.Equal(t, "opentelemetry-collector", labels["app.kubernetes.io/component"])
+}


### PR DESCRIPTION
When specifying the image to `otel/opentelemetry-collector-contrib` or `otel/opentelemetry-collector` The version is getting set to latest on service which is not correct. This should fix that and properly set the version label.