### PR TITLE
Bump dependencies in Node.JS autoinstrumentation to latest

### DIFF
--- a/.chloggen/bump-nodejs-versions.yaml
+++ b/.chloggen/bump-nodejs-versions.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: autoinstrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bump nodejs dependencies to latest versions
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/bump-nodejs-versions.yaml
+++ b/.chloggen/bump-nodejs-versions.yaml
@@ -8,7 +8,7 @@ component: autoinstrumentation
 note: Bump nodejs dependencies to latest versions
 
 # One or more tracking issues related to the change
-issues: []
+issues: [1626]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -14,14 +14,14 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.3.0",
-    "@opentelemetry/auto-instrumentations-node": "0.35.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.34.0",
-    "@opentelemetry/resource-detector-alibaba-cloud": "0.27.3",
-    "@opentelemetry/resource-detector-aws": "1.2.1",
-    "@opentelemetry/resource-detector-container": "0.2.1",
-    "@opentelemetry/resource-detector-gcp": "0.27.4",
-    "@opentelemetry/resources": "1.9.0",
-    "@opentelemetry/sdk-node": "0.34.0"
+    "@opentelemetry/api": "1.4.1",
+    "@opentelemetry/auto-instrumentations-node": "0.36.4",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.37.0",
+    "@opentelemetry/resource-detector-alibaba-cloud": "0.27.4",
+    "@opentelemetry/resource-detector-aws": "1.2.2",
+    "@opentelemetry/resource-detector-container": "0.2.2",
+    "@opentelemetry/resource-detector-gcp": "0.28.0",
+    "@opentelemetry/resources": "1.11.0",
+    "@opentelemetry/sdk-node": "0.37.0"
   }
 }


### PR DESCRIPTION
Replacement for #1625, this only bumps all versions in the nodejs auto instrumentation to latest.