### PR TITLE
Update default python exporters to use OTLP

### DIFF
--- a/.chloggen/update-python-metrics-exporter.yaml
+++ b/.chloggen/update-python-metrics-exporter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: instrumentation/python
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Updates the default exporters to `otlp` and sets `OTEL_EXPORTER_OTLP_[TRACES|METRICS]_PROTOCOL` to `http/protobuf`
+
+# One or more tracking issues related to the change
+issues: [1328]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -406,15 +406,15 @@ func TestMutatePod(t *testing.T) {
 							},
 							{
 								Name:  "OTEL_TRACES_EXPORTER",
-								Value: "otlp_proto_http",
+								Value: "otlp",
 							},
 							{
 								Name:  "OTEL_METRICS_EXPORTER",
-								Value: "none",
+								Value: "otlp",
 							},
 							{
 								Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
-								Value: "http://localhost:4317",
+								Value: "http://localhost:4318",
 							},
 						},
 					},
@@ -491,19 +491,27 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_TRACES_EXPORTER",
-									Value: "otlp_proto_http",
+									Value: "otlp",
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
-									Value: "none",
+									Value: "otlp",
 								},
 								{
 									Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
-									Value: "http://localhost:4317",
+									Value: "http://localhost:4318",
 								},
 								{
 									Name:  "PYTHONPATH",
 									Value: fmt.Sprintf("%s:%s", pythonPathPrefix, pythonPathSuffix),
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+									Value: "http/protobuf",
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+									Value: "http/protobuf",
 								},
 								{
 									Name:  "OTEL_EXPORTER_OTLP_TIMEOUT",

--- a/pkg/instrumentation/python.go
+++ b/pkg/instrumentation/python.go
@@ -66,15 +66,15 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 			Name:  envOtelTracesExporter,
 			Value: "otlp",
 		})
+	}
 
-		// Set OTEL_EXPORTER_OTLP_TRACES_PROTOCOL to http/protobuf if not set by user because it is what our autoinstrumentation supports.
-		idx = getIndexOfEnv(container.Env, envOtelExporterOTLPTracesProtocol)
-		if idx == -1 {
-			container.Env = append(container.Env, corev1.EnvVar{
-				Name:  envOtelExporterOTLPTracesProtocol,
-				Value: "http/protobuf",
-			})
-		}
+	// Set OTEL_EXPORTER_OTLP_TRACES_PROTOCOL to http/protobuf if not set by user because it is what our autoinstrumentation supports.
+	idx = getIndexOfEnv(container.Env, envOtelExporterOTLPTracesProtocol)
+	if idx == -1 {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  envOtelExporterOTLPTracesProtocol,
+			Value: "http/protobuf",
+		})
 	}
 
 	// Set OTEL_METRICS_EXPORTER to HTTP exporter if not set by user because it is what our autoinstrumentation supports.
@@ -84,15 +84,15 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 			Name:  envOtelMetricsExporter,
 			Value: "otlp",
 		})
+	}
 
-		// Set OTEL_EXPORTER_OTLP_METRICS_PROTOCOL to http/protobuf if not set by user because it is what our autoinstrumentation supports.
-		idx = getIndexOfEnv(container.Env, envOtelExporterOTLPMetricsProtocol)
-		if idx == -1 {
-			container.Env = append(container.Env, corev1.EnvVar{
-				Name:  envOtelExporterOTLPMetricsProtocol,
-				Value: "http/protobuf",
-			})
-		}
+	// Set OTEL_EXPORTER_OTLP_METRICS_PROTOCOL to http/protobuf if not set by user because it is what our autoinstrumentation supports.
+	idx = getIndexOfEnv(container.Env, envOtelExporterOTLPMetricsProtocol)
+	if idx == -1 {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  envOtelExporterOTLPMetricsProtocol,
+			Value: "http/protobuf",
+		})
 	}
 
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{

--- a/pkg/instrumentation/python.go
+++ b/pkg/instrumentation/python.go
@@ -66,15 +66,11 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 		})
 	}
 
-	// TODO: https://github.com/open-telemetry/opentelemetry-python/issues/2447 this should
-	// also be set to `otlp_proto_http` once an exporter is implemented. For now, set
-	// OTEL_METRICS_EXPORTER to none if not set by user to prevent using the default grpc
-	// exporter which is not included in the image.
 	idx = getIndexOfEnv(container.Env, envOtelMetricsExporter)
 	if idx == -1 {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  envOtelMetricsExporter,
-			Value: "none",
+			Value: "otlp_proto_http",
 		})
 	}
 

