### PR TITLE
[instrumentation] Prevent event and log for disabled instrumentation when instr is nil

### DIFF
--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -106,7 +106,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 		logger.Error(err, "failed to select an OpenTelemetry Instrumentation instance for this pod")
 		return pod, err
 	}
-	if featuregate.EnableDotnetAutoInstrumentationSupport.IsEnabled() {
+	if featuregate.EnableDotnetAutoInstrumentationSupport.IsEnabled() || inst == nil {
 		insts.DotNet = inst
 	} else {
 		logger.Error(nil, "support for .NET auto instrumentation is not enabled")


### PR DESCRIPTION
This PR cleans up the dotnet featuregate implementation by ensuring the log and event are only written if the `instr` pointer is not nil and the feature gate is disabled.  The unit tests didn't catch this because to don't do any mocking/expecting of the recorder or logging, I found it while working on the Go autoinstrumentation support.