### PR TITLE
Use standard collector selectors in target allocator config

### DIFF
--- a/.chloggen/feat_targetallocator-selector.yaml
+++ b/.chloggen/feat_targetallocator-selector.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use standard K8s label selectors for collectors in target allocator config
+
+# One or more tracking issues related to the change
+issues: [2422]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is a breaking change only for users of standalone target allocator. Operator users are unaffected.

--- a/.chloggen/feat_targetallocator-selector.yaml
+++ b/.chloggen/feat_targetallocator-selector.yaml
@@ -13,4 +13,6 @@ issues: [2422]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: This is a breaking change only for users of standalone target allocator. Operator users are unaffected.
+subtext: |
+  This is a breaking change only for users of standalone target allocator. Operator users are unaffected.
+  The operator is still compatible with previous target allocator versions, and will be for the next 3 releases.

--- a/cmd/otel-allocator/collector/collector_test.go
+++ b/cmd/otel-allocator/collector/collector_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
@@ -42,14 +41,16 @@ func getTestClient() (Client, watch.Interface) {
 		close:     make(chan struct{}),
 		log:       logger,
 	}
-
-	labelMap := map[string]string{
-		"app.kubernetes.io/instance":   "default.test",
-		"app.kubernetes.io/managed-by": "opentelemetry-operator",
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app.kubernetes.io/instance":   "default.test",
+			"app.kubernetes.io/managed-by": "opentelemetry-operator",
+		},
 	}
+	selector, _ := metav1.LabelSelectorAsSelector(&labelSelector)
 
 	opts := metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(labelMap).String(),
