### PR TITLE
[chore] Change the base image to use the glibc version and not the musl version of test image

### DIFF
--- a/tests/instrumentation-e2e-apps/apache-httpd/Dockerfile
+++ b/tests/instrumentation-e2e-apps/apache-httpd/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM httpd:2.4-alpine
+FROM httpd:2.4
 
 RUN sed -i "s#Listen 80#Listen 8080#g" /usr/local/apache2/conf/httpd.conf
 RUN chmod 777 -R /usr/local/apache2/


### PR DESCRIPTION
Related to #2073.

Changed the base image to use the glibc version and not musl (not supported).