### PR TITLE
[chore] Fix `make` on MacOS by using `gsed`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
+## On MacOS, use gsed instead of sed, to make sed behavior
+## consistent with Linux.
+SED ?= $(shell which gsed 2>/dev/null || which sed)
+
 .PHONY: ensure-generate-is-noop
 ensure-generate-is-noop: VERSION=$(OPERATOR_VERSION)
 ensure-generate-is-noop: USER=open-telemetry
@@ -182,7 +186,7 @@ e2e-log-operator:
 
 .PHONY: prepare-e2e
 prepare-e2e: kuttl set-image-controller container container-target-allocator container-operator-opamp-bridge start-kind cert-manager install-metrics-server install-openshift-routes load-image-all deploy
-	TARGETALLOCATOR_IMG=$(TARGETALLOCATOR_IMG) ./hack/modify-test-images.sh
+	TARGETALLOCATOR_IMG=$(TARGETALLOCATOR_IMG) SED_BIN="$(SED)" ./hack/modify-test-images.sh
 
 .PHONY: scorecard-tests
 scorecard-tests: operator-sdk

--- a/hack/modify-test-images.sh
+++ b/hack/modify-test-images.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-sed -i "s#local/opentelemetry-operator-targetallocator:e2e#${TARGETALLOCATOR_IMG}#g" tests/e2e/smoke-targetallocator/00-install.yaml
-sed -i "s#local/opentelemetry-operator-targetallocator:e2e#${TARGETALLOCATOR_IMG}#g" tests/e2e/targetallocator-features/00-install.yaml
+SED_BIN=${SED_BIN:-sed}
+
+${SED_BIN} -i "s#local/opentelemetry-operator-targetallocator:e2e#${TARGETALLOCATOR_IMG}#g" tests/e2e/smoke-targetallocator/00-install.yaml
+${SED_BIN} -i "s#local/opentelemetry-operator-targetallocator:e2e#${TARGETALLOCATOR_IMG}#g" tests/e2e/targetallocator-features/00-install.yaml


### PR DESCRIPTION
Opt for using `gsed` instead of the MacOS version of `sed`, which is incompatible with certain flags that work on Linux.
