### PR TITLE
[target-allocator] Use `gin` in release mode and without default logger middleware

### DIFF
--- a/.chloggen/1414-adjust-gin-config.yaml
+++ b/.chloggen/1414-adjust-gin-config.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: "target allocator"
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Configure `gin` router to be used in release mode and do not use the default logging middleware which is noisy and not formatted properly."
+
+# One or more tracking issues related to the change
+issues: [1352]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/server/server.go
+++ b/cmd/otel-allocator/server/server.go
@@ -70,7 +70,9 @@ func NewServer(log logr.Logger, allocator allocation.Allocator, discoveryManager
 		compareHash:      uint64(0),
 	}
 
-	router := gin.Default()
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+	router.Use(gin.Recovery())
 	router.UseRawPath = true
 	router.UnescapePathValues = false
 	router.Use(s.PrometheusMiddleware)


### PR DESCRIPTION
Signed-off-by: Matej Gera <matej.gera@coralogix.com>

This is a follow-up to #1383.

This PR changes the `gin` router configuration to be suitable for production use, namely:
- It sets `gin` to be used in `release` mode (to my surprise, the default was `debug`)
- it opts out of using the default logger middleware. The logging seems rather verbose (logging each request) and the middleware is not using logging format that is consistent with logging format of the rest of the components in `target-allocator`. 

Eventually, it would be nice if we introduced our own logging middleware with formatting consistent with other components, but for now the default one seems noisy and not too useful to me.

cc @kristinapathak 