### PR TITLE
Add otel sdk group to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,10 @@ updates:
         patterns:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
+      otel:
+        patterns:
+          - go.opentelemetry.io/otel
+          - go.opentelemetry.io/otel/*
   - package-ecosystem: gomod
     directory: /cmd/otel-allocator
     schedule:


### PR DESCRIPTION
Right now it opens 4 PRs for the same module, which is annoying.
