### PR TITLE
docs: add note about sidecar injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ EOF
 
 When using sidecar mode the OpenTelemetry collector container will have the environment variable `OTEL_RESOURCE_ATTRIBUTES`set with Kubernetes resource attributes, ready to be consumed by the [resourcedetection](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor) processor.
 
+**_Note:_** Sidecar injection from a namespace different from the pod to be injected into cannot currently be accomplished due to the requirement to mount the sidecar's config map.
+
 ### OpenTelemetry auto-instrumentation injection
 
 The operator can inject and configure OpenTelemetry auto-instrumentation libraries. Currently DotNet, Java, NodeJS and Python are supported.


### PR DESCRIPTION
Adds a quick note for anyone trying to inject sidecars from namespaces other than the one the pod they are injecting into is in.