### PR TITLE
[target allocator] Re-add default global scrape interval in Promethues CR watcher configuration.

### DIFF
--- a/.chloggen/1811-fix-empty-scrape-interval.yaml
+++ b/.chloggen/1811-fix-empty-scrape-interval.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the empty global scrape interval in Prometheus CR watcher, which causes configuration unmarshalling to fail.
+
+# One or more tracking issues related to the change
+issues: [1811]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/watcher/promOperator.go
+++ b/cmd/otel-allocator/watcher/promOperator.go
@@ -57,7 +57,16 @@ func NewPrometheusCRWatcher(cfg allocatorconfig.Config, cliConfig allocatorconfi
 		monitoringv1.PodMonitorName:     podMonitorInformers,
 	}
 
-	generator, err := prometheus.NewConfigGenerator(log.NewNopLogger(), &monitoringv1.Prometheus{}, true) // TODO replace Nop?
+	// TODO: We should make these durations configurable
+	prom := &monitoringv1.Prometheus{
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ScrapeInterval: monitoringv1.Duration("30s"),
+			},
+		},
+	}
+
+	generator, err := prometheus.NewConfigGenerator(log.NewNopLogger(), prom, true) // TODO replace Nop?
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Resolves #1811.

After recent changes (https://github.com/open-telemetry/opentelemetry-operator/pull/1653) to update some TA dependencies (Prometheus Operator and Prometheus), the Prometheus CR watcher's method `LoadConfig` started to fail. This has been traced to the fact that we have previously removed the default scrape interval from the config passed to the method for config generation. This change simply reinstates the default to fix unmarshalling again.

Although for now this has been tested manually, ideally we'll have this tested as part of the unit tests, but we're missing some more changes in order to introduce unit tests. This is part of work in https://github.com/open-telemetry/opentelemetry-operator/pull/1710 which I intend to finish and update soon.