### PR TITLE
[chore] Skip flaky test instrumentation-apache-multicontainer

### DIFF
--- a/tests/e2e/instrumentation-apache-multicontainer/00-install-collector.yaml
+++ b/tests/e2e/instrumentation-apache-multicontainer/00-install-collector.yaml
@@ -1,21 +1,22 @@
-apiVersion: opentelemetry.io/v1alpha1
-kind: OpenTelemetryCollector
-metadata:
-  name: sidecar
-spec:
-  mode: sidecar
-  config: |
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-          http:
-    processors:
-    exporters:
-      logging:
-    service:
-      pipelines:
-        traces:
-          receivers: [otlp]
-          processors: []
-          exporters: [logging]
+# skipping test, see https://github.com/open-telemetry/opentelemetry-operator/issues/1936
+#apiVersion: opentelemetry.io/v1alpha1
+#kind: OpenTelemetryCollector
+#metadata:
+#  name: sidecar
+#spec:
+#  mode: sidecar
+#  config: |
+#    receivers:
+#      otlp:
+#        protocols:
+#          grpc:
+#          http:
+#    processors:
+#    exporters:
+#      logging:
+#    service:
+#      pipelines:
+#        traces:
+#          receivers: [otlp]
+#          processors: []
+#          exporters: [logging]

--- a/tests/e2e/instrumentation-apache-multicontainer/00-install-instrumentation.yaml
+++ b/tests/e2e/instrumentation-apache-multicontainer/00-install-instrumentation.yaml
@@ -1,17 +1,18 @@
-apiVersion: opentelemetry.io/v1alpha1
-kind: Instrumentation
-metadata:
-  name: apache
-spec:
-  exporter:
-    endpoint: http://localhost:4317
-  propagators:
-    - jaeger
-    - b3
-  sampler:
-    type: parentbased_traceidratio
-    argument: "0.25"
-  apacheHttpd:
-    attrs:
-    - name: ApacheModuleOtelMaxQueueSize
-      value: "4096"
+# skipping test, see https://github.com/open-telemetry/opentelemetry-operator/issues/1936
+#apiVersion: opentelemetry.io/v1alpha1
+#kind: Instrumentation
+#metadata:
+#  name: apache
+#spec:
+#  exporter:
+#    endpoint: http://localhost:4317
+#  propagators:
+#    - jaeger
+#    - b3
+#  sampler:
+#    type: parentbased_traceidratio
+#    argument: "0.25"
+#  apacheHttpd:
+#    attrs:
+#    - name: ApacheModuleOtelMaxQueueSize
+#      value: "4096"

