### PR TITLE
Otel Operator Release v0.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ Changes by Version
 0.58.0
 -------------------
 ### 🧰 Bug fixes 🧰
-
 * Fix unnecessary and incorrect reallocation ([#1041](https://github.com/open-telemetry/opentelemetry-operator/pull/1041), [@jaronoff97](https://github.com/jaronoff97))
 #### OpenTelemetry Collector and Contrib
 * [OpenTelemetry Collector - v0.58.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.58.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,31 @@
 Changes by Version
 ==================
 
+0.58.0
+-------------------
+### 🧰 Bug fixes 🧰
+
+* Fix unnecessary and incorrect reallocation ([#1041](https://github.com/open-telemetry/opentelemetry-operator/pull/1041), [@jaronoff97](https://github.com/jaronoff97))
+#### OpenTelemetry Collector and Contrib
+* [OpenTelemetry Collector - v0.58.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.58.0)
+* [OpenTelemetry Contrib - v0.58.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.58.0)
+
 0.57.2
 -------------------
 ### 🚀 New components 🚀
 * Support DotNet auto-instrumentation ([#976](https://github.com/open-telemetry/opentelemetry-operator/pull/976), [@avadhut123pisal](https://github.com/avadhut123pisal))
 * Enable instrumentation injecting only core SDK config ([#1000](https://github.com/open-telemetry/opentelemetry-operator/pull/1000), [@bilbof](https://github.com/bilbof))
+* Instrument TA with prometheus ([#1030](https://github.com/open-telemetry/opentelemetry-operator/pull/1030), [@jaronoff97](https://github.com/jaronoff97))
 ### 💡 Enhancements 💡
+* Protect allocator maps behind mutex, create getter funcs for them ([#1040](https://github.com/open-telemetry/opentelemetry-operator/pull/1040), [@kristinapathak](https://github.com/kristinapathak))
+* Simultaneously support versions v2 and v2beta2 of Autoscaling ([#1014](https://github.com/open-telemetry/opentelemetry-operator/pull/1014), [@kevinearls](https://github.com/kevinearls))
+* Update the target allocator on any manifest change ([#1027](https://github.com/open-telemetry/opentelemetry-operator/pull/1027), [@jaronoff97](https://github.com/jaronoff97))
 * chore(nodejs): update versions.txt to 0.31.0 ([#1015](https://github.com/open-telemetry/opentelemetry-operator/pull/1015), [@mat-rumian](https://github.com/mat-rumian))
 * chore(nodejs): update to 0.31.0 ([#955](https://github.com/open-telemetry/opentelemetry-operator/pull/955), [@mat-rumian](https://github.com/mat-rumian))
 * chore(operator): update python inst to 0.32b0 ([#1012](https://github.com/open-telemetry/opentelemetry-operator/pull/1012), [@ianmcnally](https://github.com/ianmcnally))
 * Sort order of ports returned to fix flaky tests ([#1003](https://github.com/open-telemetry/opentelemetry-operator/pull/1003), [@kevinearls](https://github.com/kevinearls))
 ### 🧰 Bug fixes 🧰
+* Resolve bug where TA doesn't allocate all targets ([#1039](https://github.com/open-telemetry/opentelemetry-operator/pull/1039), [@jaronoff97](https://github.com/jaronoff97))
 * Fix the issue that target-level metadata labels were missing (#948) ([#949](https://github.com/open-telemetry/opentelemetry-operator/pull/949), [@CoderPoet](https://github.com/CoderPoet))
 #### OpenTelemetry Collector and Contrib
 * [OpenTelemetry Collector - v0.57.2](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.57.2)

--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ The OpenTelemetry Operator *might* work on versions outside of the given range, 
 
 | OpenTelemetry Operator | Kubernetes           | Cert-Manager         |
 |------------------------|----------------------|----------------------|
+| v0.58.0                | v1.19 to v1.24       | v1                   |
+| v0.57.2                | v1.19 to v1.24       | v1                   |
 | v0.56.0                | v1.19 to v1.24       | v1                   |
 | v0.55.0                | v1.19 to v1.24       | v1                   |
 | v0.54.0                | v1.19 to v1.24       | v1                   |
@@ -339,8 +341,7 @@ The OpenTelemetry Operator *might* work on versions outside of the given range, 
 | v0.41.0                | v1.20 to v1.22       | v1alpha2             |
 | v0.40.0                | v1.20 to v1.22       | v1alpha2             |
 | v0.39.0                | v1.20 to v1.22       | v1alpha2             |
-| v0.38.0                | v1.20 to v1.22       | v1alpha2             |
-| v0.37.1                | v1.20 to v1.22       | v1alpha2             |
+
 
 
 ## Contributing and Developing

--- a/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: github.com/open-telemetry/opentelemetry-operator
     support: OpenTelemetry Community
-  name: opentelemetry-operator.v0.57.2
+  name: opentelemetry-operator.v0.58.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -282,7 +282,7 @@ spec:
               - args:
                 - --metrics-addr=127.0.0.1:8080
                 - --enable-leader-election
-                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.57.2
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.58.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -392,7 +392,7 @@ spec:
   maturity: alpha
   provider:
     name: OpenTelemetry Community
-  version: 0.57.2
+  version: 0.58.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/versions.txt
+++ b/versions.txt
@@ -2,10 +2,10 @@
 # by default with the OpenTelemetry Operator. This would usually be the latest
 # stable OpenTelemetry version. When you update this file, make sure to update the
 # the docs as well.
-opentelemetry-collector=0.57.2
+opentelemetry-collector=0.58.0
 
 # Represents the current release of the OpenTelemetry Operator.
-operator=0.57.2
+operator=0.58.0
 
 # Represents the current release of the Target Allocator.
 targetallocator=0.1.0


### PR DESCRIPTION
[x] Release OpenTelemetry Operator v0.58.0
[x] Adding missing PRs into the changelog and compatibility table related to v0.57.2