### PR TITLE
Fix Target Allocator builds by using versions.txt

### DIFF
--- a/.github/workflows/publish-target-allocator.yaml
+++ b/.github/workflows/publish-target-allocator.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Read version
-        run: echo "VERSION=$(cat cmd/otel-allocator/version.txt)" >> $GITHUB_ENV
+        run: grep -v '\#' versions.txt | grep targetallocator | awk -F= '{print "VERSION="$2}' >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta

--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -1,7 +1,8 @@
 # Target Allocator
 
 The TargetAllocator is an optional separately deployed component of an OpenTelemetry Collector setup, which is used to
-distribute targets of the PrometheusReceiver on all deployed Collector instances.
+distribute targets of the PrometheusReceiver on all deployed Collector instances. The release version matches the
+operator's most recent release as well.
 
 # Design
 

--- a/versions.txt
+++ b/versions.txt
@@ -8,7 +8,7 @@ opentelemetry-collector=0.60.0
 operator=0.60.0
 
 # Represents the current release of the Target Allocator.
-targetallocator=0.1.0
+targetallocator=0.60.0
 
 # Represents the current release of Java instrumentation.
 # Should match autoinstrumentation/java/version.txt


### PR DESCRIPTION
Closes #1139 

This PR updates the target allocator's version to match the current operator release. I also updated the readme to reflect these changes. The code for getting the version is the same as the one found in the publish-images.yaml file.