### PR TITLE
[target-allocator] Exit on invalid config

### DIFF
--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -74,6 +74,7 @@ func main() {
 
 	if validationErr := config.ValidateConfig(cfg); validationErr != nil {
 		setupLog.Error(validationErr, "Invalid configuration")
+		os.Exit(1)
 	}
 
 	cfg.RootLogger.Info("Starting the Target Allocator")


### PR DESCRIPTION
Target allocator should exit if its combined configuration is invalid. This change should've been part of #1729 .