### PR TITLE
Add E2E test for metrics collection using Prometheus CRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ e2e-opampbridge:
 	$(KUTTL) test --config kuttl-test-opampbridge.yaml
 
 .PHONY: prepare-e2e
-prepare-e2e: kuttl set-image-controller container container-target-allocator container-operator-opamp-bridge start-kind cert-manager install-metrics-server load-image-all deploy
+prepare-e2e: kuttl set-image-controller container container-target-allocator container-operator-opamp-bridge start-kind cert-manager install-metrics-server install-targetallocator-prometheus-crds load-image-all deploy
 	TARGETALLOCATOR_IMG=$(TARGETALLOCATOR_IMG) OPERATOROPAMPBRIDGE_IMG=$(OPERATOROPAMPBRIDGE_IMG) OPERATOR_IMG=$(IMG) SED_BIN="$(SED)" ./hack/modify-test-images.sh
 
 .PHONY: enable-prometheus-feature-flag
@@ -273,6 +273,11 @@ install-metrics-server:
 .PHONY: install-prometheus-operator
 install-prometheus-operator:
 	./hack/install-prometheus-operator.sh
+
+# This only installs the CRDs Target Allocator supports
+.PHONY: install-targetallocator-prometheus-crds
+install-targetallocator-prometheus-crds:
+	./hack/install-targetallocator-prometheus-crds.sh
 
 .PHONY: load-image-all
 load-image-all: load-image-operator load-image-target-allocator load-image-operator-opamp-bridge

--- a/hack/install-targetallocator-prometheus-crds.sh
+++ b/hack/install-targetallocator-prometheus-crds.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ "$(kubectl api-resources --api-group=monitoring.coreos.com -o name)" ]]; then
+    echo "Prometheus CRDs are there"
+else
+    kubectl create -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+    kubectl create -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+fi

