### PR TITLE
Bump the NodeJS dependencies for the autoinstrumentation to 0.41.1

### DIFF
--- a/.chloggen/bump-nodejs-dependencies.yaml
+++ b/.chloggen/bump-nodejs-dependencies.yaml
@@ -8,7 +8,7 @@ component: operator
 note: "Bump NodeJS dependencies. Also, increase the size of the default size for the volume used to copy the autoinstrumentation libraries from 150M to 200M"
 
 # One or more tracking issues related to the change
-issues: [2240, 2237]
+issues: [2240, 2237, 2236]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -15,16 +15,16 @@
   },
   "dependencies": {
     "@opentelemetry/api": "1.6.0",
-    "@opentelemetry/auto-instrumentations-node": "0.39.4",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.44.0",
-    "@opentelemetry/exporter-prometheus": "0.44.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.44.0",
-    "@opentelemetry/resource-detector-alibaba-cloud": "0.28.2",
-    "@opentelemetry/resource-detector-aws": "1.3.2",
-    "@opentelemetry/resource-detector-container": "0.3.2",
-    "@opentelemetry/resource-detector-gcp": "0.29.2",
-    "@opentelemetry/resources": "1.17.1",
-    "@opentelemetry/sdk-metrics": "1.17.1",
-    "@opentelemetry/sdk-node": "0.44.0"
+    "@opentelemetry/auto-instrumentations-node": "0.38.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.41.1",
+    "@opentelemetry/exporter-prometheus": "0.41.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.41.1",
+    "@opentelemetry/resource-detector-alibaba-cloud": "0.28.0",
+    "@opentelemetry/resource-detector-aws": "1.3.0",
+    "@opentelemetry/resource-detector-container": "0.3.0",
+    "@opentelemetry/resource-detector-gcp": "0.29.0",
+    "@opentelemetry/resources": "1.15.1",
+    "@opentelemetry/sdk-metrics": "1.15.1",
+    "@opentelemetry/sdk-node": "0.41.1"
   }
 }


### PR DESCRIPTION
Resolves #2236.

