### PR TITLE
[pkg/instrumentation] Add feature gate for dotnet instrumentation

### DIFF
--- a/.chloggen/add-featuregate-for-dotnet.yaml
+++ b/.chloggen/add-featuregate-for-dotnet.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: pkg/instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add dotnet instrumentation capability behind a feature gate which is enabled by default.
+
+# One or more tracking issues related to the change
+issues: [1629]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/README.md
+++ b/README.md
@@ -334,6 +334,21 @@ You can configure the OpenTelemetry SDK for applications which can't currently b
 instrumentation.opentelemetry.io/inject-sdk: "true"
 ```
 
+#### Controlling Instrumentation Capabilities
+
+The operator allows specifying, via the feature gates,  which languages the Instrumentation resource may instrument.
+These feature gates must be passed to the operator via the `--feature-gates` flag.
+The flag allows for a comma-delimited list of feature gate identifiers.
+Prefix a gate with '-' to disable support for the corresponding language.
+Prefixing a gate with '+' or no prefix will enable support for the corresponding language.
+If a language is enabled by default its gate only needs to be supplied when disabling the gate.
+
+| Language | Gate                                  | Default Value   |
+|----------|---------------------------------------|-----------------|
+| .NET     | `operator.autoinstrumentation.dotnet` | enabled         |
+
+Language not specified in the table are always supported and cannot be disabled.
+
 ### Target Allocator
 
 The OpenTelemetry Operator comes with an optional component, the Target Allocator (TA). When creating an OpenTelemetryCollector Custom Resource (CR) and setting the TA as enabled, the Operator will create a new deployment and service to serve specific `http_sd_config` directives for each Collector pod as part of that CR. It will also change the Prometheus receiver configuration in the CR, so that it uses the [http_sd_config](https://prometheus.io/docs/prometheus/latest/http_sd/) from the TA. The following example shows how to get started with the Target Allocator:

--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ func main() {
 		"auto-instrumentation-nodejs", autoInstrumentationNodeJS,
 		"auto-instrumentation-python", autoInstrumentationPython,
 		"auto-instrumentation-dotnet", autoInstrumentationDotNet,
+		"feature-gates", flagset.Lookup(featuregate.FeatureGatesFlag).Value.String(),
 		"build-date", v.BuildDate,
 		"go-version", v.Go,
 		"go-arch", runtime.GOARCH,

--- a/main.go
+++ b/main.go
@@ -243,7 +243,7 @@ func main() {
 			Handler: webhookhandler.NewWebhookHandler(cfg, ctrl.Log.WithName("pod-webhook"), mgr.GetClient(),
 				[]webhookhandler.PodMutator{
 					sidecar.NewMutator(logger, cfg, mgr.GetClient()),
-					instrumentation.NewMutator(logger, mgr.GetClient()),
+					instrumentation.NewMutator(logger, mgr.GetClient(), mgr.GetEventRecorderFor("opentelemetry-operator")),
 				}),
 		})
 	} else {
@@ -298,6 +298,7 @@ func addDependencies(_ context.Context, mgr ctrl.Manager, cfg config.Config, v v
 			DefaultAutoInstPython: cfg.AutoInstrumentationPythonImage(),
 			DefaultAutoInstDotNet: cfg.AutoInstrumentationDotNetImage(),
 			Client:                mgr.GetClient(),
+			Recorder:              mgr.GetEventRecorderFor("opentelemetry-operator"),
 		}
 		return u.ManagedInstances(c)
 	}))

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	featureGatesFlag = "feature-gates"
+	FeatureGatesFlag = "feature-gates"
 )
 
 var (
@@ -34,7 +34,7 @@ var (
 // Flags creates a new FlagSet that represents the available featuregate flags using the supplied featuregate registry.
 func Flags(reg *featuregate.Registry) *flag.FlagSet {
 	flagSet := new(flag.FlagSet)
-	flagSet.Var(featuregate.NewFlag(reg), featureGatesFlag,
+	flagSet.Var(featuregate.NewFlag(reg), FeatureGatesFlag,
 		"Comma-delimited list of feature gate identifiers. Prefix with '-' to disable the feature. '+' or no prefix will enable the feature.")
 	return flagSet
 }

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -24,6 +24,13 @@ const (
 	featureGatesFlag = "feature-gates"
 )
 
+var (
+	EnableDotnetAutoInstrumentationSupport = featuregate.GlobalRegistry().MustRegister(
+		"operator.autoinstrumentation.dotnet",
+		featuregate.StageBeta,
+		featuregate.WithRegisterDescription("controls whether the operator supports .NET auto-instrumentation"))
+)
+
 // Flags creates a new FlagSet that represents the available featuregate flags using the supplied featuregate registry.
 func Flags(reg *featuregate.Registry) *flag.FlagSet {
 	flagSet := new(flag.FlagSet)

--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -20,23 +20,18 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"go.opentelemetry.io/collector/featuregate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/webhookhandler"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
 
 var (
 	errMultipleInstancesPossible = errors.New("multiple OpenTelemetry Instrumentation instances available, cannot determine which one to select")
 	errNoInstancesAvailable      = errors.New("no OpenTelemetry Instrumentation instances available")
-
-	EnableDotnetAutoInstrumentationSupport = featuregate.GlobalRegistry().MustRegister(
-		"operator.autoinstrumentation.dotnet",
-		featuregate.StageBeta,
-		featuregate.WithRegisterDescription("controls whether the operator supports .NET auto-instrumentation"))
 )
 
 type instPodMutator struct {
@@ -108,7 +103,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 		logger.Error(err, "failed to select an OpenTelemetry Instrumentation instance for this pod")
 		return pod, err
 	}
-	if EnableDotnetAutoInstrumentationSupport.IsEnabled() {
+	if featuregate.EnableDotnetAutoInstrumentationSupport.IsEnabled() {
 		insts.DotNet = inst
 	} else {
 		logger.Error(nil, "support for .NET auto instrumentation is not enabled")

--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -111,7 +111,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 	if EnableDotnetAutoInstrumentationSupport.IsEnabled() {
 		insts.DotNet = inst
 	} else {
-		logger.Error(nil, "support for .NET auto instrumentation is not enable")
+		logger.Error(nil, "support for .NET auto instrumentation is not enabled")
 	}
 
 	if inst, err = pm.getInstrumentationInstance(ctx, ns, pod, annotationInjectSdk); err != nil {

--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -109,6 +109,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 	if featuregate.EnableDotnetAutoInstrumentationSupport.IsEnabled() {
 		insts.DotNet = inst
 	} else {
+		logger.Error(nil, "support for .NET auto instrumentation is not enabled")
 		pm.Recorder.Event(pod.DeepCopy(), "Warning", "InstrumentationRequestRejected", "support for .NET auto instrumentation is not enabled")
 	}
 

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -25,13 +25,14 @@ import (
 	colfeaturegate "go.opentelemetry.io/collector/featuregate"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
 
 func TestMutatePod(t *testing.T) {
-	mutator := NewMutator(logr.Discard(), k8sClient)
+	mutator := NewMutator(logr.Discard(), k8sClient, record.NewFakeRecorder(1))
 	require.NotNil(t, mutator)
 
 	tests := []struct {

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -22,11 +22,12 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/featuregate"
+	colfeaturegate "go.opentelemetry.io/collector/featuregate"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
 
 func TestMutatePod(t *testing.T) {
@@ -826,10 +827,10 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			setFeatureGates: func(t *testing.T) {
-				originalVal := EnableDotnetAutoInstrumentationSupport.IsEnabled()
-				require.NoError(t, featuregate.GlobalRegistry().Set(EnableDotnetAutoInstrumentationSupport.ID(), false))
+				originalVal := featuregate.EnableDotnetAutoInstrumentationSupport.IsEnabled()
+				require.NoError(t, colfeaturegate.GlobalRegistry().Set(featuregate.EnableDotnetAutoInstrumentationSupport.ID(), false))
 				t.Cleanup(func() {
-					require.NoError(t, featuregate.GlobalRegistry().Set(EnableDotnetAutoInstrumentationSupport.ID(), originalVal))
+					require.NoError(t, colfeaturegate.GlobalRegistry().Set(featuregate.EnableDotnetAutoInstrumentationSupport.ID(), originalVal))
 				})
 			},
 		},

--- a/pkg/instrumentation/upgrade/upgrade.go
+++ b/pkg/instrumentation/upgrade/upgrade.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/pkg/instrumentation"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
 
 type InstrumentationUpgrade struct {
@@ -96,7 +96,7 @@ func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instru
 	}
 	autoInstDotnet := inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationDotNet]
 	if autoInstDotnet != "" {
-		if instrumentation.EnableDotnetAutoInstrumentationSupport.IsEnabled() {
+		if featuregate.EnableDotnetAutoInstrumentationSupport.IsEnabled() {
 			// upgrade the image only if the image matches the annotation
 			if inst.Spec.DotNet.Image == autoInstDotnet {
 				inst.Spec.DotNet.Image = u.DefaultAutoInstDotNet

--- a/pkg/instrumentation/upgrade/upgrade.go
+++ b/pkg/instrumentation/upgrade/upgrade.go
@@ -105,6 +105,7 @@ func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instru
 				inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationDotNet] = u.DefaultAutoInstDotNet
 			}
 		} else {
+			u.Logger.Error(nil, "support for .NET auto instrumentation is not enabled")
 			u.Recorder.Event(inst.DeepCopy(), "Warning", "InstrumentationUpgradeRejected", "support for .NET auto instrumentation is not enabled")
 		}
 	}

--- a/pkg/instrumentation/upgrade/upgrade.go
+++ b/pkg/instrumentation/upgrade/upgrade.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/instrumentation"
 )
 
 type InstrumentationUpgrade struct {
@@ -95,10 +96,14 @@ func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instru
 	}
 	autoInstDotnet := inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationDotNet]
 	if autoInstDotnet != "" {
-		// upgrade the image only if the image matches the annotation
-		if inst.Spec.DotNet.Image == autoInstDotnet {
-			inst.Spec.DotNet.Image = u.DefaultAutoInstDotNet
-			inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationDotNet] = u.DefaultAutoInstDotNet
+		if instrumentation.EnableDotnetAutoInstrumentationSupport.IsEnabled() {
+			// upgrade the image only if the image matches the annotation
+			if inst.Spec.DotNet.Image == autoInstDotnet {
+				inst.Spec.DotNet.Image = u.DefaultAutoInstDotNet
+				inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationDotNet] = u.DefaultAutoInstDotNet
+			}
+		} else {
+			u.Logger.Error(nil, "support for .NET auto instrumentation is not enable")
 		}
 	}
 	return inst

--- a/pkg/instrumentation/upgrade/upgrade.go
+++ b/pkg/instrumentation/upgrade/upgrade.go
@@ -103,7 +103,7 @@ func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instru
 				inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationDotNet] = u.DefaultAutoInstDotNet
 			}
 		} else {
-			u.Logger.Error(nil, "support for .NET auto instrumentation is not enable")
+			u.Logger.Error(nil, "support for .NET auto instrumentation is not enabled")
 		}
 	}
 	return inst

--- a/pkg/instrumentation/upgrade/upgrade.go
+++ b/pkg/instrumentation/upgrade/upgrade.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
@@ -29,6 +30,7 @@ import (
 type InstrumentationUpgrade struct {
 	Client                client.Client
 	Logger                logr.Logger
+	Recorder              record.EventRecorder
 	DefaultAutoInstJava   string
 	DefaultAutoInstNodeJS string
 	DefaultAutoInstPython string
@@ -103,7 +105,7 @@ func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instru
 				inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationDotNet] = u.DefaultAutoInstDotNet
 			}
 		} else {
-			u.Logger.Error(nil, "support for .NET auto instrumentation is not enabled")
+			u.Recorder.Event(inst.DeepCopy(), "Warning", "InstrumentationUpgradeRejected", "support for .NET auto instrumentation is not enabled")
 		}
 	}
 	return inst


### PR DESCRIPTION
This PR puts the dotnet instrumentation behind a feature gate named `operator.autoinstrumentation.dotnet`.  This feature gate is enabled by default, but operator managers could disable it if they do not want Instrumentation to be able to inject dotnet instrumentation.

I'm using dotnet as the guinea pig, but if the pattern is good I'll submit PRs for the other languages as well.