### PR TITLE
[chore] Update go version used in workflows

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.21"
+        go-version: "~1.21.8"
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.21"
+        go-version: "~1.21.8"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "~1.21.8"
+        go-version: "~1.21.1"
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: "~1.21.8"
+        go-version: "~1.21.1"
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: "~1.21.8"
+        go-version: "~1.21.1"
 
     - name: Setup kind
       env:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: "1.21"
+        go-version: "~1.21.8"
 
     - name: Setup kind
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "~1.21.8"
+        go-version: "~1.21.1"
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.21"
+        go-version: "~1.21.8"
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "~1.21.8"
+          go-version: "~1.21.1"
 
       - name: Setup kind
         env:

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "~1.21.8"
 
       - name: Setup kind
         env:


### PR DESCRIPTION
This is a defensive PR to force a minimum go version used in gha workflows. The latest patch version contains security fixes.