### PR TITLE
[Chore] Add e2e test case for OTEL Kafka receiver and exporter.

### DIFF
--- a/tests/e2e-openshift/kafka/00-assert.yaml
+++ b/tests/e2e-openshift/kafka/00-assert.yaml
@@ -1,0 +1,180 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuttl-kafka
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: my-cluster
+    app.kubernetes.io/managed-by: strimzi-cluster-operator
+    app.kubernetes.io/name: entity-operator
+    app.kubernetes.io/part-of: strimzi-my-cluster
+    strimzi.io/cluster: my-cluster
+    strimzi.io/component-type: entity-operator
+    strimzi.io/kind: Kafka
+    strimzi.io/name: my-cluster-entity-operator
+  name: my-cluster-entity-operator
+  namespace: kuttl-kafka
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-cluster-kafka-0
+  namespace: kuttl-kafka
+status:
+  phase: Running
+
+--- 
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-cluster-zookeeper-0
+  namespace: kuttl-kafka
+status:
+  phase: Running
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: my-cluster
+    app.kubernetes.io/managed-by: strimzi-cluster-operator
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/part-of: strimzi-my-cluster
+    strimzi.io/cluster: my-cluster
+    strimzi.io/component-type: kafka
+    strimzi.io/discovery: "true"
+    strimzi.io/kind: Kafka
+    strimzi.io/name: my-cluster-kafka
+  name: my-cluster-kafka-bootstrap
+  namespace: kuttl-kafka
+spec:
+  ports:
+  - name: tcp-replication
+    port: 9091
+    protocol: TCP
+    targetPort: 9091
+  - name: tcp-clients
+    port: 9092
+    protocol: TCP
+    targetPort: 9092
+  - name: tcp-clientstls
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+  selector:
+    strimzi.io/cluster: my-cluster
+    strimzi.io/kind: Kafka
+    strimzi.io/name: my-cluster-kafka
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: my-cluster
+    app.kubernetes.io/managed-by: strimzi-cluster-operator
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/part-of: strimzi-my-cluster
+    strimzi.io/cluster: my-cluster
+    strimzi.io/component-type: kafka
+    strimzi.io/kind: Kafka
+    strimzi.io/name: my-cluster-kafka
+  name: my-cluster-kafka-brokers
+  namespace: kuttl-kafka
+spec:
+  ports:
+  - name: tcp-ctrlplane
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  - name: tcp-replication
+    port: 9091
+    protocol: TCP
+    targetPort: 9091
+  - name: tcp-kafkaagent
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  - name: tcp-clients
+    port: 9092
+    protocol: TCP
+    targetPort: 9092
+  - name: tcp-clientstls
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+  publishNotReadyAddresses: true
+  selector:
+    strimzi.io/cluster: my-cluster
+    strimzi.io/kind: Kafka
+    strimzi.io/name: my-cluster-kafka
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: my-cluster
+    app.kubernetes.io/managed-by: strimzi-cluster-operator
+    app.kubernetes.io/name: zookeeper
+    app.kubernetes.io/part-of: strimzi-my-cluster
+    strimzi.io/cluster: my-cluster
+    strimzi.io/component-type: zookeeper
+    strimzi.io/kind: Kafka
+    strimzi.io/name: my-cluster-zookeeper
+  name: my-cluster-zookeeper-client
+  namespace: kuttl-kafka
+spec:
+  ports:
+  - name: tcp-clients
+    port: 2181
+    protocol: TCP
+    targetPort: 2181
+  selector:
+    strimzi.io/cluster: my-cluster
+    strimzi.io/kind: Kafka
+    strimzi.io/name: my-cluster-zookeeper
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: my-cluster
+    app.kubernetes.io/managed-by: strimzi-cluster-operator
+    app.kubernetes.io/name: zookeeper
+    app.kubernetes.io/part-of: strimzi-my-cluster
+    strimzi.io/cluster: my-cluster
+    strimzi.io/component-type: zookeeper
+    strimzi.io/kind: Kafka
+    strimzi.io/name: my-cluster-zookeeper
+  name: my-cluster-zookeeper-nodes
+  namespace: kuttl-kafka
+spec:
+  ports:
+  - name: tcp-clients
+    port: 2181
+    protocol: TCP
+    targetPort: 2181
+  - name: tcp-clustering
+    port: 2888
+    protocol: TCP
+    targetPort: 2888
+  - name: tcp-election
+    port: 3888
+    protocol: TCP
+    targetPort: 3888
+  selector:
+    strimzi.io/cluster: my-cluster
+    strimzi.io/kind: Kafka
+    strimzi.io/name: my-cluster-zookeeper

