### PR TITLE
[instrumentation] Switch to python:3.11 image

### DIFF
--- a/autoinstrumentation/python/Dockerfile
+++ b/autoinstrumentation/python/Dockerfile
@@ -9,15 +9,11 @@
 # - Grant the necessary access to `/autoinstrumentation` directory. `chmod -R go+r /autoinstrumentation`
 # - For auto-instrumentation by container injection, the Linux command cp is
 #   used and must be availabe in the image.
-FROM python:3.11-alpine AS build
+FROM python:3.11 AS build
 
 WORKDIR /operator-build
 
 ADD requirements.txt .
-
-RUN apk update && apk add gcc \
-                          libc-dev \
-                          libffi-dev
 
 RUN mkdir workspace && pip install --target workspace -r requirements.txt
 


### PR DESCRIPTION
Switch to building the python requirements on the `3.11` image instead of the `3.11-alpine` image.  This ensures that the requirements are built using all necessary python dependencies.

Closes https://github.com/open-telemetry/opentelemetry-operator/issues/1515