--- a/pkg/instrumentation/python.go
+++ b/pkg/instrumentation/python.go
@@ -23,11 +23,13 @@ import (
 )
 
 const (
-	envPythonPath          = "PYTHONPATH"
-	envOtelTracesExporter  = "OTEL_TRACES_EXPORTER"
-	envOtelMetricsExporter = "OTEL_METRICS_EXPORTER"
-	pythonPathPrefix       = "/otel-auto-instrumentation/opentelemetry/instrumentation/auto_instrumentation"
-	pythonPathSuffix       = "/otel-auto-instrumentation"
+	envPythonPath                      = "PYTHONPATH"
+	envOtelTracesExporter              = "OTEL_TRACES_EXPORTER"
+	envOtelMetricsExporter             = "OTEL_METRICS_EXPORTER"
+	envOtelExporterOTLPTracesProtocol  = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
+	envOtelExporterOTLPMetricsProtocol = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
+	pythonPathPrefix                   = "/otel-auto-instrumentation/opentelemetry/instrumentation/auto_instrumentation"
+	pythonPathSuffix                   = "/otel-auto-instrumentation"
 )
 
 func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (corev1.Pod, error) {
@@ -62,16 +64,35 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 	if idx == -1 {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  envOtelTracesExporter,
-			Value: "otlp_proto_http",
+			Value: "otlp",
 		})
+
+		// Set OTEL_EXPORTER_OTLP_TRACES_PROTOCOL to http/protobuf if not set by user because it is what our autoinstrumentation supports.
+		idx = getIndexOfEnv(container.Env, envOtelExporterOTLPTracesProtocol)
+		if idx == -1 {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  envOtelExporterOTLPTracesProtocol,
+				Value: "http/protobuf",
+			})
+		}
 	}
 
+	// Set OTEL_METRICS_EXPORTER to HTTP exporter if not set by user because it is what our autoinstrumentation supports.
 	idx = getIndexOfEnv(container.Env, envOtelMetricsExporter)
 	if idx == -1 {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  envOtelMetricsExporter,
-			Value: "otlp_proto_http",
+			Value: "otlp",
 		})
+
+		// Set OTEL_EXPORTER_OTLP_METRICS_PROTOCOL to http/protobuf if not set by user because it is what our autoinstrumentation supports.
+		idx = getIndexOfEnv(container.Env, envOtelExporterOTLPMetricsProtocol)
+		if idx == -1 {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  envOtelExporterOTLPMetricsProtocol,
+				Value: "http/protobuf",
+			})
+		}
 	}
 
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{

--- a/pkg/instrumentation/python_test.go
+++ b/pkg/instrumentation/python_test.go
@@ -78,11 +78,19 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_TRACES_EXPORTER",
-									Value: "otlp_proto_http",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+									Value: "http/protobuf",
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
-									Value: "otlp_proto_http",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+									Value: "http/protobuf",
 								},
 							},
 						},
@@ -144,11 +152,19 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_TRACES_EXPORTER",
-									Value: "otlp_proto_http",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+									Value: "http/protobuf",
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
-									Value: "otlp_proto_http",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+									Value: "http/protobuf",
 								},
 							},
 						},
@@ -214,7 +230,11 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
-									Value: "otlp_proto_http",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+									Value: "http/protobuf",
 								},
 							},
 						},
@@ -280,7 +300,11 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_TRACES_EXPORTER",
-									Value: "otlp_proto_http",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+									Value: "http/protobuf",
 								},
 							},
 						},

--- a/pkg/instrumentation/python_test.go
+++ b/pkg/instrumentation/python_test.go
@@ -82,7 +82,7 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
-									Value: "none",
+									Value: "otlp_proto_http",
 								},
 							},
 						},
@@ -148,7 +148,7 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
-									Value: "none",
+									Value: "otlp_proto_http",
 								},
 							},
 						},
@@ -214,7 +214,7 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
-									Value: "none",
+									Value: "otlp_proto_http",
 								},
 							},
 						},

--- a/pkg/instrumentation/python_test.go
+++ b/pkg/instrumentation/python_test.go
@@ -229,6 +229,10 @@ func TestInjectPythonSDK(t *testing.T) {
 									Value: fmt.Sprintf("%s:%s", pythonPathPrefix, pythonPathSuffix),
 								},
 								{
+									Name:  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+									Value: "http/protobuf",
+								},
+								{
 									Name:  "OTEL_METRICS_EXPORTER",
 									Value: "otlp",
 								},
