### PR TITLE
Instrument TA with prometheus

### DIFF
--- a/cmd/otel-allocator/allocation/allocator.go
+++ b/cmd/otel-allocator/allocation/allocator.go
@@ -16,6 +16,10 @@ var (
 		Name: "allocator_collectors_allocatable",
 		Help: "Number of collectors the allocator is able to allocate to.",
 	})
+	targetsPerCollector = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "allocator_targets_per_collector",
+		Help: "The number of targets for each collector.",
+	}, []string{"collector_name"})
 	timeToAssign = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "allocator_time_to_allocate",
 		Help: "The time it takes to allocate",
@@ -157,6 +161,7 @@ func (allocator *Allocator) processWaitingTargets() {
 				Collector: col,
 			}
 			col.NumTargets++
+			targetsPerCollector.WithLabelValues(col.Name).Set(float64(col.NumTargets))
 			allocator.TargetItems[v.JobName+v.TargetURL] = &targetItem
 		}
 	}

--- a/cmd/otel-allocator/allocation/allocator.go
+++ b/cmd/otel-allocator/allocation/allocator.go
@@ -2,26 +2,26 @@ package allocation
 
 import (
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"net/url"
 	"sync"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 )
 
 var (
 	collectorsAllocatable = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "allocator_collectors_allocatable",
+		Name: "opentelemetry_allocator_collectors_allocatable",
 		Help: "Number of collectors the allocator is able to allocate to.",
 	})
 	targetsPerCollector = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "allocator_targets_per_collector",
+		Name: "opentelemetry_allocator_targets_per_collector",
 		Help: "The number of targets for each collector.",
 	}, []string{"collector_name"})
 	timeToAssign = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "allocator_time_to_allocate",
+		Name: "opentelemetry_allocator_time_to_allocate",
 		Help: "The time it takes to allocate",
 	}, []string{"method"})
 )

--- a/cmd/otel-allocator/collector/collector.go
+++ b/cmd/otel-allocator/collector/collector.go
@@ -2,13 +2,13 @@ package collector
 
 import (
 	"context"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -24,7 +24,7 @@ const (
 var (
 	ns         = os.Getenv("OTELCOL_NAMESPACE")
 	collectors = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "allocator_collectors_discovered",
+		Name: "opentelemetry_allocator_collectors_discovered",
 		Help: "Number of collectors discovered.",
 	})
 )

--- a/cmd/otel-allocator/discovery/discovery.go
+++ b/cmd/otel-allocator/discovery/discovery.go
@@ -2,6 +2,8 @@ package discovery
 
 import (
 	"context"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/go-kit/log"
 	"github.com/go-logr/logr"
@@ -10,6 +12,13 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
+)
+
+var (
+	targetsDiscovered = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "allocator_targets",
+		Help: "Number of targets discovered.",
+	}, []string{"job_name"})
 )
 
 type Manager struct {
@@ -63,8 +72,10 @@ func (m *Manager) Watch(fn func(targets []allocation.TargetItem)) {
 				targets := []allocation.TargetItem{}
 
 				for jobName, tgs := range tsets {
+					var count float64 = 0
 					for _, tg := range tgs {
 						for _, t := range tg.Targets {
+							count++
 							targets = append(targets, allocation.TargetItem{
 								JobName:   jobName,
 								TargetURL: string(t[model.AddressLabel]),
@@ -72,6 +83,7 @@ func (m *Manager) Watch(fn func(targets []allocation.TargetItem)) {
 							})
 						}
 					}
+					targetsDiscovered.WithLabelValues(jobName).Set(count)
 				}
 				fn(targets)
 			}

--- a/cmd/otel-allocator/discovery/discovery.go
+++ b/cmd/otel-allocator/discovery/discovery.go
@@ -2,13 +2,13 @@ package discovery
 
 import (
 	"context"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/go-kit/log"
 	"github.com/go-logr/logr"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
 	allocatorWatcher "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
@@ -16,7 +16,7 @@ import (
 
 var (
 	targetsDiscovered = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "allocator_targets",
+		Name: "opentelemetry_allocator_targets",
 		Help: "Number of targets discovered.",
 	}, []string{"job_name"})
 )

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -86,7 +86,7 @@ func main() {
 			}
 			os.Exit(0)
 		case event := <-watcher.Events:
-			eventsMetric.WithLabelValues(allocatorWatcher.EventSourceToString[event.Source]).Inc()
+			eventsMetric.WithLabelValues(event.Source.String()).Inc()
 			switch event.Source {
 			case allocatorWatcher.EventSourceConfigMap:
 				setupLog.Info("ConfigMap updated!")

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -3,9 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
 	"net/url"
 	"os"
@@ -20,17 +17,20 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
 	lbdiscovery "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/discovery"
 	allocatorWatcher "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var (
 	setupLog     = ctrl.Log.WithName("setup")
 	httpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "allocator_http_duration_seconds",
-		Help: "Duration of HTTP requests.",
+		Name: "opentelemetry_allocator_http_duration_seconds",
+		Help: "Duration of received HTTP requests.",
 	}, []string{"path"})
-	events = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "allocator_events",
+	eventsMetric = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "opentelemetry_allocator_events",
 		Help: "Number of events in the channel.",
 	}, []string{"source"})
 )
