### PR TITLE
Add a note that dotnet autoinstrumentation defaults to http/protobuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,14 @@ spec:
     env:
       # Required if endpoint is set to 4317.
       # Python autoinstrumentation uses http/proto by default
-      # so data must be sent to 4318 instead of 4137.
+      # so data must be sent to 4318 instead of 4317.
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://otel-collector:4318
+  dotnet:
+    env:
+      # Required if endpoint is set to 4317.
+      # Dotnet autoinstrumentation uses http/proto by default
+      # See https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/888e2cd216c77d12e56b54ee91dafbc4e7452a52/docs/config.md#otlp
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://otel-collector:4318
 EOF


### PR DESCRIPTION
Followup #1465 
Addresses https://github.com/open-telemetry/opentelemetry-operator/issues/1465#issuecomment-1465896037