### PR TITLE
fix issues related to prometheus relabel configs when target allocator is enabled

### DIFF
--- a/pkg/collector/reconcile/config_replace.go
+++ b/pkg/collector/reconcile/config_replace.go
@@ -47,7 +47,7 @@ func ReplaceConfig(instance v1alpha1.OpenTelemetryCollector) (string, error) {
 		return "", getStringErr
 	}
 
-	// Get the Prometheus config map with dollar signs replaced
+	// Get the Prometheus config map with dollar signs replaced to ensure successful validation of Prometheus regex
 	promCfgMap, getCfgPromErr := ta.ReplaceDollarSignInPromConfig(instance.Spec.Config)
 	if getCfgPromErr != nil {
 		return "", getCfgPromErr

--- a/pkg/collector/reconcile/config_replace_test.go
+++ b/pkg/collector/reconcile/config_replace_test.go
@@ -15,6 +15,7 @@
 package reconcile
 
 import (
+	"os"
 	"testing"
 
 	"github.com/prometheus/prometheus/discovery/http"
@@ -95,4 +96,32 @@ func TestPrometheusParser(t *testing.T) {
 		}
 	})
 
+}
+
+func TestRelabelConfig(t *testing.T) {
+	param, err := newParams("test/test-img", "../testdata/relabel_config_original.yaml")
+	assert.NoError(t, err)
+
+	t.Run("should escape $ characters in relabel configs replacement key", func(t *testing.T) {
+		expectedConfigBytes, err := os.ReadFile("../testdata/relabel_config_expected.yaml")
+		assert.NoError(t, err)
+		expectedConfig := string(expectedConfigBytes)
+
+		actualConfig, err := ReplaceConfig(param.Instance)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedConfig, actualConfig)
+	})
+
+	t.Run("should not modify config when TargetAllocator is disabled", func(t *testing.T) {
+		param.Instance.Spec.TargetAllocator.Enabled = false
+		expectedConfigBytes, err := os.ReadFile("../testdata/relabel_config_original.yaml")
+		assert.NoError(t, err)
+		expectedConfig := string(expectedConfigBytes)
+
+		actualConfig, err := ReplaceConfig(param.Instance)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expectedConfig, actualConfig)
+	})
 }

--- a/pkg/collector/reconcile/configmap.go
+++ b/pkg/collector/reconcile/configmap.go
@@ -103,7 +103,7 @@ func desiredTAConfigMap(params Params) (corev1.ConfigMap, error) {
 		labels["app.kubernetes.io/version"] = "latest"
 	}
 
-	promConfig, err := ta.ConfigToPromConfig(params.Instance.Spec.Config)
+	promConfig, err := ta.ReplaceDollarSignInTAPromConfig(params.Instance.Spec.Config)
 	if err != nil {
 		return corev1.ConfigMap{}, err
 	}

--- a/pkg/collector/testdata/relabel_config_expected.yaml
+++ b/pkg/collector/testdata/relabel_config_expected.yaml
@@ -1,0 +1,63 @@
+exporters:
+  logging: null
+processors: null
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+        evaluation_interval: 1m
+      scrape_configs:
+      - job_name: service-x
+        honor_timestamps: true
+        scrape_interval: 1m
+        scrape_timeout: 10s
+        metrics_path: /metrics
+        scheme: http
+        follow_redirects: true
+        enable_http2: true
+        relabel_configs:
+        - source_labels: [label1]
+          separator: ;
+          regex: (.*)
+          replacement: $$1
+          action: keep
+        - source_labels: [label2]
+          separator: ;
+          regex: (.*)
+          target_label: label3
+          replacement: $$1_$2
+          action: replace
+        - source_labels: [label4]
+          separator: ;
+          regex: (.*)
+          replacement: $$1
+          action: labelmap
+        - separator: ;
+          regex: foo_.*
+          replacement: $$1
+          action: labeldrop
+        metric_relabel_configs:
+        - source_labels: [label1]
+          separator: ;
+          regex: (.*)
+          replacement: $1
+          action: keep
+        - source_labels: [label4]
+          separator: ;
+          regex: (.*)
+          replacement: $$1
+          action: labelmap
+        http_sd_configs:
+        - follow_redirects: false
+          enable_http2: false
+          url: http://test-targetallocator:80/jobs/service-x/targets?collector_id=$POD_NAME
+service:
+  pipelines:
+    metrics:
+      exporters:
+      - logging
+      processors: []
+      receivers:
+      - prometheus

