### PR TITLE
Add retry loop for client.get of replicaset as that sometimes fails

### DIFF
--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -296,7 +296,7 @@ func (i *sdkInjector) addParentResourceLabels(ctx context.Context, uid bool, ns 
 			// parent of ReplicaSet is e.g. Deployment which we are interested to know
 			rs := appsv1.ReplicaSet{}
 			nsn := types.NamespacedName{Namespace: ns.Name, Name: owner.Name}
-			backOff := wait.Backoff{Duration: 10 * time.Millisecond, Factor: 1.5, Jitter: 0.1, Steps: 20, Cap: 10 * time.Second}
+			backOff := wait.Backoff{Duration: 10 * time.Millisecond, Factor: 1.5, Jitter: 0.1, Steps: 20, Cap: 2 * time.Second}
 
 			checkError := func(err error) bool {
 				return apierrors.IsNotFound(err)

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -299,11 +299,7 @@ func (i *sdkInjector) addParentResourceLabels(ctx context.Context, uid bool, ns 
 			backOff := wait.Backoff{Duration: 10 * time.Millisecond, Factor: 1.5, Jitter: 0.1, Steps: 20, Cap: 10 * time.Second}
 
 			checkError := func(err error) bool {
-				// if the error looks like 'ReplicaSet.apps "my-deployment-with-sidecar-f46b479f" not found' ignore it
-				if apierrors.IsNotFound(err) {
-					return true
-				}
-				return false
+				return apierrors.IsNotFound(err)
 			}
 
 			getReplicaSet := func() error {

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -295,7 +295,7 @@ func (i *sdkInjector) addParentResourceLabels(ctx context.Context, uid bool, ns 
 			// parent of ReplicaSet is e.g. Deployment which we are interested to know
 			rs := appsv1.ReplicaSet{}
 			nsn := types.NamespacedName{Namespace: ns.Name, Name: owner.Name}
-			backOff := wait.Backoff{Duration: 10 * time.Millisecond, Factor: 1.5, Jitter: 0.1, Steps: 20, Cap: 30 * time.Second} // TODO decide which of these we need and what they should be set to
+			backOff := wait.Backoff{Duration: 10 * time.Millisecond, Factor: 1.5, Jitter: 0.1, Steps: 20, Cap: 10 * time.Second}
 
 			checkError := func(err error) bool {
 				// if the error looks like 'ReplicaSet.apps "my-deployment-with-sidecar-f46b479f" not found' ignore it


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This fixes some of the test failures we occasionally see in CI as described in #959 

There are others which I believe are related to acquiring a leader lease taking more than 2.5 minutes.  I will add more information about that to #959 

Resolves #959 