### PR TITLE
[chore] Add dependabot checks for nested go module files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: gomod
+    directory: /cmd/operator-opamp-bridge
+    schedule:
+      interval: daily
+  - package-ecosystem: gomod
+    directory: /cmd/otel-allocator
+    schedule:
+      interval: daily
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
This adds entries to the `dependabot.yml` configuration file to target nested `go.mod` files for automatic package updates. 