### PR TITLE
[pkg/instrumentation] Add featuregate to nodejs instrumentation

### DIFF
--- a/.chloggen/nodejs-featuregate.yaml
+++ b/.chloggen/nodejs-featuregate.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: pkg/instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add python instrumentation capability behind a feature gate which is enabled by default.
+
+# One or more tracking issues related to the change
+issues: [1697]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/nodejs-featuregate.yaml
+++ b/.chloggen/nodejs-featuregate.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: pkg/instrumentation
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add python instrumentation capability behind a feature gate which is enabled by default.
+note: Add nodejs instrumentation capability behind a feature gate which is enabled by default.
 
 # One or more tracking issues related to the change
 issues: [1697]

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ If a language is enabled by default its gate only needs to be supplied when disa
 | Language | Gate                                  | Default Value   |
 |----------|---------------------------------------|-----------------|
 | Java     | `operator.autoinstrumentation.java`   | enabled         |
+| NodeJS   | `operator.autoinstrumentation.nodejs` | enabled         |
 | Python   | `operator.autoinstrumentation.python` | enabled         |
 | DotNet   | `operator.autoinstrumentation.dotnet` | enabled         |
 

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -37,6 +37,10 @@ var (
 		"operator.autoinstrumentation.java",
 		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("controls whether the operator supports Java auto-instrumentation"))
+	EnableNodeJSAutoInstrumentationSupport = featuregate.GlobalRegistry().MustRegister(
+		"operator.autoinstrumentation.nodejs",
+		featuregate.StageBeta,
+		featuregate.WithRegisterDescription("controls whether the operator supports NodeJS auto-instrumentation"))
 
 	// EnableTargetAllocatorRewrite is the feature gate that controls whether the collector's configuration should
 	// automatically be rewritten when the target allocator is enabled.

--- a/pkg/instrumentation/upgrade/upgrade.go
+++ b/pkg/instrumentation/upgrade/upgrade.go
@@ -87,10 +87,15 @@ func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instru
 	}
 	autoInstNodeJS := inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationNodeJS]
 	if autoInstNodeJS != "" {
-		// upgrade the image only if the image matches the annotation
-		if inst.Spec.NodeJS.Image == autoInstNodeJS {
-			inst.Spec.NodeJS.Image = u.DefaultAutoInstNodeJS
-			inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationNodeJS] = u.DefaultAutoInstNodeJS
+		if featuregate.EnableNodeJSAutoInstrumentationSupport.IsEnabled() {
+			// upgrade the image only if the image matches the annotation
+			if inst.Spec.NodeJS.Image == autoInstNodeJS {
+				inst.Spec.NodeJS.Image = u.DefaultAutoInstNodeJS
+				inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationNodeJS] = u.DefaultAutoInstNodeJS
+			}
+		} else {
+			u.Logger.Error(nil, "support for NodeJS auto instrumentation is not enabled")
+			u.Recorder.Event(inst.DeepCopy(), "Warning", "InstrumentationUpgradeRejected", "support for NodeJS auto instrumentation is not enabled")
 		}
 	}
 	autoInstPython := inst.Annotations[v1alpha1.AnnotationDefaultAutoInstrumentationPython]


### PR DESCRIPTION
This PR puts the NodeJS instrumentation behind a feature gate named `operator.autoinstrumentation.nodejs`.  This feature gate is enabled by default, but operator managers could disable it if they do not want Instrumentation to be able to inject NodeJS instrumentation.