### PR TITLE
Explicitly set kind version when running tests in CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  CURRENT_KIND_VERSION: 0.20.0
+  LEGACY_KIND_VERSION: 0.17.0  # for K8s versions latest kind doesn't support anymore  
+
 jobs:
   e2e-tests:
     name: End-to-end tests
@@ -28,11 +32,16 @@ jobs:
          - e2e-autoscale
 
     steps:
-
+  
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: "1.20"
+
+    - name: Setup kind
+      env:
+        KIND_VERSION: ${{ matrix.kube_version >= 1.21 && env.KIND_VERSION || env.LEGACY_KIND_VERSION }}
+      run: go install sigs.k8s.io/kind@v${KIND_VERSION}
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  CURRENT_KIND_VERSION: 0.20.0
+  LEGACY_KIND_VERSION: 0.17.0  # for K8s versions latest kind doesn't support anymore  
+
 jobs:
   scorecard-tests:
     name: test on k8s
@@ -26,6 +30,11 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.20"
+
+      - name: Setup kind
+        env:
+          KIND_VERSION: ${{ matrix.kube_version >= 1.21 && env.KIND_VERSION || env.LEGACY_KIND_VERSION }}
+        run: go install sigs.k8s.io/kind@v${KIND_VERSION}
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/hack/install-kuttl.sh
+++ b/hack/install-kuttl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.12.1/kubectl-kuttl_0.12.1_linux_x86_64
+sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64
 sudo chmod +x /usr/local/bin/kubectl-kuttl
 export PATH=$PATH:/usr/local/bin

--- a/kind-1.19.yaml
+++ b/kind-1.19.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.19.16@sha256:707469aac7e6805e52c3bde2a8a8050ce2b15decff60db6c5077ba9975d28b98
+  image: kindest/node:v1.19.16@sha256:476cb3269232888437b61deca013832fee41f9f074f9bed79f57e4280f7c48b7

--- a/kind-1.20.yaml
+++ b/kind-1.20.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.20.15@sha256:d67de8f84143adebe80a07672f370365ec7d23f93dc86866f0e29fa29ce026fe
+  image: kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394

--- a/kind-1.21.yaml
+++ b/kind-1.21.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.21.14@sha256:f9b4d3d1112f24a7254d2ee296f177f628f9b4c1b32f0006567af11b91c1f301
+  image: kindest/node:v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093

--- a/kind-1.22.yaml
+++ b/kind-1.22.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.22.13@sha256:4904eda4d6e64b402169797805b8ec01f50133960ad6c19af45173a27eadf959
+  image: kindest/node:v1.22.17@sha256:f5b2e5698c6c9d6d0adc419c0deae21a425c07d81bbf3b6a6834042f25d4fba2

--- a/kind-1.23.yaml
+++ b/kind-1.23.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.23.10@sha256:f047448af6a656fae7bc909e2fab360c18c487ef3edc93f06d78cdfd864b2d12
+  image: kindest/node:v1.23.17@sha256:59c989ff8a517a93127d4a536e7014d28e235fb3529d9fba91b3951d461edfdb

--- a/kind-1.24.yaml
+++ b/kind-1.24.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98
+    image: kindest/node:v1.24.15@sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab

--- a/kind-1.25.yaml
+++ b/kind-1.25.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.25.3@sha256:f1de3b0670462f43280114eccceab8bf1b9576d2afe0582f8f74529da6fd0365
+    image: kindest/node:v1.25.11@sha256:227fa11ce74ea76a0474eeefb84cb75d8dad1b08638371ecf0e86259b35be0c8

--- a/kind-1.26.yaml
+++ b/kind-1.26.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.26.0@sha256:691e24bd2417609db7e589e1a479b902d2e209892a10ce375fab60a8407c7352
+    image: kindest/node:v1.26.6@sha256:6e2d8b28a5b601defe327b98bd1c2d1930b49e5d8c512e1895099e4504007adb

--- a/kind-1.27.yaml
+++ b/kind-1.27.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.27.0@sha256:c6b22e613523b1af67d4bc8a0c38a4c3ea3a2b8fbc5b367ae36345c9cb844518
+    image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72


### PR DESCRIPTION
Up until now we depended on the `kind` version shipped by Github, which opened us up to unexpected breakage whenever they upgraded. This has happened recently with an upgrade from `0.19.0` to `0.20.0`.

This change:
- explicitly sets the kind version in CI
- updates Node images for kind 0.20.0
- uses kind 0.17.0 to run tests for K8s <1.21, which kind 0.20.0 doesn't support out of the box
- updates kuttl to the latest released version