### PR TITLE
Fixed minimal target allocator example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ spec:
   config: |
     receivers:
       prometheus:
+        config:
 
     exporters:
       logging:


### PR DESCRIPTION
Fixes minimal example for target allocator when using feature flag `operator.collector.rewritetargetallocator`. 

Fixes #1891