### PR TITLE
[Chore] Add cluster role and binding required for OpenShift monitoring dependent cases.

### DIFF
--- a/tests/e2e-openshift/monitoring/03-create-monitoring-roles.yaml
+++ b/tests/e2e-openshift/monitoring/03-create-monitoring-roles.yaml
@@ -1,16 +1,12 @@
+# Add the clusterrole and rolebinding required for fetching metrics from Thanos querier. Refer https://issues.redhat.com/browse/MON-3379
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kuttl-cluster-monitoring-metrics-api
 rules:
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - prometheuses/api
-  verbs:
-  - get
-  - list
-  - watch
+- apiGroups: ["monitoring.coreos.com"]
+  resources: ["prometheuses/api"]
+  verbs: ["get", "list", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -25,9 +21,3 @@ subjects:
 - kind: ServiceAccount
   name: prometheus-user-workload
   namespace: openshift-user-workload-monitoring
-
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
-- script: ./tests/e2e-openshift/monitoring/check_metrics.sh

--- a/tests/e2e-openshift/otlp-metrics-traces/03-assert.yaml
+++ b/tests/e2e-openshift/otlp-metrics-traces/03-assert.yaml
@@ -1,3 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuttl-cluster-monitoring-metrics-api
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheuses/api
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuttl-cluster-monitoring-metrics-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuttl-cluster-monitoring-metrics-api
+subjects:
+- kind: ServiceAccount
+  name: prometheus-user-workload
+  namespace: openshift-user-workload-monitoring
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/tests/e2e-openshift/otlp-metrics-traces/03-metrics-traces-gen.yaml
+++ b/tests/e2e-openshift/otlp-metrics-traces/03-metrics-traces-gen.yaml
@@ -1,3 +1,28 @@
+# Add the clusterrole and rolebinding required for fetching metrics from Thanos querier. Refer https://issues.redhat.com/browse/MON-3379
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuttl-cluster-monitoring-metrics-api
+rules:
+- apiGroups: ["monitoring.coreos.com"]
+  resources: ["prometheuses/api"]
+  verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuttl-cluster-monitoring-metrics-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuttl-cluster-monitoring-metrics-api
+subjects:
+- kind: ServiceAccount
+  name: prometheus-user-workload
+  namespace: openshift-user-workload-monitoring
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The Thanos Querier has switched to using kube-rbac-proxy in OpenShift 4.15 which requires creation of additional role and binding to query for metrics. https://issues.redhat.com/browse/MON-3379 This PR adds the required ClusterRole and ClusterRolebinding so that the in-cluster monitoring dependent cases work on OCP 4.15.

**Testing:** <Describe what testing was performed and which tests were added.>
Tested on both OpenShift 4.14 and 4.15. 

```
--- PASS: kuttl (139.01s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/otlp-metrics-traces (136.04s)
PASS

--- PASS: kuttl (168.76s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/monitoring (165.21s)
PASS
```



