### PR TITLE
Fix ServiceAccount naming for target allocator

### DIFF
--- a/.chloggen/fix_ta-serviceaccount.yaml
+++ b/.chloggen/fix_ta-serviceaccount.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix ServiceAccount naming for target allocator
+
+# One or more tracking issues related to the change
+issues: [2443]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/targetallocator/serviceaccount.go
+++ b/internal/manifests/targetallocator/serviceaccount.go
@@ -27,7 +27,7 @@ import (
 // ServiceAccountName returns the name of the existing or self-provisioned service account to use for the given instance.
 func ServiceAccountName(instance v1alpha1.OpenTelemetryCollector) string {
 	if len(instance.Spec.TargetAllocator.ServiceAccount) == 0 {
-		return naming.ServiceAccount(instance.Name)
+		return naming.TargetAllocatorServiceAccount(instance.Name)
 	}
 
 	return instance.Spec.TargetAllocator.ServiceAccount
@@ -35,6 +35,10 @@ func ServiceAccountName(instance v1alpha1.OpenTelemetryCollector) string {
 
 // ServiceAccount returns the service account for the given instance.
 func ServiceAccount(params manifests.Params) *corev1.ServiceAccount {
+	if len(params.OtelCol.Spec.TargetAllocator.ServiceAccount) > 0 {
+		return nil
+	}
+
 	name := naming.TargetAllocatorServiceAccount(params.OtelCol.Name)
 	labels := Labels(params.OtelCol, name)
 


### PR DESCRIPTION
**Description:**
Fix default ServiceAccount name for target allocator. Up until now it erroneously used the collector name.

Don't create the ServiceAccount for the target allocator if the user provided one themselves.

**Link to tracking Issue:** #2443 

**Testing:**
Added some unit tests and modified existing ones.

Looks like we don't have any builder tests for target allocator manifests. Adding them will require some refactoring, so I'd like to do it in a separate PR.