@@ -304,6 +308,10 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+									Value: "http/protobuf",
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
 									Value: "http/protobuf",
 								},
 							},

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -638,7 +638,7 @@ func TestInjectPython(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_METRICS_EXPORTER",
-							Value: "none",
+							Value: "otlp_proto_http",
 						},
 						{
 							Name:  "OTEL_SERVICE_NAME",

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -634,11 +634,19 @@ func TestInjectPython(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_TRACES_EXPORTER",
-							Value: "otlp_proto_http",
+							Value: "otlp",
+						},
+						{
+							Name:  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+							Value: "http/protobuf",
 						},
 						{
 							Name:  "OTEL_METRICS_EXPORTER",
-							Value: "otlp_proto_http",
+							Value: "otlp",
+						},
+						{
+							Name:  "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+							Value: "http/protobuf",
 						},
 						{
 							Name:  "OTEL_SERVICE_NAME",

--- a/tests/e2e/instrumentation-python-multicontainer/01-assert.yaml
+++ b/tests/e2e/instrumentation-python-multicontainer/01-assert.yaml
@@ -14,9 +14,13 @@ spec:
     - name: PYTHONPATH
       value: /otel-auto-instrumentation/opentelemetry/instrumentation/auto_instrumentation:/otel-auto-instrumentation
     - name: OTEL_TRACES_EXPORTER
-      value: otlp_proto_http
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+      value: http/protobuf
     - name: OTEL_METRICS_EXPORTER
-      value: none
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+      value: http/protobuf
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://localhost:4317
     - name: OTEL_EXPORTER_OTLP_TIMEOUT
@@ -43,9 +47,13 @@ spec:
     - name: PYTHONPATH
       value: /otel-auto-instrumentation/opentelemetry/instrumentation/auto_instrumentation:/otel-auto-instrumentation
     - name: OTEL_TRACES_EXPORTER
-      value: otlp_proto_http
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+      value: http/protobuf
     - name: OTEL_METRICS_EXPORTER
-      value: none
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+      value: http/protobuf
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://localhost:4317
     - name: OTEL_EXPORTER_OTLP_TIMEOUT

--- a/tests/e2e/instrumentation-python-multicontainer/02-assert.yaml
+++ b/tests/e2e/instrumentation-python-multicontainer/02-assert.yaml
@@ -17,9 +17,13 @@ spec:
     - name: PYTHONPATH
       value: /otel-auto-instrumentation/opentelemetry/instrumentation/auto_instrumentation:/otel-auto-instrumentation
     - name: OTEL_TRACES_EXPORTER
-      value: otlp_proto_http
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+      value: http/protobuf
     - name: OTEL_METRICS_EXPORTER
-      value: none
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+      value: http/protobuf
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://localhost:4317
     - name: OTEL_EXPORTER_OTLP_TIMEOUT

--- a/tests/e2e/instrumentation-python/00-install-instrumentation.yaml
+++ b/tests/e2e/instrumentation-python/00-install-instrumentation.yaml
@@ -25,6 +25,6 @@ spec:
       - name: OTEL_LOG_LEVEL
         value: "debug"
       - name: OTEL_TRACES_EXPORTER
-        value: otlp_proto_http
+        value: otlp
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://localhost:4317
+        value: http://localhost:4318

--- a/tests/e2e/instrumentation-python/01-assert.yaml
+++ b/tests/e2e/instrumentation-python/01-assert.yaml
@@ -14,16 +14,16 @@ spec:
       value: "debug"
     - name: OTEL_TRACES_EXPORTER
       value: otlp
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4318
+    - name: PYTHONPATH
+      value: "/otel-auto-instrumentation/opentelemetry/instrumentation/auto_instrumentation:/otel-auto-instrumentation"
     - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
       value: http/protobuf
     - name: OTEL_METRICS_EXPORTER
       value: otlp
     - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
       value: http/protobuf
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4318
-    - name: PYTHONPATH
-      value: "/otel-auto-instrumentation/opentelemetry/instrumentation/auto_instrumentation:/otel-auto-instrumentation"
     - name: OTEL_EXPORTER_OTLP_TIMEOUT
       value: "20"
     - name: OTEL_TRACES_SAMPLER

--- a/tests/e2e/instrumentation-python/01-assert.yaml
+++ b/tests/e2e/instrumentation-python/01-assert.yaml
@@ -13,13 +13,17 @@ spec:
     - name: OTEL_LOG_LEVEL
       value: "debug"
     - name: OTEL_TRACES_EXPORTER
-      value: otlp_proto_http
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL
+      value: http/protobuf
+    - name: OTEL_METRICS_EXPORTER
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
+      value: http/protobuf
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4317
+      value: http://localhost:4318
     - name: PYTHONPATH
       value: "/otel-auto-instrumentation/opentelemetry/instrumentation/auto_instrumentation:/otel-auto-instrumentation"
-    - name: OTEL_METRICS_EXPORTER
-      value: none
     - name: OTEL_EXPORTER_OTLP_TIMEOUT
       value: "20"
     - name: OTEL_TRACES_SAMPLER


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-operator/issues/1168.

Updates the default exporters for python to use `otlp` and `OTEL_EXPORTER_OTLP_[TRACES|METRICS]_PROTOCOL=http/protobuf`

Depends on https://github.com/open-telemetry/opentelemetry-operator/pull/1321