### PR TITLE
[target-allocator] Remove json conversion from /scrape_configs

### DIFF
--- a/.chloggen/scrapeconfig-json-conversion.yaml
+++ b/.chloggen/scrapeconfig-json-conversion.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: yaml response instead of json for the scrape configs endpoint
+
+# One or more tracking issues related to the change
+issues: [1404]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/server/server.go
+++ b/cmd/otel-allocator/server/server.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"time"
 
-	yaml2 "github.com/ghodss/yaml"
 	"github.com/gin-gonic/gin"
 	"github.com/go-logr/logr"
 	"github.com/mitchellh/hashstructure"
@@ -113,13 +112,7 @@ func (s *Server) ScrapeConfigsHandler(c *gin.Context) {
 			s.errorHandler(c.Writer, err)
 			return
 		}
-		var jsonConfig []byte
-		jsonConfig, err = yaml2.YAMLToJSON(configBytes)
-		if err != nil {
-			s.errorHandler(c.Writer, err)
-			return
-		}
-		s.scrapeConfigResponse = jsonConfig
+		s.scrapeConfigResponse = configBytes
 		s.compareHash = hash
 	}
 	// We don't use the jsonHandler method because we don't want our bytes to be re-encoded


### PR DESCRIPTION
fixes https://github.com/open-telemetry/opentelemetry-operator/issues/1404

This change is breaking in that the scrape configs endpoint will now response with YAML instead of JSON.  However, the prometheus receiver which sends requests to `/scrape_configs` is currently using `yam.Unmarshal`: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/72d590e8e76a18bbec6d4ce8b6200520c5e94732/receiver/prometheusreceiver/metrics_receiver.go#L205-L233

This doesn't give us a large performance gain (compared to using jsoniter), but it is noticeable in benchmarks:
[scrapeconfig_bench_results.txt](https://github.com/open-telemetry/opentelemetry-operator/files/10542012/scrapeconfig_bench_results.txt)
