### PR TITLE
[bug_fix] Missing resource from OpenShift Routes prevents them to be deployed in OpenShift clusters

### DIFF
--- a/.chloggen/1337-fix-routes-openshift.yaml
+++ b/.chloggen/1337-fix-routes-openshift.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "There was a missing resource in the OpenShift routes ClusterBinding"
+
+# One or more tracking issues related to the change
+issues: [1337]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -261,6 +261,7 @@ spec:
           - route.openshift.io
           resources:
           - routes
+          - routes/custom-host
           verbs:
           - create
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -172,6 +172,7 @@ rules:
   - route.openshift.io
   resources:
   - routes
+  - routes/custom-host
   verbs:
   - create
   - delete

--- a/controllers/opentelemetrycollector_controller.go
+++ b/controllers/opentelemetrycollector_controller.go
@@ -181,7 +181,7 @@ func NewReconciler(p Params) *OpenTelemetryCollectorReconciler {
 // +kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 


### PR DESCRIPTION
After #1206 , OpenShift routes are supported by the OpenTelemetry Collector Operator.

In upstream, this works because we're installing the OpenShift Routes CRD in the Kubernetes cluster. But, for OpenShift, the creation of routes don't work.

## How to reproduce
When this manifest is deployed:
```yaml
apiVersion: opentelemetry.io/v1alpha1
kind: OpenTelemetryCollector
metadata:
  name: simplest
spec:
  mode: "deployment"
  ingress:
    type: route
    hostname: "example.com"
    annotations:
      something.com: "true"
    route:
      termination: "insecure"

  config: |
    receivers:
      otlp:
        protocols:
          grpc:

    exporters:
      logging:

    service:
      pipelines:
        traces:
          receivers: [otlp]
          processors: []
          exporters: [logging]
```

This error is logged in the OTEL Collector Operator:
```json
{"level":"error","ts":"2022-12-21T16:32:48.213626Z","msg":"Reconciler error","controller":"opentelemetrycollector","controllerGroup":"opentelemetry.io","controllerKind":"OpenTelemetryCollector","OpenTelemetryCollector":{"name":"simplest","namespace":"israel"},"namespace":"israel","name":"simplest","reconcileID":"83890790-0c84-49de-ace1-9c0c305e8d51","error":"failed to reconcile the expected routes: failed to create: Route.route.openshift.io \"otlp-grpc-simplest-route\" is invalid: spec.host: Forbidden: you do not have permission to set the host field of the route","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.1/pkg/internal/controller/controller.go:326\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.1/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.13.1/pkg/internal/controller/controller.go:234"}
```
And the Collector nor the Route are created.

## Environment
OCP version: `4.11`
Branch: `main`
Commit: `06503f9eb1ff8dcaddcbb13c97a3fe9d5a7fbb18`