### PR TITLE
[chore] Change instance to otelcol for reconciliation

### DIFF
--- a/controllers/builder_test.go
+++ b/controllers/builder_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
 var (
@@ -40,7 +41,7 @@ var (
 	pathTypePrefix = networkingv1.PathTypePrefix
 )
 
-func TestBuildAll(t *testing.T) {
+func TestBuildCollector(t *testing.T) {
 	var goodConfig = `receivers:
   examplereceiver:
     endpoint: "0.0.0.0:12345"
@@ -585,12 +586,12 @@ service:
 				config.WithCollectorImage("default-collector"),
 				config.WithTargetAllocatorImage("default-ta-allocator"),
 			)
-			reconciler := NewReconciler(Params{
-				Log:    logr.Discard(),
-				Config: cfg,
-			})
-			params := reconciler.getParams(tt.args.instance)
-			got, err := reconciler.BuildAll(params)
+			params := manifests.Params{
+				Log:     logr.Discard(),
+				Config:  cfg,
+				OtelCol: tt.args.instance,
+			}
+			got, err := BuildCollector(params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildAll() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -1,0 +1,100 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/targetallocator"
+)
+
+func isNamespaceScoped(obj client.Object) bool {
+	switch obj.(type) {
+	case *rbacv1.ClusterRole, *rbacv1.ClusterRoleBinding:
+		return false
+	default:
+		return true
+	}
+}
+
+// BuildCollector returns the generation and collected errors of all manifests for a given instance.
+func BuildCollector(params manifests.Params) ([]client.Object, error) {
+	builders := []manifests.Builder{
+		collector.Build,
+		targetallocator.Build,
+	}
+	var resources []client.Object
+	for _, builder := range builders {
+		objs, err := builder(params)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, objs...)
+	}
+	return resources, nil
+}
+
+// reconcileDesiredObjects runs the reconcile process using the mutateFn over the given list of objects.
+func reconcileDesiredObjects(ctx context.Context, kubeClient client.Client, logger logr.Logger, owner metav1.Object, scheme *runtime.Scheme, desiredObjects ...client.Object) error {
+	var errs []error
+	for _, desired := range desiredObjects {
+		l := logger.WithValues(
+			"object_name", desired.GetName(),
+			"object_kind", desired.GetObjectKind(),
+		)
+		if isNamespaceScoped(desired) {
+			if setErr := ctrl.SetControllerReference(owner, desired, scheme); setErr != nil {
+				l.Error(setErr, "failed to set controller owner reference to desired")
+				errs = append(errs, setErr)
+				continue
+			}
+		}
+
+		// existing is an object the controller runtime will hydrate for us
+		// we obtain the existing object by deep copying the desired object because it's the most convenient way
+		existing := desired.DeepCopyObject().(client.Object)
+		mutateFn := manifests.MutateFuncFor(existing, desired)
+		op, crudErr := ctrl.CreateOrUpdate(ctx, kubeClient, existing, mutateFn)
+		if crudErr != nil && errors.Is(crudErr, manifests.ImmutableChangeErr) {
+			l.Error(crudErr, "detected immutable field change, trying to delete, new object will be created on next reconcile", "existing", existing.GetName())
+			delErr := kubeClient.Delete(ctx, existing)
+			if delErr != nil {
+				return delErr
+			}
+			continue
+		} else if crudErr != nil {
+			l.Error(crudErr, "failed to configure desired")
+			errs = append(errs, crudErr)
+			continue
+		}
+
+		l.V(1).Info(fmt.Sprintf("desired has been %s", op))
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to create objects for %s: %w", owner.GetName(), errors.Join(errs...))
+	}
+	return nil
+}

--- a/controllers/opentelemetrycollector_controller.go
+++ b/controllers/opentelemetrycollector_controller.go
@@ -17,7 +17,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -26,7 +25,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -36,8 +34,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/targetallocator"
 	"github.com/open-telemetry/opentelemetry-operator/internal/status"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/autodetect"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/reconcile"
@@ -118,67 +114,11 @@ func (r *OpenTelemetryCollectorReconciler) removeRouteTask(ora autodetect.OpenSh
 	return nil
 }
 
-func (r *OpenTelemetryCollectorReconciler) doCRUD(ctx context.Context, params manifests.Params) error {
-	// Collect all objects owned by the operator, to be able to prune objects
-	// which exist in the cluster but are not managed by the operator anymore.
-	desiredObjects, err := r.BuildAll(params)
-	if err != nil {
-		return err
-	}
-	var errs []error
-	for _, desired := range desiredObjects {
-		l := r.log.WithValues(
-			"object_name", desired.GetName(),
-			"object_kind", desired.GetObjectKind(),
-		)
-		if isNamespaceScoped(desired) {
-			if setErr := ctrl.SetControllerReference(&params.Instance, desired, params.Scheme); setErr != nil {
-				l.Error(setErr, "failed to set controller owner reference to desired")
-				errs = append(errs, setErr)
-				continue
-			}
-		}
-
-		// existing is an object the controller runtime will hydrate for us
-		// we obtain the existing object by deep copying the desired object because it's the most convenient way
-		existing := desired.DeepCopyObject().(client.Object)
-		mutateFn := manifests.MutateFuncFor(existing, desired)
-		op, crudErr := ctrl.CreateOrUpdate(ctx, r.Client, existing, mutateFn)
-		if crudErr != nil && errors.Is(crudErr, manifests.ImmutableChangeErr) {
-			l.Error(crudErr, "detected immutable field change, trying to delete, new object will be created on next reconcile", "existing", existing.GetName())
-			delErr := r.Client.Delete(ctx, existing)
-			if delErr != nil {
-				return delErr
-			}
-			continue
-		} else if crudErr != nil {
-			l.Error(crudErr, "failed to configure desired")
-			errs = append(errs, crudErr)
-			continue
-		}
-
-		l.V(1).Info(fmt.Sprintf("desired has been %s", op))
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to create objects for Collector %s: %w", params.Instance.GetName(), errors.Join(errs...))
-	}
-	return nil
-}
-
-func isNamespaceScoped(obj client.Object) bool {
-	switch obj.(type) {
-	case *rbacv1.ClusterRole, *rbacv1.ClusterRoleBinding:
-		return false
-	default:
-		return true
-	}
-}
-
 func (r *OpenTelemetryCollectorReconciler) getParams(instance v1alpha1.OpenTelemetryCollector) manifests.Params {
 	return manifests.Params{
 		Config:   r.config,
 		Client:   r.Client,
-		Instance: instance,
+		OtelCol:  instance,
 		Log:      r.log,
 		Scheme:   r.scheme,
 		Recorder: r.recorder,
@@ -243,7 +183,11 @@ func (r *OpenTelemetryCollectorReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
-	err := r.doCRUD(ctx, params)
+	desiredObjects, buildErr := BuildCollector(params)
+	if buildErr != nil {
+		return ctrl.Result{}, buildErr
+	}
+	err := reconcileDesiredObjects(ctx, r.Client, log, &params.OtelCol, params.Scheme, desiredObjects...)
 	return status.HandleReconcileStatus(ctx, log, params, err)
 }
 
@@ -255,7 +199,7 @@ func (r *OpenTelemetryCollectorReconciler) RunTasks(ctx context.Context, params 
 		if err := task.Do(ctx, params); err != nil {
 			// If we get an error that occurs because a pod is being terminated, then exit this loop
 			if apierrors.IsForbidden(err) && apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
-				r.log.V(2).Info("Exiting reconcile loop because namespace is being terminated", "namespace", params.Instance.Namespace)
+				r.log.V(2).Info("Exiting reconcile loop because namespace is being terminated", "namespace", params.OtelCol.Namespace)
 				return nil
 			}
 			r.log.Error(err, fmt.Sprintf("failed to reconcile %s", task.Name))
@@ -265,23 +209,6 @@ func (r *OpenTelemetryCollectorReconciler) RunTasks(ctx context.Context, params 
 		}
 	}
 	return nil
-}
-
-// BuildAll returns the generation and collected errors of all manifests for a given instance.
-func (r *OpenTelemetryCollectorReconciler) BuildAll(params manifests.Params) ([]client.Object, error) {
-	builders := []manifests.Builder{
-		collector.Build,
-		targetallocator.Build,
-	}
-	var resources []client.Object
-	for _, builder := range builders {
-		objs, err := builder(params)
-		if err != nil {
-			return nil, err
-		}
-		resources = append(resources, objs...)
-	}
-	return resources, nil
 }
 
 // SetupWithManager tells the manager what our controller is interested in.

--- a/controllers/reconcile_test.go
+++ b/controllers/reconcile_test.go
@@ -65,34 +65,34 @@ func newParamsAssertNoErr(t *testing.T, taContainerImage string, file string) ma
 	p, err := newParams(taContainerImage, file)
 	assert.NoError(t, err)
 	if len(taContainerImage) == 0 {
-		p.Instance.Spec.TargetAllocator.Enabled = false
+		p.OtelCol.Spec.TargetAllocator.Enabled = false
 	}
 	return p
 }
 
 func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 	addedMetadataDeployment := paramsWithMode(v1alpha1.ModeDeployment)
-	addedMetadataDeployment.Instance.Labels = map[string]string{
+	addedMetadataDeployment.OtelCol.Labels = map[string]string{
 		labelName: labelVal,
 	}
-	addedMetadataDeployment.Instance.Annotations = map[string]string{
+	addedMetadataDeployment.OtelCol.Annotations = map[string]string{
 		annotationName: annotationVal,
 	}
 	deploymentExtraPorts := paramsWithModeAndReplicas(v1alpha1.ModeDeployment, 3)
-	deploymentExtraPorts.Instance.Spec.Ports = append(deploymentExtraPorts.Instance.Spec.Ports, extraPorts)
+	deploymentExtraPorts.OtelCol.Spec.Ports = append(deploymentExtraPorts.OtelCol.Spec.Ports, extraPorts)
 	ingressParams := newParamsAssertNoErr(t, "", testFileIngress)
-	ingressParams.Instance.Spec.Ingress.Type = "ingress"
+	ingressParams.OtelCol.Spec.Ingress.Type = "ingress"
 	updatedIngressParams := newParamsAssertNoErr(t, "", testFileIngress)
-	updatedIngressParams.Instance.Spec.Ingress.Type = "ingress"
-	updatedIngressParams.Instance.Spec.Ingress.Annotations = map[string]string{"blub": "blob"}
-	updatedIngressParams.Instance.Spec.Ingress.Hostname = expectHostname
+	updatedIngressParams.OtelCol.Spec.Ingress.Type = "ingress"
+	updatedIngressParams.OtelCol.Spec.Ingress.Annotations = map[string]string{"blub": "blob"}
+	updatedIngressParams.OtelCol.Spec.Ingress.Hostname = expectHostname
 	routeParams := newParamsAssertNoErr(t, "", testFileIngress)
-	routeParams.Instance.Spec.Ingress.Type = v1alpha1.IngressTypeRoute
-	routeParams.Instance.Spec.Ingress.Route.Termination = v1alpha1.TLSRouteTerminationTypeInsecure
+	routeParams.OtelCol.Spec.Ingress.Type = v1alpha1.IngressTypeRoute
+	routeParams.OtelCol.Spec.Ingress.Route.Termination = v1alpha1.TLSRouteTerminationTypeInsecure
 	updatedRouteParams := newParamsAssertNoErr(t, "", testFileIngress)
-	updatedRouteParams.Instance.Spec.Ingress.Type = v1alpha1.IngressTypeRoute
-	updatedRouteParams.Instance.Spec.Ingress.Route.Termination = v1alpha1.TLSRouteTerminationTypeInsecure
-	updatedRouteParams.Instance.Spec.Ingress.Hostname = expectHostname
+	updatedRouteParams.OtelCol.Spec.Ingress.Type = v1alpha1.IngressTypeRoute
+	updatedRouteParams.OtelCol.Spec.Ingress.Route.Termination = v1alpha1.TLSRouteTerminationTypeInsecure
+	updatedRouteParams.OtelCol.Spec.Ingress.Hostname = expectHostname
 
 	type args struct {
 		params manifests.Params
@@ -389,7 +389,7 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 							assert.NoError(t, err)
 							assert.True(t, exists)
 
-							promConfig, err := ta.ConfigToPromConfig(newParamsAssertNoErr(t, baseTaImage, promFile).Instance.Spec.Config)
+							promConfig, err := ta.ConfigToPromConfig(newParamsAssertNoErr(t, baseTaImage, promFile).OtelCol.Spec.Config)
 							assert.NoError(t, err)
 
 							taConfig := make(map[interface{}]interface{})
@@ -452,7 +452,7 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testContext := context.Background()
-			nsn := types.NamespacedName{Name: tt.args.params.Instance.Name, Namespace: tt.args.params.Instance.Namespace}
+			nsn := types.NamespacedName{Name: tt.args.params.OtelCol.Name, Namespace: tt.args.params.OtelCol.Namespace}
 			reconciler := controllers.NewReconciler(controllers.Params{
 				Client:   k8sClient,
 				Log:      logger,
@@ -465,7 +465,7 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 			})
 			assert.True(t, len(tt.want) > 0, "must have at least one group of checks to run")
 			firstCheck := tt.want[0]
-			createErr := k8sClient.Create(testContext, &tt.args.params.Instance)
+			createErr := k8sClient.Create(testContext, &tt.args.params.OtelCol)
 			if !firstCheck.validateErr(t, createErr) {
 				return
 			}
@@ -474,12 +474,12 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 			}
 			got, reconcileErr := reconciler.Reconcile(testContext, req)
 			if !firstCheck.wantErr(t, reconcileErr) {
-				require.NoError(t, k8sClient.Delete(testContext, &tt.args.params.Instance))
+				require.NoError(t, k8sClient.Delete(testContext, &tt.args.params.OtelCol))
 				return
 			}
 			assert.Equal(t, firstCheck.result, got)
 			for _, check := range firstCheck.checks {
-				check(t, tt.args.params.Instance)
+				check(t, tt.args.params.OtelCol)
 			}
 			// run the next set of checks
 			for pid, updateParam := range tt.args.updates {
@@ -488,9 +488,9 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 				assert.True(t, found)
 				assert.NoError(t, err)
 
-				updateParam.Instance.SetResourceVersion(existing.ResourceVersion)
-				updateParam.Instance.SetUID(existing.UID)
-				err = k8sClient.Update(testContext, &updateParam.Instance)
+				updateParam.OtelCol.SetResourceVersion(existing.ResourceVersion)
+				updateParam.OtelCol.SetUID(existing.UID)
+				err = k8sClient.Update(testContext, &updateParam.OtelCol)
 				assert.NoError(t, err)
 				if err != nil {
 					continue
@@ -506,12 +506,12 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 				}
 				assert.Equal(t, checkGroup.result, got)
 				for _, check := range checkGroup.checks {
-					check(t, updateParam.Instance)
+					check(t, updateParam.OtelCol)
 				}
 			}
 			// Only delete upon a successful creation
 			if createErr == nil {
-				require.NoError(t, k8sClient.Delete(testContext, &tt.args.params.Instance))
+				require.NoError(t, k8sClient.Delete(testContext, &tt.args.params.OtelCol))
 			}
 		})
 	}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -193,7 +193,7 @@ func paramsWithModeAndReplicas(mode v1alpha1.Mode, replicas int32) manifests.Par
 	return manifests.Params{
 		Config: config.New(config.WithCollectorImage(defaultCollectorImage), config.WithTargetAllocatorImage(defaultTaAllocationImage)),
 		Client: k8sClient,
-		Instance: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha1.OpenTelemetryCollector{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "opentelemetry.io",
 				APIVersion: "v1",
@@ -243,7 +243,7 @@ func newParams(taContainerImage string, file string) (manifests.Params, error) {
 	return manifests.Params{
 		Config: cfg,
 		Client: k8sClient,
-		Instance: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha1.OpenTelemetryCollector{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "opentelemetry.io",
 				APIVersion: "v1",
@@ -289,7 +289,7 @@ func paramsWithHPA(minReps, maxReps int32) manifests.Params {
 	return manifests.Params{
 		Config: configuration,
 		Client: k8sClient,
-		Instance: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha1.OpenTelemetryCollector{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "opentelemetry.io",
 				APIVersion: "v1",

--- a/internal/manifests/builder.go
+++ b/internal/manifests/builder.go
@@ -17,28 +17,24 @@ package manifests
 import (
 	"reflect"
 
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 )
 
 type Builder func(params Params) ([]client.Object, error)
 
-type ManifestFactory[T client.Object] func(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) (T, error)
-type SimpleManifestFactory[T client.Object] func(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) T
+type ManifestFactory[T client.Object] func(params Params) (T, error)
+type SimpleManifestFactory[T client.Object] func(params Params) T
 type K8sManifestFactory ManifestFactory[client.Object]
 
 func FactoryWithoutError[T client.Object](f SimpleManifestFactory[T]) K8sManifestFactory {
-	return func(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) (client.Object, error) {
-		return f(cfg, logger, otelcol), nil
+	return func(params Params) (client.Object, error) {
+		return f(params), nil
 	}
 }
 
 func Factory[T client.Object](f ManifestFactory[T]) K8sManifestFactory {
-	return func(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) (client.Object, error) {
-		return f(cfg, logger, otelcol)
+	return func(params Params) (client.Object, error) {
+		return f(params)
 	}
 }
 

--- a/internal/manifests/collector/config_replace_test.go
+++ b/internal/manifests/collector/config_replace_test.go
@@ -32,7 +32,7 @@ func TestPrometheusParser(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("should update config with http_sd_config", func(t *testing.T) {
-		actualConfig, err := ReplaceConfig(param.Instance)
+		actualConfig, err := ReplaceConfig(param.OtelCol)
 		assert.NoError(t, err)
 
 		// prepare
@@ -65,12 +65,12 @@ func TestPrometheusParser(t *testing.T) {
 
 	t.Run("should update config with targetAllocator block", func(t *testing.T) {
 		err := colfeaturegate.GlobalRegistry().Set(featuregate.EnableTargetAllocatorRewrite.ID(), true)
-		param.Instance.Spec.TargetAllocator.Enabled = true
+		param.OtelCol.Spec.TargetAllocator.Enabled = true
 		assert.NoError(t, err)
 
 		// Set up the test scenario
-		param.Instance.Spec.TargetAllocator.Enabled = true
-		actualConfig, err := ReplaceConfig(param.Instance)
+		param.OtelCol.Spec.TargetAllocator.Enabled = true
+		actualConfig, err := ReplaceConfig(param.OtelCol)
 		assert.NoError(t, err)
 
 		// Verify the expected changes in the config
@@ -94,8 +94,8 @@ func TestPrometheusParser(t *testing.T) {
 	})
 
 	t.Run("should not update config with http_sd_config", func(t *testing.T) {
-		param.Instance.Spec.TargetAllocator.Enabled = false
-		actualConfig, err := ReplaceConfig(param.Instance)
+		param.OtelCol.Spec.TargetAllocator.Enabled = false
+		actualConfig, err := ReplaceConfig(param.OtelCol)
 		assert.NoError(t, err)
 
 		// prepare
@@ -133,25 +133,25 @@ func TestReplaceConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("should not modify config when TargetAllocator is disabled", func(t *testing.T) {
-		param.Instance.Spec.TargetAllocator.Enabled = false
+		param.OtelCol.Spec.TargetAllocator.Enabled = false
 		expectedConfigBytes, err := os.ReadFile("testdata/relabel_config_original.yaml")
 		assert.NoError(t, err)
 		expectedConfig := string(expectedConfigBytes)
 
-		actualConfig, err := ReplaceConfig(param.Instance)
+		actualConfig, err := ReplaceConfig(param.OtelCol)
 		assert.NoError(t, err)
 
 		assert.Equal(t, expectedConfig, actualConfig)
 	})
 
 	t.Run("should rewrite scrape configs with SD config when TargetAllocator is enabled and feature flag is not set", func(t *testing.T) {
-		param.Instance.Spec.TargetAllocator.Enabled = true
+		param.OtelCol.Spec.TargetAllocator.Enabled = true
 
 		expectedConfigBytes, err := os.ReadFile("testdata/relabel_config_expected_with_sd_config.yaml")
 		assert.NoError(t, err)
 		expectedConfig := string(expectedConfigBytes)
 
-		actualConfig, err := ReplaceConfig(param.Instance)
+		actualConfig, err := ReplaceConfig(param.OtelCol)
 		assert.NoError(t, err)
 
 		assert.Equal(t, expectedConfig, actualConfig)

--- a/internal/manifests/collector/configmap.go
+++ b/internal/manifests/collector/configmap.go
@@ -15,30 +15,28 @@
 package collector
 
 import (
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
-func ConfigMap(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) *corev1.ConfigMap {
-	name := naming.ConfigMap(otelcol.Name)
-	labels := Labels(otelcol, name, []string{})
+func ConfigMap(params manifests.Params) *corev1.ConfigMap {
+	name := naming.ConfigMap(params.OtelCol.Name)
+	labels := Labels(params.OtelCol, name, []string{})
 
-	replacedConf, err := ReplaceConfig(otelcol)
+	replacedConf, err := ReplaceConfig(params.OtelCol)
 	if err != nil {
-		logger.V(2).Info("failed to update prometheus config to use sharded targets: ", "err", err)
+		params.Log.V(2).Info("failed to update prometheus config to use sharded targets: ", "err", err)
 	}
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   otelcol.Namespace,
+			Namespace:   params.OtelCol.Namespace,
 			Labels:      labels,
-			Annotations: otelcol.Annotations,
+			Annotations: params.OtelCol.Annotations,
 		},
 		Data: map[string]string{
 			"collector.yaml": replacedConf,

--- a/internal/manifests/collector/configmap_test.go
+++ b/internal/manifests/collector/configmap_test.go
@@ -63,7 +63,7 @@ service:
 		}
 
 		param := deploymentParams()
-		actual := ConfigMap(param.Config, param.Log, param.Instance)
+		actual := ConfigMap(param)
 
 		assert.Equal(t, "test-collector", actual.Name)
 		assert.Equal(t, expectedLables, actual.Labels)
@@ -103,8 +103,8 @@ service:
 		}
 
 		param := deploymentParams()
-		param.Instance.Spec.TargetAllocator.Enabled = true
-		actual := ConfigMap(param.Config, param.Log, param.Instance)
+		param.OtelCol.Spec.TargetAllocator.Enabled = true
+		actual := ConfigMap(param)
 
 		assert.Equal(t, "test-collector", actual.GetName())
 		assert.Equal(t, expectedLables, actual.GetLabels())
@@ -147,8 +147,8 @@ service:
 
 		param, err := newParams("test/test-img", "testdata/http_sd_config_servicemonitor_test_ta_set.yaml")
 		assert.NoError(t, err)
-		param.Instance.Spec.TargetAllocator.Enabled = true
-		actual := ConfigMap(param.Config, param.Log, param.Instance)
+		param.OtelCol.Spec.TargetAllocator.Enabled = true
+		actual := ConfigMap(param)
 
 		assert.Equal(t, "test-collector", actual.Name)
 		assert.Equal(t, expectedLables, actual.Labels)
@@ -190,8 +190,8 @@ service:
 
 		param, err := newParams("test/test-img", "testdata/http_sd_config_servicemonitor_test.yaml")
 		assert.NoError(t, err)
-		param.Instance.Spec.TargetAllocator.Enabled = true
-		actual := ConfigMap(param.Config, param.Log, param.Instance)
+		param.OtelCol.Spec.TargetAllocator.Enabled = true
+		actual := ConfigMap(param)
 
 		assert.Equal(t, "test-collector", actual.Name)
 		assert.Equal(t, expectedLables, actual.Labels)

--- a/internal/manifests/collector/daemonset.go
+++ b/internal/manifests/collector/daemonset.go
@@ -15,33 +15,31 @@
 package collector
 
 import (
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 // DaemonSet builds the deployment for the given instance.
-func DaemonSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) *appsv1.DaemonSet {
-	name := naming.Collector(otelcol.Name)
-	labels := Labels(otelcol, name, cfg.LabelsFilter())
+func DaemonSet(params manifests.Params) *appsv1.DaemonSet {
+	name := naming.Collector(params.OtelCol.Name)
+	labels := Labels(params.OtelCol, name, params.Config.LabelsFilter())
 
-	annotations := Annotations(otelcol)
-	podAnnotations := PodAnnotations(otelcol)
+	annotations := Annotations(params.OtelCol)
+	podAnnotations := PodAnnotations(params.OtelCol)
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        naming.Collector(otelcol.Name),
-			Namespace:   otelcol.Namespace,
+			Name:        naming.Collector(params.OtelCol.Name),
+			Namespace:   params.OtelCol.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: SelectorLabels(otelcol),
+				MatchLabels: SelectorLabels(params.OtelCol),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -49,17 +47,17 @@ func DaemonSet(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: ServiceAccountName(otelcol),
-					InitContainers:     otelcol.Spec.InitContainers,
-					Containers:         append(otelcol.Spec.AdditionalContainers, Container(cfg, logger, otelcol, true)),
-					Volumes:            Volumes(cfg, otelcol),
-					Tolerations:        otelcol.Spec.Tolerations,
-					NodeSelector:       otelcol.Spec.NodeSelector,
-					HostNetwork:        otelcol.Spec.HostNetwork,
-					DNSPolicy:          getDNSPolicy(otelcol),
-					SecurityContext:    otelcol.Spec.PodSecurityContext,
-					PriorityClassName:  otelcol.Spec.PriorityClassName,
-					Affinity:           otelcol.Spec.Affinity,
+					ServiceAccountName: ServiceAccountName(params.OtelCol),
+					InitContainers:     params.OtelCol.Spec.InitContainers,
+					Containers:         append(params.OtelCol.Spec.AdditionalContainers, Container(params.Config, params.Log, params.OtelCol, true)),
+					Volumes:            Volumes(params.Config, params.OtelCol),
+					Tolerations:        params.OtelCol.Spec.Tolerations,
+					NodeSelector:       params.OtelCol.Spec.NodeSelector,
+					HostNetwork:        params.OtelCol.Spec.HostNetwork,
+					DNSPolicy:          getDNSPolicy(params.OtelCol),
+					SecurityContext:    params.OtelCol.Spec.PodSecurityContext,
+					PriorityClassName:  params.OtelCol.Spec.PriorityClassName,
+					Affinity:           params.OtelCol.Spec.Affinity,
 				},
 			},
 		},

--- a/internal/manifests/collector/deployment.go
+++ b/internal/manifests/collector/deployment.go
@@ -15,35 +15,33 @@
 package collector
 
 import (
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 // Deployment builds the deployment for the given instance.
-func Deployment(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) *appsv1.Deployment {
-	name := naming.Collector(otelcol.Name)
-	labels := Labels(otelcol, name, cfg.LabelsFilter())
+func Deployment(params manifests.Params) *appsv1.Deployment {
+	name := naming.Collector(params.OtelCol.Name)
+	labels := Labels(params.OtelCol, name, params.Config.LabelsFilter())
 
-	annotations := Annotations(otelcol)
-	podAnnotations := PodAnnotations(otelcol)
+	annotations := Annotations(params.OtelCol)
+	podAnnotations := PodAnnotations(params.OtelCol)
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   otelcol.Namespace,
+			Namespace:   params.OtelCol.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: otelcol.Spec.Replicas,
+			Replicas: params.OtelCol.Spec.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: SelectorLabels(otelcol),
+				MatchLabels: SelectorLabels(params.OtelCol),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -51,19 +49,19 @@ func Deployment(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTele
 					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName:            ServiceAccountName(otelcol),
-					InitContainers:                otelcol.Spec.InitContainers,
-					Containers:                    append(otelcol.Spec.AdditionalContainers, Container(cfg, logger, otelcol, true)),
-					Volumes:                       Volumes(cfg, otelcol),
-					DNSPolicy:                     getDNSPolicy(otelcol),
-					HostNetwork:                   otelcol.Spec.HostNetwork,
-					Tolerations:                   otelcol.Spec.Tolerations,
-					NodeSelector:                  otelcol.Spec.NodeSelector,
-					SecurityContext:               otelcol.Spec.PodSecurityContext,
-					PriorityClassName:             otelcol.Spec.PriorityClassName,
-					Affinity:                      otelcol.Spec.Affinity,
-					TerminationGracePeriodSeconds: otelcol.Spec.TerminationGracePeriodSeconds,
-					TopologySpreadConstraints:     otelcol.Spec.TopologySpreadConstraints,
+					ServiceAccountName:            ServiceAccountName(params.OtelCol),
+					InitContainers:                params.OtelCol.Spec.InitContainers,
+					Containers:                    append(params.OtelCol.Spec.AdditionalContainers, Container(params.Config, params.Log, params.OtelCol, true)),
+					Volumes:                       Volumes(params.Config, params.OtelCol),
+					DNSPolicy:                     getDNSPolicy(params.OtelCol),
+					HostNetwork:                   params.OtelCol.Spec.HostNetwork,
+					Tolerations:                   params.OtelCol.Spec.Tolerations,
+					NodeSelector:                  params.OtelCol.Spec.NodeSelector,
+					SecurityContext:               params.OtelCol.Spec.PodSecurityContext,
+					PriorityClassName:             params.OtelCol.Spec.PriorityClassName,
+					Affinity:                      params.OtelCol.Spec.Affinity,
+					TerminationGracePeriodSeconds: params.OtelCol.Spec.TerminationGracePeriodSeconds,
+					TopologySpreadConstraints:     params.OtelCol.Spec.TopologySpreadConstraints,
 				},
 			},
 		},

--- a/internal/manifests/collector/deployment_test.go
+++ b/internal/manifests/collector/deployment_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	. "github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
 )
 
@@ -78,8 +79,14 @@ func TestDeploymentNewDefault(t *testing.T) {
 	}
 	cfg := config.New()
 
+	params := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol,
+		Log:     logger,
+	}
+
 	// test
-	d := Deployment(cfg, logger, otelcol)
+	d := Deployment(params)
 
 	// verify
 	assert.Equal(t, "my-instance-collector", d.Name)
@@ -137,8 +144,14 @@ func TestDeploymentPodAnnotations(t *testing.T) {
 	}
 	cfg := config.New()
 
+	params := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol,
+		Log:     logger,
+	}
+
 	// test
-	d := Deployment(cfg, logger, otelcol)
+	d := Deployment(params)
 
 	// Add sha256 podAnnotation
 	testPodAnnotationValues["opentelemetry-operator-config/sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -177,7 +190,13 @@ func TestDeploymenttPodSecurityContext(t *testing.T) {
 
 	cfg := config.New()
 
-	d := Deployment(cfg, logger, otelcol)
+	params := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol,
+		Log:     logger,
+	}
+
+	d := Deployment(params)
 
 	assert.Equal(t, &runAsNonRoot, d.Spec.Template.Spec.SecurityContext.RunAsNonRoot)
 	assert.Equal(t, &runAsUser, d.Spec.Template.Spec.SecurityContext.RunAsUser)
@@ -194,7 +213,13 @@ func TestDeploymentHostNetwork(t *testing.T) {
 
 	cfg := config.New()
 
-	d1 := Deployment(cfg, logger, otelcol1)
+	params1 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol1,
+		Log:     logger,
+	}
+
+	d1 := Deployment(params1)
 
 	assert.Equal(t, d1.Spec.Template.Spec.HostNetwork, false)
 	assert.Equal(t, d1.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirst)
@@ -211,7 +236,13 @@ func TestDeploymentHostNetwork(t *testing.T) {
 
 	cfg = config.New()
 
-	d2 := Deployment(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol2,
+		Log:     logger,
+	}
+
+	d2 := Deployment(params2)
 	assert.Equal(t, d2.Spec.Template.Spec.HostNetwork, true)
 	assert.Equal(t, d2.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirstWithHostNet)
 }
@@ -232,7 +263,13 @@ func TestDeploymentFilterLabels(t *testing.T) {
 
 	cfg := config.New(config.WithLabelFilters([]string{"foo*", "app.*.bar"}))
 
-	d := Deployment(cfg, logger, otelcol)
+	params := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol,
+		Log:     logger,
+	}
+
+	d := Deployment(params)
 
 	assert.Len(t, d.ObjectMeta.Labels, 6)
 	for k := range excludedLabels {
@@ -250,7 +287,13 @@ func TestDeploymentNodeSelector(t *testing.T) {
 
 	cfg := config.New()
 
-	d1 := Deployment(cfg, logger, otelcol1)
+	params1 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol1,
+		Log:     logger,
+	}
+
+	d1 := Deployment(params1)
 
 	assert.Empty(t, d1.Spec.Template.Spec.NodeSelector)
 
@@ -269,7 +312,13 @@ func TestDeploymentNodeSelector(t *testing.T) {
 
 	cfg = config.New()
 
-	d2 := Deployment(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol2,
+		Log:     logger,
+	}
+
+	d2 := Deployment(params2)
 	assert.Equal(t, d2.Spec.Template.Spec.NodeSelector, map[string]string{"node-key": "node-value"})
 }
 
@@ -282,7 +331,13 @@ func TestDeploymentPriorityClassName(t *testing.T) {
 
 	cfg := config.New()
 
-	d1 := Deployment(cfg, logger, otelcol1)
+	params1 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol1,
+		Log:     logger,
+	}
+
+	d1 := Deployment(params1)
 	assert.Empty(t, d1.Spec.Template.Spec.PriorityClassName)
 
 	priorityClassName := "test-class"
@@ -298,7 +353,13 @@ func TestDeploymentPriorityClassName(t *testing.T) {
 
 	cfg = config.New()
 
-	d2 := Deployment(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol2,
+		Log:     logger,
+	}
+
+	d2 := Deployment(params2)
 	assert.Equal(t, priorityClassName, d2.Spec.Template.Spec.PriorityClassName)
 }
 
@@ -311,7 +372,13 @@ func TestDeploymentAffinity(t *testing.T) {
 
 	cfg := config.New()
 
-	d1 := Deployment(cfg, logger, otelcol1)
+	params1 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol1,
+		Log:     logger,
+	}
+
+	d1 := Deployment(params1)
 	assert.Nil(t, d1.Spec.Template.Spec.Affinity)
 
 	otelcol2 := v1alpha1.OpenTelemetryCollector{
@@ -325,7 +392,13 @@ func TestDeploymentAffinity(t *testing.T) {
 
 	cfg = config.New()
 
-	d2 := Deployment(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol2,
+		Log:     logger,
+	}
+
+	d2 := Deployment(params2)
 	assert.NotNil(t, d2.Spec.Template.Spec.Affinity)
 	assert.Equal(t, *testAffinityValue, *d2.Spec.Template.Spec.Affinity)
 }
@@ -339,7 +412,13 @@ func TestDeploymentTerminationGracePeriodSeconds(t *testing.T) {
 
 	cfg := config.New()
 
-	d1 := Deployment(cfg, logger, otelcol1)
+	params1 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol1,
+		Log:     logger,
+	}
+
+	d1 := Deployment(params1)
 	assert.Nil(t, d1.Spec.Template.Spec.TerminationGracePeriodSeconds)
 
 	gracePeriodSec := int64(60)
@@ -355,7 +434,13 @@ func TestDeploymentTerminationGracePeriodSeconds(t *testing.T) {
 
 	cfg = config.New()
 
-	d2 := Deployment(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol2,
+		Log:     logger,
+	}
+
+	d2 := Deployment(params2)
 	assert.NotNil(t, d2.Spec.Template.Spec.TerminationGracePeriodSeconds)
 	assert.Equal(t, gracePeriodSec, *d2.Spec.Template.Spec.TerminationGracePeriodSeconds)
 }
@@ -377,8 +462,14 @@ func TestDeploymentSetInitContainer(t *testing.T) {
 	}
 	cfg := config.New()
 
+	params := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol,
+		Log:     logger,
+	}
+
 	// test
-	d := Deployment(cfg, logger, otelcol)
+	d := Deployment(params)
 	assert.Equal(t, "my-instance-collector", d.Name)
 	assert.Equal(t, "my-instance-collector", d.Labels["app.kubernetes.io/name"])
 	assert.Equal(t, "true", d.Annotations["prometheus.io/scrape"])
@@ -396,7 +487,13 @@ func TestDeploymentTopologySpreadConstraints(t *testing.T) {
 	}
 
 	cfg := config.New()
-	d1 := Deployment(cfg, logger, otelcol1)
+
+	params1 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol1,
+		Log:     logger,
+	}
+	d1 := Deployment(params1)
 	assert.Equal(t, "my-instance-collector", d1.Name)
 	assert.Empty(t, d1.Spec.Template.Spec.TopologySpreadConstraints)
 
@@ -411,7 +508,13 @@ func TestDeploymentTopologySpreadConstraints(t *testing.T) {
 	}
 
 	cfg = config.New()
-	d2 := Deployment(cfg, logger, otelcol2)
+
+	params2 := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol2,
+		Log:     logger,
+	}
+	d2 := Deployment(params2)
 	assert.Equal(t, "my-instance-topologyspreadconstraint-collector", d2.Name)
 	assert.NotNil(t, d2.Spec.Template.Spec.TopologySpreadConstraints)
 	assert.NotEmpty(t, d2.Spec.Template.Spec.TopologySpreadConstraints)
@@ -435,8 +538,14 @@ func TestDeploymentAdditionalContainers(t *testing.T) {
 	}
 	cfg := config.New()
 
+	params := manifests.Params{
+		Config:  cfg,
+		OtelCol: otelcol,
+		Log:     logger,
+	}
+
 	// test
-	d := Deployment(cfg, logger, otelcol)
+	d := Deployment(params)
 	assert.Equal(t, "my-instance-collector", d.Name)
 	assert.Equal(t, "my-instance-collector", d.Labels["app.kubernetes.io/name"])
 	assert.Equal(t, "true", d.Annotations["prometheus.io/scrape"])

--- a/internal/manifests/collector/horizontalpodautoscaler.go
+++ b/internal/manifests/collector/horizontalpodautoscaler.go
@@ -15,72 +15,71 @@
 package collector
 
 import (
-	"github.com/go-logr/logr"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
-func HorizontalPodAutoscaler(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) client.Object {
-	name := naming.Collector(otelcol.Name)
-	labels := Labels(otelcol, name, cfg.LabelsFilter())
-	annotations := Annotations(otelcol)
+func HorizontalPodAutoscaler(params manifests.Params) client.Object {
+	name := naming.Collector(params.OtelCol.Name)
+	labels := Labels(params.OtelCol, name, params.Config.LabelsFilter())
+	annotations := Annotations(params.OtelCol)
 	var result client.Object
 
 	objectMeta := metav1.ObjectMeta{
-		Name:        naming.HorizontalPodAutoscaler(otelcol.Name),
-		Namespace:   otelcol.Namespace,
+		Name:        naming.HorizontalPodAutoscaler(params.OtelCol.Name),
+		Namespace:   params.OtelCol.Namespace,
 		Labels:      labels,
 		Annotations: annotations,
 	}
 
 	// defaulting webhook should always set this, but if unset then return nil.
-	if otelcol.Spec.Autoscaler == nil {
-		logger.Info("hpa field is unset in Spec, skipping autoscaler creation")
+	if params.OtelCol.Spec.Autoscaler == nil {
+		params.Log.Info("hpa field is unset in Spec, skipping autoscaler creation")
 		return nil
 	}
 
-	if otelcol.Spec.Autoscaler.MaxReplicas == nil {
-		otelcol.Spec.Autoscaler.MaxReplicas = otelcol.Spec.MaxReplicas
+	if params.OtelCol.Spec.Autoscaler.MaxReplicas == nil {
+		params.OtelCol.Spec.Autoscaler.MaxReplicas = params.OtelCol.Spec.MaxReplicas
 	}
 
-	if otelcol.Spec.Autoscaler.MinReplicas == nil {
-		if otelcol.Spec.MinReplicas != nil {
-			otelcol.Spec.Autoscaler.MinReplicas = otelcol.Spec.MinReplicas
+	if params.OtelCol.Spec.Autoscaler.MinReplicas == nil {
+		if params.OtelCol.Spec.MinReplicas != nil {
+			params.OtelCol.Spec.Autoscaler.MinReplicas = params.OtelCol.Spec.MinReplicas
 		} else {
-			otelcol.Spec.Autoscaler.MinReplicas = otelcol.Spec.Replicas
+			params.OtelCol.Spec.Autoscaler.MinReplicas = params.OtelCol.Spec.Replicas
 		}
 	}
 
 	metrics := []autoscalingv2.MetricSpec{}
 
-	if otelcol.Spec.Autoscaler.TargetMemoryUtilization != nil {
+	if params.OtelCol.Spec.Autoscaler.TargetMemoryUtilization != nil {
 		memoryTarget := autoscalingv2.MetricSpec{
 			Type: autoscalingv2.ResourceMetricSourceType,
 			Resource: &autoscalingv2.ResourceMetricSource{
 				Name: corev1.ResourceMemory,
 				Target: autoscalingv2.MetricTarget{
 					Type:               autoscalingv2.UtilizationMetricType,
-					AverageUtilization: otelcol.Spec.Autoscaler.TargetMemoryUtilization,
+					AverageUtilization: params.OtelCol.Spec.Autoscaler.TargetMemoryUtilization,
 				},
 			},
 		}
 		metrics = append(metrics, memoryTarget)
 	}
 
-	if otelcol.Spec.Autoscaler.TargetCPUUtilization != nil {
+	if params.OtelCol.Spec.Autoscaler.TargetCPUUtilization != nil {
 		cpuTarget := autoscalingv2.MetricSpec{
 			Type: autoscalingv2.ResourceMetricSourceType,
 			Resource: &autoscalingv2.ResourceMetricSource{
 				Name: corev1.ResourceCPU,
 				Target: autoscalingv2.MetricTarget{
 					Type:               autoscalingv2.UtilizationMetricType,
-					AverageUtilization: otelcol.Spec.Autoscaler.TargetCPUUtilization,
+					AverageUtilization: params.OtelCol.Spec.Autoscaler.TargetCPUUtilization,
 				},
 			},
 		}
@@ -93,19 +92,19 @@ func HorizontalPodAutoscaler(cfg config.Config, logger logr.Logger, otelcol v1al
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				APIVersion: v1alpha1.GroupVersion.String(),
 				Kind:       "OpenTelemetryCollector",
-				Name:       naming.OpenTelemetryCollector(otelcol.Name),
+				Name:       naming.OpenTelemetryCollector(params.OtelCol.Name),
 			},
-			MinReplicas: otelcol.Spec.Autoscaler.MinReplicas,
-			MaxReplicas: *otelcol.Spec.Autoscaler.MaxReplicas,
+			MinReplicas: params.OtelCol.Spec.Autoscaler.MinReplicas,
+			MaxReplicas: *params.OtelCol.Spec.Autoscaler.MaxReplicas,
 			Metrics:     metrics,
 		},
 	}
-	if otelcol.Spec.Autoscaler.Behavior != nil {
-		autoscaler.Spec.Behavior = otelcol.Spec.Autoscaler.Behavior
+	if params.OtelCol.Spec.Autoscaler.Behavior != nil {
+		autoscaler.Spec.Behavior = params.OtelCol.Spec.Autoscaler.Behavior
 	}
 
 	// convert from v1alpha1.MetricSpec into a autoscalingv2.MetricSpec.
-	for _, metric := range otelcol.Spec.Autoscaler.Metrics {
+	for _, metric := range params.OtelCol.Spec.Autoscaler.Metrics {
 		if metric.Type == autoscalingv2.PodsMetricSourceType {
 			v2metric := autoscalingv2.MetricSpec{
 				Type: metric.Type,

--- a/internal/manifests/collector/horizontalpodautoscaler_test.go
+++ b/internal/manifests/collector/horizontalpodautoscaler_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	. "github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
 )
 
@@ -72,7 +73,12 @@ func TestHPA(t *testing.T) {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
 				configuration := config.New()
-				raw := HorizontalPodAutoscaler(configuration, logger, otelcol)
+				params := manifests.Params{
+					Config:  configuration,
+					OtelCol: otelcol,
+					Log:     logger,
+				}
+				raw := HorizontalPodAutoscaler(params)
 
 				hpa := raw.(*autoscalingv2.HorizontalPodAutoscaler)
 

--- a/internal/manifests/collector/ingress.go
+++ b/internal/manifests/collector/ingress.go
@@ -23,51 +23,51 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/adapters"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
-func Ingress(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) *networkingv1.Ingress {
-	if otelcol.Spec.Ingress.Type != v1alpha1.IngressTypeNginx {
+func Ingress(params manifests.Params) *networkingv1.Ingress {
+	if params.OtelCol.Spec.Ingress.Type != v1alpha1.IngressTypeNginx {
 		return nil
 	}
 
-	ports := servicePortsFromCfg(logger, otelcol)
+	ports := servicePortsFromCfg(params.Log, params.OtelCol)
 
 	// if we have no ports, we don't need a ingress entry
 	if len(ports) == 0 {
-		logger.V(1).Info(
+		params.Log.V(1).Info(
 			"the instance's configuration didn't yield any ports to open, skipping ingress",
-			"instance.name", otelcol.Name,
-			"instance.namespace", otelcol.Namespace,
+			"instance.name", params.OtelCol.Name,
+			"instance.namespace", params.OtelCol.Namespace,
 		)
 		return nil
 	}
 
 	var rules []networkingv1.IngressRule
-	switch otelcol.Spec.Ingress.RuleType {
+	switch params.OtelCol.Spec.Ingress.RuleType {
 	case v1alpha1.IngressRuleTypePath, "":
-		rules = []networkingv1.IngressRule{createPathIngressRules(otelcol.Name, otelcol.Spec.Ingress.Hostname, ports)}
+		rules = []networkingv1.IngressRule{createPathIngressRules(params.OtelCol.Name, params.OtelCol.Spec.Ingress.Hostname, ports)}
 	case v1alpha1.IngressRuleTypeSubdomain:
-		rules = createSubdomainIngressRules(otelcol.Name, otelcol.Spec.Ingress.Hostname, ports)
+		rules = createSubdomainIngressRules(params.OtelCol.Name, params.OtelCol.Spec.Ingress.Hostname, ports)
 	}
 
 	return &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        naming.Ingress(otelcol.Name),
-			Namespace:   otelcol.Namespace,
-			Annotations: otelcol.Spec.Ingress.Annotations,
+			Name:        naming.Ingress(params.OtelCol.Name),
+			Namespace:   params.OtelCol.Namespace,
+			Annotations: params.OtelCol.Spec.Ingress.Annotations,
 			Labels: map[string]string{
-				"app.kubernetes.io/name":       naming.Ingress(otelcol.Name),
-				"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", otelcol.Namespace, otelcol.Name),
+				"app.kubernetes.io/name":       naming.Ingress(params.OtelCol.Name),
+				"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params.OtelCol.Namespace, params.OtelCol.Name),
 				"app.kubernetes.io/managed-by": "opentelemetry-operator",
 			},
 		},
 		Spec: networkingv1.IngressSpec{
-			TLS:              otelcol.Spec.Ingress.TLS,
+			TLS:              params.OtelCol.Spec.Ingress.TLS,
 			Rules:            rules,
-			IngressClassName: otelcol.Spec.Ingress.IngressClassName,
+			IngressClassName: params.OtelCol.Spec.Ingress.IngressClassName,
 		},
 	}
 }

--- a/internal/manifests/collector/ingress_test.go
+++ b/internal/manifests/collector/ingress_test.go
@@ -37,7 +37,7 @@ func TestDesiredIngresses(t *testing.T) {
 		params := manifests.Params{
 			Config: config.Config{},
 			Log:    logger,
-			Instance: v1alpha1.OpenTelemetryCollector{
+			OtelCol: v1alpha1.OpenTelemetryCollector{
 				Spec: v1alpha1.OpenTelemetryCollectorSpec{
 					Ingress: v1alpha1.Ingress{
 						Type: v1alpha1.IngressType("unknown"),
@@ -46,7 +46,7 @@ func TestDesiredIngresses(t *testing.T) {
 			},
 		}
 
-		actual := Ingress(params.Config, params.Log, params.Instance)
+		actual := Ingress(params)
 		assert.Nil(t, actual)
 	})
 
@@ -54,7 +54,7 @@ func TestDesiredIngresses(t *testing.T) {
 		params := manifests.Params{
 			Config: config.Config{},
 			Log:    logger,
-			Instance: v1alpha1.OpenTelemetryCollector{
+			OtelCol: v1alpha1.OpenTelemetryCollector{
 				Spec: v1alpha1.OpenTelemetryCollectorSpec{
 					Config: "!!!",
 					Ingress: v1alpha1.Ingress{
@@ -64,7 +64,7 @@ func TestDesiredIngresses(t *testing.T) {
 			},
 		}
 
-		actual := Ingress(params.Config, params.Log, params.Instance)
+		actual := Ingress(params)
 		assert.Nil(t, actual)
 	})
 
@@ -72,7 +72,7 @@ func TestDesiredIngresses(t *testing.T) {
 		params := manifests.Params{
 			Config: config.Config{},
 			Log:    logger,
-			Instance: v1alpha1.OpenTelemetryCollector{
+			OtelCol: v1alpha1.OpenTelemetryCollector{
 				Spec: v1alpha1.OpenTelemetryCollectorSpec{
 					Config: "---",
 					Ingress: v1alpha1.Ingress{
@@ -82,7 +82,7 @@ func TestDesiredIngresses(t *testing.T) {
 			},
 		}
 
-		actual := Ingress(params.Config, params.Log, params.Instance)
+		actual := Ingress(params)
 		assert.Nil(t, actual)
 	})
 
@@ -98,25 +98,25 @@ func TestDesiredIngresses(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		params.Instance.Namespace = ns
-		params.Instance.Spec.Ingress = v1alpha1.Ingress{
+		params.OtelCol.Namespace = ns
+		params.OtelCol.Spec.Ingress = v1alpha1.Ingress{
 			Type:             v1alpha1.IngressTypeNginx,
 			Hostname:         hostname,
 			Annotations:      map[string]string{"some.key": "some.value"},
 			IngressClassName: &ingressClassName,
 		}
 
-		got := Ingress(params.Config, params.Log, params.Instance)
+		got := Ingress(params)
 		pathType := networkingv1.PathTypePrefix
 
 		assert.NotEqual(t, &networkingv1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        naming.Ingress(params.Instance.Name),
+				Name:        naming.Ingress(params.OtelCol.Name),
 				Namespace:   ns,
-				Annotations: params.Instance.Spec.Ingress.Annotations,
+				Annotations: params.OtelCol.Spec.Ingress.Annotations,
 				Labels: map[string]string{
-					"app.kubernetes.io/name":       naming.Ingress(params.Instance.Name),
-					"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params.Instance.Namespace, params.Instance.Name),
+					"app.kubernetes.io/name":       naming.Ingress(params.OtelCol.Name),
+					"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params.OtelCol.Namespace, params.OtelCol.Name),
 					"app.kubernetes.io/managed-by": "opentelemetry-operator",
 				},
 			},
@@ -184,8 +184,8 @@ func TestDesiredIngresses(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		params.Instance.Namespace = ns
-		params.Instance.Spec.Ingress = v1alpha1.Ingress{
+		params.OtelCol.Namespace = ns
+		params.OtelCol.Spec.Ingress = v1alpha1.Ingress{
 			Type:             v1alpha1.IngressTypeNginx,
 			RuleType:         v1alpha1.IngressRuleTypeSubdomain,
 			Hostname:         hostname,
@@ -193,17 +193,17 @@ func TestDesiredIngresses(t *testing.T) {
 			IngressClassName: &ingressClassName,
 		}
 
-		got := Ingress(params.Config, params.Log, params.Instance)
+		got := Ingress(params)
 		pathType := networkingv1.PathTypePrefix
 
 		assert.NotEqual(t, &networkingv1.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        naming.Ingress(params.Instance.Name),
+				Name:        naming.Ingress(params.OtelCol.Name),
 				Namespace:   ns,
-				Annotations: params.Instance.Spec.Ingress.Annotations,
+				Annotations: params.OtelCol.Spec.Ingress.Annotations,
 				Labels: map[string]string{
-					"app.kubernetes.io/name":       naming.Ingress(params.Instance.Name),
-					"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params.Instance.Namespace, params.Instance.Name),
+					"app.kubernetes.io/name":       naming.Ingress(params.OtelCol.Name),
+					"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params.OtelCol.Namespace, params.OtelCol.Name),
 					"app.kubernetes.io/managed-by": "opentelemetry-operator",
 				},
 			},

--- a/internal/manifests/collector/route.go
+++ b/internal/manifests/collector/route.go
@@ -17,28 +17,27 @@ package collector
 import (
 	"fmt"
 
-	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
-func Routes(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) []*routev1.Route {
-	if otelcol.Spec.Ingress.Type != v1alpha1.IngressTypeRoute {
+func Routes(params manifests.Params) []*routev1.Route {
+	if params.OtelCol.Spec.Ingress.Type != v1alpha1.IngressTypeRoute {
 		return nil
 	}
 
-	if otelcol.Spec.Mode == v1alpha1.ModeSidecar {
-		logger.V(3).Info("ingress settings are not supported in sidecar mode")
+	if params.OtelCol.Spec.Mode == v1alpha1.ModeSidecar {
+		params.Log.V(3).Info("ingress settings are not supported in sidecar mode")
 		return nil
 	}
 
 	var tlsCfg *routev1.TLSConfig
-	switch otelcol.Spec.Ingress.Route.Termination {
+	switch params.OtelCol.Spec.Ingress.Route.Termination {
 	case v1alpha1.TLSRouteTerminationTypeInsecure:
 		// NOTE: insecure, no tls cfg.
 	case v1alpha1.TLSRouteTerminationTypeEdge:
@@ -51,14 +50,14 @@ func Routes(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetr
 		return nil
 	}
 
-	ports := servicePortsFromCfg(logger, otelcol)
+	ports := servicePortsFromCfg(params.Log, params.OtelCol)
 
 	// if we have no ports, we don't need a ingress entry
 	if len(ports) == 0 {
-		logger.V(1).Info(
+		params.Log.V(1).Info(
 			"the instance's configuration didn't yield any ports to open, skipping ingress",
-			"instance.name", otelcol.Name,
-			"instance.namespace", otelcol.Namespace,
+			"instance.name", params.OtelCol.Name,
+			"instance.namespace", params.OtelCol.Namespace,
 		)
 		return nil
 	}
@@ -67,18 +66,18 @@ func Routes(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetr
 	for i, p := range ports {
 		portName := naming.PortName(p.Name, p.Port)
 		host := ""
-		if otelcol.Spec.Ingress.Hostname != "" {
-			host = fmt.Sprintf("%s.%s", portName, otelcol.Spec.Ingress.Hostname)
+		if params.OtelCol.Spec.Ingress.Hostname != "" {
+			host = fmt.Sprintf("%s.%s", portName, params.OtelCol.Spec.Ingress.Hostname)
 		}
 
 		routes[i] = &routev1.Route{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        naming.Route(otelcol.Name, p.Name),
-				Namespace:   otelcol.Namespace,
-				Annotations: otelcol.Spec.Ingress.Annotations,
+				Name:        naming.Route(params.OtelCol.Name, p.Name),
+				Namespace:   params.OtelCol.Namespace,
+				Annotations: params.OtelCol.Spec.Ingress.Annotations,
 				Labels: map[string]string{
-					"app.kubernetes.io/name":       naming.Route(otelcol.Name, p.Name),
-					"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", otelcol.Namespace, otelcol.Name),
+					"app.kubernetes.io/name":       naming.Route(params.OtelCol.Name, p.Name),
+					"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params.OtelCol.Namespace, params.OtelCol.Name),
 					"app.kubernetes.io/managed-by": "opentelemetry-operator",
 				},
 			},
@@ -86,7 +85,7 @@ func Routes(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetr
 				Host: host,
 				To: routev1.RouteTargetReference{
 					Kind: "Service",
-					Name: naming.Service(otelcol.Name),
+					Name: naming.Service(params.OtelCol.Name),
 				},
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.FromString(portName),

--- a/internal/manifests/collector/service.go
+++ b/internal/manifests/collector/service.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/adapters"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
@@ -34,16 +34,16 @@ const (
 	headlessExists = "Exists"
 )
 
-func HeadlessService(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) *corev1.Service {
-	h := Service(cfg, logger, otelcol)
+func HeadlessService(params manifests.Params) *corev1.Service {
+	h := Service(params)
 	if h == nil {
 		return h
 	}
 
-	h.Name = naming.HeadlessService(otelcol.Name)
+	h.Name = naming.HeadlessService(params.OtelCol.Name)
 	h.Labels[headlessLabel] = headlessExists
 
-	// copy to avoid modifying otelcol.Annotations
+	// copy to avoid modifying params.OtelCol.Annotations
 	annotations := map[string]string{
 		"service.beta.openshift.io/serving-cert-secret-name": fmt.Sprintf("%s-tls", h.Name),
 	}
@@ -56,32 +56,32 @@ func HeadlessService(cfg config.Config, logger logr.Logger, otelcol v1alpha1.Ope
 	return h
 }
 
-func MonitoringService(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) *corev1.Service {
-	name := naming.MonitoringService(otelcol.Name)
-	labels := Labels(otelcol, name, []string{})
+func MonitoringService(params manifests.Params) *corev1.Service {
+	name := naming.MonitoringService(params.OtelCol.Name)
+	labels := Labels(params.OtelCol, name, []string{})
 
-	c, err := adapters.ConfigFromString(otelcol.Spec.Config)
+	c, err := adapters.ConfigFromString(params.OtelCol.Spec.Config)
 	// TODO: Update this to properly return an error https://github.com/open-telemetry/opentelemetry-operator/issues/1972
 	if err != nil {
-		logger.Error(err, "couldn't extract the configuration")
+		params.Log.Error(err, "couldn't extract the configuration")
 		return nil
 	}
 
-	metricsPort, err := adapters.ConfigToMetricsPort(logger, c)
+	metricsPort, err := adapters.ConfigToMetricsPort(params.Log, c)
 	if err != nil {
-		logger.V(2).Info("couldn't determine metrics port from configuration, using 8888 default value", "error", err)
+		params.Log.V(2).Info("couldn't determine metrics port from configuration, using 8888 default value", "error", err)
 		metricsPort = 8888
 	}
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   otelcol.Namespace,
+			Namespace:   params.OtelCol.Namespace,
 			Labels:      labels,
-			Annotations: otelcol.Annotations,
+			Annotations: params.OtelCol.Annotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector:  SelectorLabels(otelcol),
+			Selector:  SelectorLabels(params.OtelCol),
 			ClusterIP: "",
 			Ports: []corev1.ServicePort{{
 				Name: "monitoring",
@@ -91,28 +91,28 @@ func MonitoringService(cfg config.Config, logger logr.Logger, otelcol v1alpha1.O
 	}
 }
 
-func Service(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) *corev1.Service {
-	name := naming.Service(otelcol.Name)
-	labels := Labels(otelcol, name, []string{})
+func Service(params manifests.Params) *corev1.Service {
+	name := naming.Service(params.OtelCol.Name)
+	labels := Labels(params.OtelCol, name, []string{})
 
-	configFromString, err := adapters.ConfigFromString(otelcol.Spec.Config)
+	configFromString, err := adapters.ConfigFromString(params.OtelCol.Spec.Config)
 	if err != nil {
-		logger.Error(err, "couldn't extract the configuration from the context")
+		params.Log.Error(err, "couldn't extract the configuration from the context")
 		return nil
 	}
 
-	ports := adapters.ConfigToPorts(logger, configFromString)
+	ports := adapters.ConfigToPorts(params.Log, configFromString)
 
 	// set appProtocol to h2c for grpc ports on OpenShift.
 	// OpenShift uses HA proxy that uses appProtocol for its configuration.
 	for i := range ports {
 		h2c := "h2c"
-		if otelcol.Spec.Ingress.Type == v1alpha1.IngressTypeRoute && ports[i].AppProtocol != nil && strings.EqualFold(*ports[i].AppProtocol, "grpc") {
+		if params.OtelCol.Spec.Ingress.Type == v1alpha1.IngressTypeRoute && ports[i].AppProtocol != nil && strings.EqualFold(*ports[i].AppProtocol, "grpc") {
 			ports[i].AppProtocol = &h2c
 		}
 	}
 
-	if len(otelcol.Spec.Ports) > 0 {
+	if len(params.OtelCol.Spec.Ports) > 0 {
 		// we should add all the ports from the CR
 		// there are two cases where problems might occur:
 		// 1) when the port number is already being used by a receiver
@@ -120,38 +120,38 @@ func Service(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemet
 		//
 		// in the first case, we remove the port we inferred from the list
 		// in the second case, we rename our inferred port to something like "port-%d"
-		portNumbers, portNames := extractPortNumbersAndNames(otelcol.Spec.Ports)
+		portNumbers, portNames := extractPortNumbersAndNames(params.OtelCol.Spec.Ports)
 		var resultingInferredPorts []corev1.ServicePort
 		for _, inferred := range ports {
-			if filtered := filterPort(logger, inferred, portNumbers, portNames); filtered != nil {
+			if filtered := filterPort(params.Log, inferred, portNumbers, portNames); filtered != nil {
 				resultingInferredPorts = append(resultingInferredPorts, *filtered)
 			}
 		}
 
-		ports = append(otelcol.Spec.Ports, resultingInferredPorts...)
+		ports = append(params.OtelCol.Spec.Ports, resultingInferredPorts...)
 	}
 
 	// if we have no ports, we don't need a service
 	if len(ports) == 0 {
-		logger.V(1).Info("the instance's configuration didn't yield any ports to open, skipping service", "instance.name", otelcol.Name, "instance.namespace", otelcol.Namespace)
+		params.Log.V(1).Info("the instance's configuration didn't yield any ports to open, skipping service", "instance.name", params.OtelCol.Name, "instance.namespace", params.OtelCol.Namespace)
 		return nil
 	}
 
 	trafficPolicy := corev1.ServiceInternalTrafficPolicyCluster
-	if otelcol.Spec.Mode == v1alpha1.ModeDaemonSet {
+	if params.OtelCol.Spec.Mode == v1alpha1.ModeDaemonSet {
 		trafficPolicy = corev1.ServiceInternalTrafficPolicyLocal
 	}
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        naming.Service(otelcol.Name),
-			Namespace:   otelcol.Namespace,
+			Name:        naming.Service(params.OtelCol.Name),
+			Namespace:   params.OtelCol.Namespace,
 			Labels:      labels,
-			Annotations: otelcol.Annotations,
+			Annotations: params.OtelCol.Annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			InternalTrafficPolicy: &trafficPolicy,
-			Selector:              SelectorLabels(otelcol),
+			Selector:              SelectorLabels(params.OtelCol),
 			ClusterIP:             "",
 			Ports:                 ports,
 		},

--- a/internal/manifests/collector/serviceaccount.go
+++ b/internal/manifests/collector/serviceaccount.go
@@ -15,12 +15,11 @@
 package collector
 
 import (
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
@@ -34,16 +33,16 @@ func ServiceAccountName(instance v1alpha1.OpenTelemetryCollector) string {
 }
 
 // ServiceAccount returns the service account for the given instance.
-func ServiceAccount(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) *corev1.ServiceAccount {
-	name := naming.ServiceAccount(otelcol.Name)
-	labels := Labels(otelcol, name, []string{})
+func ServiceAccount(params manifests.Params) *corev1.ServiceAccount {
+	name := naming.ServiceAccount(params.OtelCol.Name)
+	labels := Labels(params.OtelCol, name, []string{})
 
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   otelcol.Namespace,
+			Namespace:   params.OtelCol.Namespace,
 			Labels:      labels,
-			Annotations: otelcol.Annotations,
+			Annotations: params.OtelCol.Annotations,
 		},
 	}
 }

--- a/internal/manifests/collector/servicemonitor.go
+++ b/internal/manifests/collector/servicemonitor.go
@@ -23,40 +23,40 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/adapters"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 // ServiceMonitor returns the service monitor for the given instance.
-func ServiceMonitor(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) (*monitoringv1.ServiceMonitor, error) {
-	if !otelcol.Spec.Observability.Metrics.EnableMetrics {
-		logger.V(2).Info("Metrics disabled for this OTEL Collector",
-			"otelcol.name", otelcol.Name,
-			"otelcol.namespace", otelcol.Namespace,
+func ServiceMonitor(params manifests.Params) (*monitoringv1.ServiceMonitor, error) {
+	if !params.OtelCol.Spec.Observability.Metrics.EnableMetrics {
+		params.Log.V(2).Info("Metrics disabled for this OTEL Collector",
+			"params.OtelCol.name", params.OtelCol.Name,
+			"params.OtelCol.namespace", params.OtelCol.Namespace,
 		)
 		return nil, nil
 	}
 
 	sm := monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: otelcol.Namespace,
-			Name:      naming.ServiceMonitor(otelcol.Name),
+			Namespace: params.OtelCol.Namespace,
+			Name:      naming.ServiceMonitor(params.OtelCol.Name),
 			Labels: map[string]string{
-				"app.kubernetes.io/name":       naming.ServiceMonitor(otelcol.Name),
-				"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", otelcol.Namespace, otelcol.Name),
+				"app.kubernetes.io/name":       naming.ServiceMonitor(params.OtelCol.Name),
+				"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params.OtelCol.Namespace, params.OtelCol.Name),
 				"app.kubernetes.io/managed-by": "opentelemetry-operator",
 			},
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{},
 			NamespaceSelector: monitoringv1.NamespaceSelector{
-				MatchNames: []string{otelcol.Namespace},
+				MatchNames: []string{params.OtelCol.Namespace},
 			},
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app.kubernetes.io/managed-by": "opentelemetry-operator",
-					"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", otelcol.Namespace, otelcol.Name),
+					"app.kubernetes.io/instance":   fmt.Sprintf("%s.%s", params.OtelCol.Namespace, params.OtelCol.Name),
 				},
 			},
 		},
@@ -68,7 +68,7 @@ func ServiceMonitor(cfg config.Config, logger logr.Logger, otelcol v1alpha1.Open
 		},
 	}
 
-	sm.Spec.Endpoints = append(endpoints, endpointsFromConfig(logger, otelcol)...)
+	sm.Spec.Endpoints = append(endpoints, endpointsFromConfig(params.Log, params.OtelCol)...)
 	return &sm, nil
 }
 

--- a/internal/manifests/collector/servicemonitor_test.go
+++ b/internal/manifests/collector/servicemonitor_test.go
@@ -24,26 +24,26 @@ import (
 func TestDesiredServiceMonitors(t *testing.T) {
 	params := deploymentParams()
 
-	actual, err := ServiceMonitor(params.Config, params.Log, params.Instance)
+	actual, err := ServiceMonitor(params)
 	assert.NoError(t, err)
 	assert.Nil(t, actual)
 
-	params.Instance.Spec.Observability.Metrics.EnableMetrics = true
-	actual, err = ServiceMonitor(params.Config, params.Log, params.Instance)
+	params.OtelCol.Spec.Observability.Metrics.EnableMetrics = true
+	actual, err = ServiceMonitor(params)
 	assert.NoError(t, err)
 	assert.NotNil(t, actual)
-	assert.Equal(t, fmt.Sprintf("%s-collector", params.Instance.Name), actual.Name)
-	assert.Equal(t, params.Instance.Namespace, actual.Namespace)
+	assert.Equal(t, fmt.Sprintf("%s-collector", params.OtelCol.Name), actual.Name)
+	assert.Equal(t, params.OtelCol.Namespace, actual.Namespace)
 	assert.Equal(t, "monitoring", actual.Spec.Endpoints[0].Port)
 
 	params, err = newParams("", "testdata/prometheus-exporter.yaml")
 	assert.NoError(t, err)
-	params.Instance.Spec.Observability.Metrics.EnableMetrics = true
-	actual, err = ServiceMonitor(params.Config, params.Log, params.Instance)
+	params.OtelCol.Spec.Observability.Metrics.EnableMetrics = true
+	actual, err = ServiceMonitor(params)
 	assert.NoError(t, err)
 	assert.NotNil(t, actual)
-	assert.Equal(t, fmt.Sprintf("%s-collector", params.Instance.Name), actual.Name)
-	assert.Equal(t, params.Instance.Namespace, actual.Namespace)
+	assert.Equal(t, fmt.Sprintf("%s-collector", params.OtelCol.Name), actual.Name)
+	assert.Equal(t, params.OtelCol.Namespace, actual.Namespace)
 	assert.Equal(t, "monitoring", actual.Spec.Endpoints[0].Port)
 	assert.Equal(t, "prometheus-dev", actual.Spec.Endpoints[1].Port)
 	assert.Equal(t, "prometheus-prod", actual.Spec.Endpoints[2].Port)

--- a/internal/manifests/collector/statefulset_test.go
+++ b/internal/manifests/collector/statefulset_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	. "github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
 )
 
@@ -43,8 +44,14 @@ func TestStatefulSetNewDefault(t *testing.T) {
 	}
 	cfg := config.New()
 
+	params := manifests.Params{
+		OtelCol: otelcol,
+		Config:  cfg,
+		Log:     logger,
+	}
+
 	// test
-	ss := StatefulSet(cfg, logger, otelcol)
+	ss := StatefulSet(params)
 
 	// verify
 	assert.Equal(t, "my-instance-collector", ss.Name)
@@ -109,8 +116,14 @@ func TestStatefulSetReplicas(t *testing.T) {
 	}
 	cfg := config.New()
 
+	params := manifests.Params{
+		OtelCol: otelcol,
+		Config:  cfg,
+		Log:     logger,
+	}
+
 	// test
-	ss := StatefulSet(cfg, logger, otelcol)
+	ss := StatefulSet(params)
 
 	// assert correct number of replicas
 	assert.Equal(t, int32(3), *ss.Spec.Replicas)
@@ -139,8 +152,14 @@ func TestStatefulSetVolumeClaimTemplates(t *testing.T) {
 	}
 	cfg := config.New()
 
+	params := manifests.Params{
+		OtelCol: otelcol,
+		Config:  cfg,
+		Log:     logger,
+	}
+
 	// test
-	ss := StatefulSet(cfg, logger, otelcol)
+	ss := StatefulSet(params)
 
 	// assert correct pvc name
 	assert.Equal(t, "added-volume", ss.Spec.VolumeClaimTemplates[0].Name)
@@ -165,8 +184,14 @@ func TestStatefulSetPodAnnotations(t *testing.T) {
 	}
 	cfg := config.New()
 
+	params := manifests.Params{
+		OtelCol: otelcol,
+		Config:  cfg,
+		Log:     logger,
+	}
+
 	// test
-	ss := StatefulSet(cfg, logger, otelcol)
+	ss := StatefulSet(params)
 
 	// Add sha256 podAnnotation
 	testPodAnnotationValues["opentelemetry-operator-config/sha256"] = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -203,7 +228,13 @@ func TestStatefulSetPodSecurityContext(t *testing.T) {
 
 	cfg := config.New()
 
-	d := StatefulSet(cfg, logger, otelcol)
+	params := manifests.Params{
+		OtelCol: otelcol,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	d := StatefulSet(params)
 
 	assert.Equal(t, &runAsNonRoot, d.Spec.Template.Spec.SecurityContext.RunAsNonRoot)
 	assert.Equal(t, &runAsUser, d.Spec.Template.Spec.SecurityContext.RunAsUser)
@@ -220,7 +251,13 @@ func TestStatefulSetHostNetwork(t *testing.T) {
 
 	cfg := config.New()
 
-	d1 := StatefulSet(cfg, logger, otelcol1)
+	params1 := manifests.Params{
+		OtelCol: otelcol1,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	d1 := StatefulSet(params1)
 
 	assert.Equal(t, d1.Spec.Template.Spec.HostNetwork, false)
 	assert.Equal(t, d1.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirst)
@@ -237,7 +274,13 @@ func TestStatefulSetHostNetwork(t *testing.T) {
 
 	cfg = config.New()
 
-	d2 := StatefulSet(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		OtelCol: otelcol2,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	d2 := StatefulSet(params2)
 	assert.Equal(t, d2.Spec.Template.Spec.HostNetwork, true)
 	assert.Equal(t, d2.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirstWithHostNet)
 }
@@ -258,7 +301,13 @@ func TestStatefulSetFilterLabels(t *testing.T) {
 
 	cfg := config.New(config.WithLabelFilters([]string{"foo*", "app.*.bar"}))
 
-	d := StatefulSet(cfg, logger, otelcol)
+	params := manifests.Params{
+		OtelCol: otelcol,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	d := StatefulSet(params)
 
 	assert.Len(t, d.ObjectMeta.Labels, 6)
 	for k := range excludedLabels {
@@ -276,7 +325,13 @@ func TestStatefulSetNodeSelector(t *testing.T) {
 
 	cfg := config.New()
 
-	d1 := StatefulSet(cfg, logger, otelcol1)
+	params1 := manifests.Params{
+		OtelCol: otelcol1,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	d1 := StatefulSet(params1)
 
 	assert.Empty(t, d1.Spec.Template.Spec.NodeSelector)
 
@@ -295,7 +350,13 @@ func TestStatefulSetNodeSelector(t *testing.T) {
 
 	cfg = config.New()
 
-	d2 := StatefulSet(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		OtelCol: otelcol2,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	d2 := StatefulSet(params2)
 	assert.Equal(t, d2.Spec.Template.Spec.NodeSelector, map[string]string{"node-key": "node-value"})
 }
 
@@ -308,7 +369,13 @@ func TestStatefulSetPriorityClassName(t *testing.T) {
 
 	cfg := config.New()
 
-	sts1 := StatefulSet(cfg, logger, otelcol1)
+	params1 := manifests.Params{
+		OtelCol: otelcol1,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	sts1 := StatefulSet(params1)
 	assert.Empty(t, sts1.Spec.Template.Spec.PriorityClassName)
 
 	priorityClassName := "test-class"
@@ -324,7 +391,13 @@ func TestStatefulSetPriorityClassName(t *testing.T) {
 
 	cfg = config.New()
 
-	sts2 := StatefulSet(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		OtelCol: otelcol2,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	sts2 := StatefulSet(params2)
 	assert.Equal(t, priorityClassName, sts2.Spec.Template.Spec.PriorityClassName)
 }
 
@@ -337,7 +410,13 @@ func TestStatefulSetAffinity(t *testing.T) {
 
 	cfg := config.New()
 
-	sts1 := Deployment(cfg, logger, otelcol1)
+	params1 := manifests.Params{
+		OtelCol: otelcol1,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	sts1 := Deployment(params1)
 	assert.Nil(t, sts1.Spec.Template.Spec.Affinity)
 
 	otelcol2 := v1alpha1.OpenTelemetryCollector{
@@ -351,7 +430,13 @@ func TestStatefulSetAffinity(t *testing.T) {
 
 	cfg = config.New()
 
-	sts2 := StatefulSet(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		OtelCol: otelcol2,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	sts2 := StatefulSet(params2)
 	assert.NotNil(t, sts2.Spec.Template.Spec.Affinity)
 	assert.Equal(t, *testAffinityValue, *sts2.Spec.Template.Spec.Affinity)
 }
@@ -373,8 +458,14 @@ func TestStatefulSetInitContainer(t *testing.T) {
 	}
 	cfg := config.New()
 
+	params := manifests.Params{
+		OtelCol: otelcol,
+		Config:  cfg,
+		Log:     logger,
+	}
+
 	// test
-	s := StatefulSet(cfg, logger, otelcol)
+	s := StatefulSet(params)
 	assert.Equal(t, "my-instance-collector", s.Name)
 	assert.Equal(t, "my-instance-collector", s.Labels["app.kubernetes.io/name"])
 	assert.Equal(t, "true", s.Annotations["prometheus.io/scrape"])
@@ -392,7 +483,13 @@ func TestStatefulSetTopologySpreadConstraints(t *testing.T) {
 	}
 
 	cfg := config.New()
-	s1 := StatefulSet(cfg, logger, otelcol1)
+
+	params1 := manifests.Params{
+		OtelCol: otelcol1,
+		Config:  cfg,
+		Log:     logger,
+	}
+	s1 := StatefulSet(params1)
 	assert.Equal(t, "my-instance-collector", s1.Name)
 	assert.Empty(t, s1.Spec.Template.Spec.TopologySpreadConstraints)
 
@@ -408,7 +505,13 @@ func TestStatefulSetTopologySpreadConstraints(t *testing.T) {
 
 	cfg = config.New()
 
-	s2 := StatefulSet(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		OtelCol: otelcol2,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	s2 := StatefulSet(params2)
 	assert.Equal(t, "my-instance-topologyspreadconstraint-collector", s2.Name)
 	assert.NotNil(t, s2.Spec.Template.Spec.TopologySpreadConstraints)
 	assert.NotEmpty(t, s2.Spec.Template.Spec.TopologySpreadConstraints)
@@ -432,8 +535,14 @@ func TestStatefulSetAdditionalContainers(t *testing.T) {
 	}
 	cfg := config.New()
 
+	params := manifests.Params{
+		OtelCol: otelcol,
+		Config:  cfg,
+		Log:     logger,
+	}
+
 	// test
-	s := StatefulSet(cfg, logger, otelcol)
+	s := StatefulSet(params)
 	assert.Equal(t, "my-instance-collector", s.Name)
 	assert.Equal(t, "my-instance-collector", s.Labels["app.kubernetes.io/name"])
 	assert.Equal(t, "true", s.Annotations["prometheus.io/scrape"])

--- a/internal/manifests/collector/suite_test.go
+++ b/internal/manifests/collector/suite_test.go
@@ -52,7 +52,7 @@ func paramsWithMode(mode v1alpha1.Mode) manifests.Params {
 	}
 	return manifests.Params{
 		Config: config.New(config.WithCollectorImage(defaultCollectorImage), config.WithTargetAllocatorImage(defaultTaAllocationImage)),
-		Instance: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha1.OpenTelemetryCollector{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "opentelemetry.io",
 				APIVersion: "v1",
@@ -101,7 +101,7 @@ func newParams(taContainerImage string, file string) (manifests.Params, error) {
 
 	return manifests.Params{
 		Config: cfg,
-		Instance: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha1.OpenTelemetryCollector{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "opentelemetry.io",
 				APIVersion: "v1",

--- a/internal/manifests/params.go
+++ b/internal/manifests/params.go
@@ -30,6 +30,6 @@ type Params struct {
 	Recorder record.EventRecorder
 	Scheme   *runtime.Scheme
 	Log      logr.Logger
-	Instance v1alpha1.OpenTelemetryCollector
+	OtelCol  v1alpha1.OpenTelemetryCollector
 	Config   config.Config
 }

--- a/internal/manifests/targetallocator/annotations_test.go
+++ b/internal/manifests/targetallocator/annotations_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
 func TestPodAnnotations(t *testing.T) {
@@ -38,7 +39,12 @@ func TestPodAnnotations(t *testing.T) {
 func TestConfigMapHash(t *testing.T) {
 	cfg := config.New()
 	instance := collectorInstance()
-	expectedConfigMap, err := ConfigMap(cfg, logr.Discard(), instance)
+	params := manifests.Params{
+		OtelCol: instance,
+		Config:  cfg,
+		Log:     logr.Discard(),
+	}
+	expectedConfigMap, err := ConfigMap(params)
 	require.NoError(t, err)
 	expectedConfig := expectedConfigMap.Data[targetAllocatorFilename]
 	require.NotEmpty(t, expectedConfig)

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
 func TestDesiredConfigMap(t *testing.T) {
@@ -56,7 +57,12 @@ label_selector:
 		}
 		instance := collectorInstance()
 		cfg := config.New()
-		actual, err := ConfigMap(cfg, logr.Discard(), instance)
+		params := manifests.Params{
+			OtelCol: instance,
+			Config:  cfg,
+			Log:     logr.Discard(),
+		}
+		actual, err := ConfigMap(params)
 		assert.NoError(t, err)
 
 		assert.Equal(t, "my-instance-targetallocator", actual.Name)
@@ -97,7 +103,12 @@ service_monitor_selector:
 			"release": "my-instance",
 		}
 		cfg := config.New()
-		actual, err := ConfigMap(cfg, logr.Discard(), instance)
+		params := manifests.Params{
+			OtelCol: instance,
+			Config:  cfg,
+			Log:     logr.Discard(),
+		}
+		actual, err := ConfigMap(params)
 		assert.NoError(t, err)
 
 		assert.Equal(t, "my-instance-targetallocator", actual.Name)
@@ -132,7 +143,12 @@ prometheus_cr:
 		collector := collectorInstance()
 		collector.Spec.TargetAllocator.PrometheusCR.ScrapeInterval = &metav1.Duration{Duration: time.Second * 30}
 		cfg := config.New()
-		actual, err := ConfigMap(cfg, logr.Discard(), collector)
+		params := manifests.Params{
+			OtelCol: collector,
+			Config:  cfg,
+			Log:     logr.Discard(),
+		}
+		actual, err := ConfigMap(params)
 		assert.NoError(t, err)
 
 		assert.Equal(t, "my-instance-targetallocator", actual.Name)

--- a/internal/manifests/targetallocator/deployment.go
+++ b/internal/manifests/targetallocator/deployment.go
@@ -15,36 +15,34 @@
 package targetallocator
 
 import (
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 // Deployment builds the deployment for the given instance.
-func Deployment(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) *appsv1.Deployment {
-	name := naming.TargetAllocator(otelcol.Name)
-	labels := Labels(otelcol, name)
+func Deployment(params manifests.Params) *appsv1.Deployment {
+	name := naming.TargetAllocator(params.OtelCol.Name)
+	labels := Labels(params.OtelCol, name)
 
-	configMap, err := ConfigMap(cfg, logger, otelcol)
+	configMap, err := ConfigMap(params)
 	if err != nil {
-		logger.Info("failed to construct target allocator config map for annotations")
+		params.Log.Info("failed to construct target allocator config map for annotations")
 		configMap = nil
 	}
-	annotations := Annotations(otelcol, configMap)
+	annotations := Annotations(params.OtelCol, configMap)
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: otelcol.Namespace,
+			Namespace: params.OtelCol.Namespace,
 			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: otelcol.Spec.TargetAllocator.Replicas,
+			Replicas: params.OtelCol.Spec.TargetAllocator.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},
@@ -54,11 +52,11 @@ func Deployment(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTele
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName:        ServiceAccountName(otelcol),
-					Containers:                []corev1.Container{Container(cfg, logger, otelcol)},
-					Volumes:                   Volumes(cfg, otelcol),
-					NodeSelector:              otelcol.Spec.TargetAllocator.NodeSelector,
-					TopologySpreadConstraints: otelcol.Spec.TargetAllocator.TopologySpreadConstraints,
+					ServiceAccountName:        ServiceAccountName(params.OtelCol),
+					Containers:                []corev1.Container{Container(params.Config, params.Log, params.OtelCol)},
+					Volumes:                   Volumes(params.Config, params.OtelCol),
+					NodeSelector:              params.OtelCol.Spec.TargetAllocator.NodeSelector,
+					TopologySpreadConstraints: params.OtelCol.Spec.TargetAllocator.TopologySpreadConstraints,
 				},
 			},
 		},

--- a/internal/manifests/targetallocator/deployment_test.go
+++ b/internal/manifests/targetallocator/deployment_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
 var testTopologySpreadConstraintValue = []v1.TopologySpreadConstraint{
@@ -45,8 +46,14 @@ func TestDeploymentNewDefault(t *testing.T) {
 	otelcol := collectorInstance()
 	cfg := config.New()
 
+	params := manifests.Params{
+		OtelCol: otelcol,
+		Config:  cfg,
+		Log:     logger,
+	}
+
 	// test
-	d := Deployment(cfg, logger, otelcol)
+	d := Deployment(params)
 
 	// verify
 	assert.Equal(t, "my-instance-targetallocator", d.GetName())
@@ -69,8 +76,14 @@ func TestDeploymentPodAnnotations(t *testing.T) {
 	otelcol.Spec.PodAnnotations = testPodAnnotationValues
 	cfg := config.New()
 
+	params := manifests.Params{
+		OtelCol: otelcol,
+		Config:  cfg,
+		Log:     logger,
+	}
+
 	// test
-	ds := Deployment(cfg, logger, otelcol)
+	ds := Deployment(params)
 
 	// verify
 	assert.Equal(t, "my-instance-targetallocator", ds.Name)
@@ -103,7 +116,13 @@ func TestDeploymentNodeSelector(t *testing.T) {
 	}
 
 	cfg := config.New()
-	d1 := Deployment(cfg, logger, otelcol1)
+
+	params1 := manifests.Params{
+		OtelCol: otelcol1,
+		Config:  cfg,
+		Log:     logger,
+	}
+	d1 := Deployment(params1)
 	assert.Empty(t, d1.Spec.Template.Spec.NodeSelector)
 
 	// Test nodeSelector
@@ -122,7 +141,13 @@ func TestDeploymentNodeSelector(t *testing.T) {
 
 	cfg = config.New()
 
-	d2 := Deployment(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		OtelCol: otelcol2,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	d2 := Deployment(params2)
 	assert.Equal(t, map[string]string{"node-key": "node-value"}, d2.Spec.Template.Spec.NodeSelector)
 }
 
@@ -135,7 +160,13 @@ func TestDeploymentTopologySpreadConstraints(t *testing.T) {
 	}
 
 	cfg := config.New()
-	d1 := Deployment(cfg, logger, otelcol1)
+
+	params1 := manifests.Params{
+		OtelCol: otelcol1,
+		Config:  cfg,
+		Log:     logger,
+	}
+	d1 := Deployment(params1)
 	assert.Equal(t, "my-instance-targetallocator", d1.Name)
 	assert.Empty(t, d1.Spec.Template.Spec.TopologySpreadConstraints)
 
@@ -152,7 +183,13 @@ func TestDeploymentTopologySpreadConstraints(t *testing.T) {
 	}
 
 	cfg = config.New()
-	d2 := Deployment(cfg, logger, otelcol2)
+	params2 := manifests.Params{
+		OtelCol: otelcol2,
+		Config:  cfg,
+		Log:     logger,
+	}
+
+	d2 := Deployment(params2)
 	assert.Equal(t, "my-instance-topologyspreadconstraint-targetallocator", d2.Name)
 	assert.NotNil(t, d2.Spec.Template.Spec.TopologySpreadConstraints)
 	assert.NotEmpty(t, d2.Spec.Template.Spec.TopologySpreadConstraints)

--- a/internal/manifests/targetallocator/service.go
+++ b/internal/manifests/targetallocator/service.go
@@ -15,26 +15,24 @@
 package targetallocator
 
 import (
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
-func Service(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) *corev1.Service {
-	name := naming.TAService(otelcol.Name)
-	labels := Labels(otelcol, name)
+func Service(params manifests.Params) *corev1.Service {
+	name := naming.TAService(params.OtelCol.Name)
+	labels := Labels(params.OtelCol, name)
 
-	selector := Labels(otelcol, name)
+	selector := Labels(params.OtelCol, name)
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      naming.TAService(otelcol.Name),
-			Namespace: otelcol.Namespace,
+			Name:      naming.TAService(params.OtelCol.Name),
+			Namespace: params.OtelCol.Namespace,
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{

--- a/internal/manifests/targetallocator/serviceaccount.go
+++ b/internal/manifests/targetallocator/serviceaccount.go
@@ -15,11 +15,10 @@
 package targetallocator
 
 import (
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
@@ -35,16 +34,16 @@ func ServiceAccountName(instance v1alpha1.OpenTelemetryCollector) string {
 }
 
 // ServiceAccount returns the service account for the given instance.
-func ServiceAccount(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) *corev1.ServiceAccount {
-	name := naming.TargetAllocatorServiceAccount(otelcol.Name)
-	labels := Labels(otelcol, name)
+func ServiceAccount(params manifests.Params) *corev1.ServiceAccount {
+	name := naming.TargetAllocatorServiceAccount(params.OtelCol.Name)
+	labels := Labels(params.OtelCol, name)
 
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   otelcol.Namespace,
+			Namespace:   params.OtelCol.Namespace,
 			Labels:      labels,
-			Annotations: otelcol.Annotations,
+			Annotations: params.OtelCol.Annotations,
 		},
 	}
 }

--- a/internal/manifests/targetallocator/targetallocator.go
+++ b/internal/manifests/targetallocator/targetallocator.go
@@ -23,7 +23,7 @@ import (
 // Build creates the manifest for the TargetAllocator resource.
 func Build(params manifests.Params) ([]client.Object, error) {
 	var resourceManifests []client.Object
-	if !params.Instance.Spec.TargetAllocator.Enabled {
+	if !params.OtelCol.Spec.TargetAllocator.Enabled {
 		return resourceManifests, nil
 	}
 	resourceFactories := []manifests.K8sManifestFactory{
@@ -33,7 +33,7 @@ func Build(params manifests.Params) ([]client.Object, error) {
 		manifests.FactoryWithoutError(Service),
 	}
 	for _, factory := range resourceFactories {
-		res, err := factory(params.Config, params.Log, params.Instance)
+		res, err := factory(params)
 		if err != nil {
 			return nil, err
 		} else if manifests.ObjectIsNotNil(res) {

--- a/internal/status/handle.go
+++ b/internal/status/handle.go
@@ -41,10 +41,10 @@ const (
 func HandleReconcileStatus(ctx context.Context, log logr.Logger, params manifests.Params, err error) (ctrl.Result, error) {
 	log.V(2).Info("updating collector status")
 	if err != nil {
-		params.Recorder.Event(&params.Instance, eventTypeWarning, reasonError, err.Error())
+		params.Recorder.Event(&params.OtelCol, eventTypeWarning, reasonError, err.Error())
 		return ctrl.Result{}, err
 	}
-	changed := params.Instance.DeepCopy()
+	changed := params.OtelCol.DeepCopy()
 
 	up := &collectorupgrade.VersionUpgrade{
 		Log:      params.Log,
@@ -63,7 +63,7 @@ func HandleReconcileStatus(ctx context.Context, log logr.Logger, params manifest
 		params.Recorder.Event(changed, eventTypeWarning, reasonStatusFailure, statusErr.Error())
 		return ctrl.Result{}, statusErr
 	}
-	statusPatch := client.MergeFrom(&params.Instance)
+	statusPatch := client.MergeFrom(&params.OtelCol)
 	if err := params.Client.Status().Patch(ctx, changed, statusPatch); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to apply status changes to the OpenTelemetry CR: %w", err)
 	}

--- a/pkg/collector/reconcile/route_test.go
+++ b/pkg/collector/reconcile/route_test.go
@@ -37,24 +37,24 @@ func TestExpectedRoutes(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		params.Instance.Spec.Ingress.Type = v1alpha1.IngressTypeRoute
-		params.Instance.Spec.Ingress.Route.Termination = v1alpha1.TLSRouteTerminationTypeInsecure
+		params.OtelCol.Spec.Ingress.Type = v1alpha1.IngressTypeRoute
+		params.OtelCol.Spec.Ingress.Route.Termination = v1alpha1.TLSRouteTerminationTypeInsecure
 
-		routes := collector.Routes(params.Config, params.Log, params.Instance)
+		routes := collector.Routes(params)
 		err = expectedRoutes(ctx, params, routes)
 		assert.NoError(t, err)
 
-		nns := types.NamespacedName{Namespace: params.Instance.Namespace, Name: "otlp-grpc-test-route"}
+		nns := types.NamespacedName{Namespace: params.OtelCol.Namespace, Name: "otlp-grpc-test-route"}
 		exists, err := populateObjectIfExists(t, &routev1.Route{}, nns)
 		assert.NoError(t, err)
 		assert.True(t, exists)
 
 		// update fields
 		const expectHostname = "something-else.com"
-		params.Instance.Spec.Ingress.Annotations = map[string]string{"blub": "blob"}
-		params.Instance.Spec.Ingress.Hostname = expectHostname
+		params.OtelCol.Spec.Ingress.Annotations = map[string]string{"blub": "blob"}
+		params.OtelCol.Spec.Ingress.Hostname = expectHostname
 
-		routes = collector.Routes(params.Config, params.Log, params.Instance)
+		routes = collector.Routes(params)
 		err = expectedRoutes(ctx, params, routes)
 		assert.NoError(t, err)
 
@@ -82,9 +82,9 @@ func TestDeleteRoutes(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		myParams.Instance.Spec.Ingress.Type = v1alpha1.IngressTypeRoute
+		myParams.OtelCol.Spec.Ingress.Type = v1alpha1.IngressTypeRoute
 
-		routes := collector.Routes(myParams.Config, myParams.Log, myParams.Instance)
+		routes := collector.Routes(myParams)
 		err = expectedRoutes(ctx, myParams, routes)
 		assert.NoError(t, err)
 

--- a/pkg/collector/reconcile/suite_test.go
+++ b/pkg/collector/reconcile/suite_test.go
@@ -203,7 +203,7 @@ func paramsWithMode(mode v1alpha1.Mode) manifests.Params {
 	return manifests.Params{
 		Config: config.New(config.WithCollectorImage(defaultCollectorImage), config.WithTargetAllocatorImage(defaultTaAllocationImage)),
 		Client: k8sClient,
-		Instance: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha1.OpenTelemetryCollector{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "opentelemetry.io",
 				APIVersion: "v1",
@@ -254,7 +254,7 @@ func newParams(taContainerImage string, file string) (manifests.Params, error) {
 	return manifests.Params{
 		Config: cfg,
 		Client: k8sClient,
-		Instance: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha1.OpenTelemetryCollector{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "opentelemetry.io",
 				APIVersion: "v1",


### PR DESCRIPTION
This is an internal-only PR as a follow up to #1995 and #1559. This simply pulls out the logic to change the signature for building to be more generic to resources beyond a collector, this also splits out some common reconciliation logic