### PR TITLE
[chore] Update Instrumentation example with python env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ spec:
     argument: "0.25"
   python:
     env:
+      # Required if endpoint is set to 4317.
+      # Python autoinstrumentation uses http/proto by default
+      # so data must be sent to 4318 instead of 4137.
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://otel-collector:4318
 EOF

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ spec:
   sampler:
     type: parentbased_traceidratio
     argument: "0.25"
+  python:
+    env:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://otel-collector:4318
 EOF
 ```
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-operator/issues/924

Updates the README's Instrumentation object to explicitly set python's OTEL_EXPORTER_OTLP_ENDPOINT value to 4318.  

If we want we can also update the python injection to update any existing OTEL_EXPORTER_OTLP_ENDPOINT value to be `4318` so that this distinction isn't necessary, but I think that change needs some scrutiny to make sure users can still configure anything they want with confidence that we aren't messing with it.