### PR TITLE
[target-allocator] Replace deprecated `gorilla/mux` dependency with `gin`

### DIFF
--- a/.chloggen/1383-replace-deperecated-gorilla-dependency.yaml
+++ b/.chloggen/1383-replace-deperecated-gorilla-dependency.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: "target allocator"
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Replace deprecated dependency `gorilla/mux` with `gin` and adjust HTTP method signatures and configuration to correspond functionally to existing code."
+
+# One or more tracking issues related to the change
+issues: [1352]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/go.mod
+++ b/cmd/otel-allocator/go.mod
@@ -6,9 +6,10 @@ require (
 	github.com/buraksezer/consistent v0.10.0
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/fsnotify/fsnotify v1.5.4
+	github.com/ghodss/yaml v1.0.0
+	github.com/gin-gonic/gin v1.5.0
 	github.com/go-kit/log v0.2.1
 	github.com/go-logr/logr v1.2.3
-	github.com/gorilla/mux v1.8.0
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/oklog/run v1.1.0
 	github.com/prometheus-operator/prometheus-operator v0.53.1
@@ -62,7 +63,7 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v0.6.7 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
@@ -76,6 +77,8 @@ require (
 	github.com/go-openapi/strfmt v0.21.3 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/go-openapi/validate v0.21.0 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48 // indirect
 	github.com/go-zookeeper/zk v1.0.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -113,6 +116,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kolo/xmlrpc v0.0.0-20201022064351-38db28db192b // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/linode/linodego v1.8.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
@@ -140,6 +144,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/thanos-io/thanos v0.24.0-rc.1 // indirect
+	github.com/ugorji/go/codec v1.1.7 // indirect
 	github.com/vultr/govultr/v2 v2.17.2 // indirect
 	go.mongodb.org/mongo-driver v1.10.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
@@ -165,6 +170,7 @@ require (
 	google.golang.org/genproto v0.0.0-20220808204814-fd01256a5276 // indirect
 	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/go-playground/validator.v9 v9.29.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/cmd/otel-allocator/go.sum
+++ b/cmd/otel-allocator/go.sum
@@ -438,7 +438,9 @@ github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49P
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
+github.com/gin-gonic/gin v1.5.0 h1:fi+bqFAx/oLK54somfCtEZs9HeH1LHVoEPUgARpTqyc=
 github.com/gin-gonic/gin v1.5.0/go.mod h1:Nd6IXA8m5kNZdNEHMBd93KT+mdY3+bewLgRvmCsR2Do=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -585,8 +587,10 @@ github.com/go-openapi/validate v0.21.0 h1:+Wqk39yKOhfpLqNLEC0/eViCkzM5FVXVqrvt52
 github.com/go-openapi/validate v0.21.0/go.mod h1:rjnrwK57VJ7A8xqfpAOEKRH8yQSGUriMu5/zuPSQ1hg=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
+github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
+github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-redis/redis/v8 v8.0.0-beta.10.0.20200905143926-df7fe4e2ce72/go.mod h1:CJP1ZIHwhosNYwIdaHPZK9vHsM3+roNBaZ7U9Of1DXc=
@@ -794,7 +798,6 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.1/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -1014,6 +1017,7 @@ github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtB
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/leanovate/gopter v0.2.4/go.mod h1:gNcbPWNEWRe4lm+bycKqxUYoH5uoVje5SkOJ3uoLer8=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
+github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -1485,6 +1489,7 @@ github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6
 github.com/uber/jaeger-lib v2.4.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
+github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
@@ -2365,7 +2370,9 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
+gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
+gopkg.in/go-playground/validator.v9 v9.29.1 h1:SvGtYmN60a5CVKTOzMSyfzWDeZRxRuGvRQyEAKbw1xc=
 gopkg.in/go-playground/validator.v9 v9.29.1/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/cmd/otel-allocator/server/server.go
+++ b/cmd/otel-allocator/server/server.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	yaml2 "github.com/ghodss/yaml"
+	"github.com/gin-gonic/gin"
 	"github.com/go-logr/logr"
-	"github.com/gorilla/mux"
 	"github.com/mitchellh/hashstructure"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -64,12 +64,16 @@ func NewServer(log logr.Logger, allocator allocation.Allocator, discoveryManager
 		discoveryManager: discoveryManager,
 		compareHash:      uint64(0),
 	}
-	router := mux.NewRouter().UseEncodedPath()
+
+	router := gin.Default()
+	router.UseRawPath = true
+	router.UnescapePathValues = false
 	router.Use(s.PrometheusMiddleware)
-	router.HandleFunc("/scrape_configs", s.ScrapeConfigsHandler).Methods("GET")
-	router.HandleFunc("/jobs", s.JobHandler).Methods("GET")
-	router.HandleFunc("/jobs/{job_id}/targets", s.TargetsHandler).Methods("GET")
-	router.Path("/metrics").Handler(promhttp.Handler())
+	router.GET("/scrape_configs", s.ScrapeConfigsHandler)
+	router.GET("/jobs", s.JobHandler)
+	router.GET("/jobs/:job_id/targets", s.TargetsHandler)
+	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+
 	s.server = &http.Server{Addr: *listenAddr, Handler: router, ReadHeaderTimeout: 90 * time.Second}
 	return s
 }
@@ -87,13 +91,13 @@ func (s *Server) Shutdown(ctx context.Context) error {
 // ScrapeConfigsHandler returns the available scrape configuration discovered by the target allocator.
 // The target allocator first marshals these configurations such that the underlying prometheus marshaling is used.
 // After that, the YAML is converted in to a JSON format for consumers to use.
-func (s *Server) ScrapeConfigsHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) ScrapeConfigsHandler(c *gin.Context) {
 	configs := s.discoveryManager.GetScrapeConfigs()
 
 	hash, err := hashstructure.Hash(configs, nil)
 	if err != nil {
 		s.logger.Error(err, "failed to hash the config")
-		s.errorHandler(w, err)
+		s.errorHandler(c.Writer, err)
 		return
 	}
 	// if the hashes are different, we need to recompute the scrape config
@@ -101,67 +105,63 @@ func (s *Server) ScrapeConfigsHandler(w http.ResponseWriter, r *http.Request) {
 		var configBytes []byte
 		configBytes, err = yaml.Marshal(configs)
 		if err != nil {
-			s.errorHandler(w, err)
+			s.errorHandler(c.Writer, err)
 			return
 		}
 		var jsonConfig []byte
 		jsonConfig, err = yaml2.YAMLToJSON(configBytes)
 		if err != nil {
-			s.errorHandler(w, err)
+			s.errorHandler(c.Writer, err)
 			return
 		}
 		s.scrapeConfigResponse = jsonConfig
 		s.compareHash = hash
 	}
 	// We don't use the jsonHandler method because we don't want our bytes to be re-encoded
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(s.scrapeConfigResponse)
+	c.Writer.Header().Set("Content-Type", "application/json")
+	_, err = c.Writer.Write(s.scrapeConfigResponse)
 	if err != nil {
-		s.errorHandler(w, err)
+		s.errorHandler(c.Writer, err)
 	}
 }
 
-func (s *Server) JobHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) JobHandler(c *gin.Context) {
 	displayData := make(map[string]target.LinkJSON)
 	for _, v := range s.allocator.TargetItems() {
 		displayData[v.JobName] = target.LinkJSON{Link: v.Link.Link}
 	}
-	s.jsonHandler(w, displayData)
+	s.jsonHandler(c.Writer, displayData)
 }
 
-// PrometheusMiddleware implements mux.MiddlewareFunc.
-func (s *Server) PrometheusMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		route := mux.CurrentRoute(r)
-		path, _ := route.GetPathTemplate()
-		timer := prometheus.NewTimer(httpDuration.WithLabelValues(path))
-		next.ServeHTTP(w, r)
-		timer.ObserveDuration()
-	})
+func (s *Server) PrometheusMiddleware(c *gin.Context) {
+	path := c.FullPath()
+	timer := prometheus.NewTimer(httpDuration.WithLabelValues(path))
+	c.Next()
+	timer.ObserveDuration()
 }
 
