### PR TITLE
Prepare release 0.63.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 Changes by Version
 ==================
+0.63.1
+------------------
+### 🚀 New components 🚀
+* Adds support of affinity in collector spec ([#1204](https://github.com/open-telemetry/opentelemetry-operator/pull/1204), [@avadhut123pisal](https://github.com/avadhut123pisal))
+
+### 💡 Enhancements 💡
+
+* Make logging easier to configure ([#1193](https://github.com/open-telemetry/opentelemetry-operator/pull/1193), [@pavolloffay](https://github.com/pavolloffay))
+* Using immutable labels as service selectors ([#1152](https://github.com/open-telemetry/opentelemetry-operator/pull/1152), [@angelokurtis](https://github.com/angelokurtis))
+* Avoid OOM of the operator ([#1194](https://github.com/open-telemetry/opentelemetry-operator/pull/1194), [@pavolloffay](https://github.com/pavolloffay))
+* Update the javaagent version to 1.19.1 ([#1188](https://github.com/open-telemetry/opentelemetry-operator/pull/1188), [@opentelemetrybot](https://github.com/opentelemetrybot))
+* Bump OTel .NET AutoInstrumentation to 0.4.0-beta.1 ([#1209](https://github.com/open-telemetry/opentelemetry-operator/pull/1209), [@pellared](https://github.com/pellared))
+* Skip .NET auto-instrumentation if OTEL_DOTNET_AUTO_HOME env var is already set ([#1177](https://github.com/open-telemetry/opentelemetry-operator/pull/1177), [@avadhut123pisal](https://github.com/avadhut123pisal))
+
+### 🧰 Bug fixes 🧰
+* Fix panic if maxreplicas is set but autoscale is not defined in the CR ([#1201](https://github.com/open-telemetry/opentelemetry-operator/pull/1201), [@kevinearls](https://github.com/kevinearls))
+
+#### OpenTelemetry Collector and Contrib
+* [OpenTelemetry Collector - v0.63.1](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.63.1)
+* [OpenTelemetry Contrib - v0.63.1](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.63.1)
+* [OpenTelemetry Collector - v0.63.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.63.0)
+* [OpenTelemetry Contrib - v0.63.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.63.0)
+* [OpenTelemetry Collector - v0.62.1](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.62.1)
+* [OpenTelemetry Contrib - v0.62.1](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.62.1)
+* [OpenTelemetry Collector - v0.62.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.62.0)
+* [OpenTelemetry Contrib - v0.62.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.62.0)
+
+
 0.61.0
 -------------------
 #### :x: Breaking Changes :x:
@@ -437,18 +465,18 @@ _Note: The default port for the OTLP receiver has been changed from 55680 to 431
 
 0.15.0 (2020-11-27)
 -------------------
-* Bumped OpenTelemetry Collector to v0.15.0 ([#131](https://github.com/open-telemetry/opentelemetry-operator/pull/131), [@jpkrohling](https://github.com/jpkrohling)) 
+* Bumped OpenTelemetry Collector to v0.15.0 ([#131](https://github.com/open-telemetry/opentelemetry-operator/pull/131), [@jpkrohling](https://github.com/jpkrohling))
 
 0.14.0 (2020-11-09)
 -------------------
-* Bumped OpenTelemetry Collector to v0.14.0 ([#112](https://github.com/open-telemetry/opentelemetry-operator/pull/112), [@jpkrohling](https://github.com/jpkrohling)) 
+* Bumped OpenTelemetry Collector to v0.14.0 ([#112](https://github.com/open-telemetry/opentelemetry-operator/pull/112), [@jpkrohling](https://github.com/jpkrohling))
 
 _Note: The `tailsampling` processor was moved to the contrib repository, requiring a manual intervention in case this processor is being used: either replace the image with the contrib one (v0.14.0, which includes this processor), or remove the processor._
 
 0.13.0 (2020-10-22)
 -------------------
 
-* Bumped OpenTelemetry Collector to v0.13.0 ([#101](https://github.com/open-telemetry/opentelemetry-operator/pull/101), [@dengliming](https://github.com/dengliming)) 
+* Bumped OpenTelemetry Collector to v0.13.0 ([#101](https://github.com/open-telemetry/opentelemetry-operator/pull/101), [@dengliming](https://github.com/dengliming))
 * Allow for spec.Env to be set on the OTEL Collector Spec ([#94](https://github.com/open-telemetry/opentelemetry-operator/pull/94), [@ekarlso](https://github.com/ekarlso))
 
 _Note: The `groupbytrace` processor was moved to the contrib repository, requiring a manual intervention in case this processor is being used: either replace the image with the contrib one (v0.13.1, which includes this processor), or remove the processor._

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ The OpenTelemetry Operator *might* work on versions outside of the given range, 
 
 | OpenTelemetry Operator | Kubernetes           | Cert-Manager         |
 |------------------------|----------------------|----------------------|
+| v0.63.1                | v1.19 to v1.25       | v1                   |
 | v0.61.0                | v1.19 to v1.25       | v1                   |
 | v0.60.0                | v1.19 to v1.25       | v1                   |
 | v0.59.0                | v1.19 to v1.24       | v1                   |
@@ -347,7 +348,6 @@ The OpenTelemetry Operator *might* work on versions outside of the given range, 
 | v0.44.0                | v1.21 to v1.23       | v1alpha2             |
 | v0.43.0                | v1.21 to v1.23       | v1alpha2             |
 | v0.42.0                | v1.21 to v1.23       | v1alpha2             |
-| v0.41.1                | v1.21 to v1.23       | v1alpha2             |
 
 
 ## Contributing and Developing
@@ -386,7 +386,7 @@ Thanks to all the people who already contributed!
 [![Contributors][contributors-img]][contributors]
 
 ## License
-  
+
 [Apache 2.0 License](./LICENSE).
 
 [github-workflow]: https://github.com/open-telemetry/opentelemetry-operator/actions

--- a/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: github.com/open-telemetry/opentelemetry-operator
     support: OpenTelemetry Community
-  name: opentelemetry-operator.v0.61.0
+  name: opentelemetry-operator.v0.63.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -296,7 +296,7 @@ spec:
                 - --enable-leader-election
                 - --zap-log-level=info
                 - --zap-time-encoding=rfc3339nano
-                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.61.0
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.63.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -403,7 +403,7 @@ spec:
   maturity: alpha
   provider:
     name: OpenTelemetry Community
-  version: 0.61.0
+  version: 0.63.1
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/versions.txt
+++ b/versions.txt
@@ -2,17 +2,17 @@
 # by default with the OpenTelemetry Operator. This would usually be the latest
 # stable OpenTelemetry version. When you update this file, make sure to update the
 # the docs as well.
-opentelemetry-collector=0.61.0
+opentelemetry-collector=0.63.1
 
 # Represents the current release of the OpenTelemetry Operator.
-operator=0.61.0
+operator=0.63.1
 
 # Represents the current release of the Target Allocator.
 targetallocator=0.60.0
 
 # Represents the current release of Java instrumentation.
 # Should match autoinstrumentation/java/version.txt
-autoinstrumentation-java=1.11.1
+autoinstrumentation-java=1.19.1
 
 # Represents the current release of NodeJS instrumentation.
 # Should match value in autoinstrumentation/nodejs/package.json
@@ -24,4 +24,4 @@ autoinstrumentation-python=0.34b0
 
 # Represents the current release of DotNet instrumentation.
 # Should match autoinstrumentation/dotnet/version.txt
-autoinstrumentation-dotnet=0.3.1-beta.1
+autoinstrumentation-dotnet=0.4.0-beta.1


### PR DESCRIPTION
Are there any missing migrations? [[otelcol-contrib-v0.62.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.62.0)][[otelcol-contrib-v0.63.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.63.0)]

Please have a look on the bumped versions in `version.txt`.

Ups i didnt see https://github.com/open-telemetry/opentelemetry-operator/issues/1210#issuecomment-1295696100. Let me change it to `v0.63.1`.

Closes #1210 #1176

cc @pavolloffay 