### PR TITLE
Improve config validation for prometheus receiver and target allocator

### DIFF
--- a/.chloggen/fix_validate-ta-config.yaml
+++ b/.chloggen/fix_validate-ta-config.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Improve config validation for prometheus receiver and target allocator
+
+# One or more tracking issues related to the change
+issues: [1581]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1alpha1/opentelemetrycollector_webhook.go
+++ b/apis/v1alpha1/opentelemetrycollector_webhook.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
-
 	ta "github.com/open-telemetry/opentelemetry-operator/pkg/targetallocator/adapters"
 )
 

--- a/apis/v1alpha1/opentelemetrycollector_webhook.go
+++ b/apis/v1alpha1/opentelemetrycollector_webhook.go
@@ -26,6 +26,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
+
 	ta "github.com/open-telemetry/opentelemetry-operator/pkg/targetallocator/adapters"
 )
 
@@ -160,7 +162,11 @@ func (r *OpenTelemetryCollector) validateCRDSpec() error {
 
 	// validate Prometheus config for target allocation
 	if r.Spec.TargetAllocator.Enabled {
-		_, err := ta.ConfigToPromConfig(r.Spec.Config)
+		promCfg, err := ta.ConfigToPromConfig(r.Spec.Config)
+		if err != nil {
+			return fmt.Errorf("the OpenTelemetry Spec Prometheus configuration is incorrect, %w", err)
+		}
+		err = ta.ValidatePromConfig(promCfg, r.Spec.TargetAllocator.Enabled, featuregate.EnableTargetAllocatorRewrite.IsEnabled())
 		if err != nil {
 			return fmt.Errorf("the OpenTelemetry Spec Prometheus configuration is incorrect, %w", err)
 		}

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -132,7 +132,7 @@ func ParseCLI() (CLIConfig, error) {
 
 // ValidateConfig validates the cli and file configs together.
 func ValidateConfig(config *Config, cliConfig *CLIConfig) error {
-	scrapeConfigsPresent := (config.Config != nil || len(config.Config.ScrapeConfigs) > 0)
+	scrapeConfigsPresent := (config.Config != nil && len(config.Config.ScrapeConfigs) > 0)
 	if !(*cliConfig.PromCRWatcherConf.Enabled || scrapeConfigsPresent) {
 		return fmt.Errorf("at least one scrape config must be defined, or Prometheus CR watching must be enabled")
 	}

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -132,10 +132,9 @@ func ParseCLI() (CLIConfig, error) {
 
 // ValidateConfig validates the cli and file configs together.
 func ValidateConfig(config *Config, cliConfig *CLIConfig) error {
-	if !*cliConfig.PromCRWatcherConf.Enabled &&
-		(config.Config == nil ||
-			len(config.Config.ScrapeConfigs) == 0) {
-		return fmt.Errorf("either at least one scrape config must be defined, or Prometheus CR watching must be enabled")
+	scrapeConfigsPresent := (config.Config != nil || len(config.Config.ScrapeConfigs) > 0)
+	if !(*cliConfig.PromCRWatcherConf.Enabled || scrapeConfigsPresent) {
+		return fmt.Errorf("at least one scrape config must be defined, or Prometheus CR watching must be enabled")
 	}
 	return nil
 }

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -129,3 +129,13 @@ func ParseCLI() (CLIConfig, error) {
 	cLIConf.ClusterConfig = clusterConfig
 	return cLIConf, nil
 }
+
+// ValidateConfig validates the cli and file configs together.
+func ValidateConfig(config *Config, cliConfig *CLIConfig) error {
+	if !*cliConfig.PromCRWatcherConf.Enabled &&
+		(config.Config == nil ||
+			len(config.Config.ScrapeConfigs) == 0) {
+		return fmt.Errorf("either at least one scrape config must be defined, or Prometheus CR watching must be enabled")
+	}
+	return nil
+}

--- a/cmd/otel-allocator/config/config_test.go
+++ b/cmd/otel-allocator/config/config_test.go
@@ -92,6 +92,14 @@ func TestLoad(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "no config",
+			args: args{
+				file: "./testdata/no_config.yaml",
+			},
+			want:    Config{},
+			wantErr: assert.NoError,
+		},
+		{
 			name: "service monitor pod monitor selector",
 			args: args{
 				file: "./testdata/pod_service_selector_test.yaml",

--- a/cmd/otel-allocator/config/config_test.go
+++ b/cmd/otel-allocator/config/config_test.go
@@ -165,3 +165,56 @@ func TestLoad(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateConfig(t *testing.T) {
+	enabled := true
+	disabled := false
+	testCases := []struct {
+		name        string
+		cliConfig   CLIConfig
+		fileConfig  Config
+		expectedErr error
+	}{
+		{
+			name:        "promCR enabled, no Prometheus config",
+			cliConfig:   CLIConfig{PromCRWatcherConf: PrometheusCRWatcherConfig{Enabled: &enabled}},
+			fileConfig:  Config{Config: nil},
+			expectedErr: nil,
+		},
+		{
+			name:        "promCR disabled, no Prometheus config",
+			cliConfig:   CLIConfig{PromCRWatcherConf: PrometheusCRWatcherConfig{Enabled: &disabled}},
+			fileConfig:  Config{Config: nil},
+			expectedErr: fmt.Errorf("at least one scrape config must be defined, or Prometheus CR watching must be enabled"),
+		},
+		{
+			name:        "promCR disabled, Prometheus config present, no scrapeConfigs",
+			cliConfig:   CLIConfig{PromCRWatcherConf: PrometheusCRWatcherConfig{Enabled: &disabled}},
+			fileConfig:  Config{Config: &promconfig.Config{}},
+			expectedErr: fmt.Errorf("at least one scrape config must be defined, or Prometheus CR watching must be enabled"),
+		},
+		{
+			name:      "promCR disabled, Prometheus config present, scrapeConfigs present",
+			cliConfig: CLIConfig{PromCRWatcherConf: PrometheusCRWatcherConfig{Enabled: &disabled}},
+			fileConfig: Config{
+				Config: &promconfig.Config{ScrapeConfigs: []*promconfig.ScrapeConfig{{}}},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:      "promCR enabled, Prometheus config present, scrapeConfigs present",
+			cliConfig: CLIConfig{PromCRWatcherConf: PrometheusCRWatcherConfig{Enabled: &enabled}},
+			fileConfig: Config{
+				Config: &promconfig.Config{ScrapeConfigs: []*promconfig.ScrapeConfig{{}}},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateConfig(&tc.fileConfig, &tc.cliConfig)
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -74,6 +74,10 @@ func main() {
 		setupLog.Error(configLoadErr, "Unable to load configuration")
 	}
 
+	if validationErr := config.ValidateConfig(&cfg, &cliConf); validationErr != nil {
+		setupLog.Error(validationErr, "Invalid configuration")
+	}
+
 	cliConf.RootLogger.Info("Starting the Target Allocator")
 	ctx := context.Background()
 	log := ctrl.Log.WithName("allocator")
@@ -148,10 +152,12 @@ func main() {
 	runGroup.Add(
 		func() error {
 			// Initial loading of the config file's scrape config
-			err = targetDiscoverer.ApplyConfig(allocatorWatcher.EventSourceConfigMap, cfg.Config)
-			if err != nil {
-				setupLog.Error(err, "Unable to apply initial configuration")
-				return err
+			if cfg.Config != nil {
+				err = targetDiscoverer.ApplyConfig(allocatorWatcher.EventSourceConfigMap, cfg.Config)
+				if err != nil {
+					setupLog.Error(err, "Unable to apply initial configuration")
+					return err
+				}
 			}
 			err := targetDiscoverer.Watch(allocator.SetTargets)
 			setupLog.Info("Target discoverer exited")

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -152,12 +152,10 @@ func main() {
 	runGroup.Add(
 		func() error {
 			// Initial loading of the config file's scrape config
-			if cfg.Config != nil {
-				err = targetDiscoverer.ApplyConfig(allocatorWatcher.EventSourceConfigMap, cfg.Config)
-				if err != nil {
-					setupLog.Error(err, "Unable to apply initial configuration")
-					return err
-				}
+			err = targetDiscoverer.ApplyConfig(allocatorWatcher.EventSourceConfigMap, cfg.Config)
+			if err != nil {
+				setupLog.Error(err, "Unable to apply initial configuration")
+				return err
 			}
 			err := targetDiscoverer.Watch(allocator.SetTargets)
 			setupLog.Info("Target discoverer exited")

--- a/cmd/otel-allocator/target/discovery.go
+++ b/cmd/otel-allocator/target/discovery.go
@@ -65,6 +65,7 @@ func NewDiscoverer(log logr.Logger, manager *discovery.Manager, hook discoveryHo
 
 func (m *Discoverer) ApplyConfig(source allocatorWatcher.EventSource, cfg *config.Config) error {
 	if cfg == nil {
+		m.log.Info("Service Discovery got empty Prometheus config", "source", source.String())
 		return nil
 	}
 	m.configsMap[source] = cfg

--- a/cmd/otel-allocator/target/discovery.go
+++ b/cmd/otel-allocator/target/discovery.go
@@ -64,6 +64,9 @@ func NewDiscoverer(log logr.Logger, manager *discovery.Manager, hook discoveryHo
 }
 
 func (m *Discoverer) ApplyConfig(source allocatorWatcher.EventSource, cfg *config.Config) error {
+	if cfg == nil {
+		return nil
+	}
 	m.configsMap[source] = cfg
 	jobToScrapeConfig := make(map[string]*config.ScrapeConfig)
 

--- a/cmd/otel-allocator/target/discovery_test.go
+++ b/cmd/otel-allocator/target/discovery_test.go
@@ -334,6 +334,23 @@ func TestDiscovery_ScrapeConfigHashing(t *testing.T) {
 	}
 }
 
+func TestDiscovery_NoConfig(t *testing.T) {
+	scu := &mockScrapeConfigUpdater{mockCfg: map[string]*promconfig.ScrapeConfig{}}
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	d := discovery.NewManager(ctx, gokitlog.NewNopLogger())
+	manager := NewDiscoverer(ctrl.Log.WithName("test"), d, nil, scu)
+	defer close(manager.close)
+	defer cancelFunc()
+
+	go func() {
+		err := d.Run()
+		assert.NoError(t, err)
+	}()
+	// check the updated scrape configs
+	expectedScrapeConfigs := map[string]*promconfig.ScrapeConfig{}
+	assert.Equal(t, expectedScrapeConfigs, scu.mockCfg)
+}
+
 func BenchmarkApplyScrapeConfig(b *testing.B) {
 	numConfigs := 1000
 	scrapeConfig := promconfig.ScrapeConfig{

--- a/pkg/collector/reconcile/config_replace.go
+++ b/pkg/collector/reconcile/config_replace.go
@@ -60,6 +60,11 @@ func ReplaceConfig(instance v1alpha1.OpenTelemetryCollector) (string, error) {
 		return "", getCfgPromErr
 	}
 
+	validateCfgPromErr := ta.ValidatePromConfig(promCfgMap, instance.Spec.TargetAllocator.Enabled, featuregate.EnableTargetAllocatorRewrite.IsEnabled())
+	if validateCfgPromErr != nil {
+		return "", validateCfgPromErr
+	}
+
 	// yaml marshaling/unsmarshaling is preferred because of the problems associated with the conversion of map to a struct using mapstructure
 	promCfg, marshalErr := yaml.Marshal(promCfgMap)
 	if marshalErr != nil {

--- a/pkg/collector/reconcile/configmap.go
+++ b/pkg/collector/reconcile/configmap.go
@@ -103,7 +103,7 @@ func desiredTAConfigMap(params Params) (corev1.ConfigMap, error) {
 		labels["app.kubernetes.io/version"] = "latest"
 	}
 
-	promConfig, err := ta.ConfigToPromConfig(params.Instance.Spec.Config)
+	prometheusReceiverConfig, err := ta.ConfigToPromConfig(params.Instance.Spec.Config)
 	if err != nil {
 		return corev1.ConfigMap{}, err
 	}
@@ -114,8 +114,11 @@ func desiredTAConfigMap(params Params) (corev1.ConfigMap, error) {
 		"app.kubernetes.io/managed-by": "opentelemetry-operator",
 		"app.kubernetes.io/component":  "opentelemetry-collector",
 	}
-	// We only take the "config" from the returned object, we don't need the "target_allocator" configuration here.
-	taConfig["config"] = promConfig["config"]
+	// We only take the "config" from the returned object, if it's present
+	if prometheusConfig, ok := prometheusReceiverConfig["config"]; ok {
+		taConfig["config"] = prometheusConfig
+	}
+
 	if len(params.Instance.Spec.TargetAllocator.AllocationStrategy) > 0 {
 		taConfig["allocation_strategy"] = params.Instance.Spec.TargetAllocator.AllocationStrategy
 	} else {

--- a/pkg/targetallocator/adapters/config_to_prom_config.go
+++ b/pkg/targetallocator/adapters/config_to_prom_config.go
@@ -15,6 +15,7 @@
 package adapters
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/adapters"
@@ -56,4 +57,29 @@ func ConfigToPromConfig(cfg string) (map[interface{}]interface{}, error) {
 	}
 
 	return prometheus, nil
+}
+
+// ValidatePromConfig checks if the prometheus receiver config is valid given other collector-level settings.
+func ValidatePromConfig(config map[interface{}]interface{}, targetAllocatorEnabled bool, targetAllocatorRewriteEnabled bool) error {
+	_, promConfigExists := config["config"]
+
+	if targetAllocatorEnabled {
+		if targetAllocatorRewriteEnabled { // if rewrite is enabled, we will add a target_allocator section during rewrite
+			return nil
+		}
+		_, targetAllocatorExists := config["target_allocator"]
+
+		// otherwise, either the target_allocator or config section needs to be here
+		if !(promConfigExists || targetAllocatorExists) {
+			return errors.New("either target allocator or prometheus config needs to be present")
+		}
+
+		return nil
+	}
+	// if target allocator isn't enabled, we need a config section
+	if !promConfigExists {
+		return errorNoComponent("prometheusConfig")
+	}
+
+	return nil
 }


### PR DESCRIPTION
In a follow-up to #1688, improve validation for prometheus receiver configuration. This turned out to be more complicated than expected, so I'd like some more eyes to verify I haven't missed anything.

The validation logic for the prometheus receiver config itself is:
* if target allocator is not enabled on the Collector CR, prometheus config under the `config` key is required
* if target allocator is enabled
  - either `config` has to exist to inject http_sd_configs, or `target_allocator` needs to exist 
  - if additionally target allocator rewrite is enabled, nothing is required

However, I also noticed that target allocator itself doesn't correctly validate its configuration. For example, it's possible to pass an empty Prometheus config, but this will cause a crash in the targetDiscoverer. So I added an additional check, requiring that either:
* there is a non-empty Prometheus config
* or PrometheusCR is enabled

I submitted both of these changes in a single PR, as they're related, but I can resubmit separately if that'll make review easier.