### PR TITLE
Add dependabot rules for target allocator and opamp-bridge Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,3 +71,13 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  - package-ecosystem: docker
+    directory: /cmd/otel-allocator
+    schedule:
+      interval: daily
+
+  - package-ecosystem: docker
+    directory: /cmd/operator-opamp-bridge
+    schedule:
+      interval: daily


### PR DESCRIPTION
Resolves #2004 