### PR TITLE
[target-allocator] Change the github action to match the operator

### DIFF
--- a/.chloggen/1298-change-ta-build-proc.yaml
+++ b/.chloggen/1298-change-ta-build-proc.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target-allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: This PR changes how the target allocator images are released by having all new target allocator changes in a "main" tagged image, with the version tag being generated only on an official release.
+
+# One or more tracking issues related to the change
+issues: [1298]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/publish-target-allocator.yaml
+++ b/.github/workflows/publish-target-allocator.yaml
@@ -19,7 +19,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Read version
-        run: grep -v '\#' versions.txt | grep targetallocator | awk -F= '{print "VERSION="$2}' >> $GITHUB_ENV
+        run: |
+          echo "VERSION=$(git describe --tags | sed 's/^v//')" >> $GITHUB_ENV
+          echo "VERSION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta
@@ -27,7 +29,10 @@ jobs:
         with:
           images: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
           tags: |
-            type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{raw}}
+            type=ref,event=branch
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -56,7 +61,9 @@ jobs:
           context: cmd/otel-allocator
           platforms: linux/amd64,linux/arm64
           push: true
-          build-args: version=${{ env.VERSION }}
+          build-args: |
+            VERSION=${{ env.VERSION }}
+            VERSION_DATE=${{ env.VERSION_DATE }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
Closes #1298

This changes the target allocator image building process to set the versions the same the operator does. This means that when a new release is created, the target allocator will be made using that version tag. This also will have a "main" release like the operator as well.