### PR TITLE
[Chore] Fix targetallocator-features test case to work on OpenShift.

### DIFF
--- a/tests/e2e/targetallocator-features/00-install.yaml
+++ b/tests/e2e/targetallocator-features/00-install.yaml
@@ -20,6 +20,11 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - command: kubectl -n $NAMESPACE create rolebinding default-view-$NAMESPACE --role=pod-view --serviceaccount=$NAMESPACE:ta
+  # Annotate the namespace to allow the application to run using an specific group and user in OpenShift
+  # https://docs.openshift.com/dedicated/authentication/managing-security-context-constraints.html
+  # This annotation has no effect in Kubernetes
+  - command: kubectl annotate namespace ${NAMESPACE} openshift.io/sa.scc.uid-range=1000/1000 --overwrite
+  - command: kubectl annotate namespace ${NAMESPACE} openshift.io/sa.scc.supplemental-groups=3000/1000 --overwrite
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector
@@ -46,6 +51,11 @@ spec:
     serviceAccount: ta
     securityContext:
       runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 3000
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The PR fixes the targetallocator-features test case to work on OpenShift by adding the required securityContext configurations. Note the namespace annotations openshift.io/sa.scc.uid-range=1000/1000 openshift.io/sa.scc.supplemental-groups=3000/1000 has no effect in Kubernetes