### PR TITLE
[pkg/instrumentation] Add featuregate to python instrumentation

### DIFF
--- a/.chloggen/python-featuregate.yaml
+++ b/.chloggen/python-featuregate.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: pkg/instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add python instrumentation capability behind a feature gate which is enabled by default.
+
+# One or more tracking issues related to the change
+issues: [1696]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/README.md
+++ b/README.md
@@ -345,7 +345,8 @@ If a language is enabled by default its gate only needs to be supplied when disa
 
 | Language | Gate                                  | Default Value   |
 |----------|---------------------------------------|-----------------|
-| .NET     | `operator.autoinstrumentation.dotnet` | enabled         |
+| Python   | `operator.autoinstrumentation.python` | enabled         |
+| DotNet   | `operator.autoinstrumentation.dotnet` | enabled         |
 
 Language not specified in the table are always supported and cannot be disabled.
 

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -29,6 +29,10 @@ var (
 		"operator.autoinstrumentation.dotnet",
 		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("controls whether the operator supports .NET auto-instrumentation"))
+	EnablePythonAutoInstrumentationSupport = featuregate.GlobalRegistry().MustRegister(
+		"operator.autoinstrumentation.python",
+		featuregate.StageBeta,
+		featuregate.WithRegisterDescription("controls whether the operator supports Python auto-instrumentation"))
 )
 
 // Flags creates a new FlagSet that represents the available featuregate flags using the supplied featuregate registry.

--- a/pkg/instrumentation/upgrade/upgrade.go
+++ b/pkg/instrumentation/upgrade/upgrade.go
@@ -90,10 +90,15 @@ func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instru
 	}
 	autoInstPython := inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationPython]
 	if autoInstPython != "" {
-		// upgrade the image only if the image matches the annotation
-		if inst.Spec.Python.Image == autoInstPython {
-			inst.Spec.Python.Image = u.DefaultAutoInstPython
-			inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationPython] = u.DefaultAutoInstPython
+		if featuregate.EnablePythonAutoInstrumentationSupport.IsEnabled() {
+			// upgrade the image only if the image matches the annotation
+			if inst.Spec.Python.Image == autoInstPython {
+				inst.Spec.Python.Image = u.DefaultAutoInstPython
+				inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationPython] = u.DefaultAutoInstPython
+			}
+		} else {
+			u.Logger.Error(nil, "support for Python auto instrumentation is not enabled")
+			u.Recorder.Event(inst.DeepCopy(), "Warning", "InstrumentationUpgradeRejected", "support for Python auto instrumentation is not enabled")
 		}
 	}
 	autoInstDotnet := inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationDotNet]


### PR DESCRIPTION
This PR puts the python instrumentation behind a feature gate named `operator.autoinstrumentation.python`.  This feature gate is enabled by default, but operator managers could disable it if they do not want Instrumentation to be able to inject python instrumentation.