### PR TITLE
Enable discovery manager metrics in target allocator

### DIFF
--- a/.chloggen/discoverymanager_metrics.yaml
+++ b/.chloggen/discoverymanager_metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable discovery manager metrics in target allocator
+
+# One or more tracking issues related to the change
+issues: [2170]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -90,6 +90,8 @@ func main() {
 
 	discoveryCtx, discoveryCancel := context.WithCancel(ctx)
 	discoveryManager = discovery.NewManager(discoveryCtx, gokitlog.NewNopLogger())
+	discovery.RegisterMetrics() // discovery manager metrics need to be enabled explicitly
+
 	targetDiscoverer = target.NewDiscoverer(log, discoveryManager, allocatorPrehook, srv)
 	collectorWatcher, collectorWatcherErr := collector.NewClient(log, cfg.ClusterConfig)
 	if collectorWatcherErr != nil {


### PR DESCRIPTION
This adds the following metrics:

`prometheus_sd_failed_configs`
`prometheus_sd_discovered_targets`
`prometheus_sd_received_updates_total`
`prometheus_sd_updates_delayed_total`
`prometheus_sd_updates_total`

I was trying to profile the target allocator in a busy cluster, and would've found these very useful. I have tested manually that this works, but haven't found a reasonable way to unit test it.

Resolves #2170 