### PR TITLE
.NET auto-instrumentation include musl in docker image

### DIFF
--- a/autoinstrumentation/dotnet/Dockerfile
+++ b/autoinstrumentation/dotnet/Dockerfile
@@ -26,4 +26,6 @@ RUN wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/
 RUN unzip opentelemetry-dotnet-instrumentation-linux-glibc.zip
 RUN unzip opentelemetry-dotnet-instrumentation-linux-musl.zip "linux-musl-x64/*" -d .
 
+RUN rm opentelemetry-dotnet-instrumentation-linux-glibc.zip opentelemetry-dotnet-instrumentation-linux-musl.zip
+
 RUN chmod -R go+r .

--- a/autoinstrumentation/dotnet/Dockerfile
+++ b/autoinstrumentation/dotnet/Dockerfile
@@ -20,8 +20,8 @@ ARG version
 
 WORKDIR /autoinstrumentation
 
-RUN wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc.zip &&\
-    wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl.zip &&\
+RUN wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v${version}/opentelemetry-dotnet-instrumentation-linux-glibc.zip &&\
+    wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v${version}/opentelemetry-dotnet-instrumentation-linux-musl.zip &&\
     unzip opentelemetry-dotnet-instrumentation-linux-glibc.zip &&\
     unzip opentelemetry-dotnet-instrumentation-linux-musl.zip "linux-musl-x64/*" -d . &&\
     rm opentelemetry-dotnet-instrumentation-linux-glibc.zip opentelemetry-dotnet-instrumentation-linux-musl.zip &&\

--- a/autoinstrumentation/dotnet/Dockerfile
+++ b/autoinstrumentation/dotnet/Dockerfile
@@ -20,9 +20,10 @@ ARG version
 
 WORKDIR /autoinstrumentation
 
-RUN wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v${version}/opentelemetry-dotnet-instrumentation-linux-glibc.zip &&\
-    wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v${version}/opentelemetry-dotnet-instrumentation-linux-musl.zip &&\
-    unzip opentelemetry-dotnet-instrumentation-linux-glibc.zip &&\
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc.zip .
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl.zip .
+
+RUN unzip opentelemetry-dotnet-instrumentation-linux-glibc.zip &&\
     unzip opentelemetry-dotnet-instrumentation-linux-musl.zip "linux-musl-x64/*" -d . &&\
     rm opentelemetry-dotnet-instrumentation-linux-glibc.zip opentelemetry-dotnet-instrumentation-linux-musl.zip &&\
     chmod -R go+r .

--- a/autoinstrumentation/dotnet/Dockerfile
+++ b/autoinstrumentation/dotnet/Dockerfile
@@ -5,7 +5,7 @@
 #  - Following environment variables are injected to the application container to enable the auto-instrumentation.
 #    CORECLR_ENABLE_PROFILING=1
 #    CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
-#    CORECLR_PROFILER_PATH=%InstallationLocation%/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so # for glbic based images
+#    CORECLR_PROFILER_PATH=%InstallationLocation%/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so # for glibc based images
 #    CORECLR_PROFILER_PATH=%InstallationLocation%/linux-musl-x64/OpenTelemetry.AutoInstrumentation.Native.so # for musl based images
 #    DOTNET_ADDITIONAL_DEPS=%InstallationLocation%/AdditionalDeps
 #    DOTNET_SHARED_STORE=%InstallationLocation%/store

--- a/autoinstrumentation/dotnet/Dockerfile
+++ b/autoinstrumentation/dotnet/Dockerfile
@@ -20,8 +20,8 @@ ARG version
 
 WORKDIR /autoinstrumentation
 
-ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc.zip .
-ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl.zip .
+RUN wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc.zip
+RUN wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl.zip
 
 RUN unzip opentelemetry-dotnet-instrumentation-linux-glibc.zip
 RUN unzip opentelemetry-dotnet-instrumentation-linux-musl.zip "linux-musl-x64/*" -d .

--- a/autoinstrumentation/dotnet/Dockerfile
+++ b/autoinstrumentation/dotnet/Dockerfile
@@ -5,7 +5,8 @@
 #  - Following environment variables are injected to the application container to enable the auto-instrumentation.
 #    CORECLR_ENABLE_PROFILING=1
 #    CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
