### PR TITLE
[chore] Update PR actions to cancel when updated

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     name: Unit tests

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   e2e-tests:
     name: End-to-end tests

--- a/.github/workflows/publish-autoinstrumentation-apache-httpd.yaml
+++ b/.github/workflows/publish-autoinstrumentation-apache-httpd.yaml
@@ -13,6 +13,10 @@ on:
       - '.github/workflows/publish-autoinstrumentation-apache-httpd.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-autoinstrumentation-dotnet.yaml
+++ b/.github/workflows/publish-autoinstrumentation-dotnet.yaml
@@ -13,6 +13,10 @@ on:
       - '.github/workflows/publish-autoinstrumentation-dotnet.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-autoinstrumentation-java.yaml
+++ b/.github/workflows/publish-autoinstrumentation-java.yaml
@@ -13,6 +13,11 @@ on:
       - '.github/workflows/publish-autoinstrumentation-java.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+
 jobs:
   publish:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-autoinstrumentation-nodejs.yaml
+++ b/.github/workflows/publish-autoinstrumentation-nodejs.yaml
@@ -13,6 +13,11 @@ on:
       - '.github/workflows/publish-autoinstrumentation-nodejs.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+
 jobs:
   publish:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-autoinstrumentation-python.yaml
+++ b/.github/workflows/publish-autoinstrumentation-python.yaml
@@ -13,6 +13,11 @@ on:
       - '.github/workflows/publish-autoinstrumentation-python.yaml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+
 jobs:
   publish:
     runs-on: ubuntu-20.04

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   scorecard-tests:
     name: test on k8s


### PR DESCRIPTION
Adds concurrency rules to actions that run for PRs so that if new changes are pushed the old actions cancel. This helps keep github notifications relevant (old commit action failures don't matter), and saves on compute.

Actions will only be canceled in PRs; when running against the main branch they will always run to completion even if a new commit is pushed to main.

See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16616 for details.