### PR TITLE
Add rate limiting for scrape config updates

### DIFF
--- a/.chloggen/ta_update-rate-limit.yaml
+++ b/.chloggen/ta_update-rate-limit.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add rate limiting for scrape config updates
+
+# One or more tracking issues related to the change
+issues: [1544]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/watcher/promOperator.go
+++ b/cmd/otel-allocator/watcher/promOperator.go
@@ -38,7 +38,7 @@ import (
 	allocatorconfig "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
 )
 
-const MinEventInterval = time.Second * 5
+const minEventInterval = time.Second * 5
 
 func NewPrometheusCRWatcher(logger logr.Logger, cfg allocatorconfig.Config) (*PrometheusCRWatcher, error) {
 	mClient, err := monitoringclient.NewForConfig(cfg.ClusterConfig)
@@ -82,7 +82,7 @@ func NewPrometheusCRWatcher(logger logr.Logger, cfg allocatorconfig.Config) (*Pr
 		k8sClient:              clientset,
 		informers:              monitoringInformers,
 		stopChannel:            make(chan struct{}),
-		eventInterval:          MinEventInterval,
+		eventInterval:          minEventInterval,
 		configGenerator:        generator,
 		kubeConfigPath:         cfg.KubeConfigFilePath,
 		serviceMonitorSelector: servMonSelector,

--- a/cmd/otel-allocator/watcher/promOperator.go
+++ b/cmd/otel-allocator/watcher/promOperator.go
@@ -17,6 +17,7 @@ package watcher
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-logr/logr"
@@ -36,6 +37,8 @@ import (
 
 	allocatorconfig "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/config"
 )
+
+const MinEventInterval = time.Second * 5
 
 func NewPrometheusCRWatcher(logger logr.Logger, cfg allocatorconfig.Config) (*PrometheusCRWatcher, error) {
 	mClient, err := monitoringclient.NewForConfig(cfg.ClusterConfig)
@@ -79,6 +82,7 @@ func NewPrometheusCRWatcher(logger logr.Logger, cfg allocatorconfig.Config) (*Pr
 		k8sClient:              clientset,
 		informers:              monitoringInformers,
 		stopChannel:            make(chan struct{}),
+		eventInterval:          MinEventInterval,
 		configGenerator:        generator,
 		kubeConfigPath:         cfg.KubeConfigFilePath,
 		serviceMonitorSelector: servMonSelector,
@@ -91,6 +95,7 @@ type PrometheusCRWatcher struct {
 	kubeMonitoringClient monitoringclient.Interface
 	k8sClient            kubernetes.Interface
 	informers            map[string]*informers.ForResource
+	eventInterval        time.Duration
 	stopChannel          chan struct{}
 	configGenerator      *prometheus.ConfigGenerator
 	kubeConfigPath       string
@@ -126,11 +131,9 @@ func getInformers(factory informers.FactoriesForNamespaces) (map[string]*informe
 
 // Watch wrapped informers and wait for an initial sync.
 func (w *PrometheusCRWatcher) Watch(upstreamEvents chan Event, upstreamErrors chan error) error {
-	event := Event{
-		Source:  EventSourcePrometheusCR,
-		Watcher: Watcher(w),
-	}
 	success := true
+	// this channel needs to be buffered because notifications are asynchronous and neither producers nor consumers wait
+	notifyEvents := make(chan struct{}, 1)
 
 	for name, resource := range w.informers {
 		resource.Start(w.stopChannel)
@@ -138,23 +141,72 @@ func (w *PrometheusCRWatcher) Watch(upstreamEvents chan Event, upstreamErrors ch
 		if ok := cache.WaitForNamedCacheSync(name, w.stopChannel, resource.HasSynced); !ok {
 			success = false
 		}
+
+		// only send an event notification if there isn't one already
 		resource.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			// these functions only write to the notification channel if it's empty to avoid blocking
+			// if scrape config updates are being rate-limited
 			AddFunc: func(obj interface{}) {
-				upstreamEvents <- event
+				select {
+				case notifyEvents <- struct{}{}:
+				default:
+				}
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				upstreamEvents <- event
+				select {
+				case notifyEvents <- struct{}{}:
+				default:
+				}
 			},
 			DeleteFunc: func(obj interface{}) {
-				upstreamEvents <- event
+				select {
+				case notifyEvents <- struct{}{}:
+				default:
+				}
 			},
 		})
 	}
 	if !success {
 		return fmt.Errorf("failed to sync cache")
 	}
+
+	// limit the rate of outgoing events
+	w.rateLimitedEventSender(upstreamEvents, notifyEvents)
+
 	<-w.stopChannel
 	return nil
+}
+
+// rateLimitedEventSender sends events to the upstreamEvents channel whenever it gets a notification on the notifyEvents channel,
+// but not more frequently than once per w.eventPeriod.
+func (w *PrometheusCRWatcher) rateLimitedEventSender(upstreamEvents chan Event, notifyEvents chan struct{}) {
+	ticker := time.NewTicker(w.eventInterval)
+	defer ticker.Stop()
+
+	event := Event{
+		Source:  EventSourcePrometheusCR,
+		Watcher: Watcher(w),
+	}
+
+	for {
+		select {
+		case <-w.stopChannel:
+			return
+		case <-ticker.C: // throttle events to avoid excessive updates
+			select {
+			case <-notifyEvents:
+				select {
+				case upstreamEvents <- event:
+				default: // put the notification back in the queue if we can't send it upstream
+					select {
+					case notifyEvents <- struct{}{}:
+					default:
+					}
+				}
+			default:
+			}
+		}
+	}
 }
 
 func (w *PrometheusCRWatcher) Close() error {


### PR DESCRIPTION
Limit the rate on updates to scrape configs. The idea and code are very similar to what Prometheus' Service Discovery manager does: https://github.com/prometheus/prometheus/blob/79be1b835789d7c3fde2a907003a8799c308733f/discovery/manager.go#L341. The end result is that we emit events about changes to Prometheus CRs at most every 5 seconds.

This should help with #1544 