### PR TITLE
jpkroehling resigns as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,6 @@ Target Allocator Maintainers ([@open-telemetry/operator-ta-maintainers](https://
 Maintainers ([@open-telemetry/operator-maintainers](https://github.com/orgs/open-telemetry/teams/operator-maintainers)):
 
 - [Jacob Aronoff](https://github.com/jaronoff97), Lightstep
-- [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs
 - [Pavol Loffay](https://github.com/pavolloffay), Red Hat
 - [Vineeth Pothulapati](https://github.com/VineethReddy02), Timescale
 
@@ -470,6 +469,7 @@ Emeritus Maintainers
 
 - [Alex Boten](https://github.com/codeboten), Lightstep
 - [Bogdan Drutu](https://github.com/BogdanDrutu), Splunk
+- [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs
 - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
 
 Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).


### PR DESCRIPTION
I guess it's my time now to step out from maintainership. I was already away for a while, just lurking around in case something needed someone to break a deadlock, but there are enough maintainers now so this problem won't happen. I also trust that the current maintainers are doing a great job, and I don't deserve to be called a "maintainer" and be compared with you, the ones actually doing the work. 

Thank you for bringing this project forward, it means a lot to me.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
