### PR TITLE
Update OpAMP Bridge to comply with its design

### DIFF
--- a/.chloggen/update-opamp-bridge-spec.yaml
+++ b/.chloggen/update-opamp-bridge-spec.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: OpAMP Bridge
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Currently, the bridge doesn't adhere to the spec for the naming structure. This changes the bridge to use the <namespace>/<otelcol> structure as described.
+
+# One or more tracking issues related to the change
+issues: [2131]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  * Updates the bridge to get collectors using the reporting annotation
+  * Fixes a bug where we were using the incorrect structure for the collectors

--- a/cmd/operator-opamp-bridge/agent/agent.go
+++ b/cmd/operator-opamp-bridge/agent/agent.go
@@ -166,7 +166,7 @@ func (agent *Agent) getEffectiveConfig(ctx context.Context) (*protobufs.Effectiv
 			agent.logger.Error(err, "failed to marhsal config")
 			return nil, err
 		}
-		mapKey := newCollectorKey(instance.GetName(), instance.GetNamespace())
+		mapKey := newCollectorKey(instance.GetNamespace(), instance.GetName())
 		instanceMap[mapKey.String()] = &protobufs.AgentConfigFile{
 			Body:        marshaled,
 			ContentType: "yaml",

--- a/cmd/operator-opamp-bridge/agent/agent_test.go
+++ b/cmd/operator-opamp-bridge/agent/agent_test.go
@@ -216,7 +216,7 @@ func TestAgent_onMessage(t *testing.T) {
 				status: &protobufs.RemoteConfigStatus{
 					LastRemoteConfigHash: []byte("testnamespace/bad513"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED,
-					ErrorMessage:         "yaml: line 20: could not find expected ':'",
+					ErrorMessage:         "error converting YAML to JSON: yaml: line 21: could not find expected ':'",
 				},
 			},
 		},
@@ -379,7 +379,7 @@ func TestAgent_onMessage(t *testing.T) {
 				nextStatus: &protobufs.RemoteConfigStatus{
 					LastRemoteConfigHash: []byte("testnamespace/good513"), // The new hash should be of the bad config
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED,
-					ErrorMessage:         "yaml: line 20: could not find expected ':'",
+					ErrorMessage:         "error converting YAML to JSON: yaml: line 21: could not find expected ':'",
 				},
 			},
 		},

