### PR TITLE
Install golangci-lint in the local tools dir

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -29,9 +29,6 @@ jobs:
   lint:
     name: Code standards (linting)
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        workdir: [".", "./cmd/otel-allocator", "./cmd/operator-opamp-bridge"]
     steps:
     - name: Set up Go
       uses: actions/setup-go@v4
@@ -40,12 +37,18 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
 
-    - name: Lint
-      uses: golangci/golangci-lint-action@v3
+    - uses: actions/cache@v3
       with:
-        args: -v --timeout 5m
-        version: v1.51.2
-        working-directory: ${{ matrix.workdir }}
+        path: |
+          /home/runner/.cache/golangci-lint
+          /home/runner/go/pkg/mod
+          ./bin
+        key: golangcilint-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          golangcilint-
+
+    - name: Lint
+      run: make lint
 
   security:
     name: Security

--- a/Makefile
+++ b/Makefile
@@ -161,10 +161,10 @@ vet:
 
 # Run go lint against code
 .PHONY: lint
-lint:
-	golangci-lint run
-	cd cmd/otel-allocator && golangci-lint run
-	cd cmd/operator-opamp-bridge && golangci-lint run
+lint: golangci-lint
+	$(GOLANGCI_LINT) run
+	cd cmd/otel-allocator && $(GOLANGCI_LINT) run
+	cd cmd/operator-opamp-bridge && $(GOLANGCI_LINT) run
 
 # Generate code
 .PHONY: generate
@@ -294,14 +294,19 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 CHLOGGEN ?= $(LOCALBIN)/chloggen
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 KUSTOMIZE_VERSION ?= v5.0.3
 CONTROLLER_TOOLS_VERSION ?= v0.12.0
+GOLANGCI_LINT_VERSION ?= v1.51.2
 
 
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
+
+golangci-lint: ## Download golangci-lint locally if necessary.
+	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
Golangci-lint output can vary significantly between versions, and each project uses a different one. It makes for a better local dev experience if we explicitly install the version we want, just as we do with other local tools.

I've also made the CI use this for consistency's sake.