--- a/tests/e2e/instrumentation-apache-multicontainer/01-assert.yaml
+++ b/tests/e2e/instrumentation-apache-multicontainer/01-assert.yaml
@@ -1,70 +1,71 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  annotations:
-    sidecar.opentelemetry.io/inject: "true"
-    instrumentation.opentelemetry.io/inject-apache-httpd: "true"
-    instrumentation.opentelemetry.io/container-names: "myapp,myrabbit"
-  labels:
-    app: my-apache
-spec:
-  containers:
-  - env:
-    - name: OTEL_SERVICE_NAME
-      value: my-apache
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4317
-    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: spec.nodeName
-    - name: OTEL_PROPAGATORS
-      value: jaeger,b3
-    - name: OTEL_TRACES_SAMPLER
-      value: parentbased_traceidratio
-    - name: OTEL_TRACES_SAMPLER_ARG
-      value: "0.25"
-    - name: OTEL_RESOURCE_ATTRIBUTES
-    name: myapp
-    volumeMounts:
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-    - mountPath: /opt/opentelemetry-webserver/agent
-      name: otel-apache-agent
-    - mountPath: /usr/local/apache2/conf
-      name: otel-apache-conf-dir
-  - env:
-    - name: OTEL_SERVICE_NAME
-      value: my-apache
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4317
-    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: spec.nodeName
-    - name: OTEL_PROPAGATORS
-      value: jaeger,b3
-    - name: OTEL_TRACES_SAMPLER
-      value: parentbased_traceidratio
-    - name: OTEL_TRACES_SAMPLER_ARG
-      value: "0.25"
-    - name: OTEL_RESOURCE_ATTRIBUTES
-    name: myrabbit
-    volumeMounts:
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-  - args:
-    - --config=env:OTEL_CONFIG
-    name: otc-container
-status:
-  phase: Running
+# skipping test, see https://github.com/open-telemetry/opentelemetry-operator/issues/1936
+#apiVersion: v1
+#kind: Pod
+#metadata:
+#  annotations:
+#    sidecar.opentelemetry.io/inject: "true"
+#    instrumentation.opentelemetry.io/inject-apache-httpd: "true"
+#    instrumentation.opentelemetry.io/container-names: "myapp,myrabbit"
+#  labels:
+#    app: my-apache
+#spec:
+#  containers:
+#  - env:
+#    - name: OTEL_SERVICE_NAME
+#      value: my-apache
+#    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+#      value: http://localhost:4317
+#    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+#      valueFrom:
+#        fieldRef:
+#          apiVersion: v1
+#          fieldPath: metadata.name
+#    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+#      valueFrom:
+#        fieldRef:
+#          apiVersion: v1
+#          fieldPath: spec.nodeName
+#    - name: OTEL_PROPAGATORS
+#      value: jaeger,b3
+#    - name: OTEL_TRACES_SAMPLER
+#      value: parentbased_traceidratio
+#    - name: OTEL_TRACES_SAMPLER_ARG
+#      value: "0.25"
+#    - name: OTEL_RESOURCE_ATTRIBUTES
+#    name: myapp
+#    volumeMounts:
+#    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+#    - mountPath: /opt/opentelemetry-webserver/agent
+#      name: otel-apache-agent
+#    - mountPath: /usr/local/apache2/conf
+#      name: otel-apache-conf-dir
+#  - env:
+#    - name: OTEL_SERVICE_NAME
+#      value: my-apache
+#    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+#      value: http://localhost:4317
+#    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+#      valueFrom:
+#        fieldRef:
+#          apiVersion: v1
+#          fieldPath: metadata.name
+#    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+#      valueFrom:
+#        fieldRef:
+#          apiVersion: v1
+#          fieldPath: spec.nodeName
+#    - name: OTEL_PROPAGATORS
+#      value: jaeger,b3
+#    - name: OTEL_TRACES_SAMPLER
+#      value: parentbased_traceidratio
+#    - name: OTEL_TRACES_SAMPLER_ARG
+#      value: "0.25"
+#    - name: OTEL_RESOURCE_ATTRIBUTES
+#    name: myrabbit
+#    volumeMounts:
+#    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+#  - args:
+#    - --config=env:OTEL_CONFIG
+#    name: otc-container
+#status:
+#  phase: Running

