### PR TITLE
register pprof endpoints for allocator

### DIFF
--- a/.chloggen/allocator-pprof.yaml
+++ b/.chloggen/allocator-pprof.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: register pprof endpoints under /debug/pprof
+
+# One or more tracking issues related to the change
+issues: [188]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/allocator-pprof.yaml
+++ b/.chloggen/allocator-pprof.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: target allocator
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: register pprof endpoints under /debug/pprof
+note: Register pprof endpoints under `/debug/pprof`.
 
 # One or more tracking issues related to the change
 issues: [188]


### PR DESCRIPTION
These are generally useful for tracking down performance issues.
Allocator clients are generally trusted, these shouldn't need to be on a separate endpoint.