### PR TITLE
chore: do not log error when receiver has no endpoint

### DIFF
--- a/pkg/collector/parser/receiver.go
+++ b/pkg/collector/parser/receiver.go
@@ -115,13 +115,13 @@ func singlePortFromConfigEndpoint(logger logr.Logger, name string, config map[in
 		endpoint = getAddressFromConfig(logger, name, endpointKey, config)
 	}
 
-	switch endpoint := endpoint.(type) {
+	switch e := endpoint.(type) {
 	case nil:
 		break
 	case string:
-		port, err := portFromEndpoint(endpoint)
+		port, err := portFromEndpoint(e)
 		if err != nil {
-			logger.WithValues(endpointKey, endpoint).Info("couldn't parse the endpoint's port")
+			logger.WithValues(endpointKey, e).Error(err, "couldn't parse the endpoint's port")
 			return nil
 		}
 
@@ -130,7 +130,7 @@ func singlePortFromConfigEndpoint(logger logr.Logger, name string, config map[in
 			Port: port,
 		}
 	default:
-		logger.Info("receiver's endpoint isn't a string")
+		logger.WithValues(endpointKey, endpoint).Error(fmt.Errorf("unrecognized type %T", endpoint), "receiver's endpoint isn't a string")
 	}
 
 	return nil


### PR DESCRIPTION
Some receivers don't have an `endpoint` config value. No need to log a type error for these.

FWIW, setting `endpoint: :1` quiets the log, but causes the Kafka receiver to fail to unmarshal its config.