### PR TITLE
[chore] [target-allocator] Update docs with correct `ClusterRole` after latest release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,8 @@ Your pull-request should add a new `.yaml` file to this directory. The name of y
 
 During the collector release process, all `./.chloggen/*.yaml` files are transcribed into `CHANGELOG.md` and then deleted.
 
+If a changelog entry is not required, add either `[chore]` to the title of the pull request or add the `"Skip Changelog"` label to disable this action.
+
 **Recommended Steps**
 1. Create an entry file using `make chlog-new`. This generates a file based on your current branch (e.g. `./.chloggen/my-branch.yaml`)
 2. Fill in all fields in the new file

--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -112,6 +112,11 @@ rules:
   - configmaps
   verbs: ["get"]
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs: ["get", "list", watch"]
+- apiGroups:
   - networking.k8s.io
   resources:
   - ingresses


### PR DESCRIPTION
Related to changes introduced in https://github.com/open-telemetry/opentelemetry-operator/pull/1540.

Update cluster role with rules for `endpointslices`.

Add also small clarification on usage of `[chore]` tag in PR titles.