### PR TITLE
replace outdated link with web archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # OpenTelemetry Operator for Kubernetes
 
-The OpenTelemetry Operator is an implementation of a [Kubernetes Operator](https://coreos.com/operators/).
+The OpenTelemetry Operator is an implementation of a [Kubernetes Operator](http://web.archive.org/web/20201201093158/https://coreos.com/operators/).
 
 The operator manages:
 * [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)


### PR DESCRIPTION
To restore the content integrity, link to web archive, because the original link target at https://coreos.com nowadays redirects to redhat.com