### PR TITLE
Fix depguard linter configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,12 +44,13 @@ linters-settings:
     min-confidence: 0.8
   
   depguard:
-    list-type: denylist
-    include-go-root: true
-    packages-with-error-message:
-      # See https://github.com/open-telemetry/opentelemetry-collector/issues/5200 for rationale
-      - sync/atomic: "Use go.uber.org/atomic instead of sync/atomic"
-      - github.com/pkg/errors: "Use 'errors' or 'fmt' instead of github.com/pkg/errors"
+    rules:
+      main:
+        deny:
+          - pkg: sync/atomic
+            desc: "Use go.uber.org/atomic instead of sync/atomic"
+          - pkg: github.com/pkg/errors
+            desc: "Use 'errors' or 'fmt' instead of github.com/pkg/errors"
 
 linters:
   enable:


### PR DESCRIPTION
We were using configuration for depguard v1, but golangci-lint 1.54 ships depguard v2.

Note: This was failing on my local machine, but not in CI, which was confusing. I believe the CI was using cached values somehow. I deleted the golangci-lint cache manually and got the same failure I did locally on a job that succeeded with the cache present: https://github.com/open-telemetry/opentelemetry-operator/actions/runs/6389543772/job/17347446252