### PR TITLE
fix reconciliation error when prometheusremotewrite exporter is enabled

### DIFF
--- a/internal/manifests/collector/container.go
+++ b/internal/manifests/collector/container.go
@@ -220,7 +220,7 @@ func getPrometheusExporterPorts(c map[interface{}]interface{}) ([]corev1.Contain
 	if exporters, ok := c["exporters"]; ok && exporters != nil {
 		for e, exporterConfig := range exporters.(map[interface{}]interface{}) {
 			exporterName := e.(string)
-			if strings.Contains(exporterName, "prometheus") {
+			if exporterName == "prometheus" || strings.HasPrefix(exporterName, "prometheus/") {
 				containerPort, err := getPrometheusExporterPort(exporterConfig.(map[interface{}]interface{}))
 				if err != nil {
 					errors = append(errors,
@@ -229,6 +229,7 @@ func getPrometheusExporterPorts(c map[interface{}]interface{}) ([]corev1.Contain
 							exporterName,
 						),
 					)
+					continue
 				}
 				ports = append(ports,
 					corev1.ContainerPort{

--- a/internal/manifests/collector/container_test.go
+++ b/internal/manifests/collector/container_test.go
@@ -214,6 +214,23 @@ service:
 				},
 			},
 		},
+		{
+			description: "prometheus and prometheusremotewrite exporters",
+			specConfig: `exporters:
+    prometheus:
+        endpoint: "0.0.0.0:9090"
+    prometheusremotewrite:
+        endpoint: "https://example.com/api/v1/write"`,
+			specPorts: []corev1.ServicePort{},
+			expectedPorts: []corev1.ContainerPort{
+				metricContainerPort,
+				{
+					Name:          "prometheus",
+					ContainerPort: 9090,
+					Protocol:      corev1.ProtocolTCP,
+				},
+			},
+		},
 	}
 
 	for _, testCase := range tests {


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-operator/pull/1953 introduced the following error when prometheusremotewrite exporter is enabled

	failed to reconcile the expected deployments: failed to apply changes: Deployment.apps "cluster-collector" is invalid: spec.template.spec.containers[0].ports[3].containerPort: Required value"

required configuration is:

	exporters:
	  prometheusremotewrite:
	    endpoint: "https://example.com/api/v1/write"

getPrometheusExporterPorts() tries to parse this endpoint into a host:port pair, because the exporter name contains the string "prometheus", but prometheusremotewriteexporter's expected `endpoint` configuration is actually a URL, so that fails. additionally, due to a missing `continue` if the port parsing fails, an erroneous ContainerPort entry with port set to 0 is added to the configuration, causing the error.