### PR TITLE
Run an initContainer on an enabled flag

### DIFF
--- a/.chloggen/init-container.yaml
+++ b/.chloggen/init-container.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: adds a new runValidation field in the collector CRD to run the collector's `validate` command as an init container
+
+# One or more tracking issues related to the change
+issues: [1771]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -97,6 +97,10 @@ type OpenTelemetryCollectorSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default:=managed
 	ManagementState ManagementStateType `json:"managementState,omitempty"`
+	// RunValidation enables the operator to automatically run the collector's validate command
+	// as an initContainer to prevent the rollout of potentially bad configuration.
+	// +optional
+	RunValidation bool `json:"runValidation,omitempty"`
 	// Resources to set on the OpenTelemetry Collector pods.
 	// +optional
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`

--- a/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -31,7 +31,7 @@ metadata:
     categories: Logging & Tracing,Monitoring
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2023-09-20T15:05:15Z"
+    createdAt: "2023-09-27T17:23:38Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -3944,6 +3944,11 @@ spec:
                       resources required.
                     type: object
                 type: object
+              runValidation:
+                description: RunValidation enables the operator to automatically run
+                  the collector's validate command as an initContainer to prevent
+                  the rollout of potentially bad configuration.
+                type: boolean
               securityContext:
                 description: SecurityContext configures the container security context
                   for the opentelemetry-collector container.

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -3941,6 +3941,11 @@ spec:
                       resources required.
                     type: object
                 type: object
+              runValidation:
+                description: RunValidation enables the operator to automatically run
+                  the collector's validate command as an initContainer to prevent
+                  the rollout of potentially bad configuration.
+                type: boolean
               securityContext:
                 description: SecurityContext configures the container security context
                   for the opentelemetry-collector container.

--- a/docs/api.md
+++ b/docs/api.md
@@ -3854,6 +3854,13 @@ OpenTelemetryCollectorSpec defines the desired state of OpenTelemetryCollector.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>runValidation</b></td>
+        <td>boolean</td>
+        <td>
+          RunValidation enables the operator to automatically run the collector's validate command as an initContainer to prevent the rollout of potentially bad configuration.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#opentelemetrycollectorspecsecuritycontext">securityContext</a></b></td>
         <td>object</td>
         <td>

--- a/internal/manifests/collector/daemonset.go
+++ b/internal/manifests/collector/daemonset.go
@@ -50,7 +50,7 @@ func DaemonSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: ServiceAccountName(otelcol),
-					InitContainers:     otelcol.Spec.InitContainers,
+					InitContainers:     InitContainers(cfg, logger, otelcol),
 					Containers:         append(otelcol.Spec.AdditionalContainers, Container(cfg, logger, otelcol, true)),
 					Volumes:            Volumes(cfg, otelcol),
 					Tolerations:        otelcol.Spec.Tolerations,

--- a/internal/manifests/collector/deployment.go
+++ b/internal/manifests/collector/deployment.go
@@ -52,7 +52,7 @@ func Deployment(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTele
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            ServiceAccountName(otelcol),
-					InitContainers:                otelcol.Spec.InitContainers,
+					InitContainers:                InitContainers(cfg, logger, otelcol),
 					Containers:                    append(otelcol.Spec.AdditionalContainers, Container(cfg, logger, otelcol, true)),
 					Volumes:                       Volumes(cfg, otelcol),
 					DNSPolicy:                     getDNSPolicy(otelcol),

--- a/internal/manifests/collector/init_containers.go
+++ b/internal/manifests/collector/init_containers.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+)
+
+func InitContainers(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) []corev1.Container {
+	if !otelcol.Spec.RunValidation {
+		return otelcol.Spec.InitContainers
+	}
+	c := Container(cfg, logger, otelcol, true)
+	c.Name = fmt.Sprintf("init-%s", c.Name)
+	c.Args = append([]string{"validate"}, c.Args...)
+	// Manually disable any unsupported init container fields
+	c.LivenessProbe = nil
+	c.ReadinessProbe = nil
+	c.Lifecycle = nil
+	c.StartupProbe = nil
+	c.Ports = nil
+	return append(otelcol.Spec.InitContainers, c)
+}

--- a/internal/manifests/collector/init_containers_test.go
+++ b/internal/manifests/collector/init_containers_test.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
+)
+
+func TestInitContainers(t *testing.T) {
+	params := deploymentParams()
+	type args struct {
+		flagState bool
+		otelcol   v1alpha1.OpenTelemetryCollector
+	}
+	tests := []struct {
+		name string
+		args args
+		want []corev1.Container
+	}{
+		{
+			name: "flag disabled",
+			args: args{
+				flagState: false,
+				otelcol:   params.Instance,
+			},
+			want: params.Instance.Spec.InitContainers,
+		},
+		{
+			name: "flag enabled",
+			args: args{
+				flagState: true,
+				otelcol:   params.Instance,
+			},
+			want: append(params.Instance.Spec.InitContainers, corev1.Container{
+				Name:  "init-otc-container",
+				Image: params.Instance.Spec.Image,
+				Args:  []string{"validate", "--config=/conf/collector.yaml"},
+				Env: []corev1.EnvVar{
+					{
+						Name: "POD_NAME",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								FieldPath: "metadata.name",
+							},
+						},
+					},
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      naming.ConfigMapVolume(),
+						MountPath: "/conf",
+					},
+				},
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.args.otelcol.Spec.RunValidation = tt.args.flagState
+			assert.Equalf(t, tt.want, InitContainers(params.Config, params.Log, tt.args.otelcol), "InitContainers(%v)", tt.args.otelcol)
+		})
+	}
+}

--- a/internal/manifests/collector/statefulset.go
+++ b/internal/manifests/collector/statefulset.go
@@ -52,7 +52,7 @@ func StatefulSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTel
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:        ServiceAccountName(otelcol),
-					InitContainers:            otelcol.Spec.InitContainers,
+					InitContainers:            InitContainers(cfg, logger, otelcol),
 					Containers:                append(otelcol.Spec.AdditionalContainers, Container(cfg, logger, otelcol, true)),
 					Volumes:                   Volumes(cfg, otelcol),
 					DNSPolicy:                 getDNSPolicy(otelcol),

--- a/tests/e2e/smoke-validation/00-assert.yaml
+++ b/tests/e2e/smoke-validation/00-assert.yaml
@@ -18,16 +18,6 @@ spec:
     port: 14250
     protocol: TCP
     targetPort: 14250
-  - appProtocol: grpc
-    name: otlp-grpc
-    port: 4317
-    protocol: TCP
-    targetPort: 4317
-  - appProtocol: http
-    name: otlp-http
-    port: 4318
-    protocol: TCP
-    targetPort: 4318
 
 ---
 
@@ -42,13 +32,3 @@ spec:
     port: 14250
     protocol: TCP
     targetPort: 14250
-  - appProtocol: grpc
-    name: otlp-grpc
-    port: 4317
-    protocol: TCP
-    targetPort: 4317
-  - appProtocol: http
-    name: otlp-http
-    port: 4318
-    protocol: TCP
-    targetPort: 4318

--- a/tests/e2e/smoke-validation/00-assert.yaml
+++ b/tests/e2e/smoke-validation/00-assert.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simplest-collector
+status:
+  unavailableReplicas: 1
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: simplest-collector-headless
+spec:
+  ports:
+  - appProtocol: grpc
+    name: jaeger-grpc
+    port: 14250
+    protocol: TCP
+    targetPort: 14250
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: simplest-collector
+spec:
+  ports:
+  - appProtocol: grpc
+    name: jaeger-grpc
+    port: 14250
+    protocol: TCP
+    targetPort: 14250
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318

--- a/tests/e2e/smoke-validation/00-install.yaml
+++ b/tests/e2e/smoke-validation/00-install.yaml
@@ -1,0 +1,25 @@
+# Install a bad config
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+spec:
+  runValidation: true
+  config: |
+    receivers:
+      jaeger:
+        protocols:
+          grpc:
+      otlp:
+        protocols:
+    processors:
+
+    exporters:
+      logging:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [jaeger,otlp]
+          processors: []
+          exporters: [logging]

--- a/tests/e2e/smoke-validation/01-assert.yaml
+++ b/tests/e2e/smoke-validation/01-assert.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simplest-collector
+status:
+  readyReplicas: 1
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: simplest-collector-headless
+spec:
+  ports:
+  - appProtocol: grpc
+    name: jaeger-grpc
+    port: 14250
+    protocol: TCP
+    targetPort: 14250
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: simplest-collector
+spec:
+  ports:
+  - appProtocol: grpc
+    name: jaeger-grpc
+    port: 14250
+    protocol: TCP
+    targetPort: 14250
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318

--- a/tests/e2e/smoke-validation/01-install.yaml
+++ b/tests/e2e/smoke-validation/01-install.yaml
@@ -1,0 +1,27 @@
+# Install a good config which will replace the bad
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+spec:
+  runValidation: true
+  config: |
+    receivers:
+      jaeger:
+        protocols:
+          grpc:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+
+    exporters:
+      logging:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [jaeger,otlp]
+          processors: []
+          exporters: [logging]


### PR DESCRIPTION
closes #1771 

This PR adds a new field to the collector CRD which will automatically add an init container that runs the collector's validate command. This will ensure that no pods roll out with potentially invalid config.