### PR TITLE
Update Dockerfile comments for undocumented requirement

### DIFF
--- a/autoinstrumentation/dotnet/Dockerfile
+++ b/autoinstrumentation/dotnet/Dockerfile
@@ -9,7 +9,9 @@
 #    DOTNET_ADDITIONAL_DEPS=%InstallationLocation%/AdditionalDeps
 #    DOTNET_SHARED_STORE=%InstallationLocation%/store
 #    DOTNET_STARTUP_HOOKS=%InstallationLocation%/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll 
-#    OTEL_DOTNET_AUTO_HOME=%InstallationLocation% 
+#    OTEL_DOTNET_AUTO_HOME=%InstallationLocation%
+#  - For auto-instrumentation by container injection, the Linux command cp is
+#    used and must be availabe in the image.
 
 FROM busybox
 

--- a/autoinstrumentation/java/Dockerfile
+++ b/autoinstrumentation/java/Dockerfile
@@ -2,6 +2,8 @@
 #  - Download your customized `javaagent.jar` to `/javaagent.jar`. This is required as when instrumenting the pod,
 #    one init container will be created to copy the jar to your app's container.
 #  - Grant the necessary access to the jar. `chmod -R go+r /javaagent.jar`
+#  - For auto-instrumentation by container injection, the Linux command cp is
+#    used and must be availabe in the image.
 FROM busybox
 
 ARG version

--- a/autoinstrumentation/nodejs/Dockerfile
+++ b/autoinstrumentation/nodejs/Dockerfile
@@ -7,6 +7,8 @@
 # - Ensure you have `@opentelemetry/api`, `@opentelemetry/auto-instrumentations-node`, and `@opentelemetry/sdk-node` or your customized
 #   alternatives installed.
 # - Grant the necessary access to `/autoinstrumentation` directory. `chmod -R go+r /autoinstrumentation`
+# - For auto-instrumentation by container injection, the Linux command cp is
+#   used and must be availabe in the image.
 FROM node:16 AS build
 
 WORKDIR /operator-build

--- a/autoinstrumentation/python/Dockerfile
+++ b/autoinstrumentation/python/Dockerfile
@@ -7,7 +7,8 @@
 # - Ensure you have `opentelemetry-distro` and `opentelemetry-instrumentation` or your customized alternatives installed.
 #   Those two packages are essential to Python auto-instrumentation.
 # - Grant the necessary access to `/autoinstrumentation` directory. `chmod -R go+r /autoinstrumentation`
-
+# - For auto-instrumentation by container injection, the Linux command cp is
+#   used and must be availabe in the image.
 FROM python:3.10-alpine AS build
 
 WORKDIR /operator-build


### PR DESCRIPTION
Description:
Recently, my team and I wanted to build a minimal Docker image to be used for operator auto-instrumentation. We tried to create an image from [scratch](https://hub.docker.com/_/scratch) that only contained our instrumentation libraries, but we found out that the Linux [cp command is required for auto-instrumentation container injection](https://github.com/open-telemetry/opentelemetry-operator/search?q=cp).

This PR is only adding comments to notify other users about this undocumented requirement.