--- a/tests/e2e/instrumentation-apache-multicontainer/01-install-app.yaml
+++ b/tests/e2e/instrumentation-apache-multicontainer/01-install-app.yaml
@@ -1,35 +1,36 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-apache
-spec:
-  selector:
-    matchLabels:
-      app: my-apache
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: my-apache
-      annotations:
-        sidecar.opentelemetry.io/inject: "true"
-        instrumentation.opentelemetry.io/inject-apache-httpd: "true"
-        instrumentation.opentelemetry.io/container-names: "myapp,myrabbit"
-    spec:
-      containers:
-      - name: myapp
-        image: docker.io/chrlic/apache-test@sha256:fad58c6ce7a4f477b455bece2a1980741fa6f81cef1e1093a3b72f9b2ffa7b8e
-        # image source at https://github.com/cisco-open/appdynamics-k8s-webhook-instrumentor/tree/main/testWorkloads/apache-httpd
-        # licensed under Apache 2.0 
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8080
-        resources:
-          limits:
-            cpu: "1"
-            memory: 500Mi
-          requests:
-            cpu: 250m
-            memory: 100Mi
-      - name: myrabbit
-        image: rabbitmq
+# skipping test, see https://github.com/open-telemetry/opentelemetry-operator/issues/1936
+#apiVersion: apps/v1
+#kind: Deployment
+#metadata:
+#  name: my-apache
+#spec:
+#  selector:
+#    matchLabels:
+#      app: my-apache
+#  replicas: 1
+#  template:
+#    metadata:
+#      labels:
+#        app: my-apache
+#      annotations:
+#        sidecar.opentelemetry.io/inject: "true"
+#        instrumentation.opentelemetry.io/inject-apache-httpd: "true"
+#        instrumentation.opentelemetry.io/container-names: "myapp,myrabbit"
+#    spec:
+#      containers:
+#      - name: myapp
+#        image: docker.io/chrlic/apache-test@sha256:fad58c6ce7a4f477b455bece2a1980741fa6f81cef1e1093a3b72f9b2ffa7b8e
+#        # image source at https://github.com/cisco-open/appdynamics-k8s-webhook-instrumentor/tree/main/testWorkloads/apache-httpd
+#        # licensed under Apache 2.0
+#        imagePullPolicy: Always
+#        ports:
+#        - containerPort: 8080
+#        resources:
+#          limits:
+#            cpu: "1"
+#            memory: 500Mi
+#          requests:
+#            cpu: 250m
+#            memory: 100Mi
+#      - name: myrabbit
+#        image: rabbitmq

--- a/tests/e2e/instrumentation-apache-multicontainer/02-assert.yaml
+++ b/tests/e2e/instrumentation-apache-multicontainer/02-assert.yaml
@@ -1,67 +1,68 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  annotations:
-    instrumentation.opentelemetry.io/inject-apache-httpd: "true"
-    sidecar.opentelemetry.io/inject: "true"
-  labels:
-    app: my-apache
-spec:
-  containers:
-  - env:
-    - name: OTEL_SERVICE_NAME
-      value: my-apache
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4317
-    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: spec.nodeName
-    - name: OTEL_PROPAGATORS
-      value: jaeger,b3
-    - name: OTEL_TRACES_SAMPLER
-      value: parentbased_traceidratio
-    - name: OTEL_TRACES_SAMPLER_ARG
-      value: "0.25"
-    - name: OTEL_RESOURCE_ATTRIBUTES
-    name: myapp
-    volumeMounts:
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-    - mountPath: /opt/opentelemetry-webserver/agent
-      name: otel-apache-agent
-    - mountPath: /usr/local/apache2/conf
-      name: otel-apache-conf-dir
-  - env:
-    - name: OTEL_SERVICE_NAME
-      value: my-apache
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4317
-    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: spec.nodeName
-    - name: OTEL_PROPAGATORS
-      value: jaeger,b3
-    - name: OTEL_TRACES_SAMPLER
-      value: parentbased_traceidratio
-    - name: OTEL_TRACES_SAMPLER_ARG
-      value: "0.25"
-    - name: OTEL_RESOURCE_ATTRIBUTES
-    name: myrabbit
-  - args:
-    - --config=env:OTEL_CONFIG
-    name: otc-container
-status:
-  phase: Running
+# skipping test, see https://github.com/open-telemetry/opentelemetry-operator/issues/1936
+#apiVersion: v1
+#kind: Pod
+#metadata:
+#  annotations:
+#    instrumentation.opentelemetry.io/inject-apache-httpd: "true"
+#    sidecar.opentelemetry.io/inject: "true"
+#  labels:
+#    app: my-apache
+#spec:
+#  containers:
+#  - env:
+#    - name: OTEL_SERVICE_NAME
+#      value: my-apache
+#    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+#      value: http://localhost:4317
+#    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+#      valueFrom:
+#        fieldRef:
+#          apiVersion: v1
+#          fieldPath: metadata.name
+#    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+#      valueFrom:
+#        fieldRef:
+#          apiVersion: v1
+#          fieldPath: spec.nodeName
+#    - name: OTEL_PROPAGATORS
+#      value: jaeger,b3
+#    - name: OTEL_TRACES_SAMPLER
+#      value: parentbased_traceidratio
+#    - name: OTEL_TRACES_SAMPLER_ARG
+#      value: "0.25"
+#    - name: OTEL_RESOURCE_ATTRIBUTES
+#    name: myapp
+#    volumeMounts:
+#    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+#    - mountPath: /opt/opentelemetry-webserver/agent
+#      name: otel-apache-agent
+#    - mountPath: /usr/local/apache2/conf
+#      name: otel-apache-conf-dir
+#  - env:
+#    - name: OTEL_SERVICE_NAME
+#      value: my-apache
+#    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+#      value: http://localhost:4317
+#    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+#      valueFrom:
+#        fieldRef:
+#          apiVersion: v1
+#          fieldPath: metadata.name
+#    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+#      valueFrom:
+#        fieldRef:
+#          apiVersion: v1
+#          fieldPath: spec.nodeName
+#    - name: OTEL_PROPAGATORS
+#      value: jaeger,b3
+#    - name: OTEL_TRACES_SAMPLER
+#      value: parentbased_traceidratio
+#    - name: OTEL_TRACES_SAMPLER_ARG
+#      value: "0.25"
+#    - name: OTEL_RESOURCE_ATTRIBUTES
+#    name: myrabbit
+#  - args:
+#    - --config=env:OTEL_CONFIG
+#    name: otc-container
+#status:
+#  phase: Running

