### PR TITLE
Clarify namespace requirements for Instrumentation objects when auto-instrumenting

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ When using sidecar mode the OpenTelemetry collector container will have the envi
 
 The operator can inject and configure OpenTelemetry auto-instrumentation libraries. Currently Apache HTTPD, DotNet, Go, Java, NodeJS and Python are supported.
 
-To use auto-instrumentation, configure an `Instrumentation` resource with the configuration for the SDK and instrumentation.
+To use auto-instrumentation, configure an `Instrumentation` resource with the configuration for the SDK and instrumentation. This resource must be created within the **same namespace** as the applications being auto-instrumented.
 
 ```yaml
 kubectl apply -f - <<EOF


### PR DESCRIPTION
This PR adds a small clarification to the readme that `Instrumentation` CRDs must be created in the same namespace as the auto-instrumented applications (as opposed to the namespace the operator or collector are running in). 

If they are not in the same namespace, users will see no changes made to their annotated deployments and the operator will generate the error:

```
no OpenTelemetry Instrumentation instances available
```

Which makes sense, but is not immediately obvious how to fix if the users are not deeply familiar with Kubernetes and operators.