### PR TITLE
Fix cascading delete, retry on conflict

### DIFF
--- a/.chloggen/2364-foreground-delete.yaml
+++ b/.chloggen/2364-foreground-delete.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fixes ability to do a foreground cascading delete
+
+# One or more tracking issues related to the change
+issues: [2364]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -23,8 +23,10 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
@@ -94,7 +96,12 @@ func reconcileDesiredObjects(ctx context.Context, kubeClient client.Client, logg
 		// we obtain the existing object by deep copying the desired object because it's the most convenient way
 		existing := desired.DeepCopyObject().(client.Object)
 		mutateFn := manifests.MutateFuncFor(existing, desired)
-		op, crudErr := ctrl.CreateOrUpdate(ctx, kubeClient, existing, mutateFn)
+		var op controllerutil.OperationResult
+		crudErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			result, createOrUpdateErr := ctrl.CreateOrUpdate(ctx, kubeClient, existing, mutateFn)
+			op = result
+			return createOrUpdateErr
+		})
 		if crudErr != nil && errors.Is(crudErr, manifests.ImmutableChangeErr) {
 			l.Error(crudErr, "detected immutable field change, trying to delete, new object will be created on next reconcile", "existing", existing.GetName())
 			delErr := kubeClient.Delete(ctx, existing)

--- a/controllers/opampbridge_controller.go
+++ b/controllers/opampbridge_controller.go
@@ -92,6 +92,10 @@ func (r *OpAMPBridgeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// on deleted requests.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	// We have a deletion, short circuit and let the deletion happen
+	if deletionTimestamp := instance.GetDeletionTimestamp(); deletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
 
 	params := r.getParams(instance)
 

--- a/controllers/opentelemetrycollector_controller.go
+++ b/controllers/opentelemetrycollector_controller.go
@@ -173,6 +173,10 @@ func (r *OpenTelemetryCollectorReconciler) Reconcile(ctx context.Context, req ct
 		// on deleted requests.
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	// We have a deletion, short circuit and let the deletion happen
+	if deletionTimestamp := instance.GetDeletionTimestamp(); deletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
 
 	if instance.Spec.ManagementState == v1alpha1.ManagementStateUnmanaged {
 		log.Info("Skipping reconciliation for unmanaged OpenTelemetryCollector resource", "name", req.String())


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Closes #2364 by checking for a deletion timestamp prior to manifest generation, preventing any more resources from being generated for a deleted CRD. This also fixes an annoying bug I observed in testing that is common to [kubernetes operators](https://github.com/kubernetes/kubernetes/issues/84430)
**Link to tracking Issue:** #2364 

**Testing:** Ran tests locally, verified in a kind cluster

**Documentation:** N/A
