### PR TITLE
[instrumentation] Fix issue where default Go auto-instrumentation version was not being used in our release operator image.

### DIFF
--- a/.chloggen/fix-go-release.yaml
+++ b/.chloggen/fix-go-release.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix issue where the operator's released image did not correctly set the default go auto-instrumentation version
+
+# One or more tracking issues related to the change
+issues: [1757]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -29,6 +29,7 @@ jobs:
           grep -v '\#' versions.txt | grep autoinstrumentation-nodejs | awk -F= '{print "AUTO_INSTRUMENTATION_NODEJS_VERSION="$2}' >> $GITHUB_ENV
           grep -v '\#' versions.txt | grep autoinstrumentation-python | awk -F= '{print "AUTO_INSTRUMENTATION_PYTHON_VERSION="$2}' >> $GITHUB_ENV
           grep -v '\#' versions.txt | grep autoinstrumentation-dotnet | awk -F= '{print "AUTO_INSTRUMENTATION_DOTNET_VERSION="$2}' >> $GITHUB_ENV
+          grep -v '\#' versions.txt | grep autoinstrumentation-go | awk -F= '{print "AUTO_INSTRUMENTATION_GO_VERSION="$2}' >> $GITHUB_ENV
           grep -v '\#' versions.txt | grep autoinstrumentation-apache-httpd | awk -F= '{print "AUTO_INSTRUMENTATION_APACHE_HTTPD_VERSION="$2}' >> $GITHUB_ENV
           echo "VERSION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
           echo "VERSION=$(git describe --tags | sed 's/^v//')" >> $GITHUB_ENV
@@ -95,6 +96,7 @@ jobs:
             AUTO_INSTRUMENTATION_NODEJS_VERSION=${{ env.AUTO_INSTRUMENTATION_NODEJS_VERSION }}
             AUTO_INSTRUMENTATION_PYTHON_VERSION=${{ env.AUTO_INSTRUMENTATION_PYTHON_VERSION }}
             AUTO_INSTRUMENTATION_DOTNET_VERSION=${{ env.AUTO_INSTRUMENTATION_DOTNET_VERSION }}
+            AUTO_INSTRUMENTATION_GO_VERSION=${{ env.AUTO_INSTRUMENTATION_GO_VERSION }}
             AUTO_INSTRUMENTATION_APACHE_HTTPD_VERSION=${{ env.AUTO_INSTRUMENTATION_APACHE_HTTPD_VERSION }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/tests/e2e/instrumentation-go/01-install-app.yaml
+++ b/tests/e2e/instrumentation-go/01-install-app.yaml
@@ -19,3 +19,8 @@ spec:
       containers:
       - name: productcatalogservice
         image: ghcr.io/open-telemetry/demo:1.3.1-productcatalogservice
+        env:
+          - name: PRODUCT_CATALOG_SERVICE_PORT
+            value: 8080
+          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
+            value: localhost:50053

--- a/tests/e2e/instrumentation-go/01-install-app.yaml
+++ b/tests/e2e/instrumentation-go/01-install-app.yaml
@@ -20,7 +20,7 @@ spec:
       - name: productcatalogservice
         image: ghcr.io/open-telemetry/demo:1.3.1-productcatalogservice
         env:
-          - name: PRODUCT_CATALOG_SERVICE_PORT
-            value: 8080
-          - name: FEATURE_FLAG_GRPC_SERVICE_ADDR
-            value: localhost:50053
+          - name: "PRODUCT_CATALOG_SERVICE_PORT"
+            value: "8080"
+          - name: "FEATURE_FLAG_GRPC_SERVICE_ADDR"
+            value: "localhost:50053"


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-operator/issues/1756.

While testing I noticed that the `productcatalogservice` containers wasn't actually starting because it was missing some env vars.  This didn't affect the test bc we don't actually check if the instrumentation is working, only that the instrumentation could be injected, but I figured I'd clean things up anyways.