### PR TITLE
Only admit configurations where Target Allocator has targets

### DIFF
--- a/.chloggen/targetallocator-reject-no-targets.yaml
+++ b/.chloggen/targetallocator-reject-no-targets.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Only admit configurations where Target Allocator actually has targets
+
+# One or more tracking issues related to the change
+issues: [1859]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1alpha1/opentelemetrycollector_webhook.go
+++ b/apis/v1alpha1/opentelemetrycollector_webhook.go
@@ -170,6 +170,10 @@ func (r *OpenTelemetryCollector) validateCRDSpec() error {
 		if err != nil {
 			return fmt.Errorf("the OpenTelemetry Spec Prometheus configuration is incorrect, %w", err)
 		}
+		err = ta.ValidateTargetAllocatorConfig(r.Spec.TargetAllocator.PrometheusCR.Enabled, promCfg)
+		if err != nil {
+			return fmt.Errorf("the OpenTelemetry Spec Prometheus configuration is incorrect, %w", err)
+		}
 	}
 
 	// validator port config

--- a/apis/v1alpha1/opentelemetrycollector_webhook_test.go
+++ b/apis/v1alpha1/opentelemetrycollector_webhook_test.go
@@ -207,9 +207,9 @@ func TestOTELColValidatingWebhook(t *testing.T) {
     endpoint: "0.0.0.0:12346"
   prometheus:
     config:
-      scrape_config:
-        job_name: otel-collector
-        scrape_interval: 10s
+      scrape_configs:
+        - job_name: otel-collector
+          scrape_interval: 10s
   jaeger/custom:
     protocols:
       thrift_http:


### PR DESCRIPTION
Fixes #1859. I've also extracted some common logic in the adapters package to a separate function.