### PR TITLE
[chore] [target-allocator] Add filterStrategy to TargetAllocator README.md

### DIFF
--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -197,8 +197,11 @@ type OpenTelemetryTargetAllocator struct {
 	// +optional
 	AllocationStrategy OpenTelemetryTargetAllocatorAllocationStrategy `json:"allocationStrategy,omitempty"`
 	// FilterStrategy determines how to filter targets before allocating them among the collectors.
-	// The only current option is relabel-config (drops targets based on prom relabel_config).
-	// Filtering is disabled by default.
+	// The only current option is relabel-config (drops targets based on prom relabel_config). It's important to consider
+	// setting it with relabel-config if you have a scrape job with a discovery role for example, endpoints which could
+	// produce multiple targets per endpoint. If these targets lead to the same metric after a relabeling step and they
+	// are assigned to different collectors, the outcome may be undesirable because duplicate time series are created for
+	// the metric. Filtering is disabled by default.
 	// +optional
 	FilterStrategy string `json:"filterStrategy,omitempty"`
 	// ServiceAccount indicates the name of an existing service account to use with this instance. When set,

--- a/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -31,7 +31,7 @@ metadata:
     categories: Logging & Tracing
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2023-05-08T15:42:30Z"
+    createdAt: "2023-05-10T20:23:18Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -2013,7 +2013,13 @@ spec:
                     description: FilterStrategy determines how to filter targets before
                       allocating them among the collectors. The only current option
                       is relabel-config (drops targets based on prom relabel_config).
-                      Filtering is disabled by default.
+                      It's important to consider setting it with relabel-config if
+                      you have a scrape job with a discovery role for example, endpoints
+                      which could produce multiple targets per endpoint. If these
+                      targets lead to the same metric after a relabeling step and
+                      they are assigned to different collectors, the outcome may be
+                      undesirable because duplicate time series are created for the
+                      metric. Filtering is disabled by default.
                     type: string
                   image:
                     description: Image indicates the container image to use for the

--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -43,6 +43,12 @@ spec:
           processors: []
           exporters: [logging]
 ```
+## Set up filter_strategy
+`FilterStrategy` determines how to filter targets before allocating them among multiple collectors. `relabel-config` is the currently supported option. With `FilterStrategy`, targets will be consolidated based on Prometheus configuration "relabel_config". By default, filtering is disabled.
+
+It's important to consider setting `FilterStrategy` if you have a scrape job with a discovery role for example, `endpoints` which could produce multiple targets per endpoint. If these targets lead to the same metric after a relabeling step and they are assigned to different collectors, the outcome may be undesirable because duplicate time series are created for the metric.  
+
+For metrics collection pipeline where metrics are exported to Prometheus, you may see `out of order sample` error intermittenly if the time series produced have shifted time stamps from different collectors. 
 
 ## PrometheusCR specifics
 TargetAllocator discovery of PrometheusCRs can be turned on by setting

--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -44,7 +44,7 @@ spec:
           exporters: [logging]
 ```
 ## Set up filterStrategy
-`filterStrategy` determines how to filter targets before allocating them among multiple collectors. `relabel-config` is the currently supported option. With `filterStrategy`, targets will be consolidated based on Prometheus configuration "relabel_config". By default, filtering is disabled.
+`filterStrategy` determines how to filter targets before allocating them among multiple collectors. `relabel-config` is the currently supported option. With `filterStrategy`, targets will be consolidated based on Prometheus configuration `relabel_config`. By default, filtering is disabled.
 
 It's important to consider setting `filterStrategy` if you have a scrape job with a discovery role for example, `endpoints` which could produce multiple targets per endpoint. If these targets lead to the same metric after a relabeling step and they are assigned to different collectors, the outcome may be undesirable because duplicate time series are created for the metric. 
 

--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -43,12 +43,20 @@ spec:
           processors: []
           exporters: [logging]
 ```
-## Set up filter_strategy
-`FilterStrategy` determines how to filter targets before allocating them among multiple collectors. `relabel-config` is the currently supported option. With `FilterStrategy`, targets will be consolidated based on Prometheus configuration "relabel_config". By default, filtering is disabled.
+## Set up filterStrategy
+`filterStrategy` determines how to filter targets before allocating them among multiple collectors. `relabel-config` is the currently supported option. With `filterStrategy`, targets will be consolidated based on Prometheus configuration "relabel_config". By default, filtering is disabled.
 
-It's important to consider setting `FilterStrategy` if you have a scrape job with a discovery role for example, `endpoints` which could produce multiple targets per endpoint. If these targets lead to the same metric after a relabeling step and they are assigned to different collectors, the outcome may be undesirable because duplicate time series are created for the metric.  
+It's important to consider setting `filterStrategy` if you have a scrape job with a discovery role for example, `endpoints` which could produce multiple targets per endpoint. If these targets lead to the same metric after a relabeling step and they are assigned to different collectors, the outcome may be undesirable because duplicate time series are created for the metric. 
 
 For metrics collection pipeline where metrics are exported to Prometheus, you may see `out of order sample` error intermittenly if the time series produced have shifted time stamps from different collectors. 
+
+Here is an example of this setting,
+```yaml
+  targetAllocator:
+    enabled: true
+    allocationStrategy: consistent-hashing
+    filterStrategy: relabel-config
+```
 
 ## PrometheusCR specifics
 TargetAllocator discovery of PrometheusCRs can be turned on by setting

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -2011,7 +2011,13 @@ spec:
                     description: FilterStrategy determines how to filter targets before
                       allocating them among the collectors. The only current option
                       is relabel-config (drops targets based on prom relabel_config).
-                      Filtering is disabled by default.
+                      It's important to consider setting it with relabel-config if
+                      you have a scrape job with a discovery role for example, endpoints
+                      which could produce multiple targets per endpoint. If these
+                      targets lead to the same metric after a relabeling step and
+                      they are assigned to different collectors, the outcome may be
+                      undesirable because duplicate time series are created for the
+                      metric. Filtering is disabled by default.
                     type: string
                   image:
                     description: Image indicates the container image to use for the

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
+  newTag: 0.76.1

--- a/docs/api.md
+++ b/docs/api.md
@@ -5721,7 +5721,7 @@ TargetAllocator indicates a value which determines whether to spawn a target all
         <td><b>filterStrategy</b></td>
         <td>string</td>
         <td>
-          FilterStrategy determines how to filter targets before allocating them among the collectors. The only current option is relabel-config (drops targets based on prom relabel_config). Filtering is disabled by default.<br/>
+          FilterStrategy determines how to filter targets before allocating them among the collectors. The only current option is relabel-config (drops targets based on prom relabel_config). It's important to consider setting it with relabel-config if you have a scrape job with a discovery role for example, endpoints which could produce multiple targets per endpoint. If these targets lead to the same metric after a relabeling step and they are assigned to different collectors, the outcome may be undesirable because duplicate time series are created for the metric. Filtering is disabled by default.<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
I recommend adding a paragraph to TargetAllocator README.md to raise the awareness of using `filterStrategy` setting. 

`filterStrategy` is an important setting for developers to consider when reusing existing Prometheus scrape configuration for OpenTelemetry metrics collection pipeline. This configuration would help reduce your time to debug issues that you may be seeing in terms of intermittent `out of order sample` error. These errors are typically caused when the targets get split across multiple collectors which creates duplicate time series.

cc: @alolita @Aneurysm9