### PR TITLE
Add default settings to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ spec:
           grpc:
           http:
     processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 500
+        spike_limit_mib: 100
+      batch:
+        send_batch_size: 1000
+        timeout: 2s
 
     exporters:
       logging:

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ spec:
     processors:
       memory_limiter:
         check_interval: 1s
-        limit_mib: 500
-        spike_limit_mib: 100
+        limit_percentage: 75
+        spike_limit_percentage: 15
       batch:
-        send_batch_size: 1000
-        timeout: 2s
+        send_batch_size: 10000
+        timeout: 10s
 
     exporters:
       logging:


### PR DESCRIPTION
As many probably copy the first example in the README, this should contain the suggested two default processors. Running without them is a bad idea, therefore I suggest this change.