### PR TITLE
[target allocator] Fix concurrent map access in discoverer

### DIFF
--- a/.chloggen/1359-fix-data-race-in-discoverer.yaml
+++ b/.chloggen/1359-fix-data-race-in-discoverer.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix concurrent write and read access to config map in Discoverer"
+
+# One or more tracking issues related to the change
+issues: [1359]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
Protect the job to scrape config map with a mutex and when returning the config create a copy of the map, to prevent concurrent access.

Resolves #1359

Signed-off-by: Matej Gera <matej.gera@coralogix.com>