--- a/tests/e2e-openshift/kafka/00-create-kafka-instance.yaml
+++ b/tests/e2e-openshift/kafka/00-create-kafka-instance.yaml
@@ -1,0 +1,60 @@
+#For creating the Kafka instance, install the AMQ streams operator https://access.redhat.com/documentation/en-us/red_hat_amq_streams/2.5/html/getting_started_with_amq_streams_on_openshift/proc-deploying-cluster-operator-hub-str
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuttl-kafka
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+  namespace: kuttl-kafka
+spec:
+  entityOperator:
+    topicOperator:
+      reconciliationIntervalSeconds: 90
+    userOperator:
+      reconciliationIntervalSeconds: 120
+  kafka:
+    config:
+      log.message.format.version: 3.5.0
+      message.max.bytes: 10485760
+      offsets.topic.replication.factor: 1
+      ssl.cipher.suites: TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      ssl.enabled.protocols: TLSv1.2
+      ssl.protocol: TLSv1.2
+      transaction.state.log.min.isr: 1
+      transaction.state.log.replication.factor: 1
+    jvmOptions:
+      -Xms: 1024m
+      -Xmx: 1024m
+    listeners:
+    - configuration:
+        useServiceDnsDomain: true
+      name: plain
+      port: 9092
+      tls: false
+      type: internal
+    - authentication:
+        type: tls
+      name: tls
+      port: 9093
+      tls: true
+      type: internal
+    replicas: 1
+    resources:
+      limits:
+        cpu: "1"
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 4Gi
+    storage:
+      type: ephemeral
+    version: 3.5.0
+  zookeeper:
+    replicas: 1
+    storage:
+      type: ephemeral

--- a/tests/e2e-openshift/kafka/01-assert.yaml
+++ b/tests/e2e-openshift/kafka/01-assert.yaml
@@ -1,0 +1,13 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: otlp-spans
+  namespace: kuttl-kafka
+spec:
+  config:
+    retention.ms: 300000
+    segment.bytes: 1073741824
+  partitions: 1
+  replicas: 1
+status:
+  topicName: otlp-spans

--- a/tests/e2e-openshift/kafka/01-create-kafka-topics.yaml
+++ b/tests/e2e-openshift/kafka/01-create-kafka-topics.yaml
@@ -1,0 +1,13 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  labels:
+    strimzi.io/cluster: my-cluster
+  name: otlp-spans
+  namespace: kuttl-kafka
+spec:
+  config:
+    retention.ms: 300000
+    segment.bytes: 1073741824
+  partitions: 1
+  replicas: 1

--- a/tests/e2e-openshift/kafka/02-assert.yaml
+++ b/tests/e2e-openshift/kafka/02-assert.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: kuttl-kafka.kafka-receiver
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: kafka-receiver-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: kafka-receiver-collector
+  namespace: kuttl-kafka
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: kuttl-kafka.kafka-receiver
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: kafka-receiver-collector-monitoring
+  name: kafka-receiver-collector-monitoring
+  namespace: kuttl-kafka
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: kuttl-kafka.kafka-receiver
+    app.kubernetes.io/managed-by: opentelemetry-operator
+  type: ClusterIP

