### PR TITLE
[chore] Use tagged images in e2e tests to not trigger docker.com rate limit

### DIFF
--- a/tests/e2e/instrumentation-dotnet-multicontainer/01-install-app.yaml
+++ b/tests/e2e/instrumentation-dotnet-multicontainer/01-install-app.yaml
@@ -18,6 +18,6 @@ spec:
     spec:
       containers:
       - name: myapp
-        image: docker.io/avadhutp123/aspnetapp:latest # source code of the application: https://github.com/dotnet/dotnet-docker/tree/main/samples/aspnetapp
+        image: docker.io/avadhutp123/aspnetapp@sha256:d2e8d3415f6f12efae0369aa0a9777a58583841fb133f33e10a73adb9fb392da # source code of the application: https://github.com/dotnet/dotnet-docker/tree/main/samples/aspnetapp
       - name: myrabbit
-        image: rabbitmq
+        image: rabbitmq:3

--- a/tests/e2e/instrumentation-dotnet-multicontainer/02-install-app.yaml
+++ b/tests/e2e/instrumentation-dotnet-multicontainer/02-install-app.yaml
@@ -18,6 +18,6 @@ spec:
     spec:
       containers:
       - name: myapp
-        image: docker.io/avadhutp123/aspnetapp:latest # source code of the application: https://github.com/dotnet/dotnet-docker/tree/main/samples/aspnetapp
+        image: docker.io/avadhutp123/aspnetapp@sha256:d2e8d3415f6f12efae0369aa0a9777a58583841fb133f33e10a73adb9fb392da # source code of the application: https://github.com/dotnet/dotnet-docker/tree/main/samples/aspnetapp
       - name: myrabbit
-        image: rabbitmq
+        image: rabbitmq:3

--- a/tests/e2e/instrumentation-dotnet/01-install-app.yaml
+++ b/tests/e2e/instrumentation-dotnet/01-install-app.yaml
@@ -21,4 +21,4 @@ spec:
         fsGroup: 2000
       containers:
       - name: myapp
-        image: docker.io/avadhutp123/aspnetapp:latest  # source code of the application: https://github.com/dotnet/dotnet-docker/tree/main/samples/aspnetapp
+        image: docker.io/avadhutp123/aspnetapp@sha256:d2e8d3415f6f12efae0369aa0a9777a58583841fb133f33e10a73adb9fb392da  # source code of the application: https://github.com/dotnet/dotnet-docker/tree/main/samples/aspnetapp

--- a/tests/e2e/instrumentation-java-multicontainer/01-install-app.yaml
+++ b/tests/e2e/instrumentation-java-multicontainer/01-install-app.yaml
@@ -20,4 +20,4 @@ spec:
       - name: myapp
         image: ghcr.io/pavolloffay/spring-petclinic:latest
       - name: myrabbit
-        image: rabbitmq
+        image: rabbitmq:3

--- a/tests/e2e/instrumentation-java-multicontainer/02-install-app.yaml
+++ b/tests/e2e/instrumentation-java-multicontainer/02-install-app.yaml
@@ -20,4 +20,4 @@ spec:
       - name: myapp
         image: ghcr.io/pavolloffay/spring-petclinic:latest
       - name: myrabbit
-        image: rabbitmq
+        image: rabbitmq:3

--- a/tests/e2e/instrumentation-nodejs-multicontainer/01-install-app.yaml
+++ b/tests/e2e/instrumentation-nodejs-multicontainer/01-install-app.yaml
@@ -20,4 +20,4 @@ spec:
       - name: myapp
         image: ghcr.io/anuraaga/express-hello-world:latest
       - name: myrabbit
-        image: rabbitmq
+        image: rabbitmq:3

--- a/tests/e2e/instrumentation-nodejs-multicontainer/02-install-app.yaml
+++ b/tests/e2e/instrumentation-nodejs-multicontainer/02-install-app.yaml
@@ -20,4 +20,4 @@ spec:
       - name: myapp
         image: ghcr.io/anuraaga/express-hello-world:latest
       - name: myrabbit
-        image: rabbitmq
+        image: rabbitmq:3

--- a/tests/e2e/instrumentation-python-multicontainer/01-install-app.yaml
+++ b/tests/e2e/instrumentation-python-multicontainer/01-install-app.yaml
@@ -20,4 +20,4 @@ spec:
       - name: myapp
         image: ghcr.io/anuraaga/flask-hello-world:latest
       - name: myrabbit
-        image: rabbitmq
+        image: rabbitmq:3

--- a/tests/e2e/instrumentation-python-multicontainer/02-install-app.yaml
+++ b/tests/e2e/instrumentation-python-multicontainer/02-install-app.yaml
@@ -20,4 +20,4 @@ spec:
       - name: myapp
         image: ghcr.io/anuraaga/flask-hello-world:latest
       - name: myrabbit
-        image: rabbitmq
+        image: rabbitmq:3


### PR DESCRIPTION
Kubernetes uses imagePullPolicy: Always for images with latest or no tag, which can trigger docker.com rate limits if one runs the e2e tests too often.