### PR TITLE
[chore] Revert change in NodeJS autoinstrumentation base image for 0.41.1

### DIFF
--- a/.github/workflows/publish-autoinstrumentation-nodejs.yaml
+++ b/.github/workflows/publish-autoinstrumentation-nodejs.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: autoinstrumentation/nodejs
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'push' }}
           build-args: version=${{ env.VERSION }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/autoinstrumentation/nodejs/Dockerfile
+++ b/autoinstrumentation/nodejs/Dockerfile
@@ -9,7 +9,7 @@
 # - Grant the necessary access to `/autoinstrumentation` directory. `chmod -R go+r /autoinstrumentation`
 # - For auto-instrumentation by container injection, the Linux command cp is
 #   used and must be availabe in the image.
-FROM node:20 AS build
+FROM node:16 AS build
 
 WORKDIR /operator-build
 COPY . .


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Revert the change done by bumping the NodeJS version for 0.41.1 NodeJS autoinstrumentation.

**Link to tracking Issue:** #2236