-func (s *Server) TargetsHandler(w http.ResponseWriter, r *http.Request) {
-	q := r.URL.Query()["collector_id"]
+func (s *Server) TargetsHandler(c *gin.Context) {
+	q := c.Request.URL.Query()["collector_id"]
 
-	params := mux.Vars(r)
-	jobId, err := url.QueryUnescape(params["job_id"])
+	jobIdParam := c.Params.ByName("job_id")
+	jobId, err := url.QueryUnescape(jobIdParam)
 	if err != nil {
-		s.errorHandler(w, err)
+		s.errorHandler(c.Writer, err)
 		return
 	}
 
 	if len(q) == 0 {
 		displayData := GetAllTargetsByJob(s.allocator, jobId)
-		s.jsonHandler(w, displayData)
+		s.jsonHandler(c.Writer, displayData)
 
 	} else {
 		tgs := s.allocator.GetTargetsForCollectorAndJob(q[0], jobId)
 		// Displays empty list if nothing matches
 		if len(tgs) == 0 {
-			s.jsonHandler(w, []interface{}{})
+			s.jsonHandler(c.Writer, []interface{}{})
 			return
 		}
-		s.jsonHandler(w, tgs)
+		s.jsonHandler(c.Writer, tgs)
 	}
 }
 


### PR DESCRIPTION
Resolves #1352.

This change aims to replace the deprecated `gorilla/mux` with `gin` while maintaining the functionality of current solution.

Note: Due to difference in convention for path variables used by both frameworks (`gorilla/mux` using curly braces, .e.g `/jobs/{job_id}/targets` vs. `gin` using colon e.g. `/jobs/:job_id/targets`), the only change will be in the reported metric label for the jobs path.

Signed-off-by: Matej Gera <matej.gera@coralogix.com>