### PR TITLE
Enable X-Ray propagator for nodejs-instrumentation

### DIFF
--- a/.chloggen/1869-xray-propagator.yaml
+++ b/.chloggen/1869-xray-propagator.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: autoinstrumentation/nodejs
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable AWS X-Ray propagator on NodeJs auto-instrumentation
+# One or more tracking issues related to the change
+issues: [1869]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/xray-propagator.yaml
+++ b/.chloggen/xray-propagator.yaml
@@ -5,7 +5,8 @@ change_type: enhancement
 component: autoinstrumentation/nodejs
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Enable AWS X-Ray propagator on NodeJs auto-instrumentation
+note: Adding AWS X-Ray propagator to nodejs instrumentation
+
 # One or more tracking issues related to the change
 issues: [1869]
 

--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -19,6 +19,7 @@
     "@opentelemetry/exporter-metrics-otlp-grpc": "0.40.0",
     "@opentelemetry/exporter-prometheus": "0.40.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.40.0",
+    "@opentelemetry/propagator-aws-xray": "1.2.1",
     "@opentelemetry/resource-detector-alibaba-cloud": "0.27.7",
     "@opentelemetry/resource-detector-aws": "1.2.5",
     "@opentelemetry/resource-detector-container": "0.2.5",

--- a/autoinstrumentation/nodejs/src/autoinstrumentation.ts
+++ b/autoinstrumentation/nodejs/src/autoinstrumentation.ts
@@ -1,4 +1,5 @@
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { AWSXRayPropagator } from "@opentelemetry/propagator-aws-xray";
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
@@ -35,6 +36,7 @@ function getMetricReader() {
 const sdk = new NodeSDK({
     autoDetectResources: true,
     instrumentations: [getNodeAutoInstrumentations()],
+    textMapPropagator: new AWSXRayPropagator(),
     traceExporter: new OTLPTraceExporter(),
     metricReader: getMetricReader(),
     resourceDetectors:


### PR DESCRIPTION
Following [issue](https://github.com/open-telemetry/opentelemetry-operator/issues/1869)

Added X-Ray propagator in the NodeSDK constructor.
I'm not sure how propragators are configured, is it the `NodeSDK` selecting the right propagator based on env variable config or should we implement this logic on our side ? 

Thanks, 
 