### PR TITLE
[docs] Update sampler and propagation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,13 @@ spec:
 EOF
 ```
 
+The values for `propagators` are added to the `OTEL_PROPAGATORS` environment variable.
+Valid values for `propagators` are defined by the [OpenTelemetry Specification for OTEL_PROPAGATORS](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_propagators).
+
+The value for `sampler.type` is added to the `OTEL_TRACES_SAMPLER` envrionment variable.
+Valid values for `sampler.type` are defined by the [OpenTelemetry Specification for OTEL_TRACES_SAMPLER](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_traces_sampler).
+The value for `sampler.argument` is added to the `OTEL_TRACES_SAMPLER_ARG` environment variable. Valid values for `sampler.argument` will depend on the chosen sampler. See the [OpenTelemetry Specification for OTEL_TRACES_SAMPLER_ARG](https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_traces_sampler_arg) for more details.  
+
 The above CR can be queried by `kubectl get otelinst`.
 
 Then add an annotation to a pod to enable injection. The annotation can be added to a namespace, so that all pods within

--- a/apis/v1alpha1/instrumentation_types.go
+++ b/apis/v1alpha1/instrumentation_types.go
@@ -31,7 +31,7 @@ type InstrumentationSpec struct {
 
 	// Propagators defines inter-process context propagation configuration.
 	// Values in this list will be set in the OTEL_PROPAGATORS env var.
-	// +kubebuilder:validation:Enum=tracecontext;baggage;b3;b3multi;jaeger;xray;ottrace;none
+	// Enum=tracecontext;baggage;b3;b3multi;jaeger;xray;ottrace;none
 	// +optional
 	Propagators []Propagator `json:"propagators,omitempty"`
 

--- a/apis/v1alpha1/instrumentation_types.go
+++ b/apis/v1alpha1/instrumentation_types.go
@@ -30,6 +30,8 @@ type InstrumentationSpec struct {
 	Resource Resource `json:"resource,omitempty"`
 
 	// Propagators defines inter-process context propagation configuration.
+	// Values in this list will be set in the OTEL_PROPAGATORS env var.
+	// +kubebuilder:validation:Enum=tracecontext;baggage;b3;b3multi;jaeger;xray;ottrace;none
 	// +optional
 	Propagators []Propagator `json:"propagators,omitempty"`
 
@@ -87,6 +89,7 @@ type Exporter struct {
 // Sampler defines sampling configuration.
 type Sampler struct {
 	// Type defines sampler type.
+	// The value will be set in the OTEL_TRACES_SAMPLER env var.
 	// The value can be for instance parentbased_always_on, parentbased_always_off, parentbased_traceidratio...
 	// +optional
 	Type SamplerType `json:"type,omitempty"`
@@ -94,6 +97,7 @@ type Sampler struct {
 	// Argument defines sampler argument.
 	// The value depends on the sampler type.
 	// For instance for parentbased_traceidratio sampler type it is a number in range [0..1] e.g. 0.25.
+	// The value will be set in the OTEL_TRACES_SAMPLER_ARG env var.
 	// +optional
 	Argument string `json:"argument,omitempty"`
 }

--- a/bundle/manifests/opentelemetry.io_instrumentations.yaml
+++ b/bundle/manifests/opentelemetry.io_instrumentations.yaml
@@ -801,7 +801,17 @@ spec:
                 type: object
               propagators:
                 description: Propagators defines inter-process context propagation
-                  configuration.
+                  configuration. Values in this list will be set in the OTEL_PROPAGATORS
+                  env var.
+                enum:
+                - tracecontext
+                - baggage
+                - b3
+                - b3multi
+                - jaeger
+                - xray
+                - ottrace
+                - none
                 items:
                   description: Propagator represents the propagation type.
                   enum:
@@ -961,10 +971,12 @@ spec:
                   argument:
                     description: Argument defines sampler argument. The value depends
                       on the sampler type. For instance for parentbased_traceidratio
-                      sampler type it is a number in range [0..1] e.g. 0.25.
+                      sampler type it is a number in range [0..1] e.g. 0.25. The value
+                      will be set in the OTEL_TRACES_SAMPLER_ARG env var.
                     type: string
                   type:
-                    description: Type defines sampler type. The value can be for instance
+                    description: Type defines sampler type. The value will be set
+                      in the OTEL_TRACES_SAMPLER env var. The value can be for instance
                       parentbased_always_on, parentbased_always_off, parentbased_traceidratio...
                     enum:
                     - always_on

--- a/bundle/manifests/opentelemetry.io_instrumentations.yaml
+++ b/bundle/manifests/opentelemetry.io_instrumentations.yaml
@@ -802,16 +802,7 @@ spec:
               propagators:
                 description: Propagators defines inter-process context propagation
                   configuration. Values in this list will be set in the OTEL_PROPAGATORS
-                  env var.
-                enum:
-                - tracecontext
-                - baggage
-                - b3
-                - b3multi
-                - jaeger
-                - xray
-                - ottrace
-                - none
+                  env var. Enum=tracecontext;baggage;b3;b3multi;jaeger;xray;ottrace;none
                 items:
                   description: Propagator represents the propagation type.
                   enum:

--- a/config/crd/bases/opentelemetry.io_instrumentations.yaml
+++ b/config/crd/bases/opentelemetry.io_instrumentations.yaml
@@ -801,16 +801,7 @@ spec:
               propagators:
                 description: Propagators defines inter-process context propagation
                   configuration. Values in this list will be set in the OTEL_PROPAGATORS
-                  env var.
-                enum:
-                - tracecontext
-                - baggage
-                - b3
-                - b3multi
-                - jaeger
-                - xray
-                - ottrace
-                - none
+                  env var. Enum=tracecontext;baggage;b3;b3multi;jaeger;xray;ottrace;none
                 items:
                   description: Propagator represents the propagation type.
                   enum:

--- a/config/crd/bases/opentelemetry.io_instrumentations.yaml
+++ b/config/crd/bases/opentelemetry.io_instrumentations.yaml
@@ -800,7 +800,17 @@ spec:
                 type: object
               propagators:
                 description: Propagators defines inter-process context propagation
-                  configuration.
+                  configuration. Values in this list will be set in the OTEL_PROPAGATORS
+                  env var.
+                enum:
+                - tracecontext
+                - baggage
+                - b3
+                - b3multi
+                - jaeger
+                - xray
+                - ottrace
+                - none
                 items:
                   description: Propagator represents the propagation type.
                   enum:
@@ -960,10 +970,12 @@ spec:
                   argument:
                     description: Argument defines sampler argument. The value depends
                       on the sampler type. For instance for parentbased_traceidratio
-                      sampler type it is a number in range [0..1] e.g. 0.25.
+                      sampler type it is a number in range [0..1] e.g. 0.25. The value
+                      will be set in the OTEL_TRACES_SAMPLER_ARG env var.
                     type: string
                   type:
-                    description: Type defines sampler type. The value can be for instance
+                    description: Type defines sampler type. The value will be set
+                      in the OTEL_TRACES_SAMPLER env var. The value can be for instance
                       parentbased_always_on, parentbased_always_off, parentbased_traceidratio...
                     enum:
                     - always_on

--- a/docs/api.md
+++ b/docs/api.md
@@ -131,7 +131,9 @@ InstrumentationSpec defines the desired state of OpenTelemetry SDK and instrumen
         <td><b>propagators</b></td>
         <td>[]enum</td>
         <td>
-          Propagators defines inter-process context propagation configuration.<br/>
+          Propagators defines inter-process context propagation configuration. Values in this list will be set in the OTEL_PROPAGATORS env var.
+          <br/><br/>
+          <i>Enum</i>: tracecontext, baggage, b3, b3multi, jaeger, xray, ottrace, none.
         </td>
         <td>false</td>
       </tr><tr>
@@ -2154,13 +2156,14 @@ Sampler defines sampling configuration.
         <td>string</td>
         <td>
           Argument defines sampler argument. The value depends on the sampler type. For instance for parentbased_traceidratio sampler type it is a number in range [0..1] e.g. 0.25.<br/>
+          The value will be set in the OTEL_TRACES_SAMPLER_ARG env var.
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Type defines sampler type. The value can be for instance parentbased_always_on, parentbased_always_off, parentbased_traceidratio...<br/>
+          Type defines sampler type.  The value will be set in the OTEL_TRACES_SAMPLER env var.          
           <br/>
             <i>Enum</i>: always_on, always_off, traceidratio, parentbased_always_on, parentbased_always_off, parentbased_traceidratio, jaeger_remote, xray<br/>
         </td>

--- a/docs/api.md
+++ b/docs/api.md
@@ -131,7 +131,9 @@ InstrumentationSpec defines the desired state of OpenTelemetry SDK and instrumen
         <td><b>propagators</b></td>
         <td>[]enum</td>
         <td>
-          Propagators defines inter-process context propagation configuration.<br/>
+          Propagators defines inter-process context propagation configuration. Values in this list will be set in the OTEL_PROPAGATORS env var.<br/>
+          <br/>
+            <i>Enum</i>: tracecontext, baggage, b3, b3multi, jaeger, xray, ottrace, none<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2153,14 +2155,14 @@ Sampler defines sampling configuration.
         <td><b>argument</b></td>
         <td>string</td>
         <td>
-          Argument defines sampler argument. The value depends on the sampler type. For instance for parentbased_traceidratio sampler type it is a number in range [0..1] e.g. 0.25.<br/>
+          Argument defines sampler argument. The value depends on the sampler type. For instance for parentbased_traceidratio sampler type it is a number in range [0..1] e.g. 0.25. The value will be set in the OTEL_TRACES_SAMPLER_ARG env var.<br/>
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Type defines sampler type. The value can be for instance parentbased_always_on, parentbased_always_off, parentbased_traceidratio...<br/>
+          Type defines sampler type. The value will be set in the OTEL_TRACES_SAMPLER env var. The value can be for instance parentbased_always_on, parentbased_always_off, parentbased_traceidratio...<br/>
           <br/>
             <i>Enum</i>: always_on, always_off, traceidratio, parentbased_always_on, parentbased_always_off, parentbased_traceidratio, jaeger_remote, xray<br/>
         </td>

--- a/docs/api.md
+++ b/docs/api.md
@@ -131,9 +131,7 @@ InstrumentationSpec defines the desired state of OpenTelemetry SDK and instrumen
         <td><b>propagators</b></td>
         <td>[]enum</td>
         <td>
-          Propagators defines inter-process context propagation configuration. Values in this list will be set in the OTEL_PROPAGATORS env var.
-          <br/><br/>
-          <i>Enum</i>: tracecontext, baggage, b3, b3multi, jaeger, xray, ottrace, none.
+          Propagators defines inter-process context propagation configuration.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2156,14 +2154,13 @@ Sampler defines sampling configuration.
         <td>string</td>
         <td>
           Argument defines sampler argument. The value depends on the sampler type. For instance for parentbased_traceidratio sampler type it is a number in range [0..1] e.g. 0.25.<br/>
-          The value will be set in the OTEL_TRACES_SAMPLER_ARG env var.
         </td>
         <td>false</td>
       </tr><tr>
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Type defines sampler type.  The value will be set in the OTEL_TRACES_SAMPLER env var.          
+          Type defines sampler type. The value can be for instance parentbased_always_on, parentbased_always_off, parentbased_traceidratio...<br/>
           <br/>
             <i>Enum</i>: always_on, always_off, traceidratio, parentbased_always_on, parentbased_always_off, parentbased_traceidratio, jaeger_remote, xray<br/>
         </td>

--- a/docs/api.md
+++ b/docs/api.md
@@ -131,9 +131,7 @@ InstrumentationSpec defines the desired state of OpenTelemetry SDK and instrumen
         <td><b>propagators</b></td>
         <td>[]enum</td>
         <td>
-          Propagators defines inter-process context propagation configuration. Values in this list will be set in the OTEL_PROPAGATORS env var.<br/>
-          <br/>
-            <i>Enum</i>: tracecontext, baggage, b3, b3multi, jaeger, xray, ottrace, none<br/>
+          Propagators defines inter-process context propagation configuration. Values in this list will be set in the OTEL_PROPAGATORS env var. Enum=tracecontext;baggage;b3;b3multi;jaeger;xray;ottrace;none<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
Updates the sampler and propagation documentation to explicitly state which environment variables get set when this fields are used.  Added links to otel specification.  For propagators, added list of valid values.

I updated the docs directly, but I get the sense they are auto-generated.  I couldn't figure out what the root source of truth is, so if I've updated stuff incorrectly please point me in the right direction.

Related to https://github.com/open-telemetry/opentelemetry.io/pull/2253