--- a/tests/e2e-openshift/kafka/02-otel-kakfa-receiver.yaml
+++ b/tests/e2e-openshift/kafka/02-otel-kakfa-receiver.yaml
@@ -1,0 +1,22 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: kafka-receiver
+  namespace: kuttl-kafka
+spec:
+  mode: "deployment"
+  config: |
+    receivers:
+      kafka/traces:
+        brokers: ["my-cluster-kafka-brokers.kuttl-kafka.svc:9092"]
+        protocol_version: 3.5.0
+        topic: otlp-spans
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        traces:
+          receivers: [kafka/traces]
+          processors: []
+          exporters: [debug]

--- a/tests/e2e-openshift/kafka/03-assert.yaml
+++ b/tests/e2e-openshift/kafka/03-assert.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: kuttl-kafka.kafka-exporter
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: kafka-exporter-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: kafka-exporter-collector
+  namespace: kuttl-kafka
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: kuttl-kafka.kafka-exporter
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: kafka-exporter-collector
+  name: kafka-exporter-collector
+  namespace: kuttl-kafka
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: kuttl-kafka.kafka-exporter
+    app.kubernetes.io/managed-by: opentelemetry-operator
+  sessionAffinity: None
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: kuttl-kafka.kafka-exporter
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: kafka-exporter-collector
+    operator.opentelemetry.io/collector-headless-service: Exists
+  name: kafka-exporter-collector-headless
+  namespace: kuttl-kafka
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: kuttl-kafka.kafka-exporter
+    app.kubernetes.io/managed-by: opentelemetry-operator
+  type: ClusterIP

--- a/tests/e2e-openshift/kafka/03-otel-kakfa-exporter.yaml
+++ b/tests/e2e-openshift/kafka/03-otel-kakfa-exporter.yaml
@@ -1,0 +1,25 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: kafka-exporter
+  namespace: kuttl-kafka
+spec:
+  mode: deployment
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+    exporters:
+      kafka/traces:
+        brokers: ["my-cluster-kafka-brokers.kuttl-kafka.svc:9092"]
+        protocol_version: 3.5.0
+        topic: otlp-spans
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [kafka/traces]

--- a/tests/e2e-openshift/kafka/04-assert.yaml
+++ b/tests/e2e-openshift/kafka/04-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: batch/v1
+kind: Job 
+metadata: 
+  labels:
+    app: telemetrygen-traces
+    job-name: telemetrygen-traces
+  name: telemetrygen-traces
+status:
+  succeeded: 1

--- a/tests/e2e-openshift/kafka/04-generate-traces.yaml
+++ b/tests/e2e-openshift/kafka/04-generate-traces.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: telemetrygen-traces
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: telemetrygen-traces
+    spec:
+      containers:
+        - name: telemetrygen-traces
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest
+          command: ["./telemetrygen"]
+          args:
+            - "--otlp-endpoint=kafka-exporter-collector-headless.kuttl-kafka.svc:4317"
+            - "--otlp-insecure=true"
+            - "--rate=1"
+            - "--duration=30s"
+            - "--otlp-attributes=test=\"kuttl-kafka\""
+            - "--otlp-header=kafka-topic=\"otlp-spans\""
+            - "--service=\"kafka\""
+            - "traces"
+      restartPolicy: Never

--- a/tests/e2e-openshift/kafka/05-assert.yaml
+++ b/tests/e2e-openshift/kafka/05-assert.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 30
+commands:
+- script: ./tests/e2e-openshift/kafka/check_traces.sh

