### PR TITLE
[target-allocator] Add a pre-hook to the allocator to filter out dropped targets

### DIFF
--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -160,8 +160,8 @@ type OpenTelemetryTargetAllocator struct {
 	// +optional
 	AllocationStrategy string `json:"allocationStrategy,omitempty"`
 	// FilterStrategy determines how to filter targets before allocating them among the collectors.
-	// The current options are no-op (no filtering) and relabel-config (drops targets based on prom relabel_config)
-	// The default is no-op
+	// The only current option is relabel-config (drops targets based on prom relabel_config).
+	// Filtering is disabled by default.
 	// +optional
 	FilterStrategy string `json:"filterStrategy,omitempty"`
 	// ServiceAccount indicates the name of an existing service account to use with this instance.

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -159,6 +159,11 @@ type OpenTelemetryTargetAllocator struct {
 	// The current options are least-weighted and consistent-hashing. The default option is least-weighted
 	// +optional
 	AllocationStrategy string `json:"allocationStrategy,omitempty"`
+	// FilterStrategy determines how to filter targets before allocating them among the collectors.
+	// The current options are no-op (no filtering) and relabel-config (drops targets based on prom relabel_config)
+	// The default is no-op
+	// +optional
+	FilterStrategy string `json:"filterStrategy,omitempty"`
 	// ServiceAccount indicates the name of an existing service account to use with this instance.
 	// +optional
 	ServiceAccount string `json:"serviceAccount,omitempty"`

--- a/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -1701,6 +1701,12 @@ spec:
                     description: Enabled indicates whether to use a target allocation
                       mechanism for Prometheus targets or not.
                     type: boolean
+                  filterStrategy:
+                    description: FilterStrategy determines how to filter targets before
+                      allocating them among the collectors. The current options are
+                      no-op (no filtering) and relabel-config (drops targets based
+                      on prom relabel_config) The default is no-op
+                    type: string
                   image:
                     description: Image indicates the container image to use for the
                       OpenTelemetry TargetAllocator.

--- a/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -1703,9 +1703,9 @@ spec:
                     type: boolean
                   filterStrategy:
                     description: FilterStrategy determines how to filter targets before
-                      allocating them among the collectors. The current options are
-                      no-op (no filtering) and relabel-config (drops targets based
-                      on prom relabel_config) The default is no-op
+                      allocating them among the collectors. The only current option
+                      is relabel-config (drops targets based on prom relabel_config).
+                      Filtering is disabled by default.
                     type: string
                   image:
                     description: Image indicates the container image to use for the

--- a/cmd/otel-allocator/allocation/consistent_hashing.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing.go
@@ -154,6 +154,15 @@ func (c *consistentHashingAllocator) SetTargets(targets map[string]*target.Item)
 
 	if c.filterFunction != nil {
 		targets = c.filterFunction.Apply(targets)
+	} else {
+		// If no filterFunction is set, then filtering will be a no-op.
+		// Add metrics for targets kept and dropped in the no-op case.
+		targetsPerJob := prehook.GetTargetsPerJob(targets)
+
+		for jName, numTargets := range targetsPerJob {
+			prehook.TargetsDropped.WithLabelValues(jName).Set(0)
+			prehook.TargetsKept.WithLabelValues(jName).Set(numTargets)
+		}
 	}
 
 	c.m.Lock()

--- a/cmd/otel-allocator/allocation/consistent_hashing.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing.go
@@ -50,10 +50,10 @@ type consistentHashingAllocator struct {
 
 	log logr.Logger
 
-	filterFunction Filter
+	filter Filter
 }
 
-func newConsistentHashingAllocator(log logr.Logger, opts ...AllocOption) Allocator {
+func newConsistentHashingAllocator(log logr.Logger, opts ...AllocationOption) Allocator {
 	config := consistent.Config{
 		PartitionCount:    1061,
 		ReplicationFactor: 5,
@@ -74,9 +74,9 @@ func newConsistentHashingAllocator(log logr.Logger, opts ...AllocOption) Allocat
 	return chAllocator
 }
 
-// SetHook sets the filtering hook to use.
-func (c *consistentHashingAllocator) SetFilter(filterFunction Filter) {
-	c.filterFunction = filterFunction
+// SetFilter sets the filtering hook to use.
+func (c *consistentHashingAllocator) SetFilter(filter Filter) {
+	c.filter = filter
 }
 
 // addTargetToTargetItems assigns a target to the collector based on its hash and adds it to the allocator's targetItems
@@ -152,10 +152,10 @@ func (c *consistentHashingAllocator) SetTargets(targets map[string]*target.Item)
 	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetTargets", consistentHashingStrategyName))
 	defer timer.ObserveDuration()
 
-	if c.filterFunction != nil {
-		targets = c.filterFunction.Apply(targets)
+	if c.filter != nil {
+		targets = c.filter.Apply(targets)
 	}
-	prehook.RecordTargetsKeptPerJob(targets)
+	RecordTargetsKeptPerJob(targets)
 
 	c.m.Lock()
 	defer c.m.Unlock()

--- a/cmd/otel-allocator/allocation/least_weighted.go
+++ b/cmd/otel-allocator/allocation/least_weighted.go
@@ -49,12 +49,12 @@ type leastWeightedAllocator struct {
 
 	log logr.Logger
 
-	filterFunction Filter
+	filter Filter
 }
 
-// SetHook sets the filtering hook to use.
-func (allocator *leastWeightedAllocator) SetFilter(filterFunction Filter) {
-	allocator.filterFunction = filterFunction
+// SetFilter sets the filtering hook to use.
+func (allocator *leastWeightedAllocator) SetFilter(filter Filter) {
+	allocator.filter = filter
 }
 
 // TargetItems returns a shallow copy of the targetItems map.
@@ -164,10 +164,10 @@ func (allocator *leastWeightedAllocator) SetTargets(targets map[string]*target.I
 	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetTargets", leastWeightedStrategyName))
 	defer timer.ObserveDuration()
 
-	if allocator.filterFunction != nil {
-		targets = allocator.filterFunction.Apply(targets)
+	if allocator.filter != nil {
+		targets = allocator.filter.Apply(targets)
 	}
-	prehook.RecordTargetsKeptPerJob(targets)
+	RecordTargetsKeptPerJob(targets)
 
 	allocator.m.Lock()
 	defer allocator.m.Unlock()
@@ -207,7 +207,7 @@ func (allocator *leastWeightedAllocator) SetCollectors(collectors map[string]*Co
 	}
 }
 
-func newLeastWeightedAllocator(log logr.Logger, opts ...AllocOption) Allocator {
+func newLeastWeightedAllocator(log logr.Logger, opts ...AllocationOption) Allocator {
 	lwAllocator := &leastWeightedAllocator{
 		log:         log,
 		collectors:  make(map[string]*Collector),

--- a/cmd/otel-allocator/allocation/least_weighted.go
+++ b/cmd/otel-allocator/allocation/least_weighted.go
@@ -166,6 +166,15 @@ func (allocator *leastWeightedAllocator) SetTargets(targets map[string]*target.I
 
 	if allocator.filterFunction != nil {
 		targets = allocator.filterFunction.Apply(targets)
+	} else {
+		// if no filterFunction is set, then filtering will be a no-op.
+		// add metrics for targets kept and dropped in the no-op case.
+		targetsPerJob := prehook.GetTargetsPerJob(targets)
+
+		for jName, numTargets := range targetsPerJob {
+			prehook.TargetsDropped.WithLabelValues(jName).Set(0)
+			prehook.TargetsKept.WithLabelValues(jName).Set(numTargets)
+		}
 	}
 
 	allocator.m.Lock()

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -54,7 +54,7 @@ var (
 type AllocationOption func(Allocator)
 
 type Filter interface {
-	Apply(map[string]*target.TargetItem) map[string]*target.TargetItem
+	Apply(map[string]*target.Item) map[string]*target.Item
 }
 
 func WithFilter(filter Filter) AllocationOption {
@@ -63,7 +63,7 @@ func WithFilter(filter Filter) AllocationOption {
 	}
 }
 
-func RecordTargetsKeptPerJob(targets map[string]*target.TargetItem) map[string]float64 {
+func RecordTargetsKeptPerJob(targets map[string]*target.Item) map[string]float64 {
 	targetsPerJob := make(map[string]float64)
 
 	for _, tItem := range targets {

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -49,9 +49,13 @@ var (
 
 type AllocOption func(Allocator)
 
-func WithFilter(hook prehook.Hook) AllocOption {
+type Filter interface {
+	Apply(map[string]*target.TargetItem) map[string]*target.TargetItem
+}
+
+func WithFilter(filterFunction Filter) AllocOption {
 	return func(allocator Allocator) {
-		allocator.SetHook(hook)
+		allocator.SetFilter(filterFunction)
 	}
 }
 
@@ -75,7 +79,7 @@ type Allocator interface {
 	SetTargets(targets map[string]*target.Item)
 	TargetItems() map[string]*target.Item
 	Collectors() map[string]*Collector
-	SetHook(hook prehook.Hook)
+	SetFilter(filterFunction Filter)
 }
 
 var _ consistent.Member = Collector{}

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -26,7 +26,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 )
 
-type AllocatorProvider func(log logr.Logger, opts ...AllocOption) Allocator
+type AllocatorProvider func(log logr.Logger, opts ...AllocationOption) Allocator
 
 var (
 	registry = map[string]AllocatorProvider{}
@@ -45,21 +45,39 @@ var (
 		Name: "opentelemetry_allocator_time_to_allocate",
 		Help: "The time it takes to allocate",
 	}, []string{"method", "strategy"})
+	targetsKeptPerJob = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "opentelemetry_allocator_targets_kept",
+		Help: "Number of targets kept after filtering.",
+	}, []string{"job_name"})
 )
 
-type AllocOption func(Allocator)
+type AllocationOption func(Allocator)
 
 type Filter interface {
 	Apply(map[string]*target.TargetItem) map[string]*target.TargetItem
 }
 
-func WithFilter(filterFunction Filter) AllocOption {
+func WithFilter(filter Filter) AllocationOption {
 	return func(allocator Allocator) {
-		allocator.SetFilter(filterFunction)
+		allocator.SetFilter(filter)
 	}
 }
 
-func New(name string, log logr.Logger, opts ...AllocOption) (Allocator, error) {
+func RecordTargetsKeptPerJob(targets map[string]*target.TargetItem) map[string]float64 {
+	targetsPerJob := make(map[string]float64)
+
+	for _, tItem := range targets {
+		targetsPerJob[tItem.JobName] += 1
+	}
+
+	for jName, numTargets := range targetsPerJob {
+		targetsKeptPerJob.WithLabelValues(jName).Set(numTargets)
+	}
+
+	return targetsPerJob
+}
+
+func New(name string, log logr.Logger, opts ...AllocationOption) (Allocator, error) {
 	if p, ok := registry[name]; ok {
 		return p(log, opts...), nil
 	}
@@ -79,7 +97,7 @@ type Allocator interface {
 	SetTargets(targets map[string]*target.Item)
 	TargetItems() map[string]*target.Item
 	Collectors() map[string]*Collector
-	SetFilter(filterFunction Filter)
+	SetFilter(filter Filter)
 }
 
 var _ consistent.Member = Collector{}

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	LabelSelector      map[string]string  `yaml:"label_selector,omitempty"`
 	Config             *promconfig.Config `yaml:"config"`
 	AllocationStrategy *string            `yaml:"allocation_strategy,omitempty"`
+	FilterStrategy     *string            `yaml:"filter_strategy,omitempty"`
 }
 
 func (c Config) GetAllocationStrategy() string {
@@ -49,6 +50,13 @@ func (c Config) GetAllocationStrategy() string {
 		return *c.AllocationStrategy
 	}
 	return "least-weighted"
+}
+
+func (c Config) GetTargetsFilterStrategy() string {
+	if c.FilterStrategy != nil {
+		return *c.FilterStrategy
+	}
+	return ""
 }
 
 type PrometheusCRWatcherConfig struct {

--- a/cmd/otel-allocator/discovery/discovery.go
+++ b/cmd/otel-allocator/discovery/discovery.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/model/relabel"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 	allocatorWatcher "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher"
@@ -42,9 +43,10 @@ type Manager struct {
 	logger     log.Logger
 	close      chan struct{}
 	configsMap map[allocatorWatcher.EventSource]*config.Config
+	hook       prehook.Hook
 }
 
-func NewManager(log logr.Logger, ctx context.Context, logger log.Logger, options ...func(*discovery.Manager)) *Manager {
+func NewManager(log logr.Logger, ctx context.Context, logger log.Logger, hook prehook.Hook, options ...func(*discovery.Manager)) *Manager {
 	manager := discovery.NewManager(ctx, logger, options...)
 
 	go func() {
@@ -58,6 +60,7 @@ func NewManager(log logr.Logger, ctx context.Context, logger log.Logger, options
 		logger:     logger,
 		close:      make(chan struct{}),
 		configsMap: make(map[allocatorWatcher.EventSource]*config.Config),
+		hook:       hook,
 	}
 }
 
@@ -75,11 +78,17 @@ func (m *Manager) ApplyConfig(source allocatorWatcher.EventSource, cfg *config.C
 	m.configsMap[source] = cfg
 
 	discoveryCfg := make(map[string]discovery.Configs)
+	relabelCfg := make(map[string][]*relabel.Config)
 
 	for _, value := range m.configsMap {
 		for _, scrapeConfig := range value.ScrapeConfigs {
 			discoveryCfg[scrapeConfig.JobName] = scrapeConfig.ServiceDiscoveryConfigs
+			relabelCfg[scrapeConfig.JobName] = scrapeConfig.RelabelConfigs
 		}
+	}
+
+	if m.hook != nil {
+		m.hook.SetConfig(relabelCfg)
 	}
 	return m.manager.ApplyConfig(discoveryCfg)
 }

--- a/cmd/otel-allocator/discovery/discovery.go
+++ b/cmd/otel-allocator/discovery/discovery.go
@@ -43,10 +43,14 @@ type Manager struct {
 	logger     log.Logger
 	close      chan struct{}
 	configsMap map[allocatorWatcher.EventSource]*config.Config
-	hook       prehook.Hook
+	hook       discoveryHook
 }
 
-func NewManager(log logr.Logger, ctx context.Context, logger log.Logger, hook prehook.Hook, options ...func(*discovery.Manager)) *Manager {
+type discoveryHook interface {
+	SetConfig(map[string][]*relabel.Config)
+}
+
+func NewManager(log logr.Logger, ctx context.Context, logger log.Logger, hook discoveryHook, options ...func(*discovery.Manager)) *Manager {
 	manager := discovery.NewManager(ctx, logger, options...)
 
 	go func() {

--- a/cmd/otel-allocator/discovery/discovery_test.go
+++ b/cmd/otel-allocator/discovery/discovery_test.go
@@ -44,7 +44,7 @@ func TestMain(m *testing.M) {
 		fmt.Printf("failed to load config file: %v", err)
 		os.Exit(1)
 	}
-	manager = NewManager(ctrl.Log.WithName("test"), context.Background(), gokitlog.NewNopLogger())
+	manager = NewManager(ctrl.Log.WithName("test"), context.Background(), gokitlog.NewNopLogger(), nil)
 
 	results = make(chan []string)
 	manager.Watch(func(targets map[string]*target.Item) {

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -73,11 +73,8 @@ func main() {
 	log := ctrl.Log.WithName("allocator")
 
 	// allocatorPrehook will be nil if filterStrategy is not set or
-	// unrecognized. This means no filtering will be used.
-	allocatorPrehook, err := prehook.New(cfg.GetTargetsFilterStrategy(), log)
-	if err != nil {
-		log.Info("Unrecognized filter strategy; filtering disabled")
-	}
+	// unrecognized. No filtering will be used in this case.
+	allocatorPrehook := prehook.New(cfg.GetTargetsFilterStrategy(), log)
 
 	allocator, err := allocation.New(cfg.GetAllocationStrategy(), log, allocation.WithFilter(allocatorPrehook))
 	if err != nil {

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/collector"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
 	lbdiscovery "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/discovery"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/prehook"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 	allocatorWatcher "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher"
 )

--- a/cmd/otel-allocator/prehook/prehook.go
+++ b/cmd/otel-allocator/prehook/prehook.go
@@ -35,10 +35,6 @@ var (
 		Name: "opentelemetry_allocator_targets_kept",
 		Help: "Number of targets kept after filtering.",
 	}, []string{"job_name"})
-	TargetsDropped = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "opentelemetry_allocator_targets_dropped",
-		Help: "Number of targets dropped after filtering.",
-	}, []string{"job_name"})
 )
 
 type Hook interface {
@@ -53,11 +49,15 @@ var (
 	registry = map[string]HookProvider{}
 )
 
-func GetTargetsPerJob(targets map[string]*target.TargetItem) map[string]float64 {
+func RecordTargetsKeptPerJob(targets map[string]*target.TargetItem) map[string]float64 {
 	targetsPerJob := make(map[string]float64)
 
 	for _, tItem := range targets {
 		targetsPerJob[tItem.JobName] += 1
+	}
+
+	for jName, numTargets := range targetsPerJob {
+		TargetsKept.WithLabelValues(jName).Set(numTargets)
 	}
 
 	return targetsPerJob

--- a/cmd/otel-allocator/prehook/prehook.go
+++ b/cmd/otel-allocator/prehook/prehook.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prehook
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/prometheus/model/relabel"
+
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
+)
+
+const (
+	relabelConfigTargetFilterName = "relabel-config"
+)
+
+type Hook interface {
+	Apply(map[string]*target.TargetItem) map[string]*target.TargetItem
+	SetConfig(map[string][]*relabel.Config)
+	GetConfig() map[string][]*relabel.Config
+}
+
+type HookProvider func(log logr.Logger) Hook
+
+var (
+	registry = map[string]HookProvider{}
+)
+
+func New(name string, log logr.Logger) (Hook, error) {
+	if p, ok := registry[name]; ok {
+		return p(log.WithName("Prehook").WithName(name)), nil
+	}
+	return nil, fmt.Errorf("unregistered filtering strategy: %s", name)
+}
+
+func Register(name string, provider HookProvider) error {
+	if _, ok := registry[name]; ok {
+		return errors.New("already registered")
+	}
+	registry[name] = provider
+	return nil
+}

--- a/cmd/otel-allocator/prehook/prehook.go
+++ b/cmd/otel-allocator/prehook/prehook.go
@@ -28,7 +28,7 @@ const (
 )
 
 type Hook interface {
-	Apply(map[string]*target.TargetItem) map[string]*target.TargetItem
+	Apply(map[string]*target.Item) map[string]*target.Item
 	SetConfig(map[string][]*relabel.Config)
 	GetConfig() map[string][]*relabel.Config
 }

--- a/cmd/otel-allocator/prehook/relabel.go
+++ b/cmd/otel-allocator/prehook/relabel.go
@@ -1,0 +1,100 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prehook
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/relabel"
+
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
+)
+
+type RelabelConfigTargetFilter struct {
+	log        logr.Logger
+	relabelCfg map[string][]*relabel.Config
+}
+
+func NewRelabelConfigTargetFilter(log logr.Logger) Hook {
+	return &RelabelConfigTargetFilter{
+		log:        log,
+		relabelCfg: make(map[string][]*relabel.Config),
+	}
+}
+
+// helper function converts from model.LabelSet to []labels.Label.
+func convertLabelToPromLabelSet(lbls model.LabelSet) []labels.Label {
+	newLabels := make([]labels.Label, len(lbls))
+	index := 0
+	for k, v := range lbls {
+		newLabels[index].Name = string(k)
+		newLabels[index].Value = string(v)
+		index++
+	}
+	return newLabels
+}
+
+func (tf *RelabelConfigTargetFilter) Apply(targets map[string]*target.TargetItem) map[string]*target.TargetItem {
+	numTargets := len(targets)
+
+	// need to wait until relabelCfg is set
+	if len(tf.relabelCfg) == 0 {
+		return targets
+	}
+	// Note: jobNameKey != tItem.JobName (jobNameKey is hashed)
+	for jobNameKey, tItem := range targets {
+		keepTarget := true
+		lset := convertLabelToPromLabelSet(tItem.Label)
+		for _, cfg := range tf.relabelCfg[tItem.JobName] {
+			if new_lset := relabel.Process(lset, cfg); new_lset == nil {
+				keepTarget = false
+				break // inner loop
+			} else {
+				lset = new_lset
+			}
+		}
+
+		if !keepTarget {
+			delete(targets, jobNameKey)
+		}
+	}
+
+	tf.log.V(2).Info("Filtering complete", "seen", numTargets, "kept", len(targets))
+	return targets
+}
+
+func (tf *RelabelConfigTargetFilter) SetConfig(cfgs map[string][]*relabel.Config) {
+	relabelCfgCopy := make(map[string][]*relabel.Config)
+	for key, val := range cfgs {
+		relabelCfgCopy[key] = val
+	}
+	tf.relabelCfg = relabelCfgCopy
+}
+
+func (tf *RelabelConfigTargetFilter) GetConfig() map[string][]*relabel.Config {
+	relabelCfgCopy := make(map[string][]*relabel.Config)
+	for k, v := range tf.relabelCfg {
+		relabelCfgCopy[k] = v
+	}
+	return relabelCfgCopy
+}
+
+func init() {
+	err := Register(relabelConfigTargetFilterName, NewRelabelConfigTargetFilter)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/cmd/otel-allocator/prehook/relabel.go
+++ b/cmd/otel-allocator/prehook/relabel.go
@@ -49,11 +49,16 @@ func convertLabelToPromLabelSet(lbls model.LabelSet) []labels.Label {
 
 func (tf *RelabelConfigTargetFilter) Apply(targets map[string]*target.TargetItem) map[string]*target.TargetItem {
 	numTargets := len(targets)
+	var droppedTargetsPerJob, targetsPerJob map[string]float64
 
 	// need to wait until relabelCfg is set
 	if len(tf.relabelCfg) == 0 {
 		return targets
 	}
+
+	droppedTargetsPerJob = make(map[string]float64)
+	targetsPerJob = GetTargetsPerJob(targets)
+
 	// Note: jobNameKey != tItem.JobName (jobNameKey is hashed)
 	for jobNameKey, tItem := range targets {
 		keepTarget := true
@@ -69,7 +74,16 @@ func (tf *RelabelConfigTargetFilter) Apply(targets map[string]*target.TargetItem
 
 		if !keepTarget {
 			delete(targets, jobNameKey)
+			droppedTargetsPerJob[tItem.JobName] += 1
 		}
+
+	}
+
+	// add metrics for number of targets kept and dropped per job.
+	for jName, numTargets := range targetsPerJob {
+		numDropped := droppedTargetsPerJob[jName]
+		TargetsDropped.WithLabelValues(jName).Set(numDropped)
+		TargetsKept.WithLabelValues(jName).Set(numTargets-numDropped)
 	}
 
 	tf.log.V(2).Info("Filtering complete", "seen", numTargets, "kept", len(targets))

--- a/cmd/otel-allocator/prehook/relabel.go
+++ b/cmd/otel-allocator/prehook/relabel.go
@@ -47,7 +47,7 @@ func convertLabelToPromLabelSet(lbls model.LabelSet) []labels.Label {
 	return newLabels
 }
 
-func (tf *RelabelConfigTargetFilter) Apply(targets map[string]*target.TargetItem) map[string]*target.TargetItem {
+func (tf *RelabelConfigTargetFilter) Apply(targets map[string]*target.Item) map[string]*target.Item {
 	numTargets := len(targets)
 
 	// need to wait until relabelCfg is set

--- a/cmd/otel-allocator/prehook/relabel_test.go
+++ b/cmd/otel-allocator/prehook/relabel_test.go
@@ -60,10 +60,6 @@ var (
 			isDrop: false,
 		},
 		{
-			// Note that usually a label not being present, with action=keep, would
-			// mean the target is dropped. However it is hard to tell what labels will
-			// never exist and which ones will exist after relabelling, so these targets
-			// are kept in this step (will later be dealt with in Prometheus' relabel_config step)
 			cfg: relabel.Config{
 				SourceLabels: model.LabelNames{"label_not_present"},
 				Regex:        relabel.MustNewRegexp("(.*)"),

--- a/cmd/otel-allocator/prehook/relabel_test.go
+++ b/cmd/otel-allocator/prehook/relabel_test.go
@@ -1,0 +1,207 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prehook
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"strconv"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/assert"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
+)
+
+var (
+	logger     = logf.Log.WithName("unit-tests")
+	numTargets = 100
+
+	relabelConfigs = []relabelConfigObj{
+		{
+			cfg: relabel.Config{
+				Action:      "replace",
+				Separator:   ";",
+				Regex:       relabel.MustNewRegexp("(.*)"),
+				Replacement: "$1",
+			},
+			isDrop: false,
+		},
+		{
+			cfg: relabel.Config{
+				SourceLabels: model.LabelNames{"i"},
+				Regex:        relabel.MustNewRegexp("(.*)"),
+				Action:       "keep",
+			},
+			isDrop: false,
+		},
+		{
+			cfg: relabel.Config{
+				SourceLabels: model.LabelNames{"i"},
+				Regex:        relabel.MustNewRegexp("bad.*match"),
+				Action:       "drop",
+			},
+			isDrop: false,
+		},
+		{
+			// Note that usually a label not being present, with action=keep, would
+			// mean the target is dropped. However it is hard to tell what labels will
+			// never exist and which ones will exist after relabelling, so these targets
+			// are kept in this step (will later be dealt with in Prometheus' relabel_config step)
+			cfg: relabel.Config{
+				SourceLabels: model.LabelNames{"label_not_present"},
+				Regex:        relabel.MustNewRegexp("(.*)"),
+				Action:       "keep",
+			},
+			isDrop: false,
+		},
+		{
+			cfg: relabel.Config{
+				SourceLabels: model.LabelNames{"i"},
+				Regex:        relabel.MustNewRegexp("(.*)"),
+				Action:       "drop",
+			},
+			isDrop: true,
+		},
+		{
+			cfg: relabel.Config{
+				SourceLabels: model.LabelNames{"collector"},
+				Regex:        relabel.MustNewRegexp("(collector.*)"),
+				Action:       "drop",
+			},
+			isDrop: true,
+		},
+		{
+			cfg: relabel.Config{
+				SourceLabels: model.LabelNames{"i"},
+				Regex:        relabel.MustNewRegexp("bad.*match"),
+				Action:       "keep",
+			},
+			isDrop: true,
+		},
+		{
+			cfg: relabel.Config{
+				SourceLabels: model.LabelNames{"collector"},
+				Regex:        relabel.MustNewRegexp("collectors-n"),
+				Action:       "keep",
+			},
+			isDrop: true,
+		},
+	}
+
+	DefaultDropRelabelConfig = relabel.Config{
+		SourceLabels: model.LabelNames{"i"},
+		Regex:        relabel.MustNewRegexp("(.*)"),
+		Action:       "drop",
+	}
+)
+
+type relabelConfigObj struct {
+	cfg    relabel.Config
+	isDrop bool
+}
+
+func colIndex(index, numCols int) int {
+	if numCols == 0 {
+		return -1
+	}
+	return index % numCols
+}
+
+func makeNNewTargets(n int, numCollectors int, startingIndex int) (map[string]*target.TargetItem, int, map[string]*target.TargetItem, map[string][]*relabel.Config) {
+	toReturn := map[string]*target.TargetItem{}
+	expectedMap := make(map[string]*target.TargetItem)
+	numItemsRemaining := n
+	relabelConfig := make(map[string][]*relabel.Config)
+	for i := startingIndex; i < n+startingIndex; i++ {
+		collector := fmt.Sprintf("collector-%d", colIndex(i, numCollectors))
+		label := model.LabelSet{
+			"collector": model.LabelValue(collector),
+			"i":         model.LabelValue(strconv.Itoa(i)),
+			"total":     model.LabelValue(strconv.Itoa(n + startingIndex)),
+		}
+		jobName := fmt.Sprintf("test-job-%d", i)
+		newTarget := target.NewTargetItem(jobName, "test-url", label, collector)
+		// add a single replace, drop, or keep action as relabel_config for targets
+		var index int
+		ind, _ := rand.Int(rand.Reader, big.NewInt(int64(len(relabelConfigs))))
+
+		index = int(ind.Int64())
+
+		relabelConfig[jobName] = []*relabel.Config{
+			&relabelConfigs[index].cfg,
+		}
+
+		targetKey := newTarget.Hash()
+		if relabelConfigs[index].isDrop {
+			numItemsRemaining--
+		} else {
+			expectedMap[targetKey] = newTarget
+		}
+		toReturn[targetKey] = newTarget
+	}
+	return toReturn, numItemsRemaining, expectedMap, relabelConfig
+}
+
+func TestApply(t *testing.T) {
+	allocatorPrehook, err := New("relabel-config", logger)
+	assert.Nil(t, err)
+
+	targets, numRemaining, expectedTargetMap, relabelCfg := makeNNewTargets(numTargets, 3, 0)
+	allocatorPrehook.SetConfig(relabelCfg)
+	remainingItems := allocatorPrehook.Apply(targets)
+	assert.Len(t, remainingItems, numRemaining)
+	assert.Equal(t, remainingItems, expectedTargetMap)
+
+	// clear out relabelCfg to test with empty values
+	for key := range relabelCfg {
+		relabelCfg[key] = nil
+	}
+
+	// cfg = createMockConfig(relabelCfg)
+	allocatorPrehook.SetConfig(relabelCfg)
+	remainingItems = allocatorPrehook.Apply(targets)
+	// relabelCfg is empty so targets should be unfiltered
+	assert.Len(t, remainingItems, len(targets))
+	assert.Equal(t, remainingItems, targets)
+}
+
+func TestApplyEmptyRelabelCfg(t *testing.T) {
+
+	allocatorPrehook, err := New("relabel-config", logger)
+	assert.Nil(t, err)
+
+	targets, _, _, _ := makeNNewTargets(numTargets, 3, 0)
+
+	relabelCfg := map[string][]*relabel.Config{}
+	allocatorPrehook.SetConfig(relabelCfg)
+	remainingItems := allocatorPrehook.Apply(targets)
+	// relabelCfg is empty so targets should be unfiltered
+	assert.Len(t, remainingItems, len(targets))
+	assert.Equal(t, remainingItems, targets)
+}
+
+func TestSetConfig(t *testing.T) {
+	allocatorPrehook, err := New("relabel-config", logger)
+	assert.Nil(t, err)
+
+	_, _, _, relabelCfg := makeNNewTargets(numTargets, 3, 0)
+	allocatorPrehook.SetConfig(relabelCfg)
+	assert.Equal(t, relabelCfg, allocatorPrehook.GetConfig())
+}

--- a/cmd/otel-allocator/prehook/relabel_test.go
+++ b/cmd/otel-allocator/prehook/relabel_test.go
@@ -156,8 +156,8 @@ func makeNNewTargets(n int, numCollectors int, startingIndex int) (map[string]*t
 }
 
 func TestApply(t *testing.T) {
-	allocatorPrehook, err := New("relabel-config", logger)
-	assert.Nil(t, err)
+	allocatorPrehook := New("relabel-config", logger)
+	assert.NotNil(t, allocatorPrehook)
 
 	targets, numRemaining, expectedTargetMap, relabelCfg := makeNNewTargets(numTargets, 3, 0)
 	allocatorPrehook.SetConfig(relabelCfg)
@@ -180,8 +180,8 @@ func TestApply(t *testing.T) {
 
 func TestApplyEmptyRelabelCfg(t *testing.T) {
 
-	allocatorPrehook, err := New("relabel-config", logger)
-	assert.Nil(t, err)
+	allocatorPrehook := New("relabel-config", logger)
+	assert.NotNil(t, allocatorPrehook)
 
 	targets, _, _, _ := makeNNewTargets(numTargets, 3, 0)
 
@@ -194,8 +194,8 @@ func TestApplyEmptyRelabelCfg(t *testing.T) {
 }
 
 func TestSetConfig(t *testing.T) {
-	allocatorPrehook, err := New("relabel-config", logger)
-	assert.Nil(t, err)
+	allocatorPrehook := New("relabel-config", logger)
+	assert.NotNil(t, allocatorPrehook)
 
 	_, _, _, relabelCfg := makeNNewTargets(numTargets, 3, 0)
 	allocatorPrehook.SetConfig(relabelCfg)

--- a/cmd/otel-allocator/prehook/relabel_test.go
+++ b/cmd/otel-allocator/prehook/relabel_test.go
@@ -120,9 +120,9 @@ func colIndex(index, numCols int) int {
 	return index % numCols
 }
 
-func makeNNewTargets(n int, numCollectors int, startingIndex int) (map[string]*target.TargetItem, int, map[string]*target.TargetItem, map[string][]*relabel.Config) {
-	toReturn := map[string]*target.TargetItem{}
-	expectedMap := make(map[string]*target.TargetItem)
+func makeNNewTargets(n int, numCollectors int, startingIndex int) (map[string]*target.Item, int, map[string]*target.Item, map[string][]*relabel.Config) {
+	toReturn := map[string]*target.Item{}
+	expectedMap := make(map[string]*target.Item)
 	numItemsRemaining := n
 	relabelConfig := make(map[string][]*relabel.Config)
 	for i := startingIndex; i < n+startingIndex; i++ {
@@ -133,7 +133,7 @@ func makeNNewTargets(n int, numCollectors int, startingIndex int) (map[string]*t
 			"total":     model.LabelValue(strconv.Itoa(n + startingIndex)),
 		}
 		jobName := fmt.Sprintf("test-job-%d", i)
-		newTarget := target.NewTargetItem(jobName, "test-url", label, collector)
+		newTarget := target.NewItem(jobName, "test-url", label, collector)
 		// add a single replace, drop, or keep action as relabel_config for targets
 		var index int
 		ind, _ := rand.Int(rand.Reader, big.NewInt(int64(len(relabelConfigs))))

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -1699,6 +1699,12 @@ spec:
                     description: Enabled indicates whether to use a target allocation
                       mechanism for Prometheus targets or not.
                     type: boolean
+                  filterStrategy:
+                    description: FilterStrategy determines how to filter targets before
+                      allocating them among the collectors. The current options are
+                      no-op (no filtering) and relabel-config (drops targets based
+                      on prom relabel_config) The default is no-op
+                    type: string
                   image:
                     description: Image indicates the container image to use for the
                       OpenTelemetry TargetAllocator.

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -1701,9 +1701,9 @@ spec:
                     type: boolean
                   filterStrategy:
                     description: FilterStrategy determines how to filter targets before
-                      allocating them among the collectors. The current options are
-                      no-op (no filtering) and relabel-config (drops targets based
-                      on prom relabel_config) The default is no-op
+                      allocating them among the collectors. The only current option
+                      is relabel-config (drops targets based on prom relabel_config).
+                      Filtering is disabled by default.
                     type: string
                   image:
                     description: Image indicates the container image to use for the

--- a/docs/api.md
+++ b/docs/api.md
@@ -4546,7 +4546,7 @@ TargetAllocator indicates a value which determines whether to spawn a target all
         <td><b>filterStrategy</b></td>
         <td>string</td>
         <td>
-          FilterStrategy determines how to filter targets before allocating them among the collectors. The current options are no-op (no filtering) and relabel-config (drops targets based on prom relabel_config) The default is no-op<br/>
+          FilterStrategy determines how to filter targets before allocating them among the collectors. The only current option is relabel-config (drops targets based on prom relabel_config). Filtering is disabled by default.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/api.md
+++ b/docs/api.md
@@ -4543,6 +4543,13 @@ TargetAllocator indicates a value which determines whether to spawn a target all
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>filterStrategy</b></td>
+        <td>string</td>
+        <td>
+          FilterStrategy determines how to filter targets before allocating them among the collectors. The current options are no-op (no filtering) and relabel-config (drops targets based on prom relabel_config) The default is no-op<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>image</b></td>
         <td>string</td>
         <td>

--- a/pkg/collector/reconcile/configmap.go
+++ b/pkg/collector/reconcile/configmap.go
@@ -119,6 +119,12 @@ func desiredTAConfigMap(params Params) (corev1.ConfigMap, error) {
 	} else {
 		taConfig["allocation_strategy"] = "least-weighted"
 	}
+
+	if len(params.Instance.Spec.TargetAllocator.FilterStrategy) > 0 {
+		taConfig["filter_strategy"] = params.Instance.Spec.TargetAllocator.FilterStrategy
+	} else {
+		taConfig["filter_strategy"] = "no-op"
+	}
 	taConfigYAML, err := yaml.Marshal(taConfig)
 	if err != nil {
 		return corev1.ConfigMap{}, err

--- a/pkg/collector/reconcile/configmap.go
+++ b/pkg/collector/reconcile/configmap.go
@@ -122,9 +122,8 @@ func desiredTAConfigMap(params Params) (corev1.ConfigMap, error) {
 
 	if len(params.Instance.Spec.TargetAllocator.FilterStrategy) > 0 {
 		taConfig["filter_strategy"] = params.Instance.Spec.TargetAllocator.FilterStrategy
-	} else {
-		taConfig["filter_strategy"] = "no-op"
 	}
+
 	taConfigYAML, err := yaml.Marshal(taConfig)
 	if err != nil {
 		return corev1.ConfigMap{}, err

--- a/pkg/collector/reconcile/configmap_test.go
+++ b/pkg/collector/reconcile/configmap_test.go
@@ -194,7 +194,6 @@ config:
     - targets:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
-filter_strategy: no-op
 label_selector:
   app.kubernetes.io/component: opentelemetry-collector
   app.kubernetes.io/instance: default.test
@@ -327,7 +326,6 @@ func TestExpectedConfigMap(t *testing.T) {
 		}
 		taConfig["config"] = parmConfig
 		taConfig["allocation_strategy"] = "least-weighted"
-		taConfig["filter_strategy"] = "no-op"
 		taConfigYAML, _ := yaml.Marshal(taConfig)
 
 		assert.Equal(t, string(taConfigYAML), actual.Data["targetallocator.yaml"])

--- a/pkg/collector/reconcile/configmap_test.go
+++ b/pkg/collector/reconcile/configmap_test.go
@@ -194,6 +194,7 @@ config:
     - targets:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
+filter_strategy: no-op
 label_selector:
   app.kubernetes.io/component: opentelemetry-collector
   app.kubernetes.io/instance: default.test
@@ -326,6 +327,7 @@ func TestExpectedConfigMap(t *testing.T) {
 		}
 		taConfig["config"] = parmConfig
 		taConfig["allocation_strategy"] = "least-weighted"
+		taConfig["filter_strategy"] = "no-op"
 		taConfigYAML, _ := yaml.Marshal(taConfig)
 
 		assert.Equal(t, string(taConfigYAML), actual.Data["targetallocator.yaml"])


### PR DESCRIPTION
PR to resolve https://github.com/open-telemetry/opentelemetry-operator/issues/1064

The goal of this PR is to drop targets before targets are assigned to the collectors by the allocator.  Not necessary to allocate targets that will be dropped in the relabel step.

Now the `Allocator` will check if there is a `Filter` set and apply it to filter down the list of targets.

 `filterStrategy=relabel-config` drops targets based on Prometheus relabel_config 
No filtering is the default.