### PR TITLE
Bump OpenTelemetry .NET Automatic Instrumentation to 0.7.0 - part 2/2

### DIFF
--- a/.chloggen/1672-bump-otel-net-auto-to-0.7.0.yaml
+++ b/.chloggen/1672-bump-otel-net-auto-to-0.7.0.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: autoinstrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bump OpenTelemetry .NET Automatic Instrumentation to 0.7.0
+
+# One or more tracking issues related to the change
+issues: [1672]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/versions.txt
+++ b/versions.txt
@@ -27,7 +27,7 @@ autoinstrumentation-python=0.38b0
 
 # Represents the current release of DotNet instrumentation.
 # Should match autoinstrumentation/dotnet/version.txt
-autoinstrumentation-dotnet=0.6.0
+autoinstrumentation-dotnet=0.7.0
 
 # Represents the current release of Apache HTTPD instrumentation.
 # Should match autoinstrumentation/apache-httpd/version.txt


### PR DESCRIPTION
Fixes #1672 
Can be merged after #1673 