### PR TITLE
fix(operator): truncate sidecar pod injected label to 63 chars

### DIFF
--- a/.chloggen/truncate-pod-label.yaml
+++ b/.chloggen/truncate-pod-label.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Truncate `sidecar.opentelemetry.io/injected` sidecar pod label to 63 characters
+
+# One or more tracking issues related to the change
+issues: [1031]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/sidecar/pod.go
+++ b/pkg/sidecar/pod.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	label      = "sidecar.opentelemetry.io/injected"
-	confEnvVar = "OTEL_CONFIG"
+	injectedLabel = "sidecar.opentelemetry.io/injected"
+	confEnvVar    = "OTEL_CONFIG"
 )
 
 // add a new sidecar container to the given pod, based on the given OpenTelemetryCollector.
@@ -53,7 +53,7 @@ func add(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCo
 	if pod.Labels == nil {
 		pod.Labels = map[string]string{}
 	}
-	pod.Labels[label] = fmt.Sprintf("%s.%s", otelcol.Namespace, otelcol.Name)
+	pod.Labels[injectedLabel] = naming.Truncate("%s.%s", 63, otelcol.Namespace, otelcol.Name)
 
 	return pod, nil
 }

--- a/pkg/sidecar/pod_test.go
+++ b/pkg/sidecar/pod_test.go
@@ -48,7 +48,7 @@ func TestAddSidecarWhenNoSidecarExists(t *testing.T) {
 	}
 	otelcol := v1alpha1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "otelcol-sample",
+			Name:      "otelcol-sample-with-a-name-that-is-longer-than-sixty-three-characters",
 			Namespace: "some-app",
 		},
 		Spec: v1alpha1.OpenTelemetryCollectorSpec{
@@ -74,7 +74,8 @@ processors:
 	require.Len(t, changed.Spec.Containers, 2)
 	require.Len(t, changed.Spec.InitContainers, 2)
 	require.Len(t, changed.Spec.Volumes, 1)
-	assert.Equal(t, "some-app.otelcol-sample", changed.Labels["sidecar.opentelemetry.io/injected"])
+	assert.Equal(t, "otelcol-sample-with-a-name-that-is-longer-than-sixty-three-cha",
+		changed.Labels["sidecar.opentelemetry.io/injected"])
 	assert.Equal(t, corev1.Container{
 		Name:  "otc-container",
 		Image: "some-default-image",


### PR DESCRIPTION
**Description:**

Truncate `sidecar.opentelemetry.io/injected` sidecar pod label to 63 characters since Kubernetes labels must be 63 characters or less.

**Link to tracking Issue:**

resolves #1031

**Testing:**

Tested with a unit test in `pod_test.go`.

**Documentation:**