--- a/tests/e2e/instrumentation-apache-multicontainer/02-install-app.yaml
+++ b/tests/e2e/instrumentation-apache-multicontainer/02-install-app.yaml
@@ -1,35 +1,36 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-apache
-spec:
-  selector:
-    matchLabels:
-      app: my-apache
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: my-apache
-      annotations:
-        sidecar.opentelemetry.io/inject: "true"
-        instrumentation.opentelemetry.io/inject-apache-httpd: "true"
-        instrumentation.opentelemetry.io/container-names: "myrabbit"
-    spec:
-      containers:
-      - name: myapp
-        image: docker.io/chrlic/apache-test@sha256:fad58c6ce7a4f477b455bece2a1980741fa6f81cef1e1093a3b72f9b2ffa7b8e
-        # image source at https://github.com/cisco-open/appdynamics-k8s-webhook-instrumentor/tree/main/testWorkloads/apache-httpd
-        # licensed under Apache 2.0 
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8080
-        resources:
-          limits:
-            cpu: "1"
-            memory: 500Mi
-          requests:
-            cpu: 250m
-            memory: 100Mi
-      - name: myrabbit
-        image: rabbitmq
+# skipping test, see https://github.com/open-telemetry/opentelemetry-operator/issues/1936
+#apiVersion: apps/v1
+#kind: Deployment
+#metadata:
+#  name: my-apache
+#spec:
+#  selector:
+#    matchLabels:
+#      app: my-apache
+#  replicas: 1
+#  template:
+#    metadata:
+#      labels:
+#        app: my-apache
+#      annotations:
+#        sidecar.opentelemetry.io/inject: "true"
+#        instrumentation.opentelemetry.io/inject-apache-httpd: "true"
+#        instrumentation.opentelemetry.io/container-names: "myrabbit"
+#    spec:
+#      containers:
+#      - name: myapp
+#        image: docker.io/chrlic/apache-test@sha256:fad58c6ce7a4f477b455bece2a1980741fa6f81cef1e1093a3b72f9b2ffa7b8e
+#        # image source at https://github.com/cisco-open/appdynamics-k8s-webhook-instrumentor/tree/main/testWorkloads/apache-httpd
+#        # licensed under Apache 2.0
+#        imagePullPolicy: Always
+#        ports:
+#        - containerPort: 8080
+#        resources:
+#          limits:
+#            cpu: "1"
+#            memory: 500Mi
+#          requests:
+#            cpu: 250m
+#            memory: 100Mi
+#      - name: myrabbit
+#        image: rabbitmq


### PR DESCRIPTION
Temporarily skips the `instrumentation-apache-multicontainer` e2e test.

Related to https://github.com/open-telemetry/opentelemetry-operator/issues/1936