### PR TITLE
[chore] Fix ci runner

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,7 +28,8 @@ jobs:
        - "1.19"
        - "1.27"
        group:
-         - e2e e2e-upgrade
+         - e2e
+         - e2e-upgrade
          - e2e-prometheuscr
          - e2e-autoscale
 


### PR DESCRIPTION
Looks like we accidentally combined e2e and upgrade which meant upgrade never ran and e2e ran twice