### PR TITLE
Add scrape configs endpoint

### DIFF
--- a/cmd/otel-allocator/discovery/discovery.go
+++ b/cmd/otel-allocator/discovery/discovery.go
@@ -47,6 +47,16 @@ func NewManager(log logr.Logger, ctx context.Context, logger log.Logger, options
 	}
 }
 
+func (m *Manager) GetScrapeConfigs() map[string]*config.ScrapeConfig {
+	jobToScrapeConfig := map[string]*config.ScrapeConfig{}
+	for _, c := range m.configsMap {
+		for _, scrapeConfig := range c.ScrapeConfigs {
+			jobToScrapeConfig[scrapeConfig.JobName] = scrapeConfig
+		}
+	}
+	return jobToScrapeConfig
+}
+
 func (m *Manager) ApplyConfig(source allocatorWatcher.EventSource, cfg *config.Config) error {
 	m.configsMap[source] = cfg
 


### PR DESCRIPTION
This PR is the first one needed in order to close #1106. We add a new endpoint which exposes the scrape configs that the target allocator has access to both from its configmap and also from prometheus CRDs. 

A followup PR will be made in collector contrib to start using the endpoint.