### PR TITLE
Allow setting Collector config through ConfigMap

### DIFF
--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -98,8 +98,11 @@ type OpenTelemetryCollectorSpec struct {
 	// +optional
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// Config is the raw JSON to be used as the collector's configuration. Refer to the OpenTelemetry Collector documentation for details.
-	// +required
+	// +optional
 	Config string `json:"config,omitempty"`
+	// ConfigMap is a reference to a ConfigMap containing the collector's configuration. Refer to the OpenTelemetry Collector documentation for details.
+	// + optional
+	ConfigMap v1.ConfigMapKeySelector `json:"configMap,omitempty"`
 	// VolumeMounts represents the mount points to use in the underlying collector deployment(s)
 	// +optional
 	// +listType=atomic

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -384,6 +384,7 @@ func (in *OpenTelemetryCollectorSpec) DeepCopyInto(out *OpenTelemetryCollectorSp
 		}
 	}
 	in.TargetAllocator.DeepCopyInto(&out.TargetAllocator)
+	in.ConfigMap.DeepCopyInto(&out.ConfigMap)
 	if in.VolumeMounts != nil {
 		in, out := &in.VolumeMounts, &out.VolumeMounts
 		*out = make([]v1.VolumeMount, len(*in))

--- a/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -1022,6 +1022,26 @@ spec:
                   configuration. Refer to the OpenTelemetry Collector documentation
                   for details.
                 type: string
+              configMap:
+                description: ConfigMap is a reference to a ConfigMap containing the
+                  collector's configuration. Refer to the OpenTelemetry Collector
+                  documentation for details.
+                properties:
+                  key:
+                    description: The key to select.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                  optional:
+                    description: Specify whether the ConfigMap or its key must be
+                      defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
               env:
                 description: ENV vars to set on the OpenTelemetry Collector's Pods.
                   These can then in certain cases be consumed in the config file for

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -1020,6 +1020,26 @@ spec:
                   configuration. Refer to the OpenTelemetry Collector documentation
                   for details.
                 type: string
+              configMap:
+                description: ConfigMap is a reference to a ConfigMap containing the
+                  collector's configuration. Refer to the OpenTelemetry Collector
+                  documentation for details.
+                properties:
+                  key:
+                    description: The key to select.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                  optional:
+                    description: Specify whether the ConfigMap or its key must be
+                      defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
               env:
                 description: ENV vars to set on the OpenTelemetry Collector's Pods.
                   These can then in certain cases be consumed in the config file for

--- a/controllers/opentelemetrycollector_controller.go
+++ b/controllers/opentelemetrycollector_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/autodetect"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/reconcile"
 )
 
@@ -148,6 +149,7 @@ func (r *OpenTelemetryCollectorReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	instance.Spec.Config = adapters.GetConfigString(r.Client, log, instance.Spec.Config, instance.Spec.ConfigMap, instance.Namespace)
 	params := reconcile.Params{
 		Config:   r.config,
 		Client:   r.Client,

--- a/docs/api.md
+++ b/docs/api.md
@@ -1713,6 +1713,13 @@ OpenTelemetryCollectorSpec defines the desired state of OpenTelemetryCollector.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b><a href="#opentelemetrycollectorspecconfigmap">configMap</a></b></td>
+        <td>object</td>
+        <td>
+          ConfigMap is a reference to a ConfigMap containing the collector's configuration. Refer to the OpenTelemetry Collector documentation for details.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#opentelemetrycollectorspecenvindex">env</a></b></td>
         <td>[]object</td>
         <td>
@@ -3438,6 +3445,47 @@ HPAScalingPolicy is a single policy which must hold true for a specified past in
             <i>Format</i>: int32<br/>
         </td>
         <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### OpenTelemetryCollector.spec.configMap
+<sup><sup>[↩ Parent](#opentelemetrycollectorspec)</sup></sup>
+
+
+
+ConfigMap is a reference to a ConfigMap containing the collector's configuration. Refer to the OpenTelemetry Collector documentation for details.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          The key to select.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>
+          Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>optional</b></td>
+        <td>boolean</td>
+        <td>
+          Specify whether the ConfigMap or its key must be defined<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/pkg/collector/adapters/config_from.go
+++ b/pkg/collector/adapters/config_from.go
@@ -16,9 +16,14 @@
 package adapters
 
 import (
+	"context"
 	"errors"
 
+	"github.com/go-logr/logr"
 	"gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -35,4 +40,21 @@ func ConfigFromString(configStr string) (map[interface{}]interface{}, error) {
 	}
 
 	return config, nil
+}
+
+// GetConfigString returns the string value for the Collector, whether that is from spec.config as a string literal
+// or from spec.configMap as stored in a ConfigMap. The value can be used later in ConfigFromString.
+func GetConfigString(client client.Client, logger logr.Logger, configStr string, configMap v1.ConfigMapKeySelector, namespace string) string {
+	// the webhook validates that only one of spec.Config or spec.ConfigMap will be set, so we can assume that here
+	if len(configStr) > 0 {
+		return configStr
+	}
+
+	obj := &v1.ConfigMap{}
+	err := client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: configMap.Name}, obj)
+	if err != nil {
+		logger.Error(err, "error getting configmap")
+		return ""
+	}
+	return obj.Data[configMap.Key]
 }

--- a/pkg/sidecar/podmutator.go
+++ b/pkg/sidecar/podmutator.go
@@ -29,6 +29,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/webhookhandler"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
 )
 
 var (
@@ -88,6 +89,7 @@ func (p *sidecarPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod
 		// something else happened, better fail here
 		return pod, err
 	}
+	otelcol.Spec.Config = adapters.GetConfigString(p.client, logger, otelcol.Spec.Config, otelcol.Spec.ConfigMap, otelcol.Namespace)
 
 	// getting pod references, if any
 	references := p.podReferences(ctx, pod.OwnerReferences, ns)


### PR DESCRIPTION
Fixes #1196

this adds a `spec.ConfigMap` field to the OpenTelemetryCollector CRD that lets users specify the name and key of a configmap that contains the collector config (rather than needing to use the string literal that currently exists). The configmap must be in the same namespace as the collector instance.

Internally, this works by the following:
1. enforce that only 1 of `spec.Config` or `spec.ConfigMap` is set at admission
2. at the top of the reconcile loop/webhooks, set the `instance.Spec.Config` string to the ConfigMap value (if it exists) or just use the string literal (if that is set instead)
3. Continue on the rest of the logic as usual

I tried a couple different approaches for this, and I think this is overall the best one. The next alternative I had tried to avoid mutating the instance in memory by passing a new param with the parsed config value to each function, and using that instead. This ended up needing a lot of changes, and looked confusing since `instance.Spec.Config` was still accessible in many cases. Ultimately, mutating the object in memory should be fine since the operator shouldn't be writing anything back to the cluster object besides its `status`.