### PR TITLE
[target allocator] Fix Target Allocator config reload

### DIFF
--- a/pkg/targetallocator/annotations.go
+++ b/pkg/targetallocator/annotations.go
@@ -35,7 +35,10 @@ func Annotations(instance v1alpha1.OpenTelemetryCollector) map[string]string {
 
 	configMap, err := ConfigMap(instance)
 	if err == nil {
-		annotations[configMapHashAnnotationKey] = getConfigMapSHA(configMap)
+		cmHash := getConfigMapSHA(configMap)
+		if cmHash != "" {
+			annotations[configMapHashAnnotationKey] = getConfigMapSHA(configMap)
+		}
 	}
 
 	return annotations
@@ -43,7 +46,10 @@ func Annotations(instance v1alpha1.OpenTelemetryCollector) map[string]string {
 
 // getConfigMapSHA returns the hash of the content of the TA ConfigMap.
 func getConfigMapSHA(configMap v1.ConfigMap) string {
-	configBytes := configMap.BinaryData[targetAllocatorFilename]
-	h := sha256.Sum256(configBytes)
+	configString, ok := configMap.Data[targetAllocatorFilename]
+	if !ok {
+		return ""
+	}
+	h := sha256.Sum256([]byte(configString))
 	return fmt.Sprintf("%x", h)
 }

--- a/pkg/targetallocator/annotations_test.go
+++ b/pkg/targetallocator/annotations_test.go
@@ -15,6 +15,8 @@
 package targetallocator
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,10 +34,15 @@ func TestPodAnnotations(t *testing.T) {
 
 func TestConfigMapHash(t *testing.T) {
 	instance := collectorInstance()
+	expectedConfigMap, err := ConfigMap(instance)
+	require.NoError(t, err)
+	expectedConfig := expectedConfigMap.Data[targetAllocatorFilename]
+	require.NotEmpty(t, expectedConfig)
+	expectedHash := sha256.Sum256([]byte(expectedConfig))
 	annotations := Annotations(instance)
 	require.Contains(t, annotations, configMapHashAnnotationKey)
 	cmHash := annotations[configMapHashAnnotationKey]
-	assert.Len(t, cmHash, 64)
+	assert.Equal(t, fmt.Sprintf("%x", expectedHash), cmHash)
 }
 
 func TestInvalidConfigNoHash(t *testing.T) {

--- a/tests/e2e/smoke-targetallocator/00-assert.yaml
+++ b/tests/e2e/smoke-targetallocator/00-assert.yaml
@@ -13,6 +13,7 @@ metadata:
 status:
   replicas: 1
   readyReplicas: 1
+  observedGeneration: 1
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/tests/e2e/smoke-targetallocator/00-install.yaml
+++ b/tests/e2e/smoke-targetallocator/00-install.yaml
@@ -28,6 +28,8 @@ spec:
     enabled: true
     serviceAccount: ta
     image: "local/opentelemetry-operator-targetallocator:e2e"
+    prometheusCR:
+      enabled: true
   config: |
     receivers:
       jaeger:
@@ -42,9 +44,9 @@ spec:
               scrape_interval: 10s
               static_configs:
                 - targets: [ '0.0.0.0:8888' ]
-    
+
     processors:
-    
+
     exporters:
       logging:
     service:

--- a/tests/e2e/smoke-targetallocator/01-change-ta-config.yaml
+++ b/tests/e2e/smoke-targetallocator/01-change-ta-config.yaml
@@ -10,6 +10,8 @@ spec:
     image: "local/opentelemetry-operator-targetallocator:e2e"
     prometheusCR:
       enabled: true
+      serviceMonitorSelector:
+        key: value # this is just an arbitrary change to the target allocator config
   config: |
     receivers:
       jaeger:
@@ -24,9 +26,9 @@ spec:
               scrape_interval: 10s
               static_configs:
                 - targets: [ '0.0.0.0:8888' ]
-    
+
     processors:
-    
+
     exporters:
       logging:
     service:


### PR DESCRIPTION
Fix a critical issue in #1889. We were reading the configuration string from the wrong ConfigMap field and not checking the result, and therefore always adding the hash of the empty string.

You might wonder how it is that the E2E test passes even though the hash doesn't change. In this specific case, the spec is modified by enabling PrometheusCR, which actually adds a command line argument to the target allocator, and thus causes it to be restarted regardless. I've updated the test to account for this.

I've made the unit test for this more specific as well, so we check if we have the hash of the right value, not just that it's syntactically correct.

Finally, I've actually tested it manually as well, and it does work.