### PR TITLE
[target-allocator] fix updating scrape configs

### DIFF
--- a/.chloggen/fix_targetallocator_update-scrape-configs.yaml
+++ b/.chloggen/fix_targetallocator_update-scrape-configs.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix updating scrape configs
+
+# One or more tracking issues related to the change
+issues: [1415]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/target/discovery.go
+++ b/cmd/otel-allocator/target/discovery.go
@@ -39,7 +39,6 @@ type Discoverer struct {
 	manager              *discovery.Manager
 	close                chan struct{}
 	configsMap           map[allocatorWatcher.EventSource]*config.Config
-	jobToScrapeConfig    map[string]*config.ScrapeConfig
 	hook                 discoveryHook
 	scrapeConfigsHash    uint64
 	scrapeConfigsUpdater scrapeConfigsUpdater
@@ -59,7 +58,6 @@ func NewDiscoverer(log logr.Logger, manager *discovery.Manager, hook discoveryHo
 		manager:              manager,
 		close:                make(chan struct{}),
 		configsMap:           make(map[allocatorWatcher.EventSource]*config.Config),
-		jobToScrapeConfig:    make(map[string]*config.ScrapeConfig),
 		hook:                 hook,
 		scrapeConfigsUpdater: scrapeConfigsUpdater,
 	}
@@ -67,33 +65,32 @@ func NewDiscoverer(log logr.Logger, manager *discovery.Manager, hook discoveryHo
 
 func (m *Discoverer) ApplyConfig(source allocatorWatcher.EventSource, cfg *config.Config) error {
 	m.configsMap[source] = cfg
-	newJobToScrapeConfig := make(map[string]*config.ScrapeConfig)
+	jobToScrapeConfig := make(map[string]*config.ScrapeConfig)
 
 	discoveryCfg := make(map[string]discovery.Configs)
 	relabelCfg := make(map[string][]*relabel.Config)
 
 	for _, value := range m.configsMap {
 		for _, scrapeConfig := range value.ScrapeConfigs {
-			newJobToScrapeConfig[scrapeConfig.JobName] = scrapeConfig
+			jobToScrapeConfig[scrapeConfig.JobName] = scrapeConfig
 			discoveryCfg[scrapeConfig.JobName] = scrapeConfig.ServiceDiscoveryConfigs
 			relabelCfg[scrapeConfig.JobName] = scrapeConfig.RelabelConfigs
 		}
 	}
 
-	hash, err := hashstructure.Hash(newJobToScrapeConfig, nil)
+	hash, err := hashstructure.Hash(jobToScrapeConfig, nil)
 	if err != nil {
 		return err
 	}
 	// If the hash has changed, updated stored hash and send the new config.
 	// Otherwise skip updating scrape configs.
 	if m.scrapeConfigsUpdater != nil && m.scrapeConfigsHash != hash {
-		err := m.scrapeConfigsUpdater.UpdateScrapeConfigResponse(newJobToScrapeConfig)
+		err := m.scrapeConfigsUpdater.UpdateScrapeConfigResponse(jobToScrapeConfig)
 		if err != nil {
 			return err
 		}
 
 		m.scrapeConfigsHash = hash
-		m.jobToScrapeConfig = newJobToScrapeConfig // only assign after we've successfully updated
 	}
 
 	if m.hook != nil {

--- a/cmd/otel-allocator/target/testdata/test.yaml
+++ b/cmd/otel-allocator/target/testdata/test.yaml
@@ -12,3 +12,6 @@ config:
     - targets: ["prom.domain:9001", "prom.domain:9002", "prom.domain:9003"]
       labels:
         my: label
+  - job_name: prometheus2
+    static_configs:
+    - targets: ["prom.domain:8001"]


### PR DESCRIPTION
Only take scrape configs from the most recently applied config, and only save them if we've successfully updated. As a result, we now correctly get rid of targets after a ServiceMonitor or PodMonitor is deleted, fixing #1415.

I've also fixed an issue where we would overwrite the job to scrapeConfig mapping even if the actual update failed - the test for this was incorrect, as it didn't deepcopy the mapping, and basically asserted that two references to the same map were equal.

I've modified the existing discovery test to look at scrape config updates, and added another job to the test data to make sure it gets deleted after an update.

I've also done a proper manual e2e test on this, and it worked as expected.