--- a/cmd/operator-opamp-bridge/agent/agent_test.go
+++ b/cmd/operator-opamp-bridge/agent/agent_test.go
@@ -109,15 +109,15 @@ func TestAgent_onMessage(t *testing.T) {
 	}
 	type args struct {
 		ctx context.Context
-		// Mapping from name/namespace to a config in testdata
+		// Mapping from namespace/name to a config in testdata
 		configFile map[string]string
-		// Mapping from name/namespace to a config in testdata (for testing updates)
+		// Mapping from namespace/name to a config in testdata (for testing updates)
 		nextConfigFile map[string]string
 	}
 	type want struct {
-		// Mapping from name/namespace to a list of expected contents
+		// Mapping from namespace/name to a list of expected contents
 		contents map[string][]string
-		// Mapping from name/namespace to a list of updated expected contents
+		// Mapping from namespace/name to a list of updated expected contents
 		nextContents map[string][]string
 		// The status after the initial config loading
 		status *protobufs.RemoteConfigStatus
@@ -152,12 +152,12 @@ func TestAgent_onMessage(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				configFile: map[string]string{
-					"good/testnamespace": "basic.yaml",
+					"testnamespace/good": "basic.yaml",
 				},
 			},
 			want: want{
 				contents: map[string][]string{
-					"good/testnamespace": {
+					"testnamespace/good": {
 						"kind: OpenTelemetryCollector",
 						"name: good",
 						"namespace: testnamespace",
@@ -167,7 +167,7 @@ func TestAgent_onMessage(t *testing.T) {
 					},
 				},
 				status: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace401"),
+					LastRemoteConfigHash: []byte("testnamespace/good512"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
 				},
 			},
@@ -180,12 +180,12 @@ func TestAgent_onMessage(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				configFile: map[string]string{
-					"good/testnamespace": "basic.yaml",
+					"testnamespace/good": "basic.yaml",
 				},
 			},
 			want: want{
 				contents: map[string][]string{
-					"good/testnamespace": {
+					"testnamespace/good": {
 						"kind: OpenTelemetryCollector",
 						"name: good",
 						"namespace: testnamespace",
@@ -195,7 +195,7 @@ func TestAgent_onMessage(t *testing.T) {
 					},
 				},
 				status: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace401"),
+					LastRemoteConfigHash: []byte("testnamespace/good512"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
 				},
 			},
@@ -208,15 +208,15 @@ func TestAgent_onMessage(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				configFile: map[string]string{
-					"bad/testnamespace": "invalid.yaml",
+					"testnamespace/bad": "invalid.yaml",
 				},
 			},
 			want: want{
 				contents: nil,
 				status: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("bad/testnamespace404"),
+					LastRemoteConfigHash: []byte("testnamespace/bad513"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED,
-					ErrorMessage:         "yaml: line 16: could not find expected ':'",
+					ErrorMessage:         "yaml: line 20: could not find expected ':'",
 				},
 			},
 		},
@@ -228,12 +228,12 @@ func TestAgent_onMessage(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				configFile: map[string]string{
-					"good/testnamespace": "basic.yaml",
+					"testnamespace/good": "basic.yaml",
 				},
 			},
 			want: want{
 				contents: map[string][]string{
-					"good/testnamespace": {
+					"testnamespace/good": {
 						"kind: OpenTelemetryCollector",
 						"name: good",
 						"namespace: testnamespace",
@@ -243,7 +243,7 @@ func TestAgent_onMessage(t *testing.T) {
 					},
 				},
 				status: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace401"),
+					LastRemoteConfigHash: []byte("testnamespace/good512"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
 				},
 			},
@@ -256,13 +256,13 @@ func TestAgent_onMessage(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				configFile: map[string]string{
-					"good/testnamespace": "basic.yaml",
+					"testnamespace/good": "basic.yaml",
 				},
 			},
 			want: want{
 				contents: nil,
 				status: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace401"),
+					LastRemoteConfigHash: []byte("testnamespace/good512"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED,
 					ErrorMessage:         "Items in config are not allowed: [processors.batch]",
 				},
@@ -276,13 +276,13 @@ func TestAgent_onMessage(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				configFile: map[string]string{
-					"good/testnamespace": "basic.yaml",
+					"testnamespace/good": "basic.yaml",
 				},
 			},
 			want: want{
 				contents: nil,
 				status: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace401"),
+					LastRemoteConfigHash: []byte("testnamespace/good512"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED,
 					ErrorMessage:         "Items in config are not allowed: [processors]",
 				},
@@ -296,15 +296,15 @@ func TestAgent_onMessage(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				configFile: map[string]string{
-					"good/testnamespace": "basic.yaml",
+					"testnamespace/good": "basic.yaml",
 				},
 				nextConfigFile: map[string]string{
-					"good/testnamespace": "updated.yaml",
+					"testnamespace/good": "updated.yaml",
 				},
 			},
 			want: want{
 				contents: map[string][]string{
-					"good/testnamespace": {
+					"testnamespace/good": {
 						"kind: OpenTelemetryCollector",
 						"name: good",
 						"namespace: testnamespace",
@@ -315,11 +315,11 @@ func TestAgent_onMessage(t *testing.T) {
 					},
 				},
 				status: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace401"),
+					LastRemoteConfigHash: []byte("testnamespace/good512"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
 				},
 				nextContents: map[string][]string{
-					"good/testnamespace": {
+					"testnamespace/good": {
 						"kind: OpenTelemetryCollector",
 						"name: good",
 						"namespace: testnamespace",
@@ -330,7 +330,7 @@ func TestAgent_onMessage(t *testing.T) {
 					},
 				},
 				nextStatus: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace435"),
+					LastRemoteConfigHash: []byte("testnamespace/good547"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
 				},
 			},
@@ -343,15 +343,15 @@ func TestAgent_onMessage(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				configFile: map[string]string{
-					"good/testnamespace": "basic.yaml",
+					"testnamespace/good": "basic.yaml",
 				},
 				nextConfigFile: map[string]string{
-					"good/testnamespace": "invalid.yaml",
+					"testnamespace/good": "invalid.yaml",
 				},
 			},
 			want: want{
 				contents: map[string][]string{
-					"good/testnamespace": {
+					"testnamespace/good": {
 						"kind: OpenTelemetryCollector",
 						"name: good",
 						"namespace: testnamespace",
@@ -362,11 +362,11 @@ func TestAgent_onMessage(t *testing.T) {
 					},
 				},
 				status: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace401"),
+					LastRemoteConfigHash: []byte("testnamespace/good512"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
 				},
 				nextContents: map[string][]string{
-					"good/testnamespace": {
+					"testnamespace/good": {
 						"kind: OpenTelemetryCollector",
 						"name: good",
 						"namespace: testnamespace",
@@ -377,9 +377,9 @@ func TestAgent_onMessage(t *testing.T) {
 					},
 				},
 				nextStatus: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace404"), // The new hash should be of the bad config
+					LastRemoteConfigHash: []byte("testnamespace/good513"), // The new hash should be of the bad config
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_FAILED,
-					ErrorMessage:         "yaml: line 16: could not find expected ':'",
+					ErrorMessage:         "yaml: line 20: could not find expected ':'",
 				},
 			},
 		},
@@ -391,16 +391,16 @@ func TestAgent_onMessage(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				configFile: map[string]string{
-					"good/testnamespace": "basic.yaml",
+					"testnamespace/good": "basic.yaml",
 				},
 				nextConfigFile: map[string]string{
-					"good/testnamespace":  "basic.yaml",
-					"other/testnamespace": "updated.yaml",
+					"testnamespace/good":  "basic.yaml",
+					"testnamespace/other": "updated.yaml",
 				},
 			},
 			want: want{
 				contents: map[string][]string{
-					"good/testnamespace": {
+					"testnamespace/good": {
 						"kind: OpenTelemetryCollector",
 						"name: good",
 						"namespace: testnamespace",
@@ -410,11 +410,11 @@ func TestAgent_onMessage(t *testing.T) {
 					},
 				},
 				status: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace401"),
+					LastRemoteConfigHash: []byte("testnamespace/good512"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
 				},
 				nextContents: map[string][]string{
-					"good/testnamespace": {
+					"testnamespace/good": {
 						"kind: OpenTelemetryCollector",
 						"name: good",
 						"namespace: testnamespace",
@@ -422,7 +422,7 @@ func TestAgent_onMessage(t *testing.T) {
 						"processors: []",
 						"status:",
 					},
-					"other/testnamespace": {
+					"testnamespace/other": {
 						"kind: OpenTelemetryCollector",
 						"name: other",
 						"namespace: testnamespace",
@@ -432,7 +432,7 @@ func TestAgent_onMessage(t *testing.T) {
 					},
 				},
 				nextStatus: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace401other/testnamespace435"),
+					LastRemoteConfigHash: []byte("testnamespace/good512testnamespace/other547"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
 				},
 			},
@@ -445,13 +445,13 @@ func TestAgent_onMessage(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				configFile: map[string]string{
-					"good/testnamespace": "basic.yaml",
+					"testnamespace/good": "basic.yaml",
 				},
 				nextConfigFile: map[string]string{},
 			},
 			want: want{
 				contents: map[string][]string{
-					"good/testnamespace": {
+					"testnamespace/good": {
 						"kind: OpenTelemetryCollector",
 						"name: good",
 						"namespace: testnamespace",
@@ -461,7 +461,7 @@ func TestAgent_onMessage(t *testing.T) {
 					},
 				},
 				status: &protobufs.RemoteConfigStatus{
-					LastRemoteConfigHash: []byte("good/testnamespace401"),
+					LastRemoteConfigHash: []byte("testnamespace/good512"),
 					Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
 				},
 				nextContents: map[string][]string{},

--- a/cmd/operator-opamp-bridge/agent/collector_key.go
+++ b/cmd/operator-opamp-bridge/agent/collector_key.go
@@ -25,7 +25,7 @@ type collectorKey struct {
 	namespace string
 }
 
-func newCollectorKey(name string, namespace string) collectorKey {
+func newCollectorKey(namespace string, name string) collectorKey {
 	return collectorKey{name: name, namespace: namespace}
 }
 
@@ -39,5 +39,5 @@ func collectorKeyFromKey(key string) (collectorKey, error) {
 }
 
 func (k collectorKey) String() string {
-	return fmt.Sprintf("%s/%s", k.name, k.namespace)
+	return fmt.Sprintf("%s/%s", k.namespace, k.name)
 }

--- a/cmd/operator-opamp-bridge/agent/collector_key_test.go
+++ b/cmd/operator-opamp-bridge/agent/collector_key_test.go
@@ -34,7 +34,7 @@ func Test_collectorKeyFromKey(t *testing.T) {
 		{
 			name: "base case",
 			args: args{
-				key: "good/namespace",
+				key: "namespace/good",
 			},
 			want: collectorKey{
 				name:      "good",
@@ -86,12 +86,12 @@ func Test_collectorKey_String(t *testing.T) {
 				name:      "good",
 				namespace: "namespace",
 			},
-			want: "good/namespace",
+			want: "namespace/good",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			k := newCollectorKey(tt.fields.name, tt.fields.namespace)
+			k := newCollectorKey(tt.fields.namespace, tt.fields.name)
 			assert.Equalf(t, tt.want, k.String(), "String()")
 		})
 	}

--- a/cmd/operator-opamp-bridge/agent/testdata/basic.yaml
+++ b/cmd/operator-opamp-bridge/agent/testdata/basic.yaml
@@ -1,24 +1,28 @@
-config: |
-  receivers:
-    otlp:
-      protocols:
-        grpc:
-        http:
-  processors:
-    memory_limiter:
-      check_interval: 1s
-      limit_percentage: 75
-      spike_limit_percentage: 15
-    batch:
-      send_batch_size: 10000
-      timeout: 10s
-  
-  exporters:
-    debug:
-  
-  service:
-    pipelines:
-      traces:
-        receivers: [otlp]
-        processors: []
-        exporters: [debug]
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+    
+    exporters:
+      debug:
+    
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]

--- a/cmd/operator-opamp-bridge/agent/testdata/invalid.yaml
+++ b/cmd/operator-opamp-bridge/agent/testdata/invalid.yaml
@@ -1,24 +1,28 @@
-config: |
-  receivers:
-    otlp:
-      protocols:
-        grpc:
-        http:
-  processors:
-    memory_limiter:
-      check_interval: 1s
-      limit_percentage: 75
-      spike_limit_percentage: 15
-    batch:
-      send_batch_size: 10000
-      timeout: 10s
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
 
-GARBAGE
-  exporters:
-    debug:
-  service:
-    pipelines:
-      traces:
-        receivers: [otlp]
-        processors: []
-        exporters: [debug]
+  GARBAGE
+    exporters:
+      debug:
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]

--- a/cmd/operator-opamp-bridge/agent/testdata/updated.yaml
+++ b/cmd/operator-opamp-bridge/agent/testdata/updated.yaml
@@ -1,25 +1,29 @@
-config: |
-  receivers:
-    otlp:
-      protocols:
-        grpc:
-        http:
-  processors:
-    memory_limiter:
-      check_interval: 1s
-      limit_percentage: 75
-      spike_limit_percentage: 15
-    batch:
-      send_batch_size: 10000
-      timeout: 10s
-  
-  exporters:
-    debug:
-  
-  service:
-    pipelines:
-      traces:
-        receivers: [otlp]
-        processors: [memory_limiter, batch]
-        exporters: [debug]
-replicas: 3
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+    
+    exporters:
+      debug:
+    
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [debug]
+  replicas: 3

--- a/cmd/operator-opamp-bridge/operator/client.go
+++ b/cmd/operator-opamp-bridge/operator/client.go
@@ -120,7 +120,7 @@ func (c Client) Apply(name string, namespace string, configmap *protobufs.AgentC
 	if len(reasons) > 0 {
 		return errors.NewBadRequest(fmt.Sprintf("Items in config are not allowed: %v", reasons))
 	}
-	updatedCollector := &v1alpha1.OpenTelemetryCollector{Spec: collector.Spec}
+	updatedCollector := collector.DeepCopy()
 	ctx := context.Background()
 	instance, err := c.GetInstance(name, namespace)
 	if err != nil {

--- a/cmd/operator-opamp-bridge/operator/client.go
+++ b/cmd/operator-opamp-bridge/operator/client.go
@@ -31,6 +31,7 @@ const (
 	CollectorResource       = "OpenTelemetryCollector"
 	ResourceIdentifierKey   = "created-by"
 	ResourceIdentifierValue = "operator-opamp-bridge"
+	ManagedAnnotationKey    = "opentelemetry.io/opamp-reporting"
 )
 
 type ConfigApplier interface {
@@ -104,31 +105,31 @@ func (c Client) update(ctx context.Context, old *v1alpha1.OpenTelemetryCollector
 
 func (c Client) Apply(name string, namespace string, configmap *protobufs.AgentConfigFile) error {
 	c.log.Info("Received new config", "name", name, "namespace", namespace)
-	var collectorSpec v1alpha1.OpenTelemetryCollectorSpec
-	err := yaml.Unmarshal(configmap.Body, &collectorSpec)
+	var collector v1alpha1.OpenTelemetryCollector
+	err := yaml.Unmarshal(configmap.Body, &collector)
 	if err != nil {
 		return err
 	}
-	if len(collectorSpec.Config) == 0 {
+	if len(collector.Spec.Config) == 0 {
 		return errors.NewBadRequest("Must supply valid configuration")
 	}
-	reasons, validateErr := c.validate(collectorSpec)
+	reasons, validateErr := c.validate(collector.Spec)
 	if validateErr != nil {
 		return validateErr
 	}
 	if len(reasons) > 0 {
 		return errors.NewBadRequest(fmt.Sprintf("Items in config are not allowed: %v", reasons))
 	}
-	collector := &v1alpha1.OpenTelemetryCollector{Spec: collectorSpec}
+	updatedCollector := &v1alpha1.OpenTelemetryCollector{Spec: collector.Spec}
 	ctx := context.Background()
 	instance, err := c.GetInstance(name, namespace)
 	if err != nil {
 		return err
 	}
 	if instance != nil {
-		return c.update(ctx, instance, collector)
+		return c.update(ctx, instance, updatedCollector)
 	}
-	return c.create(ctx, name, namespace, collector)
+	return c.create(ctx, name, namespace, updatedCollector)
 }
 
 func (c Client) Delete(name string, namespace string) error {
@@ -156,7 +157,19 @@ func (c Client) ListInstances() ([]v1alpha1.OpenTelemetryCollector, error) {
 	if err != nil {
 		return nil, err
 	}
-	return result.Items, nil
+	reportingCollectors := v1alpha1.OpenTelemetryCollectorList{}
+	err = c.k8sClient.List(ctx, &reportingCollectors, client.MatchingLabels{
+		ManagedAnnotationKey: "true",
+	})
+	if err != nil {
+		return nil, err
+	}
+	items := append(result.Items, reportingCollectors.Items...)
+	for i := range items {
+		items[i].SetManagedFields(nil)
+	}
+
+	return items, nil
 }
 
 func (c Client) GetInstance(name string, namespace string) (*v1alpha1.OpenTelemetryCollector, error) {

--- a/cmd/operator-opamp-bridge/operator/testdata/collector.yaml
+++ b/cmd/operator-opamp-bridge/operator/testdata/collector.yaml
@@ -1,24 +1,28 @@
-config: |
-  receivers:
-    otlp:
-      protocols:
-        grpc:
-        http:
-  processors:
-    memory_limiter:
-      check_interval: 1s
-      limit_percentage: 75
-      spike_limit_percentage: 15
-    batch:
-      send_batch_size: 10000
-      timeout: 10s
-  
-  exporters:
-    debug:
-  
-  service:
-    pipelines:
-      traces:
-        receivers: [otlp]
-        processors: []
-        exporters: [debug]
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+    
+    exporters:
+      debug:
+    
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]

--- a/cmd/operator-opamp-bridge/operator/testdata/invalid-collector.yaml
+++ b/cmd/operator-opamp-bridge/operator/testdata/invalid-collector.yaml
@@ -1,24 +1,28 @@
-config: |
-  receivers:
-    otlp:
-      protocols:
-        grpc:
-        http:
-  processors:
-    memory_limiter:
-      check_interval: 1s
-      limit_percentage: 75
-      spike_limit_percentage: 15
-    batch:
-      send_batch_size: 10000
-      timeout: 10s
-GARBAGE
-  exporters:
-    debug:
-  
-  service:
-    pipelines:
-      traces:
-        receivers: [otlp]
-        processors: []
-        exporters: [debug]
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+  GARBAGE
+    exporters:
+      debug:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]

--- a/cmd/operator-opamp-bridge/operator/testdata/reporting-collector.yaml
+++ b/cmd/operator-opamp-bridge/operator/testdata/reporting-collector.yaml
@@ -1,0 +1,31 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+  labels:
+    "opentelemetry.io/opamp-reporting": "true"
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+    
+    exporters:
+      debug:
+    
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]

--- a/cmd/operator-opamp-bridge/operator/testdata/updated-collector.yaml
+++ b/cmd/operator-opamp-bridge/operator/testdata/updated-collector.yaml
@@ -1,24 +1,28 @@
-config: |
-  receivers:
-    otlp:
-      protocols:
-        grpc:
-        http:
-  processors:
-    memory_limiter:
-      check_interval: 1s
-      limit_percentage: 75
-      spike_limit_percentage: 15
-    batch:
-      send_batch_size: 10000
-      timeout: 10s
-  
-  exporters:
-    debug:
-  
-  service:
-    pipelines:
-      traces:
-        receivers: [otlp]
-        processors: [memory_limiter, batch]
-        exporters: [debug]
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+    
+    exporters:
+      debug:
+    
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [debug]


### PR DESCRIPTION
**Description:** 
Right now, the bridge doesn't entirely conform to the design, it didn't support an annotation for reporting on managed instances. The naming structure also didn't match the design here:


> As part of the Bridge’s AgentToServer message, the effective configuration reported will be a map of a collector’s namespaced name `(<namespace>/<otelcol-name>)` to that collector’s CRD resource. This will let the server know what should exist in the cluster. This data can be used to enrich information received from the collector’s OpAMP extension by joining on the collector’s pool name.


Further, we also weren't allowing servers to send full CRDs, only specs (another inaccuracy)

**Link to tracking Issue:** #2131 

**Testing:** Tests were updated to reflect the changes
