### PR TITLE
Add the ability to set headers in the opamp bridge config

### DIFF
--- a/.chloggen/opamp-bridge-headers-config.yaml
+++ b/.chloggen/opamp-bridge-headers-config.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: bridge
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: adds request headers to the opamp bridge config
+
+# One or more tracking issues related to the change
+issues: [2410]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/operator-opamp-bridge/agent/agent.go
+++ b/cmd/operator-opamp-bridge/agent/agent.go
@@ -146,7 +146,7 @@ func (agent *Agent) Start() error {
 	agent.startTime = uint64(agent.clock.Now().UnixNano())
 	settings := types.StartSettings{
 		OpAMPServerURL: agent.config.Endpoint,
-		Header:         agent.config.Headers.ToHttpHeader(),
+		Header:         agent.config.Headers.ToHTTPHeader(),
 		InstanceUid:    agent.instanceId.String(),
 		Callbacks: types.CallbacksStruct{
 			OnConnectFunc:              agent.onConnect,

--- a/cmd/operator-opamp-bridge/agent/agent.go
+++ b/cmd/operator-opamp-bridge/agent/agent.go
@@ -146,6 +146,7 @@ func (agent *Agent) Start() error {
 	agent.startTime = uint64(agent.clock.Now().UnixNano())
 	settings := types.StartSettings{
 		OpAMPServerURL: agent.config.Endpoint,
+		Header:         agent.config.Headers.ToHttpHeader(),
 		InstanceUid:    agent.instanceId.String(),
 		Callbacks: types.CallbacksStruct{
 			OnConnectFunc:              agent.onConnect,

--- a/cmd/operator-opamp-bridge/config/config.go
+++ b/cmd/operator-opamp-bridge/config/config.go
@@ -94,7 +94,7 @@ type Config struct {
 	// ComponentsAllowed is a list of allowed OpenTelemetry components for each pipeline type (receiver, processor, etc.)
 	ComponentsAllowed map[string][]string `yaml:"componentsAllowed,omitempty"`
 	Endpoint          string              `yaml:"endpoint"`
-	Headers           map[string]string   `yaml:"headers,omitempty"`
+	Headers           Headers             `yaml:"headers,omitempty"`
 	Capabilities      map[Capability]bool `yaml:"capabilities"`
 	HeartbeatInterval time.Duration       `yaml:"heartbeatInterval,omitempty"`
 	Name              string              `yaml:"name,omitempty"`

--- a/cmd/operator-opamp-bridge/config/config.go
+++ b/cmd/operator-opamp-bridge/config/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	// ComponentsAllowed is a list of allowed OpenTelemetry components for each pipeline type (receiver, processor, etc.)
 	ComponentsAllowed map[string][]string `yaml:"componentsAllowed,omitempty"`
 	Endpoint          string              `yaml:"endpoint"`
+	Headers           map[string]string   `yaml:"headers,omitempty"`
 	Capabilities      map[Capability]bool `yaml:"capabilities"`
 	HeartbeatInterval time.Duration       `yaml:"heartbeatInterval,omitempty"`
 	Name              string              `yaml:"name,omitempty"`

--- a/cmd/operator-opamp-bridge/config/config_headers.go
+++ b/cmd/operator-opamp-bridge/config/config_headers.go
@@ -1,0 +1,13 @@
+package config
+
+import "net/http"
+
+type Headers map[string]string
+
+func (h Headers) ToHttpHeader() http.Header {
+	newMap := make(map[string][]string)
+	for key, value := range h {
+		newMap[key] = []string{value}
+	}
+	return newMap
+}

--- a/cmd/operator-opamp-bridge/config/config_test.go
+++ b/cmd/operator-opamp-bridge/config/config_test.go
@@ -135,6 +135,35 @@ func TestLoad(t *testing.T) {
 				return assert.ErrorContains(t, err, "error unmarshaling YAML", i...)
 			},
 		},
+		{
+			name: "base case with headers",
+			args: args{
+				file: "./testdata/agentwithheaders.yaml",
+			},
+			want: &Config{
+				RootLogger: logr.Discard(),
+				Endpoint:   "ws://127.0.0.1:4320/v1/opamp",
+				Headers: map[string]string{
+					"authentication": "access-12345-token",
+					"my-header-key":  "my-header-value",
+				},
+				Capabilities: map[Capability]bool{
+					AcceptsRemoteConfig:            true,
+					ReportsEffectiveConfig:         true,
+					ReportsOwnTraces:               true,
+					ReportsOwnMetrics:              true,
+					ReportsOwnLogs:                 true,
+					AcceptsOpAMPConnectionSettings: true,
+					AcceptsOtherConnectionSettings: true,
+					AcceptsRestartCommand:          true,
+					ReportsHealth:                  true,
+					ReportsRemoteConfig:            true,
+					AcceptsPackages:                false,
+					ReportsPackageStatuses:         false,
+				},
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/operator-opamp-bridge/config/headers.go
+++ b/cmd/operator-opamp-bridge/config/headers.go
@@ -4,7 +4,7 @@ import "net/http"
 
 type Headers map[string]string
 
-func (h Headers) ToHttpHeader() http.Header {
+func (h Headers) ToHTTPHeader() http.Header {
 	newMap := make(map[string][]string)
 	for key, value := range h {
 		newMap[key] = []string{value}

--- a/cmd/operator-opamp-bridge/config/headers.go
+++ b/cmd/operator-opamp-bridge/config/headers.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import "net/http"

--- a/cmd/operator-opamp-bridge/config/testdata/agentwithheaders.yaml
+++ b/cmd/operator-opamp-bridge/config/testdata/agentwithheaders.yaml
@@ -1,0 +1,17 @@
+endpoint: ws://127.0.0.1:4320/v1/opamp
+headers:
+  authentication: "access-12345-token"
+  my-header-key: "my-header-value"
+capabilities:
+  AcceptsRemoteConfig: true
+  ReportsEffectiveConfig: true
+  AcceptsPackages: false
+  ReportsPackageStatuses: false
+  ReportsOwnTraces: true
+  ReportsOwnMetrics: true
+  ReportsOwnLogs: true
+  AcceptsOpAMPConnectionSettings: true
+  AcceptsOtherConnectionSettings: true
+  AcceptsRestartCommand: true
+  ReportsHealth: true
+  ReportsRemoteConfig: true


### PR DESCRIPTION
**Description:**
This PR adds a `Headers` field to the opamp bridge config and weaves that value through to the opamp client startup settings. In a subsequent PR this field will be configured to populate in the CRD

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-operator/issues/2410

**Testing:** A test was added to `config_test.yaml` to show this field will be populated by the agent config yaml.

**Documentation:** None