--- a/hack/modify-test-images.sh
+++ b/hack/modify-test-images.sh
@@ -5,6 +5,7 @@ SED_BIN=${SED_BIN:-sed}
 ${SED_BIN} -i "s#local/opentelemetry-operator-targetallocator:e2e#${TARGETALLOCATOR_IMG}#g" tests/e2e/smoke-targetallocator/*.yaml
 ${SED_BIN} -i "s#local/opentelemetry-operator-targetallocator:e2e#${TARGETALLOCATOR_IMG}#g" tests/e2e/targetallocator-features/00-install.yaml
 ${SED_BIN} -i "s#local/opentelemetry-operator-targetallocator:e2e#${TARGETALLOCATOR_IMG}#g" tests/e2e/prometheus-config-validation/*.yaml
+${SED_BIN} -i "s#local/opentelemetry-operator-targetallocator:e2e#${TARGETALLOCATOR_IMG}#g" tests/e2e/targetallocator-prometheuscr/*.yaml
 
 ${SED_BIN} -i "s#local/opentelemetry-operator:e2e#${OPERATOR_IMG}#g" tests/e2e-multi-instrumentation/*.yaml
 

--- a/tests/e2e/targetallocator-prometheuscr/00-assert.yaml
+++ b/tests/e2e/targetallocator-prometheuscr/00-assert.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: prometheus-cr-collector
+status:
+  replicas: 1
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-cr-targetallocator
+status:
+  replicas: 1
+  readyReplicas: 1
+  observedGeneration: 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-cr-targetallocator
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-cr-collector
+data:
+  collector.yaml: |
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:9090
+    processors: null
+    receivers:
+      prometheus:
+        config: {}
+        target_allocator:
+          collector_id: ${POD_NAME}
+          endpoint: http://prometheus-cr-targetallocator:80
+          interval: 30s
+    service:
+      pipelines:
+        metrics:
+          exporters:
+          - prometheus
+          processors: []
+          receivers:
+          - prometheus
+---
+# Print TA pod logs if test fails
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - selector: app.kubernetes.io/managed-by=opentelemetry-operator

--- a/tests/e2e/targetallocator-prometheuscr/00-install.yaml
+++ b/tests/e2e/targetallocator-prometheuscr/00-install.yaml
@@ -1,0 +1,137 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ta
+automountServiceAccountToken: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: collector
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ta
+rules:
+- apiGroups: [""]
+  resources:
+    - pods
+    - nodes
+    - services
+    - endpoints
+    - configmaps
+    - secrets
+    - namespaces
+  verbs:
+    - get
+    - watch
+    - list
+- apiGroups: ["apps"]
+  resources:
+    - statefulsets
+    - services
+    - endpoints
+  verbs:
+    - get
+    - watch
+    - list
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+    - endpointslices
+  verbs:
+    - get
+    - watch
+    - list
+- apiGroups: ["networking.k8s.io"]
+  resources:
+    - ingresses
+  verbs:
+    - get
+    - watch
+    - list
+- apiGroups: ["monitoring.coreos.com"]
+  resources:
+    - servicemonitors
+    - podmonitors
+  verbs:
+    - get
+    - watch
+    - list
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: collector
+rules:
+- apiGroups: [""]
+  resources:
+    - pods
+    - nodes
+    - nodes/metrics
+    - services
+    - endpoints
+  verbs:
+    - get
+    - watch
+    - list
+- apiGroups: ["networking.k8s.io"]
+  resources:
+    - ingresses
+  verbs:
+    - get
+    - watch
+    - list
+- nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+  verbs: ["get"]
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl create clusterrolebinding ta-$NAMESPACE --clusterrole=ta --serviceaccount=$NAMESPACE:ta
+  - command: kubectl create clusterrolebinding collector-$NAMESPACE --clusterrole=collector --serviceaccount=$NAMESPACE:collector
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: prometheus-cr
+spec:
+  mode: statefulset
+  serviceAccount: collector
+  targetAllocator:
+    enabled: true
+    serviceAccount: ta
+    image: "local/opentelemetry-operator-targetallocator:e2e"
+    prometheusCR:
+      enabled: true
+  config: |
+    receivers:
+      prometheus:
+        config:
+          scrape_configs: []
+
+    processors:
+
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:9090
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: []
+          exporters: [prometheus]
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prometheus-cr
+spec:
+  endpoints:
+  - port: monitoring
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: opentelemetry-operator

--- a/tests/e2e/targetallocator-prometheuscr/01-assert.yaml
+++ b/tests/e2e/targetallocator-prometheuscr/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-metrics
+status:
+  succeeded: 1

--- a/tests/e2e/targetallocator-prometheuscr/01-assert.yaml
+++ b/tests/e2e/targetallocator-prometheuscr/01-assert.yaml
@@ -4,3 +4,17 @@ metadata:
   name: check-metrics
 status:
   succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-ta-jobs
+status:
+  succeeded: 1
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-ta-scrape-configs
+status:
+  succeeded: 1

--- a/tests/e2e/targetallocator-prometheuscr/01-install.yaml
+++ b/tests/e2e/targetallocator-prometheuscr/01-install.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-metrics
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: check-metrics
+          image: curlimages/curl
+          args:
+            - /bin/sh
+            - -c
+            - curl -s http://prometheus-cr-collector:9090/metrics | grep "otelcol_exporter_sent_metric_points_total{"
+

--- a/tests/e2e/targetallocator-prometheuscr/01-install.yaml
+++ b/tests/e2e/targetallocator-prometheuscr/01-install.yaml
@@ -14,4 +14,35 @@ spec:
             - /bin/sh
             - -c
             - curl -s http://prometheus-cr-collector:9090/metrics | grep "otelcol_exporter_sent_metric_points_total{"
-
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-ta-jobs
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: check-metrics
+          image: curlimages/curl
+          args:
+            - /bin/sh
+            - -c
+            - curl -s http://prometheus-cr-targetallocator/scrape_configs | grep "prometheus-cr"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-ta-scrape-configs
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: check-metrics
+          image: curlimages/curl
+          args:
+            - /bin/sh
+            - -c
+            - curl -s http://prometheus-cr-targetallocator/jobs | grep "prometheus-cr"


### PR DESCRIPTION
**Description:**

Adds an E2E test verifying collecting metrics defined by a ServiceMonitor using the target allocator.

This is done by:
* adding a ServiceMonitor covering the collector's own metrics port
* scraping the metrics with Prometheus receive,  target allocator enabled
* exporting the metrics on a different port via Prometheus exporter
* running a Job which curls the above endpoint and checks that a particular metric is present

This is a little bit convoluted, but I haven't figured out how to make it any simpler. The Job approach actually ends up working well with kuttl, as we end up just needing to check the status of a K8s resource.

**Link to tracking Issue:** #2262 

Note: This will fail before #2273 is merged. The intent of this test is to catch issues like #2262 in the future.
