### PR TITLE
java autoinstrumentaion init container running as regular user [chore]

### DIFF
--- a/autoinstrumentation/java/Dockerfile
+++ b/autoinstrumentation/java/Dockerfile
@@ -8,6 +8,10 @@ FROM busybox
 
 ARG version
 
-ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /javaagent.jar
+RUN addgroup otel -g 1000 && adduser -u 1000 -D -G otel otel
+
+USER 1000:1000
+
+ADD --chown=1000:1000 https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v$version/opentelemetry-javaagent.jar /javaagent.jar
 
 RUN chmod -R go+r /javaagent.jar


### PR DESCRIPTION
Added regular user in java init image to be able to run as non root. This allowed us to overcome the issue with setting runAsNonRoot to "true" in Pod securityContext, before this change autoinstrumentation init container would fail to run with restricted setting as it was running as root. 