### PR TITLE
Upgrade kind images and add testing for Kubernetes 1.25

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,7 +17,7 @@ jobs:
        # should be compatible with them.
        kube-version:
        - "1.19"
-       - "1.24"
+       - "1.25"
 
     steps:
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         kube-version:
           - "1.19"
-          - "1.24"
+          - "1.25"
 
     steps:
 

--- a/kind-1.19.yaml
+++ b/kind-1.19.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.19.16@sha256:5970d9629a026fbafa37207ffb8dbaff4ff373f254aadaeecfd3bebc93b7ce3b
+  image: kindest/node:v1.19.16@sha256:707469aac7e6805e52c3bde2a8a8050ce2b15decff60db6c5077ba9975d28b98

--- a/kind-1.20.yaml
+++ b/kind-1.20.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.20.15@sha256:2d93744654696ea4270c04ec83e7940177295aac99223b224b052c79d4e7693e
+  image: kindest/node:v1.20.15@sha256:d67de8f84143adebe80a07672f370365ec7d23f93dc86866f0e29fa29ce026fe

--- a/kind-1.21.yaml
+++ b/kind-1.21.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.21.10@sha256:c92d79188b958150ffde9437e9b49fb301fd8d1a11eee384475fe3c3eea76f02
+  image: kindest/node:v1.21.14@sha256:f9b4d3d1112f24a7254d2ee296f177f628f9b4c1b32f0006567af11b91c1f301

--- a/kind-1.22.yaml
+++ b/kind-1.22.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.22.7@sha256:c195c17f2a9f6ad5bbddc9eb8bad68fa21709162aabf2b84e4a3896db05c0808
+  image: kindest/node:v1.22.13@sha256:4904eda4d6e64b402169797805b8ec01f50133960ad6c19af45173a27eadf959

--- a/kind-1.23.yaml
+++ b/kind-1.23.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.23.4@sha256:1742ff7f0b79a8aaae347b9c2ffaf9738910e721d649301791c812c162092753
+  image: kindest/node:v1.23.10@sha256:f047448af6a656fae7bc909e2fab360c18c487ef3edc93f06d78cdfd864b2d12

--- a/kind-1.24.yaml
+++ b/kind-1.24.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.24.2@sha256:1f0cee2282f43150b52dc7933183ed96abdcfc8d293f30ec07082495874876f1
+    image: kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98

--- a/kind-1.25.yaml
+++ b/kind-1.25.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.25.0@sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancasa@gmail.com>

This PR:
* Upgrades the `kind` container images to the latest
* Add testing for Kubernetes 1.25