### PR TITLE
Disable configuration hot reload in target allocator

### DIFF
--- a/.chloggen/disable-hot-reload.yaml
+++ b/.chloggen/disable-hot-reload.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable configuration hot reload
+
+# One or more tracking issues related to the change
+issues: [2032]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This feature can be re-enabled by passing the --reload-config flag to the target allocator.
+  However, this is deprecated and will be removed in an upcoming release.

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	KubeConfigFilePath     string             `yaml:"kube_config_file_path,omitempty"`
 	ClusterConfig          *rest.Config       `yaml:"-"`
 	RootLogger             logr.Logger        `yaml:"-"`
+	ReloadConfig           bool               `yaml:"-"`
 	LabelSelector          map[string]string  `yaml:"label_selector,omitempty"`
 	PromConfig             *promconfig.Config `yaml:"config"`
 	AllocationStrategy     *string            `yaml:"allocation_strategy,omitempty"`
@@ -106,6 +107,11 @@ func LoadFromCLI(target *Config, flagSet *pflag.FlagSet) error {
 	}
 
 	target.PrometheusCR.Enabled, err = getPrometheusCREnabled(flagSet)
+	if err != nil {
+		return err
+	}
+
+	target.ReloadConfig, err = getConfigReloadEnabled(flagSet)
 	if err != nil {
 		return err
 	}

--- a/cmd/otel-allocator/config/flags.go
+++ b/cmd/otel-allocator/config/flags.go
@@ -30,6 +30,7 @@ const (
 	listenAddrFlagName          = "listen-addr"
 	prometheusCREnabledFlagName = "enable-prometheus-cr-watcher"
 	kubeConfigPathFlagName      = "kubeconfig-path"
+	reloadConfigFlagName        = "reload-config"
 )
 
 // We can't bind this flag to our FlagSet, so we need to handle it separately.
@@ -41,6 +42,7 @@ func getFlagSet(errorHandling pflag.ErrorHandling) *pflag.FlagSet {
 	flagSet.String(listenAddrFlagName, ":8080", "The address where this service serves.")
 	flagSet.Bool(prometheusCREnabledFlagName, false, "Enable Prometheus CRs as target sources")
 	flagSet.String(kubeConfigPathFlagName, filepath.Join(homedir.HomeDir(), ".kube", "config"), "absolute path to the KubeconfigPath file")
+	flagSet.Bool(reloadConfigFlagName, false, "Enable automatic configuration reloading. This functionality is deprecated and will be removed in a future release.")
 	zapFlagSet := flag.NewFlagSet("", flag.ErrorHandling(errorHandling))
 	zapCmdLineOpts.BindFlags(zapFlagSet)
 	flagSet.AddGoFlagSet(zapFlagSet)
@@ -61,4 +63,8 @@ func getListenAddr(flagSet *pflag.FlagSet) (string, error) {
 
 func getPrometheusCREnabled(flagSet *pflag.FlagSet) (bool, error) {
 	return flagSet.GetBool(prometheusCREnabledFlagName)
+}
+
+func getConfigReloadEnabled(flagSet *pflag.FlagSet) (bool, error) {
+	return flagSet.GetBool(reloadConfigFlagName)
 }

--- a/cmd/otel-allocator/config/flags_test.go
+++ b/cmd/otel-allocator/config/flags_test.go
@@ -65,6 +65,12 @@ func TestFlagGetters(t *testing.T) {
 			getterFunc:    func(fs *pflag.FlagSet) (interface{}, error) { return getPrometheusCREnabled(fs) },
 		},
 		{
+			name:          "GetConfigReloadEnabled",
+			flagArgs:      []string{"--" + reloadConfigFlagName, "true"},
+			expectedValue: true,
+			getterFunc:    func(fs *pflag.FlagSet) (interface{}, error) { return getConfigReloadEnabled(fs) },
+		},
+		{
 			name:        "InvalidFlag",
 			flagArgs:    []string{"--invalid-flag", "value"},
 			expectedErr: true,

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -98,10 +98,12 @@ func main() {
 		setupLog.Error(collectorWatcherErr, "Unable to initialize collector watcher")
 		os.Exit(1)
 	}
-	fileWatcher, err = allocatorWatcher.NewFileWatcher(setupLog.WithName("file-watcher"), configFilePath)
-	if err != nil {
-		setupLog.Error(err, "Can't start the file watcher")
-		os.Exit(1)
+	if cfg.ReloadConfig {
+		fileWatcher, err = allocatorWatcher.NewFileWatcher(setupLog.WithName("file-watcher"), configFilePath)
+		if err != nil {
+			setupLog.Error(err, "Can't start the file watcher")
+			os.Exit(1)
+		}
 	}
 	signal.Notify(interrupts, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer close(interrupts)
@@ -126,19 +128,21 @@ func main() {
 				}
 			})
 	}
-	runGroup.Add(
-		func() error {
-			fileWatcherErr := fileWatcher.Watch(eventChan, errChan)
-			setupLog.Info("File watcher exited")
-			return fileWatcherErr
-		},
-		func(_ error) {
-			setupLog.Info("Closing file watcher")
-			fileWatcherErr := fileWatcher.Close()
-			if fileWatcherErr != nil {
-				setupLog.Error(fileWatcherErr, "file watcher failed to close")
-			}
-		})
+	if cfg.ReloadConfig {
+		runGroup.Add(
+			func() error {
+				fileWatcherErr := fileWatcher.Watch(eventChan, errChan)
+				setupLog.Info("File watcher exited")
+				return fileWatcherErr
+			},
+			func(_ error) {
+				setupLog.Info("Closing file watcher")
+				fileWatcherErr := fileWatcher.Close()
+				if fileWatcherErr != nil {
+					setupLog.Error(fileWatcherErr, "file watcher failed to close")
+				}
+			})
+	}
 	runGroup.Add(
 		func() error {
 			discoveryManagerErr := discoveryManager.Run()


### PR DESCRIPTION
**Description:** 
Added a flag to control configuration hot reloading in target allocator. The flag is disabled by default, and the functionality is hence considered deprecated and slated for removal in an upcoming release.

I could've done an official feature flag, but the target allocator doesn't have support for feature flags, and I don't think it's necessary to add it just for this.

**Link to tracking Issue:** #2032

**Testing:**
Added a unit test for the flag.
