### PR TITLE
Update the target allocator on any manifest change

### DIFF
--- a/pkg/collector/parser/receiver.go
+++ b/pkg/collector/parser/receiver.go
@@ -107,6 +107,10 @@ func singlePortFromConfigEndpoint(logger logr.Logger, name string, config map[in
 	case name == "kubeletstats":
 		return nil
 
+	// ignore prometheus receiver as it has no listening endpoint
+	case name == "prometheus":
+		return nil
+
 	default:
 		endpoint = getAddressFromConfig(logger, name, endpointKey, config)
 	}

--- a/pkg/collector/reconcile/deployment.go
+++ b/pkg/collector/reconcile/deployment.go
@@ -85,11 +85,7 @@ func expectedDeployments(ctx context.Context, params Params, expected []appsv1.D
 			updated.Labels = map[string]string{}
 		}
 
-		if desired.Labels["app.kubernetes.io/component"] == "opentelemetry-targetallocator" {
-			updated.Spec.Template.Spec.Containers[0].Image = desired.Spec.Template.Spec.Containers[0].Image
-		} else {
-			updated.Spec = desired.Spec
-		}
+		updated.Spec = desired.Spec
 		updated.ObjectMeta.OwnerReferences = desired.ObjectMeta.OwnerReferences
 
 		for k, v := range desired.ObjectMeta.Annotations {

--- a/pkg/collector/reconcile/deployment_test.go
+++ b/pkg/collector/reconcile/deployment_test.go
@@ -209,7 +209,8 @@ func TestExpectedDeployments(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, exists)
 		assert.Equal(t, orgUID, actual.OwnerReferences[0].UID)
-		assert.NotEqual(t, expectedTADeploy.Spec.Template.Spec.Containers[0].Image, actual.Spec.Template.Spec.Containers[0].Image)
+		assert.True(t, len(actual.Spec.Template.Spec.Containers[0].Args) == 1)
+		assert.True(t, actual.Spec.Template.Spec.Containers[0].Args[0] == "--enable-prometheus-cr-watcher")
 		assert.Equal(t, int32(1), *actual.Spec.Replicas)
 	})
 


### PR DESCRIPTION
This PR closes #1008 by removing the special target allocator behavior for not updating the container's spec. The desired behavior is to update the TA on a spec change. This also fixes a superfluous print from the operator that clogs operator logs due to the fact that the prometheus receiver has no endpoint to expose as it is a scrape based receiver.

### Evidence of testing:

```
  targetAllocator:
    ...
    prometheusCR:
      enabled: false
```

There was no prometheusCR flag initially
<img width="909" alt="Screen Shot 2022-08-09 at 4 09 04 PM" src="https://user-images.githubusercontent.com/10070047/183751757-01d79139-47e8-47bc-a174-336ad01cab7d.png">

```
  targetAllocator:
    ...
    prometheusCR:
      enabled: true
```
<img width="906" alt="Screen Shot 2022-08-09 at 4 09 25 PM" src="https://user-images.githubusercontent.com/10070047/183751883-f20222e5-f52c-4a11-9d51-0efd27032fe0.png">
<img width="914" alt="Screen Shot 2022-08-09 at 4 09 35 PM" src="https://user-images.githubusercontent.com/10070047/183751892-dad30609-7251-4fc9-b38a-54afb5468c77.png">

