### PR TITLE
[Chore] Fix test instrumentation-apache-httpd to work on OpenShift.

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-apache-httpd/00-install-collector.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-httpd/00-install-collector.yaml
@@ -19,3 +19,13 @@ spec:
           receivers: [otlp]
           processors: []
           exporters: [debug]
+
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Annotate the namespace to allow the application to run using an specific group and user in OpenShift
+  # https://docs.openshift.com/dedicated/authentication/managing-security-context-constraints.html
+  # This annotation has no effect in Kubernetes
+  - command: kubectl annotate namespace ${NAMESPACE} openshift.io/sa.scc.uid-range=1000/1000 --overwrite
+  - command: kubectl annotate namespace ${NAMESPACE} openshift.io/sa.scc.supplemental-groups=3000/1000 --overwrite

--- a/tests/e2e-instrumentation/instrumentation-apache-httpd/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-httpd/01-install-app.yaml
@@ -18,10 +18,14 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 3000
-        fsGroup: 2000
+        fsGroup: 3000
       containers:
       - name: myapp
         image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-apache-httpd:main
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         ports:
         - containerPort: 8080
         resources:


### PR DESCRIPTION
**Testing:**
```
$ kuttl test --test=instrumentation-apache-httpd tests/e2e-instrumentation/
2023/11/06 12:30:23 kutt-test config testdirs is overridden with args: [ tests/e2e-instrumentation/ ]
=== RUN   kuttl
    harness.go:462: starting setup
    harness.go:252: running tests using configured kubeconfig.
    harness.go:275: Successful connection to cluster at: https://api.REDACTED:6443
    harness.go:360: running tests
    harness.go:73: going to run test suite with timeout of 150 seconds for each step
    harness.go:372: testsuite: tests/e2e-instrumentation/ has 17 tests
=== RUN   kuttl/harness
=== RUN   kuttl/harness/instrumentation-apache-httpd
=== PAUSE kuttl/harness/instrumentation-apache-httpd
=== CONT  kuttl/harness/instrumentation-apache-httpd
    logger.go:42: 12:30:26 | instrumentation-apache-httpd | Creating namespace: kuttl-test-liberal-bluegill
    logger.go:42: 12:30:26 | instrumentation-apache-httpd/0-install-collector | starting test step 0-install-collector
    logger.go:42: 12:30:26 | instrumentation-apache-httpd/0-install-collector | running command: [kubectl annotate namespace kuttl-test-liberal-bluegill openshift.io/sa.scc.uid-range=1000/1000 --overwrite]
    logger.go:42: 12:30:28 | instrumentation-apache-httpd/0-install-collector | namespace/kuttl-test-liberal-bluegill annotate
    logger.go:42: 12:30:28 | instrumentation-apache-httpd/0-install-collector | running command: [kubectl annotate namespace kuttl-test-liberal-bluegill openshift.io/sa.scc.supplemental-groups=3000/1000 --overwrite]
    logger.go:42: 12:30:29 | instrumentation-apache-httpd/0-install-collector | namespace/kuttl-test-liberal-bluegill annotate
    logger.go:42: 12:30:31 | instrumentation-apache-httpd/0-install-collector | OpenTelemetryCollector:kuttl-test-liberal-bluegill/sidecar created
    logger.go:42: 12:30:32 | instrumentation-apache-httpd/0-install-collector | Instrumentation:kuttl-test-liberal-bluegill/apache created
    logger.go:42: 12:30:32 | instrumentation-apache-httpd/0-install-collector | test step completed 0-install-collector
    logger.go:42: 12:30:32 | instrumentation-apache-httpd/1-install-app | starting test step 1-install-app
    logger.go:42: 12:30:33 | instrumentation-apache-httpd/1-install-app | Deployment:kuttl-test-liberal-bluegill/my-apache created
    logger.go:42: 12:30:39 | instrumentation-apache-httpd/1-install-app | test step completed 1-install-app
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | instrumentation-apache-httpd events from ns kuttl-test-liberal-bluegill:
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:31 +0530 IST	Normal	OpenTelemetryCollector.opentelemetry.io sidecar		Info	applied status changes	opentelemetry-operator	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:33 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj	Binding	Scheduled	Successfully assigned kuttl-test-liberal-bluegill/my-apache-5fdfcd5c5c-mrwsj to REDACTED	default-scheduler	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:33 +0530 IST	Normal	ReplicaSet.apps my-apache-5fdfcd5c5c		SuccessfulCreate	Created pod: my-apache-5fdfcd5c5c-mrwsj	replicaset-controller	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:33 +0530 IST	Normal	Deployment.apps my-apache		ScalingReplicaSet	Scaled up replica set my-apache-5fdfcd5c5c to 1	deployment-controller	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:35 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj		AddedInterfaceAdd eth0 [10.131.0.123/23] from openshift-sdn		
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:35 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.initContainers{otel-agent-source-container-clone}		Pulled	Container image "ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-apache-httpd:main" already present on machine	kubelet	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:35 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.initContainers{otel-agent-source-container-clone}		Created	Created container otel-agent-source-container-clone	kubelet	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:35 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.initContainers{otel-agent-source-container-clone}		Started	Started container otel-agent-source-container-clone	kubelet	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:36 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.initContainers{otel-agent-attach-apache}		Pulled	Container image "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-apache-httpd:1.0.3" already present on machine	kubelet	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:36 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.initContainers{otel-agent-attach-apache}		Created	Created container otel-agent-attach-apache	kubelet	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:36 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.initContainers{otel-agent-attach-apache}		Started	Started container otel-agent-attach-apache	kubelet	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:37 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.containers{myapp}Pulled	Container image "ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-apache-httpd:main" already present on machine	kubelet	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:37 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.containers{myapp}Created	Created container myapp	kubelet	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:37 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.containers{myapp}Started	Started container myapp	kubelet	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:37 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.containers{otc-container}		Pulled	Container image "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.88.0" already present on machine	kubelet	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:37 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.containers{otc-container}		Created	Created container otc-container	kubelet	
    logger.go:42: 12:30:39 | instrumentation-apache-httpd | 2023-11-06 12:30:37 +0530 IST	Normal	Pod my-apache-5fdfcd5c5c-mrwsj.spec.containers{otc-container}		Started	Started container otc-container	kubelet	
    logger.go:42: 12:30:40 | instrumentation-apache-httpd | Deleting namespace: kuttl-test-liberal-bluegill
=== CONT  kuttl
    harness.go:405: run tests finished
    harness.go:513: cleaning up
    harness.go:570: removing temp folder: ""
--- PASS: kuttl (24.38s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/instrumentation-apache-httpd (21.16s)
PASS
```
