### PR TITLE
[instrumentation] Bump js packages to 1.13.0/0.39.1

### DIFF
--- a/.chloggen/bump-oteljs-versions.yaml
+++ b/.chloggen/bump-oteljs-versions.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: autoinstrumentaiton/nodejs
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bump js packages to latest versions
+
+# One or more tracking issues related to the change
+issues: [1791]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -15,15 +15,15 @@
   },
   "dependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/auto-instrumentations-node": "0.36.6",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.38.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.38.0",
-    "@opentelemetry/resource-detector-alibaba-cloud": "0.27.5",
-    "@opentelemetry/resource-detector-aws": "1.2.3",
-    "@opentelemetry/resource-detector-container": "0.2.3",
-    "@opentelemetry/resource-detector-gcp": "0.28.1",
-    "@opentelemetry/resources": "1.12.0",
-    "@opentelemetry/sdk-metrics": "1.12.0",
-    "@opentelemetry/sdk-node": "0.38.0"
+    "@opentelemetry/auto-instrumentations-node": "0.37.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.39.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.39.1",
+    "@opentelemetry/resource-detector-alibaba-cloud": "0.27.6",
+    "@opentelemetry/resource-detector-aws": "1.2.4",
+    "@opentelemetry/resource-detector-container": "0.2.4",
+    "@opentelemetry/resource-detector-gcp": "0.28.2",
+    "@opentelemetry/resources": "1.13.0",
+    "@opentelemetry/sdk-metrics": "1.13.0",
+    "@opentelemetry/sdk-node": "0.39.1"
   }
 }


### PR DESCRIPTION
Bumps all the js packages to their latest versions.