### PR TITLE
[autoinstrumentation/nodejs] Bump js packages

### DIFF
--- a/.chloggen/bump-nodejs.yaml
+++ b/.chloggen/bump-nodejs.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: autoinstrumentation/nodejs
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bump python packages to 1.14.0/0.40.0
+
+# One or more tracking issues related to the change
+issues: [1790]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -15,16 +15,16 @@
   },
   "dependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/auto-instrumentations-node": "0.37.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.39.1",
-    "@opentelemetry/exporter-prometheus": "0.39.1",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.39.1",
-    "@opentelemetry/resource-detector-alibaba-cloud": "0.27.6",
-    "@opentelemetry/resource-detector-aws": "1.2.4",
-    "@opentelemetry/resource-detector-container": "0.2.4",
-    "@opentelemetry/resource-detector-gcp": "0.28.2",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-metrics": "1.13.0",
-    "@opentelemetry/sdk-node": "0.39.1"
+    "@opentelemetry/auto-instrumentations-node": "0.37.1",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.40.0",
+    "@opentelemetry/exporter-prometheus": "0.40.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.40.0",
+    "@opentelemetry/resource-detector-alibaba-cloud": "0.27.7",
+    "@opentelemetry/resource-detector-aws": "1.2.5",
+    "@opentelemetry/resource-detector-container": "0.2.5",
+    "@opentelemetry/resource-detector-gcp": "0.28.3",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-metrics": "1.14.0",
+    "@opentelemetry/sdk-node": "0.40.0"
   }
 }


### PR DESCRIPTION
Bumps the node js packages to 1.14.0/0.40.0 and all corresponding contrib bumps.