--- a/tests/e2e-openshift/kafka/check_traces.sh
+++ b/tests/e2e-openshift/kafka/check_traces.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# This script checks the kafka-receiver OTEL collector pod for the presence of Traces.
+
+# Define the label selector
+LABEL_SELECTOR="app.kubernetes.io/instance=kuttl-kafka.kafka-receiver"
+
+# Define the search strings
+SEARCH_STRING1='-> service.name: Str("kafka")'
+SEARCH_STRING2='-> test: Str(kuttl-kafka)'
+
+# Get the list of pods with the specified label
+PODS=$(kubectl -n kuttl-kafka get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}')
+
+# Initialize flags to track if strings are found
+FOUND1=false
+FOUND2=false
+
+# Loop through each pod and search for the strings in the logs
+for POD in $PODS; do
+    # Search for the first string
+    if ! $FOUND1 && kubectl -n kuttl-kafka logs $POD | grep -q -- "$SEARCH_STRING1"; then
+        echo "\"$SEARCH_STRING1\" found in $POD"
+        FOUND1=true
+    fi
+    # Search for the second string
+    if ! $FOUND2 && kubectl -n kuttl-kafka logs $POD | grep -q -- "$SEARCH_STRING2"; then
+        echo "\"$SEARCH_STRING2\" found in $POD"
+        FOUND2=true
+    fi
+done
+
+# Check if either of the strings was not found
+if ! $FOUND1 || ! $FOUND2; then
+    echo "No Traces with service name Kafka and attribute test=kuttl-kafka found."
+    exit 1
+else
+    echo "Traces with service name Kafka and attribute test=kuttl-kafka found."
+fi
+


### PR DESCRIPTION
**Testing:**

This e2e case tests the Kafka receiver and exporter. 

