### PR TITLE
Fix `.sampler.type` being incorrectly required for Instrumentation

### DIFF
--- a/.chloggen/fix_sampler-type-required.yaml
+++ b/.chloggen/fix_sampler-type-required.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix `.sampler.type` being incorrectly required for Instrumentation
+
+# One or more tracking issues related to the change
+issues: [1886]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1alpha1/instrumentation_webhook.go
+++ b/apis/v1alpha1/instrumentation_webhook.go
@@ -246,6 +246,7 @@ func validateJaegerRemoteSamplerArgument(argument string) error {
 
 func (r *Instrumentation) validate() error {
 	switch r.Spec.Sampler.Type {
+	case "": // not set, do nothing
 	case TraceIDRatio, ParentBasedTraceIDRatio:
 		if r.Spec.Sampler.Argument != "" {
 			rate, err := strconv.ParseFloat(r.Spec.Sampler.Argument, 64)

--- a/apis/v1alpha1/instrumentation_webhook_test.go
+++ b/apis/v1alpha1/instrumentation_webhook_test.go
@@ -48,6 +48,20 @@ func TestInstrumentationValidatingWebhook(t *testing.T) {
 		inst Instrumentation
 	}{
 		{
+			name: "all defaults",
+			inst: Instrumentation{
+				Spec: InstrumentationSpec{},
+			},
+		},
+		{
+			name: "sampler configuration not present",
+			inst: Instrumentation{
+				Spec: InstrumentationSpec{
+					Sampler: Sampler{},
+				},
+			},
+		},
+		{
 			name: "argument is not a number",
 			err:  "spec.sampler.argument is not a number",
 			inst: Instrumentation{


### PR DESCRIPTION
Fixes #1886. I've also added an E2E test with a minimal configuration to ensure optional attributes stay optional.