### PR TITLE
[target allocator] Fix flaky server test in targets handler

### DIFF
--- a/cmd/otel-allocator/server/server_test.go
+++ b/cmd/otel-allocator/server/server_test.go
@@ -174,7 +174,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 			var itemResponse []*target.Item
 			err = json.Unmarshal(bodyBytes, &itemResponse)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.want.items, itemResponse)
+			assert.ElementsMatch(t, tt.want.items, itemResponse)
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Matej Gera <matej.gera@coralogix.com>

We were occasionally seeing a failure in `TestServer_TargetsHandler/Multiple_entry_target_map_of_same_job_with_label_merge` with the following output:

```
    server_test.go:177: 
        	Error Trace:	/home/runner/work/opentelemetry-operator/opentelemetry-operator/cmd/otel-allocator/server/server_test.go:177
        	Error:      	Not equal: 
        	            	expected: []*target.Item{(*target.Item)(0xc000717d40), (*target.Item)(0xc000717da0)}
        	            	actual  : []*target.Item{(*target.Item)(0xc00017a840), (*target.Item)(0xc00017a8a0)}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1,16 @@
        	            	 ([]*target.Item) (len=2) {
        	            	+ (*target.Item)({
        	            	+  JobName: (string) "",
        	            	+  Link: (target.LinkJSON) {
        	            	+   Link: (string) ""
        	            	+  },
        	            	+  TargetURL: ([]string) (len=1) {
        	            	+   (string) (len=9) "test-url2"
        	            	+  },
        	            	+  Labels: (model.LabelSet) (len=1) {
        	            	+   (model.LabelName) (len=10) "test_label": (model.LabelValue) (len=11) "test-value2"
        	            	+  },
        	            	+  CollectorName: (string) "",
        	            	+  hash: (string) ""
        	            	+ }),
        	            	  (*target.Item)({
        	            	@@ -14,16 +28,2 @@
        	            	   hash: (string) ""
        	            	- }),
        	            	- (*target.Item)({
        	            	-  JobName: (string) "",
        	            	-  Link: (target.LinkJSON) {
        	            	-   Link: (string) ""
        	            	-  },
        	            	-  TargetURL: ([]string) (len=1) {
        	            	-   (string) (len=9) "test-url2"
        	            	-  },
        	            	-  Labels: (model.LabelSet) (len=1) {
        	            	-   (model.LabelName) (len=10) "test_label": (model.LabelValue) (len=11) "test-value2"
        	            	-  },
        	            	-  CollectorName: (string) "",
        	            	-  hash: (string) ""
        	            	  })
```

This is presumable due to nondeterministic order of items, which on some test runs seem to change. Using `ElementsMatch` method instead of `Equal` will ensure the order of items is not decisive for passing the test.

Tested locally with `-count=100` flag to catch the error and subsequently to test the fix.

cc @jaronoff97 