@@ -86,7 +86,7 @@ func main() {
 			}
 			os.Exit(0)
 		case event := <-watcher.Events:
-			events.WithLabelValues(allocatorWatcher.EventSourceToString[event.Source]).Inc()
+			eventsMetric.WithLabelValues(allocatorWatcher.EventSourceToString[event.Source]).Inc()
 			switch event.Source {
 			case allocatorWatcher.EventSourceConfigMap:
 				setupLog.Info("ConfigMap updated!")

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -21,8 +21,6 @@ import (
 	lbdiscovery "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/discovery"
 	allocatorWatcher "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher"
 	ctrl "sigs.k8s.io/controller-runtime"
-
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 var (

--- a/cmd/otel-allocator/watcher/main.go
+++ b/cmd/otel-allocator/watcher/main.go
@@ -34,11 +34,15 @@ const (
 )
 
 var (
-	EventSourceToString = map[EventSource]string{
+	eventSourceToString = map[EventSource]string{
 		EventSourceConfigMap:    "EventSourceConfigMap",
 		EventSourcePrometheusCR: "EventSourcePrometheusCR",
 	}
 )
+
+func (e EventSource) String() string {
+	return eventSourceToString[e]
+}
 
 func NewWatcher(logger logr.Logger, config config.CLIConfig, allocator *allocation.Allocator) (*Manager, error) {
 	watcher := Manager{

--- a/cmd/otel-allocator/watcher/main.go
+++ b/cmd/otel-allocator/watcher/main.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"

--- a/cmd/otel-allocator/watcher/main.go
+++ b/cmd/otel-allocator/watcher/main.go
@@ -2,7 +2,6 @@ package watcher
 
 import (
 	"fmt"
-
 	"github.com/go-logr/logr"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
@@ -31,6 +30,13 @@ type EventSource int
 const (
 	EventSourceConfigMap EventSource = iota
 	EventSourcePrometheusCR
+)
+
+var (
+	EventSourceToString = map[EventSource]string{
+		EventSourceConfigMap:    "EventSourceConfigMap",
+		EventSourcePrometheusCR: "EventSourcePrometheusCR",
+	}
 )
 
 func NewWatcher(logger logr.Logger, config config.CLIConfig, allocator *allocation.Allocator) (*Manager, error) {


### PR DESCRIPTION
This PR closes #1029 by adding in instrumentation for the target allocator through Prometheus. The amount of metrics was kept to be minimal so that we can migrate this to use the otel go SDK in the future. The current implementation adds a prometheus endpoint `/metrics` to the existing `:8080` port. It also adds in a mux middleware to track some metrics about requests made to the endpoints.


<details>
<summary>Metrics Reported</summary>
<br>

```
# HELP allocator_collectors_allocatable Number of collectors the allocator is able to allocate to.
# TYPE allocator_collectors_allocatable gauge
# HELP allocator_collectors_discovered Number of collectors discovered.
# TYPE allocator_collectors_discovered gauge
# HELP allocator_events Number of events in the channel.
# TYPE allocator_events counter
# HELP allocator_http_duration_seconds Duration of HTTP requests.
# TYPE allocator_http_duration_seconds histogram
# HELP allocator_targets Number of targets discovered.
# TYPE allocator_targets gauge
# HELP allocator_targets_per_collector The number of targets for each collector.
# TYPE allocator_targets_per_collector gauge
# HELP allocator_time_to_allocate The time it takes to allocate
# TYPE allocator_time_to_allocate histogram
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
# TYPE go_memstats_gc_cpu_fraction gauge
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
# HELP prometheus_sd_consul_rpc_duration_seconds The duration of a Consul RPC call in seconds.
# TYPE prometheus_sd_consul_rpc_duration_seconds summary
# HELP prometheus_sd_consul_rpc_failures_total The number of Consul RPC call failures.
# TYPE prometheus_sd_consul_rpc_failures_total counter
# HELP prometheus_sd_dns_lookup_failures_total The number of DNS-SD lookup failures.
# TYPE prometheus_sd_dns_lookup_failures_total counter
# HELP prometheus_sd_dns_lookups_total The number of DNS-SD lookups.
# TYPE prometheus_sd_dns_lookups_total counter
# HELP prometheus_sd_file_read_errors_total The number of File-SD read errors.
# TYPE prometheus_sd_file_read_errors_total counter
# HELP prometheus_sd_file_scan_duration_seconds The duration of the File-SD scan in seconds.
# TYPE prometheus_sd_file_scan_duration_seconds summary
# HELP prometheus_sd_kubernetes_events_total The number of Kubernetes events handled.
# TYPE prometheus_sd_kubernetes_events_total counter
# HELP prometheus_sd_kubernetes_http_request_duration_seconds Summary of latencies for HTTP requests to the Kubernetes API by endpoint.
# TYPE prometheus_sd_kubernetes_http_request_duration_seconds summary
# HELP prometheus_sd_kubernetes_http_request_total Total number of HTTP requests to the Kubernetes API by status code.
# TYPE prometheus_sd_kubernetes_http_request_total counter
# HELP prometheus_sd_kubernetes_workqueue_depth Current depth of the work queue.
# TYPE prometheus_sd_kubernetes_workqueue_depth gauge
# HELP prometheus_sd_kubernetes_workqueue_items_total Total number of items added to the work queue.
# TYPE prometheus_sd_kubernetes_workqueue_items_total counter
# HELP prometheus_sd_kubernetes_workqueue_latency_seconds How long an item stays in the work queue.
# TYPE prometheus_sd_kubernetes_workqueue_latency_seconds summary
# HELP prometheus_sd_kubernetes_workqueue_longest_running_processor_seconds Duration of the longest running processor in the work queue.
# TYPE prometheus_sd_kubernetes_workqueue_longest_running_processor_seconds gauge
# HELP prometheus_sd_kubernetes_workqueue_unfinished_work_seconds How long an item has remained unfinished in the work queue.
# TYPE prometheus_sd_kubernetes_workqueue_unfinished_work_seconds gauge
# HELP prometheus_sd_kubernetes_workqueue_work_duration_seconds How long processing an item from the work queue takes.
# TYPE prometheus_sd_kubernetes_workqueue_work_duration_seconds summary
# HELP prometheus_sd_kuma_fetch_duration_seconds The duration of a Kuma MADS fetch call.
# TYPE prometheus_sd_kuma_fetch_duration_seconds summary
# HELP prometheus_sd_kuma_fetch_failures_total The number of Kuma MADS fetch call failures.
# TYPE prometheus_sd_kuma_fetch_failures_total counter
# HELP prometheus_sd_kuma_fetch_skipped_updates_total The number of Kuma MADS fetch calls that result in no updates to the targets.
# TYPE prometheus_sd_kuma_fetch_skipped_updates_total counter
# HELP prometheus_template_text_expansion_failures_total The total number of template text expansion failures.
# TYPE prometheus_template_text_expansion_failures_total counter
# HELP prometheus_template_text_expansions_total The total number of template text expansions.
# TYPE prometheus_template_text_expansions_total counter
# HELP prometheus_treecache_watcher_goroutines The current number of watcher goroutines.
# TYPE prometheus_treecache_watcher_goroutines gauge
# HELP prometheus_treecache_zookeeper_failures_total The total number of ZooKeeper failures.
# TYPE prometheus_treecache_zookeeper_failures_total counter
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
```
</details>