--- a/pkg/collector/testdata/relabel_config_original.yaml
+++ b/pkg/collector/testdata/relabel_config_original.yaml
@@ -1,0 +1,54 @@
+exporters:
+  logging: null
+processors: null
+receivers:
+  prometheus:
+    config:
+      global:
+        scrape_interval: 1m
+        scrape_timeout: 10s
+        evaluation_interval: 1m
+      scrape_configs:
+      - job_name: service-x
+        honor_timestamps: true
+        scrape_interval: 1m
+        scrape_timeout: 10s
+        metrics_path: /metrics
+        scheme: http
+        follow_redirects: true
+        enable_http2: true
+        relabel_configs:
+        - source_labels: [label1]
+          regex: (.*)
+          action: keep
+        - source_labels: [label2]
+          separator: ;
+          regex: (.*)
+          target_label: label3
+          replacement: $$1_$2
+          action: replace
+        - source_labels: [label4]
+          separator: ;
+          regex: (.*)
+          replacement: $$1
+          action: labelmap
+        - regex: foo_.*
+          action: labeldrop
+        metric_relabel_configs:
+        - source_labels: [label1]
+          separator: ;
+          regex: (.*)
+          replacement: $1
+          action: keep
+        - source_labels: [label4]
+          separator: ;
+          regex: (.*)
+          action: labelmap
+service:
+  pipelines:
+    metrics:
+      exporters:
+      - logging
+      processors: []
+      receivers:
+      - prometheus

--- a/pkg/targetallocator/adapters/config_to_prom_config.go
+++ b/pkg/targetallocator/adapters/config_to_prom_config.go
@@ -16,6 +16,7 @@ package adapters
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
 )
