### PR TITLE
change error logs to info for building container

### DIFF
--- a/pkg/collector/container.go
+++ b/pkg/collector/container.go
@@ -15,7 +15,6 @@
 package collector
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"sort"
@@ -35,8 +34,6 @@ import (
 // maxPortLen allows us to truncate a port name according to what is considered valid port syntax:
 // https://pkg.go.dev/k8s.io/apimachinery/pkg/util/validation#IsValidPortName
 const maxPortLen = 15
-
-var errInvalidPort = errors.New("invalid port name/num")
 
 // Container builds a container for the given collector.
 func Container(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) corev1.Container {
@@ -154,7 +151,7 @@ func getConfigContainerPorts(logger logr.Logger, cfg string) map[string]corev1.C
 			nameErrs := validation.IsValidPortName(truncName)
 			numErrs := validation.IsValidPortNum(int(p.Port))
 			if len(nameErrs) > 0 || len(numErrs) > 0 {
-				logger.Error(errInvalidPort, "dropping container port", "port.name", truncName, "port.num", p.Port,
+				logger.Info("dropping invalid container port", "port.name", truncName, "port.num", p.Port,
 					"port.name.errs", nameErrs, "num.errs", numErrs)
 				continue
 			}
@@ -168,7 +165,7 @@ func getConfigContainerPorts(logger logr.Logger, cfg string) map[string]corev1.C
 
 	metricsPort, err := getMetricsPort(c)
 	if err != nil {
-		logger.Error(err, "couldn't determine metrics port from configuration, using 8888 default value")
+		logger.Info("couldn't determine metrics port from configuration, using 8888 default value", "error", err)
 		metricsPort = 8888
 	}
 	ports["metrics"] = corev1.ContainerPort{


### PR DESCRIPTION
fixes https://github.com/open-telemetry/opentelemetry-operator/issues/1143
error logs include stacktraces - changing the level to info means a stacktrace is not included.
error:
```
{"level":"error","ts":1665093234.6714225,"logger":"controllers.OpenTelemetryCollector",
"msg":"couldn't determine metrics port from configuration, using 8888 default value",
"opentelemetrycollector":"opentelemetry/lightstep-collector","error":"missing port in address",
"stacktrace":"github.com/open-telemetry/opentelemetry-operator/pkg/collector.getConfigContainerPorts\n
\t/workspace/pkg/collector/container.go:171\ngithub.com/open-telemetry/opentelemetry-operator/pkg/collector.Container\n
\t/workspace/pkg/collector/container.go:49\ngithub.com/open-telemetry/opentelemetry-operator/pkg/collector.Deployment\n
\t/workspace/pkg/collector/deployment.go:55\ngithub.com/open-telemetry/opentelemetry-operator/pkg/collector/reconcile.Deployments\n
\t/workspace/pkg/collector/reconcile/deployment.go:38\n
github.com/open-telemetry/opentelemetry-operator/controllers.(*OpenTelemetryCollectorReconciler).RunTasks\n
\t/workspace/controllers/opentelemetrycollector_controller.go:164\n
github.com/open-telemetry/opentelemetry-operator/controllers.(*OpenTelemetryCollectorReconciler).Reconcile\n
\t/workspace/controllers/opentelemetrycollector_controller.go:154\n
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:121\n
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:320\n
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:273
\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:234"}
```
info:
```
{"level":"info","ts":1665095324.665596,"logger":"controllers.OpenTelemetryCollector",
"msg":"couldn't determine metrics port from configuration, using 8888 default value",
"opentelemetrycollector":"opentelemetry/lightstep-collector","error":"missing port in address"}
```