+		LabelSelector: selector.String(),
 	}
 	watcher, err := kubeClient.k8sClient.CoreV1().Pods("test-ns").Watch(context.Background(), opts)
 	if err != nil {

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -40,17 +40,17 @@ const DefaultConfigFilePath string = "/conf/targetallocator.yaml"
 const DefaultCRScrapeInterval model.Duration = model.Duration(time.Second * 30)
 
 type Config struct {
-	ListenAddr             string               `yaml:"listen_addr,omitempty"`
-	KubeConfigFilePath     string               `yaml:"kube_config_file_path,omitempty"`
-	ClusterConfig          *rest.Config         `yaml:"-"`
-	RootLogger             logr.Logger          `yaml:"-"`
-	CollectorSelector      metav1.LabelSelector `yaml:"collector_selector,omitempty"`
-	PromConfig             *promconfig.Config   `yaml:"config"`
-	AllocationStrategy     *string              `yaml:"allocation_strategy,omitempty"`
-	FilterStrategy         *string              `yaml:"filter_strategy,omitempty"`
-	PrometheusCR           PrometheusCRConfig   `yaml:"prometheus_cr,omitempty"`
-	PodMonitorSelector     map[string]string    `yaml:"pod_monitor_selector,omitempty"`
-	ServiceMonitorSelector map[string]string    `yaml:"service_monitor_selector,omitempty"`
+	ListenAddr             string                `yaml:"listen_addr,omitempty"`
+	KubeConfigFilePath     string                `yaml:"kube_config_file_path,omitempty"`
+	ClusterConfig          *rest.Config          `yaml:"-"`
+	RootLogger             logr.Logger           `yaml:"-"`
+	CollectorSelector      *metav1.LabelSelector `yaml:"collector_selector,omitempty"`
+	PromConfig             *promconfig.Config    `yaml:"config"`
+	AllocationStrategy     *string               `yaml:"allocation_strategy,omitempty"`
+	FilterStrategy         *string               `yaml:"filter_strategy,omitempty"`
+	PrometheusCR           PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
+	PodMonitorSelector     map[string]string     `yaml:"pod_monitor_selector,omitempty"`
+	ServiceMonitorSelector map[string]string     `yaml:"service_monitor_selector,omitempty"`
 }
 
 type PrometheusCRConfig struct {

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/prometheus/prometheus/discovery/install"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
@@ -39,17 +40,17 @@ const DefaultConfigFilePath string = "/conf/targetallocator.yaml"
 const DefaultCRScrapeInterval model.Duration = model.Duration(time.Second * 30)
 
 type Config struct {
-	ListenAddr             string             `yaml:"listen_addr,omitempty"`
-	KubeConfigFilePath     string             `yaml:"kube_config_file_path,omitempty"`
-	ClusterConfig          *rest.Config       `yaml:"-"`
-	RootLogger             logr.Logger        `yaml:"-"`
-	LabelSelector          map[string]string  `yaml:"label_selector,omitempty"`
-	PromConfig             *promconfig.Config `yaml:"config"`
-	AllocationStrategy     *string            `yaml:"allocation_strategy,omitempty"`
-	FilterStrategy         *string            `yaml:"filter_strategy,omitempty"`
-	PrometheusCR           PrometheusCRConfig `yaml:"prometheus_cr,omitempty"`
-	PodMonitorSelector     map[string]string  `yaml:"pod_monitor_selector,omitempty"`
-	ServiceMonitorSelector map[string]string  `yaml:"service_monitor_selector,omitempty"`
+	ListenAddr             string               `yaml:"listen_addr,omitempty"`
+	KubeConfigFilePath     string               `yaml:"kube_config_file_path,omitempty"`
+	ClusterConfig          *rest.Config         `yaml:"-"`
+	RootLogger             logr.Logger          `yaml:"-"`
+	CollectorSelector      metav1.LabelSelector `yaml:"collector_selector,omitempty"`
+	PromConfig             *promconfig.Config   `yaml:"config"`
+	AllocationStrategy     *string              `yaml:"allocation_strategy,omitempty"`
+	FilterStrategy         *string              `yaml:"filter_strategy,omitempty"`
+	PrometheusCR           PrometheusCRConfig   `yaml:"prometheus_cr,omitempty"`
+	PodMonitorSelector     map[string]string    `yaml:"pod_monitor_selector,omitempty"`
+	ServiceMonitorSelector map[string]string    `yaml:"service_monitor_selector,omitempty"`
 }
 
 type PrometheusCRConfig struct {
@@ -114,7 +115,6 @@ func LoadFromCLI(target *Config, flagSet *pflag.FlagSet) error {
 }
 
 func unmarshal(cfg *Config, configFile string) error {
-
 	yamlFile, err := os.ReadFile(configFile)
 	if err != nil {
 		return err

--- a/cmd/otel-allocator/config/config_test.go
+++ b/cmd/otel-allocator/config/config_test.go
@@ -21,6 +21,7 @@ import (
 
 	commonconfig "github.com/prometheus/common/config"
 	promconfig "github.com/prometheus/prometheus/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery"
@@ -44,9 +45,11 @@ func TestLoad(t *testing.T) {
 				file: "./testdata/config_test.yaml",
 			},
 			want: Config{
-				LabelSelector: map[string]string{
-					"app.kubernetes.io/instance":   "default.test",
-					"app.kubernetes.io/managed-by": "opentelemetry-operator",
+				CollectorSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/instance":   "default.test",
+						"app.kubernetes.io/managed-by": "opentelemetry-operator",
+					},
 				},
 				PrometheusCR: PrometheusCRConfig{
 					ScrapeInterval: model.Duration(time.Second * 60),
@@ -108,9 +111,11 @@ func TestLoad(t *testing.T) {
 				file: "./testdata/pod_service_selector_test.yaml",
 			},
 			want: Config{
-				LabelSelector: map[string]string{
-					"app.kubernetes.io/instance":   "default.test",
-					"app.kubernetes.io/managed-by": "opentelemetry-operator",
+				CollectorSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/instance":   "default.test",
+						"app.kubernetes.io/managed-by": "opentelemetry-operator",
+					},
 				},
 				PrometheusCR: PrometheusCRConfig{
 					ScrapeInterval: DefaultCRScrapeInterval,

--- a/cmd/otel-allocator/config/config_test.go
+++ b/cmd/otel-allocator/config/config_test.go
@@ -45,7 +45,7 @@ func TestLoad(t *testing.T) {
 				file: "./testdata/config_test.yaml",
 			},
 			want: Config{
-				CollectorSelector: metav1.LabelSelector{
+				CollectorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app.kubernetes.io/instance":   "default.test",
 						"app.kubernetes.io/managed-by": "opentelemetry-operator",
@@ -111,7 +111,7 @@ func TestLoad(t *testing.T) {
 				file: "./testdata/pod_service_selector_test.yaml",
 			},
 			want: Config{
-				CollectorSelector: metav1.LabelSelector{
+				CollectorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app.kubernetes.io/instance":   "default.test",
 						"app.kubernetes.io/managed-by": "opentelemetry-operator",

--- a/cmd/otel-allocator/config/testdata/config_test.yaml
+++ b/cmd/otel-allocator/config/testdata/config_test.yaml
@@ -1,6 +1,7 @@
-label_selector:
-  app.kubernetes.io/instance: default.test
-  app.kubernetes.io/managed-by: opentelemetry-operator
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/instance: default.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
 prometheus_cr:
   scrape_interval: 60s
 config:

--- a/cmd/otel-allocator/config/testdata/pod_service_selector_test.yaml
+++ b/cmd/otel-allocator/config/testdata/pod_service_selector_test.yaml
@@ -1,6 +1,7 @@
-label_selector:
-  app.kubernetes.io/instance: default.test
-  app.kubernetes.io/managed-by: opentelemetry-operator
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/instance: default.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
 pod_monitor_selector:
   release: test
 service_monitor_selector:

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -149,7 +149,7 @@ func main() {
 		})
 	runGroup.Add(
 		func() error {
-			err := collectorWatcher.Watch(ctx, &cfg.CollectorSelector, allocator.SetCollectors)
+			err := collectorWatcher.Watch(ctx, cfg.CollectorSelector, allocator.SetCollectors)
 			setupLog.Info("Collector watcher exited")
 			return err
 		},

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -149,7 +149,7 @@ func main() {
 		})
 	runGroup.Add(
 		func() error {
-			err := collectorWatcher.Watch(ctx, cfg.LabelSelector, allocator.SetCollectors)
+			err := collectorWatcher.Watch(ctx, &cfg.CollectorSelector, allocator.SetCollectors)
 			setupLog.Info("Collector watcher exited")
 			return err
 		},

--- a/cmd/otel-allocator/target/testdata/test.yaml
+++ b/cmd/otel-allocator/target/testdata/test.yaml
@@ -1,6 +1,7 @@
-label_selector:
-  app.kubernetes.io/instance: default.test
-  app.kubernetes.io/managed-by: opentelemetry-operator
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/instance: default.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
 config:
   scrape_configs:
   - job_name: prometheus

--- a/cmd/otel-allocator/target/testdata/test_update.yaml
+++ b/cmd/otel-allocator/target/testdata/test_update.yaml
@@ -1,6 +1,7 @@
-label_selector:
-  app.kubernetes.io/instance: default.test
-  app.kubernetes.io/managed-by: opentelemetry-operator
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/instance: default.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
 config:
   scrape_configs:
     - job_name: prometheus

--- a/controllers/builder_test.go
+++ b/controllers/builder_test.go
@@ -1340,6 +1340,11 @@ config:
       source_labels:
       - __meta_service_name
       target_label: instance
+label_selector:
+  app.kubernetes.io/component: opentelemetry-collector
+  app.kubernetes.io/instance: test.test
+  app.kubernetes.io/managed-by: opentelemetry-operator
+  app.kubernetes.io/part-of: opentelemetry
 `,
 					},
 				},
@@ -1372,7 +1377,7 @@ config:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "40afbbdb738923bf9cb4a117648cd86030cc5b748601d19120226eb1ee74c91a",
+									"opentelemetry-targetallocator-config/hash": "20c09760c240d08287ff05bd2375985220b577d938e82efd85467e17174690e0",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -1724,6 +1729,11 @@ config:
       source_labels:
       - __meta_service_name
       target_label: instance
+label_selector:
+  app.kubernetes.io/component: opentelemetry-collector
+  app.kubernetes.io/instance: test.test
+  app.kubernetes.io/managed-by: opentelemetry-operator
+  app.kubernetes.io/part-of: opentelemetry
 `,
 					},
 				},
@@ -1756,7 +1766,7 @@ config:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "40afbbdb738923bf9cb4a117648cd86030cc5b748601d19120226eb1ee74c91a",
+									"opentelemetry-targetallocator-config/hash": "20c09760c240d08287ff05bd2375985220b577d938e82efd85467e17174690e0",
 								},
 							},
 							Spec: corev1.PodSpec{

--- a/controllers/builder_test.go
+++ b/controllers/builder_test.go
@@ -1316,7 +1316,31 @@ service:
 						Annotations: nil,
 					},
 					Data: map[string]string{
-						"targetallocator.yaml": "allocation_strategy: least-weighted\nconfig:\n  scrape_configs:\n  - job_name: example\n    metric_relabel_configs:\n    - replacement: $1_$2\n      source_labels:\n      - job\n      target_label: job\n    relabel_configs:\n    - replacement: my_service_$1\n      source_labels:\n      - __meta_service_id\n      target_label: job\n    - replacement: $1\n      source_labels:\n      - __meta_service_name\n      target_label: instance\nlabel_selector:\n  app.kubernetes.io/component: opentelemetry-collector\n  app.kubernetes.io/instance: test.test\n  app.kubernetes.io/managed-by: opentelemetry-operator\n  app.kubernetes.io/part-of: opentelemetry\n",
+						"targetallocator.yaml": `allocation_strategy: least-weighted
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+config:
+  scrape_configs:
+  - job_name: example
+    metric_relabel_configs:
+    - replacement: $1_$2
+      source_labels:
+      - job
+      target_label: job
+    relabel_configs:
+    - replacement: my_service_$1
+      source_labels:
+      - __meta_service_id
+      target_label: job
+    - replacement: $1
+      source_labels:
+      - __meta_service_name
+      target_label: instance
+`,
 					},
 				},
 				&appsv1.Deployment{
@@ -1348,7 +1372,7 @@ service:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "4d1911fd40106e9e2dd3d928f067a6c8c9eab0c569f737ba3701c6f5a9aad6d7",
+									"opentelemetry-targetallocator-config/hash": "40afbbdb738923bf9cb4a117648cd86030cc5b748601d19120226eb1ee74c91a",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -1676,7 +1700,31 @@ service:
 						Annotations: nil,
 					},
 					Data: map[string]string{
-						"targetallocator.yaml": "allocation_strategy: least-weighted\nconfig:\n  scrape_configs:\n  - job_name: example\n    metric_relabel_configs:\n    - replacement: $1_$2\n      source_labels:\n      - job\n      target_label: job\n    relabel_configs:\n    - replacement: my_service_$1\n      source_labels:\n      - __meta_service_id\n      target_label: job\n    - replacement: $1\n      source_labels:\n      - __meta_service_name\n      target_label: instance\nlabel_selector:\n  app.kubernetes.io/component: opentelemetry-collector\n  app.kubernetes.io/instance: test.test\n  app.kubernetes.io/managed-by: opentelemetry-operator\n  app.kubernetes.io/part-of: opentelemetry\n",
+						"targetallocator.yaml": `allocation_strategy: least-weighted
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+config:
+  scrape_configs:
+  - job_name: example
+    metric_relabel_configs:
+    - replacement: $1_$2
+      source_labels:
+      - job
+      target_label: job
+    relabel_configs:
+    - replacement: my_service_$1
+      source_labels:
+      - __meta_service_id
+      target_label: job
+    - replacement: $1
+      source_labels:
+      - __meta_service_name
+      target_label: instance
+`,
 					},
 				},
 				&appsv1.Deployment{
@@ -1708,7 +1756,7 @@ service:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "4d1911fd40106e9e2dd3d928f067a6c8c9eab0c569f737ba3701c6f5a9aad6d7",
+									"opentelemetry-targetallocator-config/hash": "40afbbdb738923bf9cb4a117648cd86030cc5b748601d19120226eb1ee74c91a",
 								},
 							},
 							Spec: corev1.PodSpec{

--- a/controllers/reconcile_test.go
+++ b/controllers/reconcile_test.go
@@ -451,6 +451,12 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 									"app.kubernetes.io/part-of":    "opentelemetry",
 								},
 							}
+							taConfig["label_selector"] = map[string]string{
+								"app.kubernetes.io/instance":   "default.test",
+								"app.kubernetes.io/managed-by": "opentelemetry-operator",
+								"app.kubernetes.io/component":  "opentelemetry-collector",
+								"app.kubernetes.io/part-of":    "opentelemetry",
+							}
 							taConfig["config"] = promConfig["config"]
 							taConfig["allocation_strategy"] = "least-weighted"
 							taConfig["prometheus_cr"] = map[string]string{

--- a/controllers/reconcile_test.go
+++ b/controllers/reconcile_test.go
@@ -443,11 +443,13 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 							assert.NoError(t, err)
 
 							taConfig := make(map[interface{}]interface{})
-							taConfig["label_selector"] = map[string]string{
-								"app.kubernetes.io/instance":   "default.test",
-								"app.kubernetes.io/managed-by": "opentelemetry-operator",
-								"app.kubernetes.io/component":  "opentelemetry-collector",
-								"app.kubernetes.io/part-of":    "opentelemetry",
+							taConfig["collector_selector"] = map[string]any{
+								"matchlabels": map[string]string{
+									"app.kubernetes.io/instance":   "default.test",
+									"app.kubernetes.io/managed-by": "opentelemetry-operator",
+									"app.kubernetes.io/component":  "opentelemetry-collector",
+									"app.kubernetes.io/part-of":    "opentelemetry",
+								},
 							}
 							taConfig["config"] = promConfig["config"]
 							taConfig["allocation_strategy"] = "least-weighted"

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -44,7 +44,9 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 
 	taConfig := make(map[interface{}]interface{})
 	prometheusCRConfig := make(map[interface{}]interface{})
-	taConfig["label_selector"] = manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, collector.ComponentOpenTelemetryCollector)
+	taConfig["collector_selector"] = map[string]any{
+		"matchlabels": manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, collector.ComponentOpenTelemetryCollector),
+	}
 	// We only take the "config" from the returned object, if it's present
 	if prometheusConfig, ok := prometheusReceiverConfig["config"]; ok {
 		taConfig["config"] = prometheusConfig

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -44,9 +44,13 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 
 	taConfig := make(map[interface{}]interface{})
 	prometheusCRConfig := make(map[interface{}]interface{})
+	collectorSelectorLabels := manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, collector.ComponentOpenTelemetryCollector)
 	taConfig["collector_selector"] = map[string]any{
-		"matchlabels": manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, collector.ComponentOpenTelemetryCollector),
+		"matchlabels": collectorSelectorLabels,
 	}
+	// The below instruction is here for compatibility with the previous target allocator version
+	// TODO: Drop it after 3 more versions
+	taConfig["label_selector"] = collectorSelectorLabels
 	// We only take the "config" from the returned object, if it's present
 	if prometheusConfig, ok := prometheusReceiverConfig["config"]; ok {
 		taConfig["config"] = prometheusConfig

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -54,6 +54,11 @@ config:
     - targets:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
+label_selector:
+  app.kubernetes.io/component: opentelemetry-collector
+  app.kubernetes.io/instance: default.my-instance
+  app.kubernetes.io/managed-by: opentelemetry-operator
+  app.kubernetes.io/part-of: opentelemetry
 `,
 		}
 		instance := collectorInstance()
@@ -91,6 +96,11 @@ config:
     - targets:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
+label_selector:
+  app.kubernetes.io/component: opentelemetry-collector
+  app.kubernetes.io/instance: default.my-instance
+  app.kubernetes.io/managed-by: opentelemetry-operator
+  app.kubernetes.io/part-of: opentelemetry
 pod_monitor_selector:
   release: my-instance
 service_monitor_selector:
@@ -138,6 +148,11 @@ config:
     - targets:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
+label_selector:
+  app.kubernetes.io/component: opentelemetry-collector
+  app.kubernetes.io/instance: default.my-instance
+  app.kubernetes.io/managed-by: opentelemetry-operator
+  app.kubernetes.io/part-of: opentelemetry
 prometheus_cr:
   scrape_interval: 30s
 `,

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -40,6 +40,12 @@ func TestDesiredConfigMap(t *testing.T) {
 
 		expectedData := map[string]string{
 			"targetallocator.yaml": `allocation_strategy: least-weighted
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: default.my-instance
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
 config:
   scrape_configs:
   - job_name: otel-collector
@@ -48,11 +54,6 @@ config:
     - targets:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
-label_selector:
-  app.kubernetes.io/component: opentelemetry-collector
-  app.kubernetes.io/instance: default.my-instance
-  app.kubernetes.io/managed-by: opentelemetry-operator
-  app.kubernetes.io/part-of: opentelemetry
 `,
 		}
 		instance := collectorInstance()
@@ -76,6 +77,12 @@ label_selector:
 
 		expectedData := map[string]string{
 			"targetallocator.yaml": `allocation_strategy: least-weighted
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: default.my-instance
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
 config:
   scrape_configs:
   - job_name: otel-collector
@@ -84,11 +91,6 @@ config:
     - targets:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
-label_selector:
-  app.kubernetes.io/component: opentelemetry-collector
-  app.kubernetes.io/instance: default.my-instance
-  app.kubernetes.io/managed-by: opentelemetry-operator
-  app.kubernetes.io/part-of: opentelemetry
 pod_monitor_selector:
   release: my-instance
 service_monitor_selector:
@@ -122,6 +124,12 @@ service_monitor_selector:
 
 		expectedData := map[string]string{
 			"targetallocator.yaml": `allocation_strategy: least-weighted
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: default.my-instance
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
 config:
   scrape_configs:
   - job_name: otel-collector
@@ -130,11 +138,6 @@ config:
     - targets:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
-label_selector:
-  app.kubernetes.io/component: opentelemetry-collector
-  app.kubernetes.io/instance: default.my-instance
-  app.kubernetes.io/managed-by: opentelemetry-operator
-  app.kubernetes.io/part-of: opentelemetry
 prometheus_cr:
   scrape_interval: 30s
 `,


### PR DESCRIPTION
**Description:**
Make the label selector for collectors in target allocator configuration use the K8s standard format. We can later explicitly expose this in the TargetAllocator CRD.

One annoying aspect of using the core struct is that it only has tags for json serialization, and the yaml marshaler just lowercases the name. So we end up with `matchlabels` rather than `matchLabels` or `match_labels`. I'm not sure the additional complexity of using a custom struct and then converting is worth it, given that target allocator is almost exclusively used and configured by the operator.

**Link to tracking Issue:** #2422

Resolves https://github.com/open-telemetry/opentelemetry-operator/issues/2422 

**Testing:**
Modified existing tests.

