### PR TITLE
Use only target address for allocation in consistent-hashing strategy

### DIFF
--- a/.chloggen/ta_really-consistent-hashing.yaml
+++ b/.chloggen/ta_really-consistent-hashing.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use only target address for allocation in consistent-hashing strategy
+
+# One or more tracking issues related to the change
+issues: [2280]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/allocation/allocatortest.go
+++ b/cmd/otel-allocator/allocation/allocatortest.go
@@ -39,7 +39,7 @@ func MakeNNewTargets(n int, numCollectors int, startingIndex int) map[string]*ta
 			"i":         model.LabelValue(strconv.Itoa(i)),
 			"total":     model.LabelValue(strconv.Itoa(n + startingIndex)),
 		}
-		newTarget := target.NewItem(fmt.Sprintf("test-job-%d", i), "test-url", label, collector)
+		newTarget := target.NewItem(fmt.Sprintf("test-job-%d", i), fmt.Sprintf("test-url-%d", i), label, collector)
 		toReturn[newTarget.Hash()] = newTarget
 	}
 	return toReturn
@@ -64,7 +64,7 @@ func MakeNNewTargetsWithEmptyCollectors(n int, startingIndex int) map[string]*ta
 			"i":     model.LabelValue(strconv.Itoa(i)),
 			"total": model.LabelValue(strconv.Itoa(n + startingIndex)),
 		}
-		newTarget := target.NewItem(fmt.Sprintf("test-job-%d", i), "test-url", label, "")
+		newTarget := target.NewItem(fmt.Sprintf("test-job-%d", i), fmt.Sprintf("test-url-%d", i), label, "")
 		toReturn[newTarget.Hash()] = newTarget
 	}
 	return toReturn

--- a/cmd/otel-allocator/allocation/consistent_hashing.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing.go
@@ -15,6 +15,7 @@
 package allocation
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/buraksezer/consistent"
@@ -111,7 +112,7 @@ func (c *consistentHashingAllocator) addTargetToTargetItems(tg *target.Item) {
 		delete(c.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName], tg.Hash())
 		TargetsPerCollector.WithLabelValues(previousColName.String(), consistentHashingStrategyName).Set(float64(c.collectors[previousColName.String()].NumTargets))
 	}
-	colOwner := c.consistentHasher.LocateKey([]byte(tg.Hash()))
+	colOwner := c.consistentHasher.LocateKey([]byte(strings.Join(tg.TargetURL, "")))
 	tg.CollectorName = colOwner.String()
 	c.targetItems[tg.Hash()] = tg
 	c.addCollectorTargetItemMapping(tg)

--- a/cmd/otel-allocator/allocation/consistent_hashing_test.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing_test.go
@@ -28,7 +28,7 @@ func TestCanSetSingleTarget(t *testing.T) {
 	actualTargetItems := c.TargetItems()
 	assert.Len(t, actualTargetItems, 1)
 	for _, item := range actualTargetItems {
-		assert.Equal(t, "collector-2", item.CollectorName)
+		assert.Equal(t, "collector-0", item.CollectorName)
 	}
 }
 


### PR DESCRIPTION
**Description:**
For the consistent-hashing strategy, base target allocation decisions only on the target url. This way, for a given collector count, we always assign targets with the same url to the same collector. Before, this decision was based on all target labels, and targets could therefore be moved between collectors even if collector count stayed the same.

**Link to tracking Issue:** #2280 

**Testing:**

Tested this in a ~500 Node production cluster in addition to the unit tests. It behaved as expected and over time resulted in an average drop of around 10% in CPU and memory usage with around 4000 scrape targets.
