### PR TITLE
[HPA/e2e] Increase e2e/autoscale reliability

### DIFF
--- a/tests/e2e/autoscale/00-install.yaml
+++ b/tests/e2e/autoscale/00-install.yaml
@@ -54,10 +54,13 @@ spec:
   minReplicas: 1
   maxReplicas: 2
   autoscaler:
-    targetCPUUtilization: 50
+    targetCPUUtilization: 99
+    behavior:
+      scaleUp:
+        stabilizationWindowSeconds: 300
   resources:
     limits:
-      cpu: 500m
+      cpu: 250m
       memory: 128Mi
     requests:
       cpu: 5m

--- a/tests/e2e/autoscale/02-install.yaml
+++ b/tests/e2e/autoscale/02-install.yaml
@@ -9,18 +9,17 @@ spec:
   minReplicas: 1
   maxReplicas: 2
   autoscaler:
-    targetCPUUtilization: 50
-    targetMemoryUtilization: 70
+    targetCPUUtilization: 60
     # Without this behavior the HPA will default to a scaledown stabilization
     # window of 300 seconds. Tests should fail if this update is not successful.
     behavior:
       scaleDown:
         stabilizationWindowSeconds: 15
       scaleUp:
-        stabilizationWindowSeconds: 25
+        stabilizationWindowSeconds: 1
   resources:
     limits:
-      cpu: 500m
+      cpu: 250m
       memory: 128Mi
     requests:
       cpu: 5m

--- a/tests/e2e/autoscale/03-verify-simplest-set-collector-hpa-metrics.yaml
+++ b/tests/e2e/autoscale/03-verify-simplest-set-collector-hpa-metrics.yaml
@@ -1,4 +1,4 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - script: go run ./cmd/verify/wait-and-validate-metrics.go --cpu-value 50 --memory-value 70 --scale-down 15 --scale-up 25 --hpa simplest-set-utilization-collector
+  - script: go run ./cmd/verify/wait-and-validate-metrics.go --cpu-value 60 --scale-down 15 --scale-up 1 --hpa simplest-set-utilization-collector


### PR DESCRIPTION
We've been having trouble with the autoscale test in the helm chart CI and I believe I have narrowed down the issue.  

The core problem is that the `e2e/autoscale` test relies on scaling up the collector under load and then scaling down when the load disappears.  We don't want it scaling up early and we want it to scale down reliably once the load disappears.  Based on my testing today the proposed changes should make this sequence consitent.

These changes have 2 goals:
1. ensure the collector does not scale up until tracegen has started sending it telemetry
2. ensure the collector scales down once the load disappears.

I achieved these goals by modifying the initial `autoscaler` values of the `simplest-set-utilization` to high and long values.  With a target CPU of 99 and a `stabilizationWindowSeconds` of 300s it should be almost impossible for the collector to scale up during startup.  During the initial install I also reduced the CPU limit. This helped me hit the CPU target under load consistently during testing.

Then in `02-install.yaml` I modify the values to be triggerable under load. I change the `stabilizationWindowSeconds` to be 1 second so it would quickly scale.  So that it can scale down when the load is removed, I increased the CPU slightly.  With the CPU reduced from `500m` to `250m` and the amount of load being generated, hitting 60% target CPU is easy.  By slightly increasing the number it makes it easier for us to scale down when load is removed.  The collector is sticky with resources sometimes, so having a higher target to get below is easier for it.  To ensure no flapping, we keep a reasonable `stabilizationWindowSeconds` for `scaleDown`.

Since the collector is sticky with resources sometimes, I was never able to get the test to pass in the helm charts if a `targetMemoryUtilization` is provided.  As valuable as e2e tests are, they can be notoriously flaky, and it seemed like the collector would not let go of the memory it grabbed.  To ensure a reliable test while still providing value I propose we remove the `targetMemoryUtilization` requirement.

Test PR: https://github.com/TylerHelmuth/opentelemetry-helm-charts/pull/24

I propose this PR replace https://github.com/open-telemetry/opentelemetry-operator/pull/1576.  Thank you @moh-osman3 @Allex1 and @iblancasa for helping troubleshoot this helm chart issue.

Closes https://github.com/open-telemetry/opentelemetry-operator/issues/1574

Related to https://github.com/open-telemetry/opentelemetry-helm-charts/pull/679