### PR TITLE
get servicename from daemonset if possible

### DIFF
--- a/.chloggen/servicename-daemonset.yaml
+++ b/.chloggen/servicename-daemonset.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Daemonsets can be instrumented so the generated servicename should use their name for better discoverability"
+
+# One or more tracking issues related to the change
+issues: [2015]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -309,6 +309,9 @@ func chooseServiceName(pod corev1.Pod, resources map[string]string, index int) s
 	if name := resources[string(semconv.K8SStatefulSetNameKey)]; name != "" {
 		return name
 	}
+	if name := resources[string(semconv.K8SDaemonSetNameKey)]; name != "" {
+		return name
+	}
 	if name := resources[string(semconv.K8SJobNameKey)]; name != "" {
 		return name
 	}


### PR DESCRIPTION
Daemonsets can be instrumented so the generated servicename should use their name for better discoverability.

Related issue:  https://github.com/open-telemetry/opentelemetry-operator/issues/2015