### PR TITLE
Refactor target allocator config handling

### DIFF
--- a/.chloggen/feat_ta-cliconfig.yaml
+++ b/.chloggen/feat_ta-cliconfig.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow target allocator to be completely configured via the config file
+
+# One or more tracking issues related to the change
+issues: [2129]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -39,10 +39,10 @@ const DefaultConfigFilePath string = "/conf/targetallocator.yaml"
 const DefaultCRScrapeInterval model.Duration = model.Duration(time.Second * 30)
 
 type Config struct {
-	ListenAddr             *string
-	KubeConfigFilePath     string
-	ClusterConfig          *rest.Config
-	RootLogger             logr.Logger
+	ListenAddr             string             `yaml:"listen_addr,omitempty"`
+	KubeConfigFilePath     string             `yaml:"kube_config_file_path,omitempty"`
+	ClusterConfig          *rest.Config       `yaml:"-"`
+	RootLogger             logr.Logger        `yaml:"-"`
 	LabelSelector          map[string]string  `yaml:"label_selector,omitempty"`
 	PromConfig             *promconfig.Config `yaml:"config"`
 	AllocationStrategy     *string            `yaml:"allocation_strategy,omitempty"`
@@ -125,7 +125,7 @@ func FromCLI() (*Config, string, error) {
 			return nil, "", err
 		}
 	}
-	config.ListenAddr = listenAddrFlag
+	config.ListenAddr = *listenAddrFlag
 	config.PrometheusCR.Enabled = *prometheusCREnabledFlag
 	config.ClusterConfig = clusterConfig
 	return &config, *configFilePathFlag, nil

