### PR TITLE
[autoinstrumentation] bump go autoinstrumentation to 0.3.0-alpha

### DIFF
--- a/.chloggen/bump-go-autoinstrumentation.yaml
+++ b/.chloggen/bump-go-autoinstrumentation.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: autoinstrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bump Go auto-instrumentation support to v0.3.0-alpha.
+
+# One or more tracking issues related to the change
+issues: [2123]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/tests/e2e-instrumentation/instrumentation-go/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-go/02-assert.yaml
@@ -19,7 +19,7 @@ spec:
         requests:
           cpu: "50m"
           memory: "32Mi"
-      image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.2.2-alpha
+      image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.3.0-alpha
       env:
         - name: OTEL_GO_AUTO_TARGET_EXE
           value: /usr/src/app/productcatalogservice

--- a/versions.txt
+++ b/versions.txt
@@ -30,7 +30,7 @@ autoinstrumentation-python=0.40b0
 autoinstrumentation-dotnet=1.0.0
 
 # Represents the current release of Go instrumentation.
-autoinstrumentation-go=v0.2.2-alpha
+autoinstrumentation-go=v0.3.0-alpha
 
 # Represents the current release of Apache HTTPD instrumentation.
 # Should match autoinstrumentation/apache-httpd/version.txt


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/tag/v0.3.0-alpha