### PR TITLE
Fixed Labels with sha256 image ref

### DIFF
--- a/.chloggen/bug-fix-labeling-process.yaml
+++ b/.chloggen/bug-fix-labeling-process.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: Operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed the labeling process which was broken at the moment to capture the current image tag when the users set the sha256 reference. 
+
+# One or more tracking issues related to the change
+issues: [1982]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: ""

--- a/internal/manifests/collector/labels.go
+++ b/internal/manifests/collector/labels.go
@@ -58,7 +58,7 @@ func Labels(instance v1alpha1.OpenTelemetryCollector, name string, filterLabels 
 	case 3:
 		base["app.kubernetes.io/version"] = versionLabel
 	case 2:
-		base["app.kubernetes.io/version"] = version[len(version)-1]
+		base["app.kubernetes.io/version"] = naming.Truncate("%s", 63, version[len(version)-1])
 	default:
 		base["app.kubernetes.io/version"] = "latest"
 	}

--- a/internal/manifests/collector/labels.go
+++ b/internal/manifests/collector/labels.go
@@ -33,6 +33,7 @@ func isFilteredLabel(label string, filterLabels []string) bool {
 
 // Labels return the common labels to all objects that are part of a managed OpenTelemetryCollector.
 func Labels(instance v1alpha1.OpenTelemetryCollector, name string, filterLabels []string) map[string]string {
+	var versionLabel string
 	// new map every time, so that we don't touch the instance's label
 	base := map[string]string{}
 	if nil != instance.Labels {
@@ -48,9 +49,17 @@ func Labels(instance v1alpha1.OpenTelemetryCollector, name string, filterLabels 
 	}
 
 	version := strings.Split(instance.Spec.Image, ":")
-	if len(version) > 1 {
+	for _, v := range version {
+		if strings.HasSuffix(v, "@sha256") {
+			versionLabel = strings.TrimSuffix(v, "@sha256")
+		}
+	}
+	switch lenVersion := len(version); lenVersion {
+	case 3:
+		base["app.kubernetes.io/version"] = versionLabel
+	case 2:
 		base["app.kubernetes.io/version"] = version[len(version)-1]
-	} else {
+	default:
 		base["app.kubernetes.io/version"] = "latest"
 	}
 

--- a/internal/manifests/collector/labels_test.go
+++ b/internal/manifests/collector/labels_test.go
@@ -57,7 +57,7 @@ func TestLabelsSha256Set(t *testing.T) {
 			Namespace: collectorNamespace,
 		},
 		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			Image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.81.0@sha256:c6671841470b83007e0553cdadbc9d05f6cfe17b3ebe9733728dc4a579a5b532",
+			Image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator@sha256:c6671841470b83007e0553cdadbc9d05f6cfe17b3ebe9733728dc4a579a5b532",
 		},
 	}
 
@@ -65,9 +65,28 @@ func TestLabelsSha256Set(t *testing.T) {
 	labels := Labels(otelcol, collectorName, []string{})
 	assert.Equal(t, "opentelemetry-operator", labels["app.kubernetes.io/managed-by"])
 	assert.Equal(t, "my-ns.my-instance", labels["app.kubernetes.io/instance"])
-	assert.Equal(t, "0.81.0", labels["app.kubernetes.io/version"])
+	assert.Equal(t, "c6671841470b83007e0553cdadbc9d05f6cfe17b3ebe9733728dc4a579a5b53", labels["app.kubernetes.io/version"])
 	assert.Equal(t, "opentelemetry", labels["app.kubernetes.io/part-of"])
 	assert.Equal(t, "opentelemetry-collector", labels["app.kubernetes.io/component"])
+
+	// prepare
+	otelcolTag := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      collectorName,
+			Namespace: collectorNamespace,
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.81.0@sha256:c6671841470b83007e0553cdadbc9d05f6cfe17b3ebe9733728dc4a579a5b532",
+		},
+	}
+
+	// test
+	labelsTag := Labels(otelcolTag, collectorName, []string{})
+	assert.Equal(t, "opentelemetry-operator", labelsTag["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "my-ns.my-instance", labelsTag["app.kubernetes.io/instance"])
+	assert.Equal(t, "0.81.0", labelsTag["app.kubernetes.io/version"])
+	assert.Equal(t, "opentelemetry", labelsTag["app.kubernetes.io/part-of"])
+	assert.Equal(t, "opentelemetry-collector", labelsTag["app.kubernetes.io/component"])
 }
 func TestLabelsTagUnset(t *testing.T) {
 	// prepare

--- a/internal/manifests/collector/labels_test.go
+++ b/internal/manifests/collector/labels_test.go
@@ -49,7 +49,26 @@ func TestLabelsCommonSet(t *testing.T) {
 	assert.Equal(t, "opentelemetry", labels["app.kubernetes.io/part-of"])
 	assert.Equal(t, "opentelemetry-collector", labels["app.kubernetes.io/component"])
 }
+func TestLabelsSha256Set(t *testing.T) {
+	// prepare
+	otelcol := v1alpha1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      collectorName,
+			Namespace: collectorNamespace,
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.81.0@sha256:c6671841470b83007e0553cdadbc9d05f6cfe17b3ebe9733728dc4a579a5b532",
+		},
+	}
 
+	// test
+	labels := Labels(otelcol, collectorName, []string{})
+	assert.Equal(t, "opentelemetry-operator", labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "my-ns.my-instance", labels["app.kubernetes.io/instance"])
+	assert.Equal(t, "0.81.0", labels["app.kubernetes.io/version"])
+	assert.Equal(t, "opentelemetry", labels["app.kubernetes.io/part-of"])
+	assert.Equal(t, "opentelemetry-collector", labels["app.kubernetes.io/component"])
+}
 func TestLabelsTagUnset(t *testing.T) {
 	// prepare
 	otelcol := v1alpha1.OpenTelemetryCollector{

--- a/tests/e2e/smoke-pod-labels/00-assert.yaml
+++ b/tests/e2e/smoke-pod-labels/00-assert.yaml
@@ -1,18 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: testlabel
+  name: testlabel-collector
   labels:
     app.kubernetes.io/component: opentelemetry-collector
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/name: testlabel
     app.kubernetes.io/part-of: opentelemetry
-    app.kubernetes.io/version: c6671841470b83007e0553cdadbc9d05f6cfe17b3ebe9733728dc4a579a5b53
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: opentelemetry-collector
-      app.kubernetes.io/managed-by: opentelemetry-operator
-      app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: a0c6dea261b3d794971c23c5665173a39f0ce2aa09b9d88b753bd46776d7b05
 status:
   readyReplicas: 1

--- a/tests/e2e/smoke-pod-labels/00-assert.yaml
+++ b/tests/e2e/smoke-pod-labels/00-assert.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/name: testlabel
     app.kubernetes.io/part-of: opentelemetry
-    app.kubernetes.io/version: 0.81.0
+    app.kubernetes.io/version: c6671841470b83007e0553cdadbc9d05f6cfe17b3ebe9733728dc4a579a5b53
 spec:
   selector:
     matchLabels:

--- a/tests/e2e/smoke-pod-labels/00-assert.yaml
+++ b/tests/e2e/smoke-pod-labels/00-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testlabel
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: testlabel
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: 0.81.0
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+status:
+  readyReplicas: 1

--- a/tests/e2e/smoke-pod-labels/00-assert.yaml
+++ b/tests/e2e/smoke-pod-labels/00-assert.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: opentelemetry-collector
     app.kubernetes.io/managed-by: opentelemetry-operator
-    app.kubernetes.io/name: testlabel
+    app.kubernetes.io/name: testlabel-collector
     app.kubernetes.io/part-of: opentelemetry
     app.kubernetes.io/version: a0c6dea261b3d794971c23c5665173a39f0ce2aa09b9d88b753bd46776d7b05
 status:

--- a/tests/e2e/smoke-pod-labels/00-install.yaml
+++ b/tests/e2e/smoke-pod-labels/00-install.yaml
@@ -1,0 +1,30 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: testlabel
+spec:
+  image: otel/opentelemetry-collector-contrib:0.81.0@sha256:c6671841470b83007e0553cdadbc9d05f6cfe17b3ebe9733728dc4a579a5b532
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+
+    exporters:
+      logging:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [logging]

--- a/tests/e2e/smoke-pod-labels/00-install.yaml
+++ b/tests/e2e/smoke-pod-labels/00-install.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: testlabel
 spec:
-  image: otel/opentelemetry-collector-contrib:0.81.0@sha256:c6671841470b83007e0553cdadbc9d05f6cfe17b3ebe9733728dc4a579a5b532
+  image: otel/opentelemetry-collector-contrib@sha256:c6671841470b83007e0553cdadbc9d05f6cfe17b3ebe9733728dc4a579a5b532
   config: |
     receivers:
       otlp:

--- a/tests/e2e/smoke-pod-labels/00-install.yaml
+++ b/tests/e2e/smoke-pod-labels/00-install.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: testlabel
 spec:
-  image: otel/opentelemetry-collector-contrib@sha256:c6671841470b83007e0553cdadbc9d05f6cfe17b3ebe9733728dc4a579a5b532
+  image: otel/opentelemetry-collector-contrib@sha256:a0c6dea261b3d794971c23c5665173a39f0ce2aa09b9d88b753bd46776d7b05b
   config: |
     receivers:
       otlp:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fixed the labeling process which was broken at the moment to capture the current image tag when the users set the sha256 reference.

**Link to tracking Issue:** <Issue number if applicable>
resolves #1982 

**Testing:** <Describe what testing was performed and which tests were added.>
Created a test using an image being declared with a sha256 and checked if there was a label with only the version number. 

**Documentation:** <Describe the documentation added.>
