### PR TITLE
[pkg/instrumentation] Add featuregate to java instrumentation

### DIFF
--- a/.chloggen/java-featuregate.yaml
+++ b/.chloggen/java-featuregate.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: pkg/instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add java instrumentation capability behind a feature gate which is enabled by default.
+
+# One or more tracking issues related to the change
+issues: [1695]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ If a language is enabled by default its gate only needs to be supplied when disa
 
 | Language | Gate                                  | Default Value   |
 |----------|---------------------------------------|-----------------|
+| Java     | `operator.autoinstrumentation.java`   | enabled         |
 | Python   | `operator.autoinstrumentation.python` | enabled         |
 | DotNet   | `operator.autoinstrumentation.dotnet` | enabled         |
 

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -33,6 +33,10 @@ var (
 		"operator.autoinstrumentation.python",
 		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("controls whether the operator supports Python auto-instrumentation"))
+	EnableJavaAutoInstrumentationSupport = featuregate.GlobalRegistry().MustRegister(
+		"operator.autoinstrumentation.java",
+		featuregate.StageBeta,
+		featuregate.WithRegisterDescription("controls whether the operator supports Java auto-instrumentation"))
 )
 
 // Flags creates a new FlagSet that represents the available featuregate flags using the supplied featuregate registry.


### PR DESCRIPTION
This PR puts the java instrumentation behind a feature gate named `operator.autoinstrumentation.java`.  This feature gate is enabled by default, but operator managers could disable it if they do not want Instrumentation to be able to inject java instrumentation.