```
$ kuttl test --timeout=180 --test=kafka tests/e2e-openshift
2023/12/08 08:15:36 kutt-test config testdirs is overridden with args: [ tests/e2e-openshift ]
=== RUN   kuttl
    harness.go:462: starting setup
    harness.go:252: running tests using configured kubeconfig.
I1208 08:15:37.940200    8630 request.go:682] Waited for 1.024173085s due to client-side throttling, not priority and fairness, request: GET:https://api.crc.testing:6443/apis/console.openshift.io/v1?timeout=32s
    harness.go:275: Successful connection to cluster at: https://api.crc.testing:6443
    harness.go:360: running tests
    harness.go:73: going to run test suite with timeout of 180 seconds for each step
    harness.go:372: testsuite: tests/e2e-openshift has 5 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/kafka
=== PAUSE kuttl/harness/kafka
=== CONT  kuttl/harness/kafka
    logger.go:42: 08:15:43 | kafka | Ignoring check_traces.sh as it does not match file name regexp: ^(\d+)-(?:[^\.]+)(?:\.yaml)?$
    logger.go:42: 08:15:43 | kafka | Creating namespace: kuttl-test-inviting-cat
    logger.go:42: 08:15:43 | kafka/0-create-kafka-instance | starting test step 0-create-kafka-instance
    logger.go:42: 08:15:46 | kafka/0-create-kafka-instance | Namespace:/kuttl-kafka created
    logger.go:42: 08:15:46 | kafka/0-create-kafka-instance | Kafka:kuttl-kafka/my-cluster created
    logger.go:42: 08:16:55 | kafka/0-create-kafka-instance | test step completed 0-create-kafka-instance
    logger.go:42: 08:16:55 | kafka/1-create-kafka-topics | starting test step 1-create-kafka-topics
I1208 08:16:56.870412    8630 request.go:682] Waited for 1.047991813s due to client-side throttling, not priority and fairness, request: GET:https://api.crc.testing:6443/apis/project.openshift.io/v1?timeout=32s
    logger.go:42: 08:16:58 | kafka/1-create-kafka-topics | KafkaTopic:kuttl-kafka/otlp-spans created
    logger.go:42: 08:16:59 | kafka/1-create-kafka-topics | test step completed 1-create-kafka-topics
    logger.go:42: 08:16:59 | kafka/2-otel-kakfa-receiver | starting test step 2-otel-kakfa-receiver
    logger.go:42: 08:17:01 | kafka/2-otel-kakfa-receiver | OpenTelemetryCollector:kuttl-kafka/kafka-receiver created
    logger.go:42: 08:17:05 | kafka/2-otel-kakfa-receiver | test step completed 2-otel-kakfa-receiver
    logger.go:42: 08:17:05 | kafka/3-otel-kakfa-exporter | starting test step 3-otel-kakfa-exporter
I1208 08:17:06.913834    8630 request.go:682] Waited for 1.398868555s due to client-side throttling, not priority and fairness, request: GET:https://api.crc.testing:6443/apis/operators.coreos.com/v1?timeout=32s
    logger.go:42: 08:17:07 | kafka/3-otel-kakfa-exporter | OpenTelemetryCollector:kuttl-kafka/kafka-exporter created
    logger.go:42: 08:17:11 | kafka/3-otel-kakfa-exporter | test step completed 3-otel-kakfa-exporter
    logger.go:42: 08:17:11 | kafka/4-generate-traces | starting test step 4-generate-traces
    logger.go:42: 08:17:14 | kafka/4-generate-traces | Job:kuttl-test-inviting-cat/telemetrygen-traces created
    logger.go:42: 08:17:52 | kafka/4-generate-traces | test step completed 4-generate-traces
    logger.go:42: 08:17:52 | kafka/5- | starting test step 5-
I1208 08:17:53.448738    8630 request.go:682] Waited for 1.048192256s due to client-side throttling, not priority and fairness, request: GET:https://api.crc.testing:6443/apis/packages.operators.coreos.com/v1?timeout=32s
    logger.go:42: 08:17:54 | kafka/5- | running command: [sh -c ./tests/e2e-openshift/kafka/check_traces.sh]
    logger.go:42: 08:17:54 | kafka/5- | "-> service.name: Str("kafka")" found in kafka-receiver-collector-6c8857c54c-mf6xx
    logger.go:42: 08:17:54 | kafka/5- | "-> test: Str(kuttl-kafka)" found in kafka-receiver-collector-6c8857c54c-mf6xx
    logger.go:42: 08:17:54 | kafka/5- | Traces with service name Kafka and attribute test=kuttl-kafka found.
    logger.go:42: 08:17:54 | kafka/5- | test step completed 5-
    logger.go:42: 08:17:54 | kafka | kafka events from ns kuttl-test-inviting-cat:
    logger.go:42: 08:17:54 | kafka | 2023-12-08 08:17:14 +0530 IST	Normal	Pod telemetrygen-traces-kfdfn		Scheduled	Successfully assigned kuttl-test-inviting-cat/telemetrygen-traces-kfdfn to crc-mmwz7-master-0		
    logger.go:42: 08:17:54 | kafka | 2023-12-08 08:17:14 +0530 IST	Normal	Job.batch telemetrygen-traces		SuccessfulCreate	Created pod: telemetrygen-traces-kfdfn		
    logger.go:42: 08:17:54 | kafka | 2023-12-08 08:17:16 +0530 IST	Normal	Pod telemetrygen-traces-kfdfn		AddedInterface	Add eth0 [10.217.0.147/23] from openshift-sdn		
    logger.go:42: 08:17:54 | kafka | 2023-12-08 08:17:16 +0530 IST	Normal	Pod telemetrygen-traces-kfdfn.spec.containers{telemetrygen-traces}		Pulling	Pulling image "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest"		
    logger.go:42: 08:17:54 | kafka | 2023-12-08 08:17:17 +0530 IST	Normal	Pod telemetrygen-traces-kfdfn.spec.containers{telemetrygen-traces}		Pulled	Successfully pulled image "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest" in 892.634803ms (892.646228ms including waiting)		
    logger.go:42: 08:17:54 | kafka | 2023-12-08 08:17:17 +0530 IST	Normal	Pod telemetrygen-traces-kfdfn.spec.containers{telemetrygen-traces}		Created	Created container telemetrygen-traces		
    logger.go:42: 08:17:54 | kafka | 2023-12-08 08:17:17 +0530 IST	Normal	Pod telemetrygen-traces-kfdfn.spec.containers{telemetrygen-traces}		Started	Started container telemetrygen-traces		
    logger.go:42: 08:17:54 | kafka | 2023-12-08 08:17:52 +0530 IST	Normal	Job.batch telemetrygen-traces		Completed	Job completed		
    logger.go:42: 08:17:55 | kafka | Deleting namespace: kuttl-test-inviting-cat
=== CONT  kuttl
    harness.go:405: run tests finished
    harness.go:513: cleaning up
    harness.go:570: removing temp folder: ""
--- PASS: kuttl (144.28s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/kafka (137.36s)
PASS

```

