### PR TITLE
bump webserver to v1.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ List of all available attributes can be found at [otel-webserver-module](https:/
 
 #### Using Nginx autoinstrumentation
 
-For `Nginx` autoinstrumentation, Nginx versions 1.22.0, 1.23.0, and 1.23.1 are supported at this time. The Nginx configuration file is expected to be `/etc/nginx/nginx.conf` by default, if it's different, see following example on how to change it. Instrumentation at this time also expects, that `conf.d` directory is present in the directory, where configuration file resides and that there is a `include <config-file-dir-path>/conf.d/*.conf;` directive in the `http { ... }` section of Nginx configuration file (like it is in the default configuration file of Nginx). You can also adjust OpenTelemetry SDK attributes. Example:
+For `Nginx` autoinstrumentation, Nginx versions 1.24.0 and 1.25.3 are supported at this time. The Nginx configuration file is expected to be `/etc/nginx/nginx.conf` by default, if it's different, see following example on how to change it. Instrumentation at this time also expects, that `conf.d` directory is present in the directory, where configuration file resides and that there is a `include <config-file-dir-path>/conf.d/*.conf;` directive in the `http { ... }` section of Nginx configuration file (like it is in the default configuration file of Nginx). You can also adjust OpenTelemetry SDK attributes. Example:
 
 ```yaml
 apiVersion: opentelemetry.io/v1alpha1

--- a/tests/e2e-instrumentation/instrumentation-nginx-contnr-secctx/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-contnr-secctx/01-install-app.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: myapp
-        image: nginxinc/nginx-unprivileged:1.23.1
+        image: nginxinc/nginx-unprivileged:1.25.3
         imagePullPolicy: Always
         securityContext:
           runAsUser: 1000

--- a/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/01-install-app.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 3000
       containers:
       - name: myapp
-        image: nginxinc/nginx-unprivileged:1.23.1
+        image: nginxinc/nginx-unprivileged:1.25.3
         imagePullPolicy: Always
         securityContext:
           runAsUser: 1000

--- a/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/02-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/02-install-app.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 3000
       containers:
       - name: myapp
-        image: nginxinc/nginx-unprivileged:1.23.1
+        image: nginxinc/nginx-unprivileged:1.25.3
         imagePullPolicy: Always
         securityContext:
           runAsUser: 1000

--- a/tests/e2e-instrumentation/instrumentation-nginx/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx/01-install-app.yaml
@@ -21,7 +21,7 @@ spec:
         fsGroup: 3000
       containers:
       - name: myapp
-        image: nginxinc/nginx-unprivileged:1.23.1
+        image: nginxinc/nginx-unprivileged:1.25.3
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false

--- a/versions.txt
+++ b/versions.txt
@@ -38,4 +38,4 @@ autoinstrumentation-apache-httpd=1.0.4
 
 # Represents the current release of Apache Nginx instrumentation.
 # Should match autoinstrumentation/apache-httpd/version.txt
-autoinstrumentation-nginx=1.0.3
+autoinstrumentation-nginx=1.0.4


### PR DESCRIPTION
**Description:** Bump webserver instrumentation to v1.0.4.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** CI

**Documentation:** https://github.com/open-telemetry/opentelemetry-cpp-contrib/releases/tag/webserver%2Fv1.0.4
