### PR TITLE
Remove legacy OTLP HTTP port

### DIFF
--- a/.chloggen/1954-remove-legacy-port.yaml
+++ b/.chloggen/1954-remove-legacy-port.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove legacy OTLP HTTP port
+
+# One or more tracking issues related to the change
+issues: [1954]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/collector/adapters/config_to_ports_test.go
+++ b/pkg/collector/adapters/config_to_ports_test.go
@@ -85,7 +85,7 @@ func TestExtractPortsFromConfig(t *testing.T) {
 	// test
 	ports, err := adapters.ConfigToReceiverPorts(logger, config)
 	assert.NoError(t, err)
-	assert.Len(t, ports, 11)
+	assert.Len(t, ports, 10)
 
 	// verify
 	httpAppProtocol := "http"
@@ -104,7 +104,6 @@ func TestExtractPortsFromConfig(t *testing.T) {
 		{Name: "otlp-2-grpc", AppProtocol: &grpcAppProtocol, Protocol: "TCP", Port: 55555},
 		{Name: "otlp-grpc", AppProtocol: &grpcAppProtocol, Port: 4317, TargetPort: targetPort4317},
 		{Name: "otlp-http", AppProtocol: &httpAppProtocol, Port: 4318, TargetPort: targetPort4318},
-		{Name: "otlp-http-legacy", AppProtocol: &httpAppProtocol, Port: 55681, TargetPort: targetPort4318},
 		{Name: "zipkin", AppProtocol: &httpAppProtocol, Protocol: "TCP", Port: 9411},
 	}
 	assert.ElementsMatch(t, expectedPorts, ports)

--- a/pkg/collector/parser/receiver_otlp.go
+++ b/pkg/collector/parser/receiver_otlp.go
@@ -27,9 +27,8 @@ var _ ReceiverParser = &OTLPReceiverParser{}
 const (
 	parserNameOTLP = "__otlp"
 
-	defaultOTLPGRPCPort       int32 = 4317
-	defaultOTLPHTTPLegacyPort int32 = 55681
-	defaultOTLPHTTPPort       int32 = 4318
+	defaultOTLPGRPCPort int32 = 4317
+	defaultOTLPHTTPPort int32 = 4318
 )
 
 var (
@@ -86,12 +85,6 @@ func (o *OTLPReceiverParser) Ports() ([]corev1.ServicePort, error) {
 					Name:        portName(fmt.Sprintf("%s-http", o.name), defaultOTLPHTTPPort),
 					Port:        defaultOTLPHTTPPort,
 					TargetPort:  intstr.FromInt(int(defaultOTLPHTTPPort)),
-					AppProtocol: &http,
-				},
-				{
-					Name:        portName(fmt.Sprintf("%s-http-legacy", o.name), defaultOTLPHTTPLegacyPort),
-					Port:        defaultOTLPHTTPLegacyPort,
-					TargetPort:  intstr.FromInt(int(defaultOTLPHTTPPort)), // we target the official port, not the legacy
 					AppProtocol: &http,
 				},
 			},

--- a/pkg/collector/parser/receiver_otlp_test.go
+++ b/pkg/collector/parser/receiver_otlp_test.go
@@ -85,9 +85,8 @@ func TestOTLPExposeDefaultPorts(t *testing.T) {
 		portNumber int32
 		seen       bool
 	}{
-		"otlp-grpc":        {portNumber: 4317},
-		"otlp-http":        {portNumber: 4318},
-		"otlp-http-legacy": {portNumber: 55681},
+		"otlp-grpc": {portNumber: 4317},
+		"otlp-http": {portNumber: 4318},
 	}
 
 	// test

--- a/tests/e2e/ingress/00-assert.yaml
+++ b/tests/e2e/ingress/00-assert.yaml
@@ -38,10 +38,3 @@ spec:
               name: otlp-http
         path: /otlp-http
         pathType: Prefix
-      - backend:
-          service:
-            name: simplest-collector
-            port:
-              name: otlp-http-legac
-        path: /otlp-http-legacy
-        pathType: Prefix

--- a/tests/e2e/managed-reconcile/00-assert.yaml
+++ b/tests/e2e/managed-reconcile/00-assert.yaml
@@ -27,11 +27,6 @@ spec:
     port: 4318
     protocol: TCP
     targetPort: 4318
-  - appProtocol: http
-    name: otlp-http-legacy
-    port: 55681
-    protocol: TCP
-    targetPort: 4318
 
 ---
 
@@ -49,10 +44,5 @@ spec:
   - appProtocol: http
     name: otlp-http
     port: 4318
-    protocol: TCP
-    targetPort: 4318
-  - appProtocol: http
-    name: otlp-http-legacy
-    port: 55681
     protocol: TCP
     targetPort: 4318

--- a/tests/e2e/managed-reconcile/01-assert.yaml
+++ b/tests/e2e/managed-reconcile/01-assert.yaml
@@ -23,11 +23,6 @@ spec:
     port: 4318
     protocol: TCP
     targetPort: 4318
-  - appProtocol: http
-    name: otlp-http-legacy
-    port: 55681
-    protocol: TCP
-    targetPort: 4318
 
 ---
 
@@ -45,11 +40,6 @@ spec:
   - appProtocol: http
     name: otlp-http
     port: 4318
-    protocol: TCP
-    targetPort: 4318
-  - appProtocol: http
-    name: otlp-http-legacy
-    port: 55681
     protocol: TCP
     targetPort: 4318
 

--- a/tests/e2e/managed-reconcile/02-assert.yaml
+++ b/tests/e2e/managed-reconcile/02-assert.yaml
@@ -27,11 +27,6 @@ spec:
     port: 4318
     protocol: TCP
     targetPort: 4318
-  - appProtocol: http
-    name: otlp-http-legacy
-    port: 55681
-    protocol: TCP
-    targetPort: 4318
 
 ---
 
@@ -49,11 +44,6 @@ spec:
   - appProtocol: http
     name: otlp-http
     port: 4318
-    protocol: TCP
-    targetPort: 4318
-  - appProtocol: http
-    name: otlp-http-legacy
-    port: 55681
     protocol: TCP
     targetPort: 4318
 

--- a/tests/e2e/smoke-init-containers/00-assert.yaml
+++ b/tests/e2e/smoke-init-containers/00-assert.yaml
@@ -33,11 +33,6 @@ spec:
     port: 4318
     protocol: TCP
     targetPort: 4318
-  - appProtocol: http
-    name: otlp-http-legacy
-    port: 55681
-    protocol: TCP
-    targetPort: 4318
 
 ---
 
@@ -60,10 +55,5 @@ spec:
   - appProtocol: http
     name: otlp-http
     port: 4318
-    protocol: TCP
-    targetPort: 4318
-  - appProtocol: http
-    name: otlp-http-legacy
-    port: 55681
     protocol: TCP
     targetPort: 4318

--- a/tests/e2e/smoke-simplest/00-assert.yaml
+++ b/tests/e2e/smoke-simplest/00-assert.yaml
@@ -28,11 +28,6 @@ spec:
     port: 4318
     protocol: TCP
     targetPort: 4318
-  - appProtocol: http
-    name: otlp-http-legacy
-    port: 55681
-    protocol: TCP
-    targetPort: 4318
 
 ---
 
@@ -55,10 +50,5 @@ spec:
   - appProtocol: http
     name: otlp-http
     port: 4318
-    protocol: TCP
-    targetPort: 4318
-  - appProtocol: http
-    name: otlp-http-legacy
-    port: 55681
     protocol: TCP
     targetPort: 4318


### PR DESCRIPTION
Resolves #1954 

The legacy OTLP HTTP port was removed from the collector in Feb 2022 - https://github.com/open-telemetry/opentelemetry-collector/pull/4916#issue-1148683041 