### PR TITLE
Resolve bug where TA doesn't allocate all targets

### DIFF
--- a/cmd/otel-allocator/allocation/allocator.go
+++ b/cmd/otel-allocator/allocation/allocator.go
@@ -40,6 +40,10 @@ type TargetItem struct {
 	Collector *collector
 }
 
+func (t TargetItem) hash() string {
+	return t.JobName + t.TargetURL + t.Label.Fingerprint().String()
+}
+
 // Create a struct that holds collector - and jobs for that collector
 // This struct will be parsed into endpoint with collector and jobs info
 
@@ -59,9 +63,13 @@ type Allocator struct {
 
 	collectors map[string]*collector // all current collectors
 
-	TargetItems map[string]*TargetItem
+	targetItems map[string]*TargetItem
 
 	log logr.Logger
+}
+
+func (allocator *Allocator) TargetItems() map[string]*TargetItem {
+	return allocator.targetItems
 }
 
 // findNextCollector finds the next collector with less number of targets.
@@ -91,8 +99,9 @@ func (allocator *Allocator) SetWaitingTargets(targets []TargetItem) {
 	allocator.targetsWaiting = make(map[string]TargetItem, len(targets))
 	// Set new data
 	for _, i := range targets {
-		allocator.targetsWaiting[i.JobName+i.TargetURL] = i
+		allocator.targetsWaiting[i.hash()] = i
 	}
+	//allocator.log.Info(fmt.Sprintf("len(targetsWaiting): %d\nlen(targets): %d", len(allocator.targetsWaiting), len(targets)))
 }
 
 // SetCollectors sets the set of collectors with key=collectorName, value=Collector object.
@@ -133,16 +142,16 @@ func (allocator *Allocator) ReallocateCollectors() {
 	timer := prometheus.NewTimer(timeToAssign.WithLabelValues("ReallocateCollectors"))
 	defer timer.ObserveDuration()
 	defer allocator.m.Unlock()
-	allocator.TargetItems = make(map[string]*TargetItem)
+	allocator.targetItems = make(map[string]*TargetItem)
 	allocator.processWaitingTargets()
 }
 
 // removeOutdatedTargets removes targets that are no longer available.
 func (allocator *Allocator) removeOutdatedTargets() {
-	for k := range allocator.TargetItems {
+	for k := range allocator.targetItems {
 		if _, ok := allocator.targetsWaiting[k]; !ok {
-			allocator.collectors[allocator.TargetItems[k].Collector.Name].NumTargets--
-			delete(allocator.TargetItems, k)
+			allocator.collectors[allocator.targetItems[k].Collector.Name].NumTargets--
+			delete(allocator.targetItems, k)
 		}
 	}
 }
@@ -150,9 +159,9 @@ func (allocator *Allocator) removeOutdatedTargets() {
 // processWaitingTargets processes the newly set targets.
 func (allocator *Allocator) processWaitingTargets() {
 	for k, v := range allocator.targetsWaiting {
-		if _, ok := allocator.TargetItems[k]; !ok {
+		if _, ok := allocator.targetItems[k]; !ok {
 			col := allocator.findNextCollector()
-			allocator.TargetItems[k] = &v
+			allocator.targetItems[k] = &v
 			targetItem := TargetItem{
 				JobName:   v.JobName,
 				Link:      LinkJSON{fmt.Sprintf("/jobs/%s/targets", url.QueryEscape(v.JobName))},
@@ -162,7 +171,7 @@ func (allocator *Allocator) processWaitingTargets() {
 			}
 			col.NumTargets++
 			targetsPerCollector.WithLabelValues(col.Name).Set(float64(col.NumTargets))
-			allocator.TargetItems[v.JobName+v.TargetURL] = &targetItem
+			allocator.targetItems[v.hash()] = &targetItem
 		}
 	}
 }
@@ -172,6 +181,6 @@ func NewAllocator(log logr.Logger) *Allocator {
 		log:            log,
 		targetsWaiting: make(map[string]TargetItem),
 		collectors:     make(map[string]*collector),
-		TargetItems:    make(map[string]*TargetItem),
+		targetItems:    make(map[string]*TargetItem),
 	}
 }

--- a/cmd/otel-allocator/allocation/allocator.go
+++ b/cmd/otel-allocator/allocation/allocator.go
@@ -101,7 +101,6 @@ func (allocator *Allocator) SetWaitingTargets(targets []TargetItem) {
 	for _, i := range targets {
 		allocator.targetsWaiting[i.hash()] = i
 	}
-	//allocator.log.Info(fmt.Sprintf("len(targetsWaiting): %d\nlen(targets): %d", len(allocator.targetsWaiting), len(targets)))
 }
 
 // SetCollectors sets the set of collectors with key=collectorName, value=Collector object.

--- a/cmd/otel-allocator/allocation/http.go
+++ b/cmd/otel-allocator/allocation/http.go
@@ -23,7 +23,7 @@ type targetGroupJSON struct {
 
 func GetAllTargetsByJob(job string, cMap map[string][]TargetItem, allocator *Allocator) map[string]collectorJSON {
 	displayData := make(map[string]collectorJSON)
-	for _, j := range allocator.TargetItems {
+	for _, j := range allocator.TargetItems() {
 		if j.JobName == job {
 			var targetList []TargetItem
 			targetList = append(targetList, cMap[j.Collector.Name+j.JobName]...)
@@ -52,7 +52,7 @@ func GetAllTargetsByCollectorAndJob(collector string, job string, cMap map[strin
 		if col.Name == collector {
 			for _, targetItemArr := range cMap {
 				for _, targetItem := range targetItemArr {
-					if targetItem.Collector.Name == collector && targetItem.JobName == job  {
+					if targetItem.Collector.Name == collector && targetItem.JobName == job {
 						group[targetItem.Label.String()] = targetItem.TargetURL
 						labelSet[targetItem.TargetURL] = targetItem.Label
 					}

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	//_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 var (
@@ -185,7 +186,7 @@ func (s *server) Shutdown(ctx context.Context) error {
 
 func (s *server) JobHandler(w http.ResponseWriter, r *http.Request) {
 	displayData := make(map[string]allocation.LinkJSON)
-	for _, v := range s.allocator.TargetItems {
+	for _, v := range s.allocator.TargetItems() {
 		displayData[v.JobName] = allocation.LinkJSON{v.Link.Link}
 	}
 	jsonHandler(w, r, displayData)
@@ -206,7 +207,7 @@ func (s *server) TargetsHandler(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()["collector_id"]
 
 	var compareMap = make(map[string][]allocation.TargetItem) // CollectorName+jobName -> TargetItem
-	for _, v := range s.allocator.TargetItems {
+	for _, v := range s.allocator.TargetItems() {
 		compareMap[v.Collector.Name+v.JobName] = append(compareMap[v.Collector.Name+v.JobName], *v)
 	}
 	params := mux.Vars(r)

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	ctrl "sigs.k8s.io/controller-runtime"
-	//_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 var (


### PR DESCRIPTION
This PR addresses and closes #1037 by introducing a new hashing function that ensure no collisions between targets based on the target's label set. This also introduces a small change that scopes the target items list to be private within the allocator and a new getter to expose that to other packages. A new test was added as well to verify that this change works as expected.