--- a/cmd/otel-allocator/config/config_test.go
+++ b/cmd/otel-allocator/config/config_test.go
@@ -99,7 +99,7 @@ func TestLoad(t *testing.T) {
 			args: args{
 				file: "./testdata/no_config.yaml",
 			},
-			want:    createDefaultConfig(),
+			want:    CreateDefaultConfig(),
 			wantErr: assert.NoError,
 		},
 		{
@@ -163,7 +163,8 @@ func TestLoad(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := Load(tt.args.file)
+			got := CreateDefaultConfig()
+			err := LoadFromFile(tt.args.file, &got)
 			if !tt.wantErr(t, err, fmt.Sprintf("Load(%v)", tt.args.file)) {
 				return
 			}

--- a/cmd/otel-allocator/config/flags.go
+++ b/cmd/otel-allocator/config/flags.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"flag"
+	"path/filepath"
+
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/util/homedir"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// flag definitions
+var (
+	configFilePathFlag      *string
+	listenAddrFlag          *string
+	prometheusCREnabledFlag *bool
+	kubeConfigPathFlag      *string
+	zapCmdLineOpts          zap.Options
+)
+
+func initFlags() {
+	configFilePathFlag = pflag.String("config-file", DefaultConfigFilePath, "The path to the config file.")
+	listenAddrFlag = pflag.String("listen-addr", ":8080", "The address where this service serves.")
+	prometheusCREnabledFlag = pflag.Bool("enable-prometheus-cr-watcher", false, "Enable Prometheus CRs as target sources")
+	kubeConfigPathFlag = pflag.String("kubeconfig-path", filepath.Join(homedir.HomeDir(), ".kube", "config"), "absolute path to the KubeconfigPath file")
+	zapCmdLineOpts.BindFlags(flag.CommandLine)
+}
+
+func init() {
+	initFlags()
+}

--- a/cmd/otel-allocator/config/flags.go
+++ b/cmd/otel-allocator/config/flags.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-// flag definitions
+// Flag definitions.
 var (
 	configFilePathFlag      *string
 	listenAddrFlag          *string

--- a/cmd/otel-allocator/config/flags_test.go
+++ b/cmd/otel-allocator/config/flags_test.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFlagSet(t *testing.T) {
+	fs := getFlagSet(pflag.ExitOnError)
+
+	// Check if each flag exists
+	assert.NotNil(t, fs.Lookup(configFilePathFlagName), "Flag %s not found", configFilePathFlagName)
+	assert.NotNil(t, fs.Lookup(listenAddrFlagName), "Flag %s not found", listenAddrFlagName)
+	assert.NotNil(t, fs.Lookup(prometheusCREnabledFlagName), "Flag %s not found", prometheusCREnabledFlagName)
+	assert.NotNil(t, fs.Lookup(kubeConfigPathFlagName), "Flag %s not found", kubeConfigPathFlagName)
+}
+
+func TestFlagGetters(t *testing.T) {
+	tests := []struct {
+		name          string
+		flagArgs      []string
+		expectedValue interface{}
+		expectedErr   bool
+		getterFunc    func(*pflag.FlagSet) (interface{}, error)
+	}{
+		{
+			name:          "GetConfigFilePath",
+			flagArgs:      []string{"--" + configFilePathFlagName, "/path/to/config"},
+			expectedValue: "/path/to/config",
+			getterFunc:    func(fs *pflag.FlagSet) (interface{}, error) { return getConfigFilePath(fs) },
+		},
+		{
+			name:          "GetKubeConfigFilePath",
+			flagArgs:      []string{"--" + kubeConfigPathFlagName, filepath.Join("~", ".kube", "config")},
+			expectedValue: filepath.Join("~", ".kube", "config"),
+			getterFunc:    func(fs *pflag.FlagSet) (interface{}, error) { return getKubeConfigFilePath(fs) },
+		},
+		{
+			name:          "GetListenAddr",
+			flagArgs:      []string{"--" + listenAddrFlagName, ":8081"},
+			expectedValue: ":8081",
+			getterFunc:    func(fs *pflag.FlagSet) (interface{}, error) { return getListenAddr(fs) },
+		},
+		{
+			name:          "GetPrometheusCREnabled",
+			flagArgs:      []string{"--" + prometheusCREnabledFlagName, "true"},
+			expectedValue: true,
+			getterFunc:    func(fs *pflag.FlagSet) (interface{}, error) { return getPrometheusCREnabled(fs) },
+		},
+		{
+			name:        "InvalidFlag",
+			flagArgs:    []string{"--invalid-flag", "value"},
+			expectedErr: true,
+			getterFunc:  func(fs *pflag.FlagSet) (interface{}, error) { return getConfigFilePath(fs) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := getFlagSet(pflag.ContinueOnError)
+			err := fs.Parse(tt.flagArgs)
+
+			// If an error is expected during parsing, we check it here.
+			if tt.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+
+			got, err := tt.getterFunc(fs)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedValue, got)
+		})
+	}
+}

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -105,7 +105,7 @@ func main() {
 	defer close(interrupts)
 
 	if cfg.PrometheusCR.Enabled {
-		promWatcher, err = allocatorWatcher.NewPrometheusCRWatcher(setupLog.WithName("prometheus-cr-watcher"), cfg)
+		promWatcher, err = allocatorWatcher.NewPrometheusCRWatcher(setupLog.WithName("prometheus-cr-watcher"), *cfg)
 		if err != nil {
 			setupLog.Error(err, "Can't start the prometheus watcher")
 			os.Exit(1)

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -66,9 +67,10 @@ func main() {
 	)
 	cfg, configFilePath, err := config.Load()
 	if err != nil {
-		setupLog.Error(err, "Failed to parse parameters")
+		fmt.Printf("Failed to load config: %v", err)
 		os.Exit(1)
 	}
+	ctrl.SetLogger(cfg.RootLogger)
 
 	if validationErr := config.ValidateConfig(cfg); validationErr != nil {
 		setupLog.Error(validationErr, "Invalid configuration")

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -64,7 +64,7 @@ func main() {
 		interrupts      = make(chan os.Signal, 1)
 		errChan         = make(chan error)
 	)
-	cfg, configFilePath, err := config.FromCLI()
+	cfg, configFilePath, err := config.Load()
 	if err != nil {
 		setupLog.Error(err, "Failed to parse parameters")
 		os.Exit(1)

--- a/cmd/otel-allocator/server/bench_test.go
+++ b/cmd/otel-allocator/server/bench_test.go
@@ -54,7 +54,7 @@ func BenchmarkServerTargetsHandler(b *testing.B) {
 			listenAddr := ":8080"
 			a.SetCollectors(cols)
 			a.SetTargets(targets)
-			s := NewServer(logger, a, &listenAddr)
+			s := NewServer(logger, a, listenAddr)
 			b.Run(fmt.Sprintf("%s_num_cols_%d_num_jobs_%d", allocatorName, v.numCollectors, v.numJobs), func(b *testing.B) {
 				b.ReportAllocs()
 				for i := 0; i < b.N; i++ {

--- a/cmd/otel-allocator/server/server.go
+++ b/cmd/otel-allocator/server/server.go
@@ -71,7 +71,7 @@ type Server struct {
 	scrapeConfigResponse []byte
 }
 
-func NewServer(log logr.Logger, allocator allocation.Allocator, listenAddr *string) *Server {
+func NewServer(log logr.Logger, allocator allocation.Allocator, listenAddr string) *Server {
 	s := &Server{
 		logger:         log,
 		allocator:      allocator,
@@ -90,7 +90,7 @@ func NewServer(log logr.Logger, allocator allocation.Allocator, listenAddr *stri
 	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 	registerPprof(router.Group("/debug/pprof/"))
 
-	s.server = &http.Server{Addr: *listenAddr, Handler: router, ReadHeaderTimeout: 90 * time.Second}
+	s.server = &http.Server{Addr: listenAddr, Handler: router, ReadHeaderTimeout: 90 * time.Second}
 	return s
 }
 

--- a/cmd/otel-allocator/server/server_test.go
+++ b/cmd/otel-allocator/server/server_test.go
@@ -154,7 +154,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			listenAddr := ":8080"
-			s := NewServer(logger, tt.args.allocator, &listenAddr)
+			s := NewServer(logger, tt.args.allocator, listenAddr)
 			tt.args.allocator.SetCollectors(map[string]*allocation.Collector{"test-collector": {Name: "test-collector"}})
 			tt.args.allocator.SetTargets(tt.args.cMap)
 			request := httptest.NewRequest("GET", fmt.Sprintf("/jobs/%s/targets?collector_id=%s", tt.args.job, tt.args.collector), nil)
@@ -445,7 +445,7 @@ func TestServer_ScrapeConfigsHandler(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			listenAddr := ":8080"
-			s := NewServer(logger, nil, &listenAddr)
+			s := NewServer(logger, nil, listenAddr)
 			assert.NoError(t, s.UpdateScrapeConfigResponse(tc.scrapeConfigs))
 
 			request := httptest.NewRequest("GET", "/scrape_configs", nil)
@@ -518,7 +518,7 @@ func TestServer_JobHandler(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			listenAddr := ":8080"
 			a := &mockAllocator{targetItems: tc.targetItems}
-			s := NewServer(logger, a, &listenAddr)
+			s := NewServer(logger, a, listenAddr)
 			request := httptest.NewRequest("GET", "/jobs", nil)
 			w := httptest.NewRecorder()
 

--- a/cmd/otel-allocator/target/discovery_test.go
+++ b/cmd/otel-allocator/target/discovery_test.go
@@ -85,8 +85,8 @@ func TestDiscovery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := config.Load(tt.args.file)
 			assert.NoError(t, err)
-			assert.True(t, len(cfg.Config.ScrapeConfigs) > 0)
-			err = manager.ApplyConfig(allocatorWatcher.EventSourcePrometheusCR, cfg.Config)
+			assert.True(t, len(cfg.PromConfig.ScrapeConfigs) > 0)
+			err = manager.ApplyConfig(allocatorWatcher.EventSourcePrometheusCR, cfg.PromConfig)
 			assert.NoError(t, err)
 
 			gotTargets := <-results
@@ -96,7 +96,7 @@ func TestDiscovery(t *testing.T) {
 
 			// check the updated scrape configs
 			expectedScrapeConfigs := map[string]*promconfig.ScrapeConfig{}
-			for _, scrapeConfig := range cfg.Config.ScrapeConfigs {
+			for _, scrapeConfig := range cfg.PromConfig.ScrapeConfigs {
 				expectedScrapeConfigs[scrapeConfig.JobName] = scrapeConfig
 			}
 			assert.Equal(t, expectedScrapeConfigs, scu.mockCfg)

--- a/cmd/otel-allocator/target/discovery_test.go
+++ b/cmd/otel-allocator/target/discovery_test.go
@@ -83,7 +83,8 @@ func TestDiscovery(t *testing.T) {
 	}()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg, err := config.Load(tt.args.file)
+			cfg := config.CreateDefaultConfig()
+			err := config.LoadFromFile(tt.args.file, &cfg)
 			assert.NoError(t, err)
 			assert.True(t, len(cfg.PromConfig.ScrapeConfigs) > 0)
 			err = manager.ApplyConfig(allocatorWatcher.EventSourcePrometheusCR, cfg.PromConfig)

--- a/cmd/otel-allocator/watcher/file.go
+++ b/cmd/otel-allocator/watcher/file.go
@@ -34,7 +34,7 @@ type FileWatcher struct {
 	closer         chan bool
 }
 
-func NewFileWatcher(logger logr.Logger, config config.CLIConfig) (*FileWatcher, error) {
+func NewFileWatcher(logger logr.Logger, configFilePath string) (*FileWatcher, error) {
 	fileWatcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		logger.Error(err, "Can't start the watcher")
@@ -43,7 +43,7 @@ func NewFileWatcher(logger logr.Logger, config config.CLIConfig) (*FileWatcher, 
 
 	return &FileWatcher{
 		logger:         logger,
-		configFilePath: *config.ConfigFilePath,
+		configFilePath: configFilePath,
 		watcher:        fileWatcher,
 		closer:         make(chan bool),
 	}, nil
@@ -55,7 +55,7 @@ func (f *FileWatcher) LoadConfig(_ context.Context) (*promconfig.Config, error) 
 		f.logger.Error(err, "Unable to load configuration")
 		return nil, err
 	}
-	return cfg.Config, nil
+	return cfg.PromConfig, nil
 }
 
 func (f *FileWatcher) Watch(upstreamEvents chan Event, upstreamErrors chan error) error {

--- a/cmd/otel-allocator/watcher/file.go
+++ b/cmd/otel-allocator/watcher/file.go
@@ -50,7 +50,8 @@ func NewFileWatcher(logger logr.Logger, configFilePath string) (*FileWatcher, er
 }
 
 func (f *FileWatcher) LoadConfig(_ context.Context) (*promconfig.Config, error) {
-	cfg, err := config.Load(f.configFilePath)
+	cfg := config.CreateDefaultConfig()
+	err := config.LoadFromFile(f.configFilePath, &cfg)
 	if err != nil {
 		f.logger.Error(err, "Unable to load configuration")
 		return nil, err

--- a/cmd/otel-allocator/watcher/promOperator.go
+++ b/cmd/otel-allocator/watcher/promOperator.go
@@ -37,13 +37,13 @@ import (
 	allocatorconfig "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
 )
 
-func NewPrometheusCRWatcher(logger logr.Logger, cfg allocatorconfig.Config, cliConfig allocatorconfig.CLIConfig) (*PrometheusCRWatcher, error) {
-	mClient, err := monitoringclient.NewForConfig(cliConfig.ClusterConfig)
+func NewPrometheusCRWatcher(logger logr.Logger, cfg *allocatorconfig.Config) (*PrometheusCRWatcher, error) {
+	mClient, err := monitoringclient.NewForConfig(cfg.ClusterConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	clientset, err := kubernetes.NewForConfig(cliConfig.ClusterConfig)
+	clientset, err := kubernetes.NewForConfig(cfg.ClusterConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func NewPrometheusCRWatcher(logger logr.Logger, cfg allocatorconfig.Config, cliC
 		informers:              monitoringInformers,
 		stopChannel:            make(chan struct{}),
 		configGenerator:        generator,
-		kubeConfigPath:         cliConfig.KubeConfigFilePath,
+		kubeConfigPath:         cfg.KubeConfigFilePath,
 		serviceMonitorSelector: servMonSelector,
 		podMonitorSelector:     podMonSelector,
 	}, nil

--- a/cmd/otel-allocator/watcher/promOperator.go
+++ b/cmd/otel-allocator/watcher/promOperator.go
@@ -37,7 +37,7 @@ import (
 	allocatorconfig "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
 )
 
-func NewPrometheusCRWatcher(logger logr.Logger, cfg *allocatorconfig.Config) (*PrometheusCRWatcher, error) {
+func NewPrometheusCRWatcher(logger logr.Logger, cfg allocatorconfig.Config) (*PrometheusCRWatcher, error) {
 	mClient, err := monitoringclient.NewForConfig(cfg.ClusterConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
TargetAllocator config is internally (rather arbitrarily) split into config from cli, contained in the `CLIConf` struct, and config loaded from the config file, contained in the `Config` struct. This change moves all configuration attributes to the latter, and explicitly gives the CLI arguments higher priority.

I've also moved the flag arguments into an explicit flag set and added tests for it.

Resolves #2129.