@@ -26,6 +27,14 @@ func errorNoComponent(component string) error {
 
 func errorNotAMap(component string) error {
 	return fmt.Errorf("%s property in the configuration doesn't contain valid %s", component, component)
+}
+
+func errorNotAList(component string) error {
+	return fmt.Errorf("%s must be a list in the config", component)
+}
+
+func errorNotAString(component string) error {
+	return fmt.Errorf("%s must be a string", component)
 }
 
 // ConfigToPromConfig converts the incoming configuration object into a the Prometheus receiver config.
@@ -63,6 +72,240 @@ func ConfigToPromConfig(cfg string) (map[interface{}]interface{}, error) {
 	prometheusConfig, ok := prometheusConfigProperty.(map[interface{}]interface{})
 	if !ok {
 		return nil, errorNotAMap("prometheusConfig")
+	}
+
+	return prometheusConfig, nil
+}
+
+// ReplaceDollarSignInPromConfig replaces "$$" with "__DOUBLE_DOLLAR__" and "$" with "__SINGLE_DOLLAR__" in
+// the "replacement" fields of both "relabel_configs" and "metric_relabel_configs" in a Prometheus configuration file.
+func ReplaceDollarSignInPromConfig(cfg string) (map[interface{}]interface{}, error) {
+	config, err := adapters.ConfigFromString(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	receiversProperty, ok := config["receivers"]
+	if !ok {
+		return nil, errorNoComponent("receivers")
+	}
+
+	receivers, ok := receiversProperty.(map[interface{}]interface{})
+	if !ok {
+		return nil, errorNotAMap("receivers")
+	}
+
+	prometheusProperty, ok := receivers["prometheus"]
+	if !ok {
+		return nil, errorNoComponent("prometheus")
+	}
+
+	prometheus, ok := prometheusProperty.(map[interface{}]interface{})
+	if !ok {
+		return nil, errorNotAMap("prometheus")
+	}
+
+	prometheusConfigProperty, ok := prometheus["config"]
+	if !ok {
+		return nil, errorNoComponent("prometheusConfig")
+	}
+
+	prometheusConfig, ok := prometheusConfigProperty.(map[interface{}]interface{})
+	if !ok {
+		return nil, errorNotAMap("prometheusConfig")
+	}
+
+	scrapeConfigsProperty, ok := prometheusConfig["scrape_configs"]
+	if !ok {
+		return nil, errorNoComponent("scrape_configs")
+	}
+
+	scrapeConfigs, ok := scrapeConfigsProperty.([]interface{})
+	if !ok {
+		return nil, errorNotAList("scrape_configs")
+	}
+
+	for _, config := range scrapeConfigs {
+		scrapeConfig, ok := config.(map[interface{}]interface{})
+		if !ok {
+			return nil, errorNotAMap("scrape_config")
+		}
+
+		relabelConfigsProperty, ok := scrapeConfig["relabel_configs"]
+		if !ok {
+			continue
+		}
+
+		relabelConfigs, ok := relabelConfigsProperty.([]interface{})
+		if !ok {
+			return nil, errorNotAList("relabel_configs")
+		}
+
+		for _, rc := range relabelConfigs {
+			relabelConfig, ok := rc.(map[interface{}]interface{})
+			if !ok {
+				return nil, errorNotAMap("relabel_config")
+			}
+
+			replacementProperty, ok := relabelConfig["replacement"]
+			if !ok {
+				continue
+			}
+
+			replacement, ok := replacementProperty.(string)
+			if !ok {
+				return nil, errorNotAString("replacement")
+			}
+
+			relabelConfig["replacement"] = strings.ReplaceAll(replacement, "$$", "__DOUBLE_DOLLAR__")
+			relabelConfig["replacement"] = strings.ReplaceAll(relabelConfig["replacement"].(string), "$", "__SINGLE_DOLLAR__")
+		}
+
+		metricRelabelConfigsProperty, ok := scrapeConfig["metric_relabel_configs"]
+		if !ok {
+			continue
+		}
+
+		metricRelabelConfigs, ok := metricRelabelConfigsProperty.([]interface{})
+		if !ok {
+			return nil, errorNotAList("metric_relabel_configs")
+		}
+
+		for _, rc := range metricRelabelConfigs {
+			relabelConfig, ok := rc.(map[interface{}]interface{})
+			if !ok {
+				return nil, errorNotAMap("relabel_config")
+			}
+
+			replacementProperty, ok := relabelConfig["replacement"]
+			if !ok {
+				continue
+			}
+
+			replacement, ok := replacementProperty.(string)
+			if !ok {
+				return nil, errorNotAString("replacement")
+			}
+
+			relabelConfig["replacement"] = strings.ReplaceAll(replacement, "$$", "__DOUBLE_DOLLAR__")
+			relabelConfig["replacement"] = strings.ReplaceAll(relabelConfig["replacement"].(string), "$", "__SINGLE_DOLLAR__")
+		}
+	}
+
+	return prometheusConfig, nil
+}
+
+// ReplaceDollarSignInTAPromConfig replaces "$$" with "$" in the "replacement" fields of
+// both "relabel_configs" and "metric_relabel_configs" in a Prometheus configuration file.
+func ReplaceDollarSignInTAPromConfig(cfg string) (map[interface{}]interface{}, error) {
+	config, err := adapters.ConfigFromString(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	receiversProperty, ok := config["receivers"]
+	if !ok {
+		return nil, errorNoComponent("receivers")
+	}
+
+	receivers, ok := receiversProperty.(map[interface{}]interface{})
+	if !ok {
+		return nil, errorNotAMap("receivers")
+	}
+
+	prometheusProperty, ok := receivers["prometheus"]
+	if !ok {
+		return nil, errorNoComponent("prometheus")
+	}
+
+	prometheus, ok := prometheusProperty.(map[interface{}]interface{})
+	if !ok {
+		return nil, errorNotAMap("prometheus")
+	}
+
+	prometheusConfigProperty, ok := prometheus["config"]
+	if !ok {
+		return nil, errorNoComponent("prometheusConfig")
+	}
+
+	prometheusConfig, ok := prometheusConfigProperty.(map[interface{}]interface{})
+	if !ok {
+		return nil, errorNotAMap("prometheusConfig")
+	}
+
+	scrapeConfigsProperty, ok := prometheusConfig["scrape_configs"]
+	if !ok {
+		return nil, errorNoComponent("scrape_configs")
+	}
+
+	scrapeConfigs, ok := scrapeConfigsProperty.([]interface{})
+	if !ok {
+		return nil, errorNotAList("scrape_configs")
+	}
+
+	for _, config := range scrapeConfigs {
+		scrapeConfig, ok := config.(map[interface{}]interface{})
+		if !ok {
+			return nil, errorNotAMap("scrape_config")
+		}
+
+		relabelConfigsProperty, ok := scrapeConfig["relabel_configs"]
+		if !ok {
+			continue
+		}
+
+		relabelConfigs, ok := relabelConfigsProperty.([]interface{})
+		if !ok {
+			return nil, errorNotAList("relabel_configs")
+		}
+
+		for _, rc := range relabelConfigs {
+			relabelConfig, ok := rc.(map[interface{}]interface{})
+			if !ok {
+				return nil, errorNotAMap("relabel_config")
+			}
+
+			replacementProperty, ok := relabelConfig["replacement"]
+			if !ok {
+				continue
+			}
+
+			replacement, ok := replacementProperty.(string)
+			if !ok {
+				return nil, errorNotAString("replacement")
+			}
+
+			relabelConfig["replacement"] = strings.ReplaceAll(replacement, "$$", "$")
+		}
+
+		metricRelabelConfigsProperty, ok := scrapeConfig["metric_relabel_configs"]
+		if !ok {
+			continue
+		}
+
+		metricRelabelConfigs, ok := metricRelabelConfigsProperty.([]interface{})
+		if !ok {
+			return nil, errorNotAList("metric_relabel_configs")
+		}
+
+		for _, rc := range metricRelabelConfigs {
+			relabelConfig, ok := rc.(map[interface{}]interface{})
+			if !ok {
+				return nil, errorNotAMap("relabel_config")
+			}
+
+			replacementProperty, ok := relabelConfig["replacement"]
+			if !ok {
+				continue
+			}
+
+			replacement, ok := replacementProperty.(string)
+			if !ok {
+				return nil, errorNotAString("replacement")
+			}
+
+			relabelConfig["replacement"] = strings.ReplaceAll(replacement, "$$", "$")
+		}
 	}
 
 	return prometheusConfig, nil

--- a/tests/e2e/smoke-targetallocator/00-install.yaml
+++ b/tests/e2e/smoke-targetallocator/00-install.yaml
@@ -24,10 +24,25 @@ metadata:
   name: stateful
 spec:
   mode: statefulset
+  volumes:
+    - name: testvolume
+  volumeMounts:
+    - name: testvolume
+      mountPath: /usr/share/testvolume
+  volumeClaimTemplates:
+    - metadata:
+        name: testvolume
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 1Gi
   targetAllocator:
     enabled: true
-    serviceAccount: ta
     image: "local/opentelemetry-operator-targetallocator:e2e"
+    serviceAccount: ta
+    prometheusCR:
+      enabled: true
   config: |
     receivers:
       jaeger:
@@ -38,13 +53,19 @@ spec:
       prometheus:
         config:
           scrape_configs:
-            - job_name: 'otel-collector'
-              scrape_interval: 10s
-              static_configs:
-                - targets: [ '0.0.0.0:8888' ]
+          - job_name: 'otel-collector'
+            scrape_interval: 10s
+            static_configs:
+            - targets: [ '0.0.0.0:8888' ]
+            relabel_configs:
+            - regex: __meta_kubernetes_node_label_(.+)
+              action: labelmap
+              replacement: $$1
+            - regex: test_.*
+              action: labeldrop  
     
     processors:
-    
+
     exporters:
       logging:
     service:


### PR DESCRIPTION
Related to following issues: #[1623](https://github.com/open-telemetry/opentelemetry-operator/issues/1623), #[1622](https://github.com/open-telemetry/opentelemetry-operator/issues/1622), #[958](https://github.com/open-telemetry/opentelemetry-operator/issues/958)

### Cause:

The issue manifests itself in two scenarios.

1. First, when Prometheus adds a default value of the replacement key with $1, the collector interprets it as an environment variable substitution and resolves it to an empty string. When the configMap is built by the operator, the unmarshalling logic calls the Prometheus relabel config validation logic ([relabel.go](https://github.com/prometheus/prometheus/blob/3923e83413075a17c5a10739696a879765a05542/model/relabel/relabel.go#L103)), which includes the additional defaults, including the $1 replacement field, appended to the original Prometheus configuration. Upon initialization, the collector pod loads the configMap and interprets $1 as an environment variable, leading to its replacement with an empty string. As a result, the same Prometheus relabel config validation logic fails when the config is unmarshalled in the collector code, as the replacement key is now replaced with an empty string due to env var substitution. 

2. Second, when Prometheus configuration explicitly contains $$ for labelmap, labeldrop, labelkeep or other Prometheus actions that undergo regex validation in the prometheus validation code ([relabel.go](https://github.com/prometheus/prometheus/blob/3923e83413075a17c5a10739696a879765a05542/model/relabel/relabel.go#L126)), the validation of the regex will fail.

### Resolution:

1. For the first scenario, the solution involved explicitly escaping the default '$' character in the replacement key while building the configMap. This was done by replacing all occurrences of '$' with ‘$$’. Upon initialization, the collector pod loads the ConfigMap and resolves ‘$$’ as ‘$’, thus ensuring that the metric relabel config validation in Prometheus passes successfully when the configuration is unmarshalled in the collector code.

2. For the second scenario, the approach involved replacing all occurrences of '$$' with the string '__DOUBLE_DOLLAR__' and '$' with the string '__SINGLE_DOLLAR__' right before unmarshalling the Prometheus config while creating the configMap. After unmarshalling, the values were reset to their original values. This solution ensured that Prometheus regex validation succeeds.