-#    CORECLR_PROFILER_PATH=%InstallationLocation%/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so
+#    CORECLR_PROFILER_PATH=%InstallationLocation%/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so # for glbic based images
+#    CORECLR_PROFILER_PATH=%InstallationLocation%/linux-musl-x64/OpenTelemetry.AutoInstrumentation.Native.so # for musl based images
 #    DOTNET_ADDITIONAL_DEPS=%InstallationLocation%/AdditionalDeps
 #    DOTNET_SHARED_STORE=%InstallationLocation%/store
 #    DOTNET_STARTUP_HOOKS=%InstallationLocation%/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll 
@@ -20,7 +21,9 @@ ARG version
 WORKDIR /autoinstrumentation
 
 ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc.zip .
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl.zip .
 
 RUN unzip opentelemetry-dotnet-instrumentation-linux-glibc.zip
+RUN unzip opentelemetry-dotnet-instrumentation-linux-musl.zip "linux-musl-x64/*" -d .
 
 RUN chmod -R go+r .

--- a/autoinstrumentation/dotnet/Dockerfile
+++ b/autoinstrumentation/dotnet/Dockerfile
@@ -20,12 +20,9 @@ ARG version
 
 WORKDIR /autoinstrumentation
 
-RUN wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc.zip
-RUN wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl.zip
-
-RUN unzip opentelemetry-dotnet-instrumentation-linux-glibc.zip
-RUN unzip opentelemetry-dotnet-instrumentation-linux-musl.zip "linux-musl-x64/*" -d .
-
-RUN rm opentelemetry-dotnet-instrumentation-linux-glibc.zip opentelemetry-dotnet-instrumentation-linux-musl.zip
-
-RUN chmod -R go+r .
+RUN wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc.zip &&\
+    wget https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl.zip &&\
+    unzip opentelemetry-dotnet-instrumentation-linux-glibc.zip &&\
+    unzip opentelemetry-dotnet-instrumentation-linux-musl.zip "linux-musl-x64/*" -d . &&\
+    rm opentelemetry-dotnet-instrumentation-linux-glibc.zip opentelemetry-dotnet-instrumentation-linux-musl.zip &&\
+    chmod -R go+r .


### PR DESCRIPTION
Towards #1849

## Changes in the docker image
 - includes musl version
 - remove redundant, zip files from final image
 - execute commands in a batch, to reduce number of layers in final image

## Tests

Tested locally with defined spec->dotnet->image

```yaml
apiVersion: opentelemetry.io/v1alpha1
kind: Instrumentation
metadata:
  name: my-instrumentation
spec:
  exporter:
    endpoint: http://otel-collector:4317
  propagators:
    - tracecontext
    - baggage
    - b3
  sampler:
    type: parentbased_traceidratio
    argument: "0.25"
  python:
    env:
      # Required if endpoint is set to 4317.
      # Python autoinstrumentation uses http/proto by default
      # so data must be sent to 4318 instead of 4317.
      - name: OTEL_EXPORTER_OTLP_ENDPOINT
        value: http://otel-collector:4318
  dotnet:
    image: local-auto:dotnet
    env:
      # Required if endpoint is set to 4317.
      # Dotnet autoinstrumentation uses http/proto by default
      # See https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/blob/888e2cd216c77d12e56b54ee91dafbc4e7452a52/docs/config.md#otlp
      - name: OTEL_EXPORTER_OTLP_ENDPOINT
        value: http://otel-collector:4318
```

By application hosted on alpine linux. with manually redefined environmental variable (operator is not injecting variable if it is already in place).
```
        env:
          - name: "CORECLR_PROFILER_PATH"
            value: "/otel-auto-instrumentation/linux-musl-x64/OpenTelemetry.AutoInstrumentation.Native.so"
```

Checked also debian (glibc) based without any changes. It is working correctly.

## Notes

Changelog will be included into follow up PR with support for annotations.
~~I am marking this as [chore], as I do not have privileges to add `Skip Changelog` label. If possible, please change it.~~ Mikołaj, thanks.

It will be great to merge it even without follow up PR. It should unblock at least some scenarios and make the further development easier.