### PR TITLE
[target-allocator] restart pod watcher when no event is found

### DIFF
--- a/.chloggen/1028-restart-podwatcher.yaml
+++ b/.chloggen/1028-restart-podwatcher.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: Target Allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: This PR restarts pod watcher on no event and adds unit tests for timeout and closed watcher channel
+
+# One or more tracking issues related to the change
+issues:
+  - 1028
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/collector/collector.go
+++ b/cmd/otel-allocator/collector/collector.go
@@ -17,7 +17,6 @@ package collector
 import (
 	"context"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -110,14 +109,14 @@ func runWatch(ctx context.Context, k *Client, c <-chan watch.Event, collectorMap
 			return "context done"
 		case event, ok := <-c:
 			if !ok {
-				log.Info(strconv.FormatBool(ok))
-				return "no event"
+				log.Info("No event found. Restarting watch routine")
+				return ""
 			}
 
 			pod, ok := event.Object.(*v1.Pod)
 			if !ok {
-				log.Info(strconv.FormatBool(ok))
-				return "no event"
+				log.Info("No pod found in event Object. Restarting watch routine")
+				return ""
 			}
 
 			switch event.Type { //nolint:exhaustive

--- a/cmd/otel-allocator/collector/collector.go
+++ b/cmd/otel-allocator/collector/collector.go
@@ -45,9 +45,9 @@ var (
 )
 
 type Client struct {
-	log            logr.Logger
-	k8sClient      kubernetes.Interface
-	close          chan struct{}
+	log       logr.Logger
+	k8sClient kubernetes.Interface
+	close     chan struct{}
 }
 
 func NewClient(logger logr.Logger, kubeConfig *rest.Config) (*Client, error) {
@@ -57,9 +57,9 @@ func NewClient(logger logr.Logger, kubeConfig *rest.Config) (*Client, error) {
 	}
 
 	return &Client{
-		log:            logger,
-		k8sClient:      clientset,
-		close:          make(chan struct{}),
+		log:       logger,
+		k8sClient: clientset,
+		close:     make(chan struct{}),
 	}, nil
 }
 
@@ -68,7 +68,7 @@ func (k *Client) Watch(ctx context.Context, labelMap map[string]string, fn func(
 	log := k.log.WithValues("component", "opentelemetry-targetallocator")
 
 	opts := metav1.ListOptions{
-		LabelSelector:  labels.SelectorFromSet(labelMap).String(),
+		LabelSelector: labels.SelectorFromSet(labelMap).String(),
 	}
 	pods, err := k.k8sClient.CoreV1().Pods(ns).List(ctx, opts)
 	if err != nil {

--- a/cmd/otel-allocator/collector/collector.go
+++ b/cmd/otel-allocator/collector/collector.go
@@ -91,7 +91,7 @@ func (k *Client) Watch(ctx context.Context, labelMap map[string]string, fn func(
 	}
 }
 
-func (k *Client) restartWatch(ctx context.Context, opts metav1.ListOptions, collectorMap map[string]*allocation.Collector, fn func(collectors map[string]*allocation.Collector)) bool { 
+func (k *Client) restartWatch(ctx context.Context, opts metav1.ListOptions, collectorMap map[string]*allocation.Collector, fn func(collectors map[string]*allocation.Collector)) bool {
 	log := k.log.WithValues("component", "opentelemetry-targetallocator")
 	// add timeout to the context before calling Watch
 	ctx, cancel := context.WithTimeout(ctx, watcherTimeout)
@@ -109,7 +109,6 @@ func (k *Client) restartWatch(ctx context.Context, opts metav1.ListOptions, coll
 
 	return true
 }
-
 
 func runWatch(ctx context.Context, k *Client, c <-chan watch.Event, collectorMap map[string]*allocation.Collector, fn func(collectors map[string]*allocation.Collector)) string {
 	log := k.log.WithValues("component", "opentelemetry-targetallocator")

--- a/cmd/otel-allocator/collector/collector.go
+++ b/cmd/otel-allocator/collector/collector.go
@@ -45,9 +45,9 @@ var (
 )
 
 type Client struct {
-	log       logr.Logger
-	k8sClient kubernetes.Interface
-	close     chan struct{}
+	log            logr.Logger
+	k8sClient      kubernetes.Interface
+	close          chan struct{}
 	timeoutSeconds int64
 }
 
@@ -58,9 +58,9 @@ func NewClient(logger logr.Logger, kubeConfig *rest.Config) (*Client, error) {
 	}
 
 	return &Client{
-		log:       logger,
-		k8sClient: clientset,
-		close:     make(chan struct{}),
+		log:            logger,
+		k8sClient:      clientset,
+		close:          make(chan struct{}),
 		timeoutSeconds: int64(watcherTimeout / time.Second),
 	}, nil
 }
@@ -72,7 +72,7 @@ func (k *Client) Watch(ctx context.Context, labelMap map[string]string, fn func(
 	// convert watcherTimeout to an integer in seconds
 	interval := int64(watcherTimeout / time.Second)
 	opts := metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labelMap).String(),
+		LabelSelector:  labels.SelectorFromSet(labelMap).String(),
 		TimeoutSeconds: &interval,
 	}
 	pods, err := k.k8sClient.CoreV1().Pods(ns).List(ctx, opts)

--- a/cmd/otel-allocator/collector/collector.go
+++ b/cmd/otel-allocator/collector/collector.go
@@ -69,7 +69,7 @@ func (k *Client) Watch(ctx context.Context, labelMap map[string]string, fn func(
 	collectorMap := map[string]*allocation.Collector{}
 	log := k.log.WithValues("component", "opentelemetry-targetallocator")
 
-	// convert watcherTimeout to an integer in seconds
+	// convert watcherTimeout to an integer in seconds.
 	interval := int64(watcherTimeout / time.Second)
 	opts := metav1.ListOptions{
 		LabelSelector:  labels.SelectorFromSet(labelMap).String(),

--- a/cmd/otel-allocator/collector/collector_test.go
+++ b/cmd/otel-allocator/collector/collector_test.go
@@ -171,16 +171,20 @@ func Test_closeChannel(t *testing.T) {
 	tests := []struct {
 		description    string
 		isCloseChannel bool
+		timeoutSeconds time.Duration
 	}{
 		{
 			// event is triggered by channel closing.
 			description:    "close_channel",
 			isCloseChannel: true,
+			// channel should be closed before this timeout occurs
+			timeoutSeconds: 10 * time.Second,
 		},
 		{
 			// event triggered by timeout.
 			description:    "watcher_timeout",
 			isCloseChannel: false,
+			timeoutSeconds: 0 * time.Second,
 		},
 	}
 
@@ -198,7 +202,7 @@ func Test_closeChannel(t *testing.T) {
 
 			go func(watcher watch.Interface) {
 				defer wg.Done()
-				ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*time.Second))
+				ctx, cancel := context.WithTimeout(context.Background(), tc.timeoutSeconds)
 				defer cancel()
 				if msg := runWatch(ctx, &kubeClient, watcher.ResultChan(), map[string]*allocation.Collector{}, func(colMap map[string]*allocation.Collector) {}); msg != "" {
 					terminated = true

--- a/cmd/otel-allocator/collector/collector_test.go
+++ b/cmd/otel-allocator/collector/collector_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"sync"
 	"testing"
-	"time"
 
 	"k8s.io/apimachinery/pkg/watch"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -52,8 +51,8 @@ func getTestClient() (Client, watch.Interface) {
 
 	opts := metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labelMap).String(),
-		// this timeout doesn't seem to be having an effect
-		// i.e. no event is triggered after this duration
+		// this timeout doesn't seem to be having an effect.
+		// i.e. no event is triggered after this duration.
 		TimeoutSeconds: &kubeClient.timeoutSeconds,
 	}
 	watcher, err := kubeClient.k8sClient.CoreV1().Pods("test-ns").Watch(context.Background(), opts)
@@ -178,12 +177,12 @@ func Test_closeChannel(t *testing.T) {
 		isCloseChannel bool
 	}{
 		{
-			// event is triggered by channel closing
+			// event is triggered by channel closing.
 			description:    "close_channel",
 			isCloseChannel: true,
 		},
 		{
-			// event triggered by timeout
+			// event triggered by timeout.
 			description:    "watcher_timeout",
 			isCloseChannel: false,
 		},
@@ -203,14 +202,14 @@ func Test_closeChannel(t *testing.T) {
 
 			go func(watcher watch.Interface) {
 				defer wg.Done()
-				if msg := runWatch(context.Background(), &kubeClient, watcher.ResultChan(), map[string]*allocation.Collector{}, func(colMap map[string]*allocation.Collector) { time.Sleep(20) }); msg != "" {
+				if msg := runWatch(context.Background(), &kubeClient, watcher.ResultChan(), map[string]*allocation.Collector{}, func(colMap map[string]*allocation.Collector) {}); msg != "" {
 					terminated = true
 					return
 				}
 			}(watcher)
 
 			if tc.isCloseChannel {
-				// stop pod watcher to trigger event
+				// stop pod watcher to trigger event.
 				watcher.Stop()
 			}
 			wg.Wait()

--- a/cmd/otel-allocator/collector/collector_test.go
+++ b/cmd/otel-allocator/collector/collector_test.go
@@ -38,9 +38,9 @@ var logger = logf.Log.WithName("collector-unit-tests")
 
 func getTestClient() (Client, watch.Interface) {
 	kubeClient := Client{
-		k8sClient:      fake.NewSimpleClientset(),
-		close:          make(chan struct{}),
-		log:            logger,
+		k8sClient: fake.NewSimpleClientset(),
+		close:     make(chan struct{}),
+		log:       logger,
 	}
 
 	labelMap := map[string]string{
@@ -198,7 +198,7 @@ func Test_closeChannel(t *testing.T) {
 
 			go func(watcher watch.Interface) {
 				defer wg.Done()
-				ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10 * time.Second))
+				ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*time.Second))
 				defer cancel()
 				if msg := runWatch(ctx, &kubeClient, watcher.ResultChan(), map[string]*allocation.Collector{}, func(colMap map[string]*allocation.Collector) {}); msg != "" {
 					terminated = true

--- a/cmd/otel-allocator/collector/collector_test.go
+++ b/cmd/otel-allocator/collector/collector_test.go
@@ -170,7 +170,7 @@ func Test_runWatch(t *testing.T) {
 	}
 }
 
-// this tests runWatch in the case of watcher channel closing and watcher timing out
+// this tests runWatch in the case of watcher channel closing and watcher timing out.
 func Test_closeChannel(t *testing.T) {
 	tests := []struct {
 		description    string

--- a/cmd/otel-allocator/collector/collector_test.go
+++ b/cmd/otel-allocator/collector/collector_test.go
@@ -198,7 +198,7 @@ func Test_closeChannel(t *testing.T) {
 
 			go func(watcher watch.Interface) {
 				defer wg.Done()
-				ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*time.Second))
+				ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*time.Second))
 				defer cancel()
 				if msg := runWatch(ctx, &kubeClient, watcher.ResultChan(), map[string]*allocation.Collector{}, func(colMap map[string]*allocation.Collector) {}); msg != "" {
 					terminated = true


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-operator/issues/1028

Before fix:
```
{"level":"info","ts":1668017421.9970064,"msg":"Starting the Target Allocator"}
{"level":"info","ts":1668017421.9972935,"logger":"allocator","msg":"Unrecognized filter strategy; filtering disabled"}
{"level":"info","ts":1668017422.0179584,"logger":"setup","msg":"Starting server..."}
{"level":"info","ts":1668017422.0202508,"logger":"allocator","msg":"Successfully started a collector pod watcher","component":"opentelemetry-targetallocator"}
{"level":"info","ts":1665127338.1837273,"logger":"allocator","msg":"false","component":"opentelemetry-targetallocator"}
{"level":"info","ts":1665127338.1838017,"logger":"allocator","msg":"Collector pod watch event stopped no event","component":"opentelemetry-targetallocator"}
```

This meant pod watcher is no longer running and the TA assigns remaining targets to pods that were already terminated

After fix:

```
{"level":"info","ts":1668017421.9970064,"msg":"Starting the Target Allocator"}
{"level":"info","ts":1668017421.9972935,"logger":"allocator","msg":"Unrecognized filter strategy; filtering disabled"}
{"level":"info","ts":1668017422.0179584,"logger":"setup","msg":"Starting server..."}
{"level":"info","ts":1668017422.0202508,"logger":"allocator","msg":"Successfully started a collector pod watcher","component":"opentelemetry-targetallocator"}
{"level":"info","ts":1668020290.9531963,"logger":"allocator","msg":"No event found. Restarting watch routine","component":"opentelemetry-targetallocator"}
{"level":"info","ts":1668020290.9575274,"logger":"allocator","msg":"Successfully started a collector pod watcher","component":"opentelemetry-targetallocator"}
{"level":"info","ts":1668023632.289222,"logger":"allocator","msg":"No event found. Restarting watch routine","component":"opentelemetry-targetallocator"}
{"level":"info","ts":1668023632.292879,"logger":"allocator","msg":"Successfully started a collector pod watcher","component":"opentelemetry-targetallocator"}
```

pod watcher gets restarted until stabilization occurs -> confirmed TA is assigning targets to correct remaining pods