### PR TITLE
[HPA/e2e] Add nil checks to behavior validation and reduce stabilization windows 

### DIFF
--- a/.chloggen/1574-HPA-e2e-fixes.yaml
+++ b/.chloggen/1574-HPA-e2e-fixes.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: Autoscaler
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add nil checks to e2e tests and reduce scaleDown stabilization window.
+
+# One or more tracking issues related to the change
+issues:
+  - 1574
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/tests/e2e/autoscale/00-install.yaml
+++ b/tests/e2e/autoscale/00-install.yaml
@@ -55,6 +55,11 @@ spec:
   maxReplicas: 2
   autoscaler:
     targetCPUUtilization: 50
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 10
+      scaleDown:
+        stabilizationWindowSeconds: 15
   resources:
     limits:
       cpu: 500m

--- a/tests/e2e/autoscale/00-install.yaml
+++ b/tests/e2e/autoscale/00-install.yaml
@@ -59,7 +59,7 @@ spec:
       scaleUp:
         stabilizationWindowSeconds: 10
       scaleDown:
-        stabilizationWindowSeconds: 15
+        stabilizationWindowSeconds: 1
   resources:
     limits:
       cpu: 500m

--- a/tests/e2e/autoscale/02-install.yaml
+++ b/tests/e2e/autoscale/02-install.yaml
@@ -11,13 +11,11 @@ spec:
   autoscaler:
     targetCPUUtilization: 50
     targetMemoryUtilization: 70
-    # Without this behavior the HPA will default to a scaledown stabilization
-    # window of 300 seconds. Tests should fail if this update is not successful.
     behavior:
       scaleDown:
-        stabilizationWindowSeconds: 15
+        stabilizationWindowSeconds: 1
       scaleUp:
-        stabilizationWindowSeconds: 25
+        stabilizationWindowSeconds: 1
   resources:
     limits:
       cpu: 500m

--- a/tests/e2e/autoscale/02-install.yaml
+++ b/tests/e2e/autoscale/02-install.yaml
@@ -1,6 +1,5 @@
 # This updates an existing deployment with a new Spec.
 # Target memory utilization is now added. 
-# scaleDown and scaleUp behavior is now added.
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:
@@ -11,11 +10,6 @@ spec:
   autoscaler:
     targetCPUUtilization: 50
     targetMemoryUtilization: 70
-    behavior:
-      scaleDown:
-        stabilizationWindowSeconds: 1
-      scaleUp:
-        stabilizationWindowSeconds: 1
   resources:
     limits:
       cpu: 500m

--- a/tests/e2e/autoscale/03-verify-simplest-set-collector-hpa-metrics.yaml
+++ b/tests/e2e/autoscale/03-verify-simplest-set-collector-hpa-metrics.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - script: go run ./cmd/verify/wait-and-validate-metrics.go --cpu-value 50 --memory-value 70 --scale-down 15 --scale-up 25 --hpa simplest-set-utilization-collector
+  - script: go run ./cmd/verify/wait-and-validate-metrics.go --cpu-value 50 --memory-value 70 --scale-down 1 --scale-up 1 --hpa simplest-set-utilization-collector

--- a/tests/e2e/autoscale/03-verify-simplest-set-collector-hpa-metrics.yaml
+++ b/tests/e2e/autoscale/03-verify-simplest-set-collector-hpa-metrics.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - script: go run ./cmd/verify/wait-and-validate-metrics.go --cpu-value 50 --memory-value 70 --scale-down 1 --scale-up 1 --hpa simplest-set-utilization-collector
+  - script: go run ./cmd/verify/wait-and-validate-metrics.go --cpu-value 50 --memory-value 70 --scale-down 1 --scale-up 10 --hpa simplest-set-utilization-collector

--- a/tests/e2e/autoscale/05-assert.yaml
+++ b/tests/e2e/autoscale/05-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 360
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector

--- a/tests/e2e/autoscale/05-assert.yaml
+++ b/tests/e2e/autoscale/05-assert.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
 metadata:

--- a/tests/e2e/autoscale/cmd/verify/wait-and-validate-metrics.go
+++ b/tests/e2e/autoscale/cmd/verify/wait-and-validate-metrics.go
@@ -157,7 +157,7 @@ func main() {
 		}
 
 		if scaleDownWindow > 0 {
-			if hpav2.Spec.Behavior.ScaleDown != nil {
+			if hpav2.Spec.Behavior.ScaleDown == nil {
 				fmt.Printf("Behavior scaledown not set for HPA %s\n", hpaName)
 				return false, nil
 			}
@@ -172,7 +172,7 @@ func main() {
 		}
 
 		if scaleUpWindow > 0 {
-			if hpav2.Spec.Behavior.ScaleUp != nil {
+			if hpav2.Spec.Behavior.ScaleUp == nil {
 				fmt.Printf("Behavior scaleup not set for HPA %s\n", hpaName)
 				return false, nil
 			}

--- a/tests/e2e/autoscale/cmd/verify/wait-and-validate-metrics.go
+++ b/tests/e2e/autoscale/cmd/verify/wait-and-validate-metrics.go
@@ -151,13 +151,39 @@ func main() {
 		}
 
 		// validate HPA behavior
-		if int32(scaleDownWindow) != *hpav2.Spec.Behavior.ScaleDown.StabilizationWindowSeconds {
-			fmt.Printf("Incorrect scaleDown stabilization window found for HPA %s\n", hpaName)
+		if hpav2.Spec.Behavior == nil && (scaleDownWindow > 0 || scaleUpWindow > 0) {
+			fmt.Printf("Behavior not set for HPA %s\n", hpaName)
 			return false, nil
 		}
-		if int32(scaleUpWindow) != *hpav2.Spec.Behavior.ScaleUp.StabilizationWindowSeconds {
-			fmt.Printf("Incorrect scaleUp stabilization window found for HPA %s\n", hpaName)
-			return false, nil
+
+		if scaleDownWindow > 0 {
+			if hpav2.Spec.Behavior.ScaleDown != nil {
+				fmt.Printf("Behavior scaledown not set for HPA %s\n", hpaName)
+				return false, nil
+			}
+			if hpav2.Spec.Behavior.ScaleDown.StabilizationWindowSeconds == nil {
+				fmt.Printf("Behavior scaledown stailization window not set for HPA %s\n", hpaName)
+				return false, nil
+			}
+			if int32(scaleDownWindow) != *hpav2.Spec.Behavior.ScaleDown.StabilizationWindowSeconds {
+				fmt.Printf("Incorrect scaleDown stabilization window found for HPA %s\n", hpaName)
+				return false, nil
+			}
+		}
+
+		if scaleUpWindow > 0 {
+			if hpav2.Spec.Behavior.ScaleUp != nil {
+				fmt.Printf("Behavior scaleup not set for HPA %s\n", hpaName)
+				return false, nil
+			}
+			if hpav2.Spec.Behavior.ScaleUp.StabilizationWindowSeconds == nil {
+				fmt.Printf("Behavior scaleup stabilization window not set for HPA %s\n", hpaName)
+				return false, nil
+			}
+			if int32(scaleUpWindow) != *hpav2.Spec.Behavior.ScaleUp.StabilizationWindowSeconds {
+				fmt.Printf("Incorrect scaleUp stabilization window found for HPA %s\n", hpaName)
+				return false, nil
+			}
 		}
 
 		return true, nil


### PR DESCRIPTION
Some fixes to the e2e tests to help resolve helm test failure from https://github.com/open-telemetry/opentelemetry-operator/issues/1574