### PR TITLE
Make OpenShift Route work with gRPC receivers

### DIFF
--- a/.chloggen/route-grpc.yaml
+++ b/.chloggen/route-grpc.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make OpenShift Route work with gRPC receivers by using h2c appProtocol
+
+# One or more tracking issues related to the change
+issues: [1969]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/collector/route.go
+++ b/internal/manifests/collector/route.go
@@ -66,6 +66,11 @@ func Routes(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetr
 	routes := make([]*routev1.Route, len(ports))
 	for i, p := range ports {
 		portName := naming.PortName(p.Name, p.Port)
+		path := "/"
+		//  passthrough termination does not support paths
+		if otelcol.Spec.Ingress.Route.Termination == v1alpha1.TLSRouteTerminationTypePassthrough {
+			path = ""
+		}
 		routes[i] = &routev1.Route{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        naming.Route(otelcol.Name, p.Name),
@@ -79,7 +84,7 @@ func Routes(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetr
 			},
 			Spec: routev1.RouteSpec{
 				Host: fmt.Sprintf("%s.%s", portName, otelcol.Spec.Ingress.Hostname),
-				Path: "/",
+				Path: path,
 				To: routev1.RouteTargetReference{
 					Kind: "Service",
 					Name: naming.Service(otelcol.Name),

--- a/internal/manifests/collector/service.go
+++ b/internal/manifests/collector/service.go
@@ -16,6 +16,7 @@ package collector
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -108,9 +109,9 @@ func Service(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemet
 
 	// set appProtocol to h2c for grpc ports on OpenShift.
 	// OpenShift uses HA proxy that uses appProtocol for its configuration.
-	for i, _ := range ports {
+	for i := range ports {
 		h2c := "h2c"
-		if otelcol.Spec.Ingress.Type == v1alpha1.IngressTypeRoute && ports[i].AppProtocol != nil && *(ports[i].AppProtocol) == "grpc" {
+		if otelcol.Spec.Ingress.Type == v1alpha1.IngressTypeRoute && ports[i].AppProtocol != nil && strings.EqualFold(*ports[i].AppProtocol, "grpc") {
 			ports[i].AppProtocol = &h2c
 		}
 	}

--- a/internal/manifests/collector/service.go
+++ b/internal/manifests/collector/service.go
@@ -106,6 +106,15 @@ func Service(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemet
 		return nil
 	}
 
+	// set appProtocol to h2c for grpc ports on OpenShift.
+	// OpenShift uses HA proxy that uses appProtocol for its configuration.
+	for i, _ := range ports {
+		h2c := "h2c"
+		if otelcol.Spec.Ingress.Type == v1alpha1.IngressTypeRoute && ports[i].AppProtocol != nil && *(ports[i].AppProtocol) == "grpc" {
+			ports[i].AppProtocol = &h2c
+		}
+	}
+
 	if len(otelcol.Spec.Ports) > 0 {
 		// we should add all the ports from the CR
 		// there are two cases where problems might occur:

--- a/internal/manifests/collector/service_test.go
+++ b/internal/manifests/collector/service_test.go
@@ -128,6 +128,24 @@ func TestDesiredService(t *testing.T) {
 
 	})
 
+	t.Run("on OpenShift gRPC appProtocol should be h2c", func(t *testing.T) {
+		h2c := "h2c"
+		jaegerPort := v1.ServicePort{
+			Name:        "jaeger-grpc",
+			Protocol:    "TCP",
+			Port:        14250,
+			AppProtocol: &h2c,
+		}
+
+		params := deploymentParams()
+		params.Instance.Spec.Ingress.Type = v1alpha1.IngressTypeRoute
+		actual := Service(params.Config, params.Log, params.Instance)
+
+		ports := append(params.Instance.Spec.Ports, jaegerPort)
+		expected := service("test-collector", ports)
+		assert.Equal(t, expected, *actual)
+	})
+
 	t.Run("should return service with local internal traffic policy", func(t *testing.T) {
 
 		grpc := "grpc"
@@ -144,7 +162,6 @@ func TestDesiredService(t *testing.T) {
 
 		assert.Equal(t, expected, *actual)
 	})
-
 }
 
 func TestHeadlessService(t *testing.T) {


### PR DESCRIPTION
Updates #1969 

The appProtocol set to h2c should work for secure (TLS) and insecure routes. 

Some test yamls: 
```yaml
kubectl apply -f - <<EOF
apiVersion: v1
kind: ConfigMap
metadata:
  name: certs
data:
  ca.crt: |
    -----BEGIN CERTIFICATE-----
    MIIDNjCCAh4CCQDm8/gmxPra7zANBgkqhkiG9w0BAQsFADBdMQswCQYDVQQGEwJB
    VTESMBAGA1UECAwJQXVzdHJhbGlhMQ8wDQYDVQQHDAZTeWRuZXkxEjAQBgNVBAoM
    CU15T3JnTmFtZTEVMBMGA1UEAwwMTXlDb21tb25OYW1lMB4XDTIyMDgwMzA0NDQ0
    OFoXDTMyMDczMTA0NDQ0OFowXTELMAkGA1UEBhMCQVUxEjAQBgNVBAgMCUF1c3Ry
    YWxpYTEPMA0GA1UEBwwGU3lkbmV5MRIwEAYDVQQKDAlNeU9yZ05hbWUxFTATBgNV
    BAMMDE15Q29tbW9uTmFtZTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
    AKDQxV8fMvsl4YhMiY3EiT0ylKQ0VkUwvWE4yfem6LFYaZa0fOe1zc3V9DXmcH9A
    PXXa+XwlK7xfXSddGoD7XfxLKdU8FiU+bXs/pEeRPQ+5oraInTcAQ265HXkPmiiQ
    XN6qRlwAoC2NgV9OKvUHEqpw/Z/edCLfbBipT+PfBeAtK9Dv0v3hXAqDQlotERxM
    uRa9VYETbw/hjj+DIVGZWCnpiQXlepxoZJJiGw1p2Ca0aN5mWDNvMz9bFWo+Szz6
    FqR1S6Tqw5M3jS0NMkI1e0mZSxGBqYXy/x7ep9j5UjmAtHl8oKpDS23HXqnxnjLi
    mnM/dipizaJKwidw9SA/fRMCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAZsJE1yx/
    m9zy29eB6l2278bWvRP/2zbpBVziOmwLq5vYdtTn9S1o8TJ8MFAa3B9D0oLSb+n5
    biJqK4rwKRWezoalHo6/vVxQDY1FgVT0RmYKdL9xdc4YBPdBfHnvlEqcXPYBpvoH
    0w0ZIu1UxkDij8RNxc5aePflAyVZxg3RNh0jN0qiwB2d4VqOzr9XAh4b1DFRaI9r
    X0MG+4ptxdNM7StKJGsJvnZ686Ep/6/2Z4B2guBGkcoSuSRUwr1ft8DuJBM5QLwa
    wUPFTcCoyfHzNpYaIp2pTSScFEXmLlV/E7TiST0EEiqNsZAaDPttuAdDRSUe/1CX
    hxDsgqzefB2kWQ==
    -----END CERTIFICATE-----
  server.crt: |
    -----BEGIN CERTIFICATE-----
    MIIDVTCCAj2gAwIBAgIJAOPSCYfRo9dUMA0GCSqGSIb3DQEBCwUAMF0xCzAJBgNV
    BAYTAkFVMRIwEAYDVQQIDAlBdXN0cmFsaWExDzANBgNVBAcMBlN5ZG5leTESMBAG
    A1UECgwJTXlPcmdOYW1lMRUwEwYDVQQDDAxNeUNvbW1vbk5hbWUwHhcNMjIwODAz
    MDQ0NDQ4WhcNMzIwNzMxMDQ0NDQ4WjBdMQswCQYDVQQGEwJBVTESMBAGA1UECAwJ
    QXVzdHJhbGlhMQ8wDQYDVQQHDAZTeWRuZXkxEjAQBgNVBAoMCU15T3JnTmFtZTEV
    MBMGA1UEAwwMTXlDb21tb25OYW1lMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
    CgKCAQEAyEPiDsD4JXTB7AeyVsFkhKLq1jQCgtWTEQoFYW6lSnbD+yGhUcN1ntpU
    R4QSFm+NmIPHzoD3wgwZ5Fcp1Tir3HgnvKJeUhVNnPE1EZcuiO69n0W8SGqLExVK
    noEH3gI9Zygen0aHhN6b1za+m67j9FYIhbxN6jZJ83XP7t5N56trWGQ3sZA8Tsqs
    oFHTrNVjE1IugPaQs4qst/qFIRbC6z47LarUmXG2jrTAMJQBqBeaxaEWy5Ty9gNy
    nz4fqli9/faUJkyocyhOn971EDK3PSR5BV/MGWHfvcgKrsNyJh6/njQjQIGHZAZo
    ooIKEzPvoCGHfJrhYd8UKw+RkHgtWwIDAQABoxgwFjAUBgNVHREEDTALgglsb2Nh
    bGhvc3QwDQYJKoZIhvcNAQELBQADggEBAGKl+WK1Mf6g5D+bKvb5fq1GCJyLLL2I
    Skmr+HRfnCzFrrdB6uL5IHiZ5xHJ1xZkoymGF0WabcsmYDe0J19nFWUH6Jv8CeFC
    2Qz/iy+XZxWQxD17yRTpek48HxGVio4bwzGGsQN13+RVPbocqpiu3oKeO1NAei8J
    intveT0LiwsKQ6VhJ39lu0ayAWUc+5FaDwtCMjU+1uSVRivMWkAXFTol6eKG8iAJ
    kqtMaeagEkWWLb+UMV22XpaYNiTfQ2OKqUTcZUPzokNn/Mr45nRsc1ZFNie8UuiK
    6HXiFa7p6QFY74Tqot9fS1tpp63S/k70KM5/wZs7E452Bj67+TRTcOY=
    -----END CERTIFICATE-----
  server.key: |
    -----BEGIN RSA PRIVATE KEY-----
    MIIEogIBAAKCAQEAyEPiDsD4JXTB7AeyVsFkhKLq1jQCgtWTEQoFYW6lSnbD+yGh
    UcN1ntpUR4QSFm+NmIPHzoD3wgwZ5Fcp1Tir3HgnvKJeUhVNnPE1EZcuiO69n0W8
    SGqLExVKnoEH3gI9Zygen0aHhN6b1za+m67j9FYIhbxN6jZJ83XP7t5N56trWGQ3
    sZA8TsqsoFHTrNVjE1IugPaQs4qst/qFIRbC6z47LarUmXG2jrTAMJQBqBeaxaEW
    y5Ty9gNynz4fqli9/faUJkyocyhOn971EDK3PSR5BV/MGWHfvcgKrsNyJh6/njQj
    QIGHZAZoooIKEzPvoCGHfJrhYd8UKw+RkHgtWwIDAQABAoIBAGjbumK1QXkDQIKg
    qQ1p54LXdxS/WM0+nOmgEJ8qexuZQhadTkVsjYqmkNh9W6cps782yQjkWFXfVjNM
    PFgrezlOJKhNcAuUofXaCkpymWgTcXAS6HoWZ0mPrWl+8Cqbi6EWzaniGRVGJd0z
    CeykTzFhVscHiNhooqH6fux4s9vn5FDgflVpka0XuOuurF6+9inCAVJHN1C3BNLD
    tyZEFW31nR7ImOp37pEI6nE/Q2ecBT97j4kFN+hzYsH4qUYq2iAA/bR4ZLwZ17xc
    FbFeGEmVhePVpNPAQ82v36AlWQsK30y7DwPsWlYRkcpsG3QP6+TGnaBM0AFCypY4
    w12DzaECgYEA+pLx3KmVH0zaPiTXFI/RRedipYkmIlyMI+/GfuSInXSWlCSvdOV/
    PTrQoVNvsmObz73kAh2I+KGS9+7arX4O4Qm74Sb3SbCHUGa/wNyv8Nqvo9LraRR0
    RY2fgAS3UL2ZHESJX5aVXa5S3it1tu10K8c9ofpekq/uJ5IaJ81FvbECgYEAzJoN
    NRTUCR721wFo4t4OYUdbxLU8CKvj0osouQAQwYhT+EKCp1I9pqvvE4Amxi2Xmysv
    Eu4JGy4Ti3jWAwu1XwhkwzSGTuN2/ECJ7EunaFXGeYef9RqR2+JCqGadLfnZZGsN
    5/NlbZZ8+Em//9wGDmZz9ZJFnZZPSHxgKmKdYssCgYAqPatYL55b8HC6GSvI45W7
    2w3eKgirsj5NsJYdvhjpskXQI38Qjb+tasTQ7WffAru5gaF2WdRFVbeY5EMpDB8m
    AKYThqYZXhDxlOCueoWObM8/JsdYp4ISV5WT1zev/MZa5ZLi8leruz9tBJaLh+wV
    lTjmnXZj9BSJxy9xlkEzgQKBgFU8ICBq6uJZ2e88ERvh8g+okJxj+/yIz0IY4wAe
    /NwDFSgpXRCjfDeBDPoMuxp4R95GoTe7nmOKUG4cCtv99rL+ZivEJ+eZbyorIMol
    wjn+8c4TKBoN1ZHKsoZBKV3L5jqlNofYp/p9ZNZyst++I2/AUrKNGx9JTQIfflhp
    +LL9AoGAKyMMGec4MyP3KA4AEEOTShgJ0P6zSj3i/rsC8jiH6yIxSO+Ii+9BdzlF
    WblemYFFa5AwWeogycdeWwAX4YVrYAsZmmVb/zt/KvJIi9OwwtmAwGaLLl1Zqtca
    uGOifl+ukutwvmL5pzKyCP3SxwkG0F9mVWQVhg13L+/YDZ8v0tg=
    -----END RSA PRIVATE KEY-----
EOF


 docker run --rm -it --net=host -v ${PWD}:/tmp ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.81.0 --config /tmp/config.yaml  
kubectl apply -f - <<EOF
kind: OpenTelemetryCollector
apiVersion: opentelemetry.io/v1alpha1
metadata:
  name: otel4
spec:
  managementState: managed
  mode: deployment
  ingress: 
    type: route
    hostname: apps-crc.testing
    route:
      termination: passthrough
  volumes:
    - name: certs
      configMap: 
        name: certs
  volumeMounts:
    - name: certs
      mountPath: /certs
  config: |

    receivers:
      otlp:
        protocols:
          http:
          grpc:
            tls:
              cert_file: /certs/server.crt
              key_file: /certs/server.key

    exporters:
      logging:

    service:
      pipelines:
        traces:
          receivers: [otlp]
          exporters: [logging]
EOF


receivers:
  otlp:
    protocols:
      grpc:
      http:

processors:

exporters:
  otlp:
    endpoint: http://otlp-grpc.apps-crc.testing:443
    tls:
      insecure: false
      insecure_skip_verify: true
  otlphttp:
    endpoint: http://otlp-http.otel.loffay:80
    tls:
      insecure: true

extensions:
  health_check:
  pprof:
  zpages:

service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: []
      exporters: [otlp]
```