### PR TITLE
Recreate stateful set on change in immutable field `volumeClaimTemplates`

### DIFF
--- a/.chloggen/1492-fix-stateful-set-reconcile.yaml
+++ b/.chloggen/1492-fix-stateful-set-reconcile.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: "operator"
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes inability of the operator to reconcile in stateful set mode when the immutable field `volumeClaimTemplates` is changed. If such change is detected, the operator will recreate the stateful set."
+
+# One or more tracking issues related to the change
+issues: [1491]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/1492-fix-stateful-set-reconcile.yaml
+++ b/.chloggen/1492-fix-stateful-set-reconcile.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
 component: "operator"

--- a/pkg/collector/reconcile/statefulset.go
+++ b/pkg/collector/reconcile/statefulset.go
@@ -160,7 +160,7 @@ func hasImmutableFieldChange(desired, existing *appsv1.StatefulSet) (bool, strin
 }
 
 // hasVolumeClaimsTemplatesChanged if volume claims template change has been detected.
-// We need to this by hand due to some fields being automatically filled by the API server
+// We need to do this manually due to some fields being automatically filled by the API server
 // and these needs to be excluded from the comparison to prevent false positives.
 func hasVolumeClaimsTemplatesChanged(desired, existing *appsv1.StatefulSet) bool {
 	if len(desired.Spec.VolumeClaimTemplates) != len(existing.Spec.VolumeClaimTemplates) {

--- a/pkg/collector/reconcile/statefulset.go
+++ b/pkg/collector/reconcile/statefulset.go
@@ -74,7 +74,8 @@ func expectedStatefulSets(ctx context.Context, params Params, expected []appsv1.
 
 		// Check for immutable fields. If set, we cannot modify the stateful set, otherwise we will face reconciliation error.
 		if needsDeletion, fieldName := hasImmutableFieldChange(&desired, existing); needsDeletion {
-			params.Log.V(2).Info("Immu field change detected, trying to delete, the new collector statfulset will be created in the next reconcile cycle", "field", fieldName, "statefulset.name", existing.Name, "statefulset.namespace", existing.Namespace)
+			params.Log.V(2).Info("Immutable field change detected, trying to delete, the new collector statfulset will be created in the next reconcile cycle",
+				"field", fieldName, "statefulset.name", existing.Name, "statefulset.namespace", existing.Namespace)
 
 			if err := params.Client.Delete(ctx, existing); err != nil {
 				return fmt.Errorf("failed to delete statefulset: %w", err)

--- a/pkg/collector/reconcile/statefulset.go
+++ b/pkg/collector/reconcile/statefulset.go
@@ -72,9 +72,9 @@ func expectedStatefulSets(ctx context.Context, params Params, expected []appsv1.
 			return fmt.Errorf("failed to get: %w", err)
 		}
 
-		// Selector is an immutable field, if set, we cannot modify it otherwise we will face reconciliation error.
-		if !apiequality.Semantic.DeepEqual(desired.Spec.Selector, existing.Spec.Selector) {
-			params.Log.V(2).Info("Spec.Selector change detected, trying to delete, the new collector statfulset will be created in the next reconcile cycle", "statefulset.name", existing.Name, "statefulset.namespace", existing.Namespace)
+		// Check for immutable fields. If set, we cannot modify the stateful set, otherwise we will face reconciliation error.
+		if needsDeletion, fieldName := hasImmutableFieldChange(&desired, existing); needsDeletion {
+			params.Log.V(2).Info("Immutable field change detected, trying to delete, the new collector statfulset will be created in the next reconcile cycle", "field", fieldName, "statefulset.name", existing.Name, "statefulset.namespace", existing.Namespace)
 
 			if err := params.Client.Delete(ctx, existing); err != nil {
 				return fmt.Errorf("failed to delete statefulset: %w", err)
@@ -144,4 +144,16 @@ func deleteStatefulSets(ctx context.Context, params Params, expected []appsv1.St
 	}
 
 	return nil
+}
+
+func hasImmutableFieldChange(desired, existing *appsv1.StatefulSet) (bool, string) {
+	if !apiequality.Semantic.DeepEqual(desired.Spec.Selector, existing.Spec.Selector) {
+		return true, "Spec.Selector"
+	}
+
+	if !apiequality.Semantic.DeepEqual(desired.Spec.VolumeClaimTemplates, existing.Spec.VolumeClaimTemplates) {
+		return true, "Spec.VolumeClaimTemplates"
+	}
+
+	return false, ""
 }

--- a/pkg/collector/reconcile/statefulset.go
+++ b/pkg/collector/reconcile/statefulset.go
@@ -74,7 +74,7 @@ func expectedStatefulSets(ctx context.Context, params Params, expected []appsv1.
 
 		// Check for immutable fields. If set, we cannot modify the stateful set, otherwise we will face reconciliation error.
 		if needsDeletion, fieldName := hasImmutableFieldChange(&desired, existing); needsDeletion {
-			params.Log.V(2).Info("Immutable field change detected, trying to delete, the new collector statfulset will be created in the next reconcile cycle", "field", fieldName, "statefulset.name", existing.Name, "statefulset.namespace", existing.Namespace)
+			params.Log.V(2).Info("Immu field change detected, trying to delete, the new collector statfulset will be created in the next reconcile cycle", "field", fieldName, "statefulset.name", existing.Name, "statefulset.namespace", existing.Namespace)
 
 			if err := params.Client.Delete(ctx, existing); err != nil {
 				return fmt.Errorf("failed to delete statefulset: %w", err)
@@ -151,9 +151,37 @@ func hasImmutableFieldChange(desired, existing *appsv1.StatefulSet) (bool, strin
 		return true, "Spec.Selector"
 	}
 
-	if !apiequality.Semantic.DeepEqual(desired.Spec.VolumeClaimTemplates, existing.Spec.VolumeClaimTemplates) {
+	if hasVolumeClaimsTemplatesChanged(desired, existing) {
 		return true, "Spec.VolumeClaimTemplates"
 	}
 
 	return false, ""
+}
+
+// hasVolumeClaimsTemplatesChanged if volume claims template change has been detected.
+// We need to this by hand due to some fields being automatically filled by the API server
+// and these needs to be excluded from the comparison to prevent false positives.
+func hasVolumeClaimsTemplatesChanged(desired, existing *appsv1.StatefulSet) bool {
+	if len(desired.Spec.VolumeClaimTemplates) != len(existing.Spec.VolumeClaimTemplates) {
+		return true
+	}
+
+	for i := range desired.Spec.VolumeClaimTemplates {
+		// VolumeMode is automatically set by the API server, so if it is not set in the CR, assume it's the same as the existing one.
+		if desired.Spec.VolumeClaimTemplates[i].Spec.VolumeMode == nil || *desired.Spec.VolumeClaimTemplates[i].Spec.VolumeMode == "" {
+			desired.Spec.VolumeClaimTemplates[i].Spec.VolumeMode = existing.Spec.VolumeClaimTemplates[i].Spec.VolumeMode
+		}
+
+		if desired.Spec.VolumeClaimTemplates[i].Name != existing.Spec.VolumeClaimTemplates[i].Name {
+			return true
+		}
+		if !apiequality.Semantic.DeepEqual(desired.Spec.VolumeClaimTemplates[i].Annotations, existing.Spec.VolumeClaimTemplates[i].Annotations) {
+			return true
+		}
+		if !apiequality.Semantic.DeepEqual(desired.Spec.VolumeClaimTemplates[i].Spec, existing.Spec.VolumeClaimTemplates[i].Spec) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/collector/reconcile/statefulset.go
+++ b/pkg/collector/reconcile/statefulset.go
@@ -74,7 +74,7 @@ func expectedStatefulSets(ctx context.Context, params Params, expected []appsv1.
 
 		// Check for immutable fields. If set, we cannot modify the stateful set, otherwise we will face reconciliation error.
 		if needsDeletion, fieldName := hasImmutableFieldChange(&desired, existing); needsDeletion {
-			params.Log.V(2).Info("Immutable field change detected, trying to delete, the new collector statfulset will be created in the next reconcile cycle",
+			params.Log.V(2).Info("Immutable field change detected, trying to delete, the new collector statefulset will be created in the next reconcile cycle",
 				"field", fieldName, "statefulset.name", existing.Name, "statefulset.namespace", existing.Namespace)
 
 			if err := params.Client.Delete(ctx, existing); err != nil {

--- a/pkg/collector/statefulset.go
+++ b/pkg/collector/statefulset.go
@@ -65,7 +65,7 @@ func StatefulSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTel
 			},
 			Replicas:             otelcol.Spec.Replicas,
 			PodManagementPolicy:  "Parallel",
-			VolumeClaimTemplates: VolumeClaimTemplates(cfg, otelcol),
+			VolumeClaimTemplates: VolumeClaimTemplates(otelcol),
 		},
 	}
 }

--- a/pkg/collector/volumeclaim.go
+++ b/pkg/collector/volumeclaim.go
@@ -29,5 +29,5 @@ func VolumeClaimTemplates(otelcol v1alpha1.OpenTelemetryCollector) []corev1.Pers
 	}
 
 	// Add all user specified claims.
-	return append([]corev1.PersistentVolumeClaim{}, otelcol.Spec.VolumeClaimTemplates...)
+	return otelcol.Spec.VolumeClaimTemplates
 }

--- a/pkg/collector/volumeclaim.go
+++ b/pkg/collector/volumeclaim.go
@@ -19,22 +19,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 )
 
 // VolumeClaimTemplates builds the volumeClaimTemplates for the given instance,
 // including the config map volume mount.
-func VolumeClaimTemplates(cfg config.Config, otelcol v1alpha1.OpenTelemetryCollector) []corev1.PersistentVolumeClaim {
-
-	var volumeClaimTemplates []corev1.PersistentVolumeClaim
-
+func VolumeClaimTemplates(otelcol v1alpha1.OpenTelemetryCollector) []corev1.PersistentVolumeClaim {
 	if otelcol.Spec.Mode != "statefulset" {
-		return volumeClaimTemplates
+		return []corev1.PersistentVolumeClaim{}
 	}
 
-	// Add all user specified claims or use default.
-	volumeClaimTemplates = append(volumeClaimTemplates,
-		otelcol.Spec.VolumeClaimTemplates...)
-
-	return volumeClaimTemplates
+	// Add all user specified claims.
+	return append([]corev1.PersistentVolumeClaim{}, otelcol.Spec.VolumeClaimTemplates...)
 }

--- a/pkg/collector/volumeclaim_test.go
+++ b/pkg/collector/volumeclaim_test.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	. "github.com/open-telemetry/opentelemetry-operator/pkg/collector"
 )
 
@@ -45,10 +44,9 @@ func TestVolumeClaimAllowsUserToAdd(t *testing.T) {
 			}},
 		},
 	}
-	cfg := config.New()
 
 	// test
-	volumeClaims := VolumeClaimTemplates(cfg, otelcol)
+	volumeClaims := VolumeClaimTemplates(otelcol)
 
 	// verify that volume claim replaces
 	assert.Len(t, volumeClaims, 1)
@@ -81,10 +79,9 @@ func TestVolumeClaimChecksForStatefulset(t *testing.T) {
 			}},
 		},
 	}
-	cfg := config.New()
 
 	// test
-	volumeClaims := VolumeClaimTemplates(cfg, otelcol)
+	volumeClaims := VolumeClaimTemplates(otelcol)
 
 	// verify that volume claim replaces
 	assert.Len(t, volumeClaims, 0)

--- a/tests/e2e/statefulset-features/01-assert.yaml
+++ b/tests/e2e/statefulset-features/01-assert.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: stateful-collector
+spec:
+  podManagementPolicy: Parallel
+  template:
+    spec:
+       containers:
+       - args:
+         - --config=/conf/collector.yaml
+         name: otc-container
+         volumeMounts:
+         - mountPath: /conf
+           name: otc-internal
+         - mountPath: /usr/share/testvolume
+           name: testvolume
+       volumes:
+       - configMap:
+           items:
+           - key: collector.yaml
+             path: collector.yaml
+           name: stateful-collector
+         name: otc-internal
+       - emptyDir: {}
+         name: testvolume
+  volumeClaimTemplates:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: testvolume
+    spec:
+      accessModes:
+      - ReadWriteMany
+      resources:
+        requests:
+          storage: 1Gi
+      volumeMode: Filesystem
+status:
+  replicas: 3
+  readyReplicas: 3

--- a/tests/e2e/statefulset-features/01-update-volume-claim-templates.yaml
+++ b/tests/e2e/statefulset-features/01-update-volume-claim-templates.yaml
@@ -1,0 +1,34 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: stateful
+spec:
+  mode: statefulset
+  replicas: 3
+  volumes:
+  - name: testvolume
+  volumeMounts:
+  - name: testvolume
+    mountPath: /usr/share/testvolume
+  volumeClaimTemplates:
+  - metadata:
+      name: testvolume 
+    spec:
+      accessModes: [ "ReadWriteMany" ] # change accessMode to trigger statefulset recreation.
+      resources:
+        requests:
+          storage: 1Gi
+  config: |
+    receivers:
+      jaeger:
+        protocols:
+          grpc:
+    processors:
+    exporters:
+      logging:
+    service:
+      pipelines:
+        traces:
+          receivers: [jaeger]
+          processors: []
+          exporters: [logging]


### PR DESCRIPTION
Fixes #1491.

Since `volumeClaimTemplates` is an immutable field, this PR provides a solution based on recreation of the stateful set when a change in this field is detected. This is analogous to how other immutable field (selector) is handled.

In addition, this PR simplifies the `VolumeClaimTemplates` method and removes unnecessary parameter.

A unit test has been added. This has also been tested manually.