### PR TITLE
Make sure dev image is always overridden

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ When deploying the operator into the cluster using `make deploy`, an image in th
 * `IMG`, to override the entire image specification
 
 ```bash
-IMG=docker.io/${USER}/opentelemetry-operator:dev-(git rev-parse --short HEAD)-$(date +%s) make generate bundle container container-push deploy
+IMG=docker.io/${USER}/opentelemetry-operator:dev-$(git rev-parse --short HEAD)-$(date +%s) make generate bundle container container-push deploy
 ```
 
 Your operator will be available in the `opentelemetry-operator-system` namespace.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ When deploying the operator into the cluster using `make deploy`, an image in th
 * `IMG`, to override the entire image specification
 
 ```bash
-IMG=docker.io/${USER}/opentelemetry-operator:latest make generate bundle container container-push deploy
+IMG=docker.io/${USER}/opentelemetry-operator:dev-(git rev-parse --short HEAD)-$(date +%s) make generate bundle container container-push deploy
 ```
 
 Your operator will be available in the `opentelemetry-operator-system` namespace.


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Make sure the dev image has always a new tag so it's deployed. 