### PR TITLE
target-allocator : Fix typo in documentation

### DIFF
--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -115,7 +115,7 @@ rules:
   - discovery.k8s.io
   resources:
   - endpointslices
-  verbs: ["get", "list", watch"]
+  verbs: ["get", "list", "watch"]
 - apiGroups:
   - networking.k8s.io
   resources:


### PR DESCRIPTION
Kubernetes accepted the manifest when copy / pasting from the docs, but ended up with verb `watch"`. Couldn't understand why target allocator failed. Simple typo in doc