### PR TITLE
Fixes reconciling Internal Traffic Policy changes and adds test

### DIFF
--- a/.chloggen/fix-otel-collector-service-reconciliation.yaml
+++ b/.chloggen/fix-otel-collector-service-reconciliation.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes reconciling otel-collector service's internal traffic policy changes.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/fix-otel-collector-service-reconciliation.yaml
+++ b/.chloggen/fix-otel-collector-service-reconciliation.yaml
@@ -8,7 +8,7 @@ component: operator
 note: Fixes reconciling otel-collector service's internal traffic policy changes.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [2061]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/collector/reconcile/service.go
+++ b/pkg/collector/reconcile/service.go
@@ -104,6 +104,7 @@ func expectedServices(ctx context.Context, params manifests.Params, expected []*
 		}
 		updated.Spec.Ports = desired.Spec.Ports
 		updated.Spec.Selector = desired.Spec.Selector
+		updated.Spec.InternalTrafficPolicy = desired.Spec.InternalTrafficPolicy
 
 		patch := client.MergeFrom(existing)
 


### PR DESCRIPTION
This PR fixes #2061 and adds a unit test for that case.