### PR TITLE
implement readinessProbe endpoint to target allocator

### DIFF
--- a/cmd/otel-allocator/server/server_test.go
+++ b/cmd/otel-allocator/server/server_test.go
@@ -548,6 +548,69 @@ func TestServer_JobHandler(t *testing.T) {
 		})
 	}
 }
+func TestServer_Readiness(t *testing.T) {
+	tests := []struct {
+		description   string
+		scrapeConfigs map[string]*promconfig.ScrapeConfig
+		expectedCode  int
+		expectedBody  []byte
+	}{
+		{
+			description:   "nil scrape config",
+			scrapeConfigs: nil,
+			expectedCode:  http.StatusServiceUnavailable,
+		},
+		{
+			description:   "empty scrape config",
+			scrapeConfigs: map[string]*promconfig.ScrapeConfig{},
+			expectedCode:  http.StatusOK,
+		},
+		{
+			description: "single entry",
+			scrapeConfigs: map[string]*promconfig.ScrapeConfig{
+				"serviceMonitor/testapp/testapp/0": {
+					JobName:         "serviceMonitor/testapp/testapp/0",
+					HonorTimestamps: true,
+					ScrapeInterval:  model.Duration(30 * time.Second),
+					ScrapeTimeout:   model.Duration(30 * time.Second),
+					MetricsPath:     "/metrics",
+					Scheme:          "http",
+					HTTPClientConfig: config.HTTPClientConfig{
+						FollowRedirects: true,
+					},
+					RelabelConfigs: []*relabel.Config{
+						{
+							SourceLabels: model.LabelNames{model.LabelName("job")},
+							Separator:    ";",
+							Regex:        relabel.MustNewRegexp("(.*)"),
+							TargetLabel:  "__tmp_prometheus_job_name",
+							Replacement:  "$$1",
+							Action:       relabel.Replace,
+						},
+					},
+				},
+			},
+			expectedCode: http.StatusOK,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			listenAddr := ":8080"
+			s := NewServer(logger, nil, listenAddr)
+			if tc.scrapeConfigs != nil {
+				assert.NoError(t, s.UpdateScrapeConfigResponse(tc.scrapeConfigs))
+			}
+
+			request := httptest.NewRequest("GET", "/readyz", nil)
+			w := httptest.NewRecorder()
+
+			s.server.Handler.ServeHTTP(w, request)
+			result := w.Result()
+
+			assert.Equal(t, tc.expectedCode, result.StatusCode)
+		})
+	}
+}
 
 func newLink(jobName string) target.LinkJSON {
 	return target.LinkJSON{Link: fmt.Sprintf("/jobs/%s/targets", url.QueryEscape(jobName))}


### PR DESCRIPTION
**Link to tracking Issue:** <Issue number if applicable>
#2258

**Testing:** 
I've added readiness tests to see if it works when `Server.scrapeConfigResponse` is nil, I didn't call `Server.UpdateScrapeConfigResponse` when the scrape config is nil during the test because I found out even the config is nil, the eventual output after marshalling is not nil, as I wasn't sure if this is the expected behavior so I skipped this make sure it works as expected.

**Side Notes**
The readiness probe will fail if both scrape config in ta configs and service monitors are not found, I wasn't sure if this is the expected behavior either.
