### PR TITLE
Changes to make TargetAllocator's getScrapeConfigHash method exported

### DIFF
--- a/.chloggen/ta_exporthashcomputer.yaml
+++ b/.chloggen/ta_exporthashcomputer.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make getScrapeConfigHash exported so that it can be used by otel collector
+
+# One or more tracking issues related to the change
+issues: [2435]

--- a/cmd/otel-allocator/target/discovery.go
+++ b/cmd/otel-allocator/target/discovery.go
@@ -85,7 +85,7 @@ func (m *Discoverer) ApplyConfig(source allocatorWatcher.EventSource, cfg *confi
 		}
 	}
 
-	hash, err := getScrapeConfigHash(jobToScrapeConfig)
+	hash, err := GetScrapeConfigHash(jobToScrapeConfig)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (m *Discoverer) Close() {
 
 // Calculate a hash for a scrape config map.
 // This is done by marshaling to YAML because it's the most straightforward and doesn't run into problems with unexported fields.
-func getScrapeConfigHash(jobToScrapeConfig map[string]*config.ScrapeConfig) (hash.Hash64, error) {
+func GetScrapeConfigHash(jobToScrapeConfig map[string]*config.ScrapeConfig) (hash.Hash64, error) {
 	var err error
 	hash := fnv.New64()
 	yamlEncoder := yaml.NewEncoder(hash)


### PR DESCRIPTION
**Description:** 
Changes to make TargetAllocator's getScrapeConfigHash method exported
This can use used to fix the [issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29313) where regex changes in scrape config for metric relabeling doesn't get picked up when using target allocator.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-operator/issues/2435

**Testing:** 
Unit test already exists

