### PR TITLE
Protect allocator maps behind mutex, create getter funcs for them

### DIFF
--- a/cmd/otel-allocator/allocation/allocator.go
+++ b/cmd/otel-allocator/allocation/allocator.go
@@ -88,7 +88,6 @@ func (allocator *Allocator) Collectors() map[string]*collector {
 		collectorsCopy[k] = v
 	}
 	return collectorsCopy
-
 }
 
 // findNextCollector finds the next collector with less number of targets.

--- a/cmd/otel-allocator/allocation/allocator_test.go
+++ b/cmd/otel-allocator/allocation/allocator_test.go
@@ -112,7 +112,7 @@ func TestAllocationCollision(t *testing.T) {
 
 	// verify results map
 	for _, i := range targetList {
-		_, ok := s.TargetItems()[i.hash()]
+		_, ok := s.targetItems[i.hash()]
 		assert.True(t, ok)
 	}
 }
@@ -139,8 +139,8 @@ func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 	// Divisor needed to get 15%
 	divisor := 6.7
 
-	count := len(s.TargetItems()) / len(s.collectors)
-	percent := float64(len(s.TargetItems())) / divisor
+	count := len(s.targetItems) / len(s.collectors)
+	percent := float64(len(s.targetItems)) / divisor
 
 	// test
 	for _, i := range s.collectors {
@@ -158,8 +158,8 @@ func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 	s.SetWaitingTargets(newTargetList)
 	s.AllocateTargets()
 
-	count = len(s.TargetItems()) / len(s.collectors)
-	percent = float64(len(s.TargetItems())) / divisor
+	count = len(s.targetItems) / len(s.collectors)
+	percent = float64(len(s.targetItems)) / divisor
 
 	// test
 	for _, i := range s.collectors {
@@ -176,8 +176,8 @@ func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 	s.SetWaitingTargets(newTargetList)
 	s.AllocateTargets()
 
-	count = len(s.TargetItems()) / len(s.collectors)
-	percent = float64(len(s.TargetItems())) / divisor
+	count = len(s.targetItems) / len(s.collectors)
+	percent = float64(len(s.targetItems)) / divisor
 
 	// test
 	for _, i := range s.collectors {

--- a/cmd/otel-allocator/allocation/allocator_test.go
+++ b/cmd/otel-allocator/allocation/allocator_test.go
@@ -31,11 +31,12 @@ func TestSetCollectors(t *testing.T) {
 	cols := []string{"col-1", "col-2", "col-3"}
 	s.SetCollectors(cols)
 
-	excpectedColLen := len(cols)
-	assert.Len(t, s.collectors, excpectedColLen)
+	expectedColLen := len(cols)
+	collectors := s.Collectors()
+	assert.Len(t, collectors, expectedColLen)
 
 	for _, i := range cols {
-		assert.NotNil(t, s.collectors[i])
+		assert.NotNil(t, collectors[i])
 	}
 }
 
@@ -73,12 +74,13 @@ func TestAddingAndRemovingTargets(t *testing.T) {
 	s.AllocateTargets()
 
 	// verify
+	targetItems := s.TargetItems()
 	expectedNewTargetLen := len(tar)
-	assert.Len(t, s.TargetItems(), expectedNewTargetLen)
+	assert.Len(t, targetItems, expectedNewTargetLen)
 
 	// verify results map
 	for _, i := range tar {
-		_, ok := s.TargetItems()["sample-name"+i+labels.Fingerprint().String()]
+		_, ok := targetItems["sample-name"+i+labels.Fingerprint().String()]
 		assert.True(t, ok)
 	}
 }
@@ -107,12 +109,13 @@ func TestAllocationCollision(t *testing.T) {
 	s.AllocateTargets()
 
 	// verify
+	targetItems := s.TargetItems()
 	expectedTargetLen := len(targetList)
-	assert.Len(t, s.TargetItems(), expectedTargetLen)
+	assert.Len(t, targetItems, expectedTargetLen)
 
 	// verify results map
 	for _, i := range targetList {
-		_, ok := s.targetItems[i.hash()]
+		_, ok := targetItems[i.hash()]
 		assert.True(t, ok)
 	}
 }
@@ -139,11 +142,13 @@ func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 	// Divisor needed to get 15%
 	divisor := 6.7
 
-	count := len(s.targetItems) / len(s.collectors)
-	percent := float64(len(s.targetItems)) / divisor
+	targetItemLen := len(s.TargetItems())
+	collectors := s.Collectors()
+	count := targetItemLen / len(collectors)
+	percent := float64(targetItemLen) / divisor
 
 	// test
-	for _, i := range s.collectors {
+	for _, i := range collectors {
 		assert.InDelta(t, i.NumTargets, count, percent)
 	}
 
@@ -158,11 +163,13 @@ func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 	s.SetWaitingTargets(newTargetList)
 	s.AllocateTargets()
 
-	count = len(s.targetItems) / len(s.collectors)
-	percent = float64(len(s.targetItems)) / divisor
+	targetItemLen = len(s.TargetItems())
+	collectors = s.Collectors()
+	count = targetItemLen / len(collectors)
+	percent = float64(targetItemLen) / divisor
 
 	// test
-	for _, i := range s.collectors {
+	for _, i := range collectors {
 		assert.InDelta(t, i.NumTargets, count, math.Round(percent))
 	}
 	// adding targets at 'random'
@@ -176,11 +183,13 @@ func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 	s.SetWaitingTargets(newTargetList)
 	s.AllocateTargets()
 
-	count = len(s.targetItems) / len(s.collectors)
-	percent = float64(len(s.targetItems)) / divisor
+	targetItemLen = len(s.TargetItems())
+	collectors = s.Collectors()
+	count = targetItemLen / len(collectors)
+	percent = float64(targetItemLen) / divisor
 
 	// test
-	for _, i := range s.collectors {
+	for _, i := range collectors {
 		assert.InDelta(t, i.NumTargets, count, math.Round(percent))
 	}
 }

--- a/cmd/otel-allocator/allocation/http.go
+++ b/cmd/otel-allocator/allocation/http.go
@@ -48,7 +48,7 @@ func GetAllTargetsByCollectorAndJob(collector string, job string, cMap map[strin
 	var tgs []targetGroupJSON
 	group := make(map[string]string)
 	labelSet := make(map[string]model.LabelSet)
-	for _, col := range allocator.collectors {
+	for _, col := range allocator.Collectors() {
 		if col.Name == collector {
 			for _, targetItemArr := range cMap {
 				for _, targetItem := range targetItemArr {


### PR DESCRIPTION
fixes https://github.com/open-telemetry/opentelemetry-operator/issues/1034

`Allocator.targetItems` and `Allocator.collectors` can no longer be accessed outside of Allocator functions.  Instead, two functions that copy the respective maps and return them for read-only use are exported.