### PR TITLE
[chore] Clean up config handling in target allocator

### DIFF
--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -35,9 +35,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-const DefaultResyncTime = 5 * time.Minute
-const DefaultConfigFilePath string = "/conf/targetallocator.yaml"
-const DefaultCRScrapeInterval model.Duration = model.Duration(time.Second * 30)
+const (
+	DefaultResyncTime                        = 5 * time.Minute
+	DefaultConfigFilePath     string         = "/conf/targetallocator.yaml"
+	DefaultCRScrapeInterval   model.Duration = model.Duration(time.Second * 30)
+	DefaultAllocationStrategy                = "consistent-hashing"
+	DefaultFilterStrategy                    = "relabel-config"
+)
 
 type Config struct {
 	ListenAddr             string                `yaml:"listen_addr,omitempty"`
@@ -46,8 +50,8 @@ type Config struct {
 	RootLogger             logr.Logger           `yaml:"-"`
 	CollectorSelector      *metav1.LabelSelector `yaml:"collector_selector,omitempty"`
 	PromConfig             *promconfig.Config    `yaml:"config"`
-	AllocationStrategy     *string               `yaml:"allocation_strategy,omitempty"`
-	FilterStrategy         *string               `yaml:"filter_strategy,omitempty"`
+	AllocationStrategy     string                `yaml:"allocation_strategy,omitempty"`
+	FilterStrategy         string                `yaml:"filter_strategy,omitempty"`
 	PrometheusCR           PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
 	PodMonitorSelector     map[string]string     `yaml:"pod_monitor_selector,omitempty"`
 	ServiceMonitorSelector map[string]string     `yaml:"service_monitor_selector,omitempty"`
@@ -56,20 +60,6 @@ type Config struct {
 type PrometheusCRConfig struct {
 	Enabled        bool           `yaml:"enabled,omitempty"`
 	ScrapeInterval model.Duration `yaml:"scrape_interval,omitempty"`
-}
-
-func (c Config) GetAllocationStrategy() string {
-	if c.AllocationStrategy != nil {
-		return *c.AllocationStrategy
-	}
-	return "consistent-hashing"
-}
-
-func (c Config) GetTargetsFilterStrategy() string {
-	if c.FilterStrategy != nil {
-		return *c.FilterStrategy
-	}
-	return "relabel-config"
 }
 
 func LoadFromFile(file string, target *Config) error {
@@ -127,6 +117,8 @@ func unmarshal(cfg *Config, configFile string) error {
 
 func CreateDefaultConfig() Config {
 	return Config{
+		AllocationStrategy: DefaultAllocationStrategy,
+		FilterStrategy:     DefaultFilterStrategy,
 		PrometheusCR: PrometheusCRConfig{
 			ScrapeInterval: DefaultCRScrapeInterval,
 		},

--- a/cmd/otel-allocator/config/config_test.go
+++ b/cmd/otel-allocator/config/config_test.go
@@ -45,12 +45,14 @@ func TestLoad(t *testing.T) {
 				file: "./testdata/config_test.yaml",
 			},
 			want: Config{
+				AllocationStrategy: DefaultAllocationStrategy,
 				CollectorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app.kubernetes.io/instance":   "default.test",
 						"app.kubernetes.io/managed-by": "opentelemetry-operator",
 					},
 				},
+				FilterStrategy: DefaultFilterStrategy,
 				PrometheusCR: PrometheusCRConfig{
 					ScrapeInterval: model.Duration(time.Second * 60),
 				},
@@ -111,12 +113,14 @@ func TestLoad(t *testing.T) {
 				file: "./testdata/pod_service_selector_test.yaml",
 			},
 			want: Config{
+				AllocationStrategy: DefaultAllocationStrategy,
 				CollectorSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"app.kubernetes.io/instance":   "default.test",
 						"app.kubernetes.io/managed-by": "opentelemetry-operator",
 					},
 				},
+				FilterStrategy: DefaultFilterStrategy,
 				PrometheusCR: PrometheusCRConfig{
 					ScrapeInterval: DefaultCRScrapeInterval,
 				},

--- a/cmd/otel-allocator/target/discovery_test.go
+++ b/cmd/otel-allocator/target/discovery_test.go
@@ -89,7 +89,7 @@ func TestDiscovery(t *testing.T) {
 			err := config.LoadFromFile(tt.args.file, &cfg)
 			assert.NoError(t, err)
 			assert.True(t, len(cfg.PromConfig.ScrapeConfigs) > 0)
-			err = manager.ApplyConfig(allocatorWatcher.EventSourcePrometheusCR, cfg.PromConfig)
+			err = manager.ApplyConfig(allocatorWatcher.EventSourcePrometheusCR, cfg.PromConfig.ScrapeConfigs)
 			assert.NoError(t, err)
 
 			gotTargets := <-results
@@ -306,11 +306,11 @@ func TestDiscovery_ScrapeConfigHashing(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			err := manager.ApplyConfig(allocatorWatcher.EventSourcePrometheusCR, tc.cfg)
+			err := manager.ApplyConfig(allocatorWatcher.EventSourcePrometheusCR, tc.cfg.ScrapeConfigs)
 			if !tc.expectErr {
 				expectedConfig = make(map[string]*promconfig.ScrapeConfig)
-				for _, value := range manager.configsMap {
-					for _, scrapeConfig := range value.ScrapeConfigs {
+				for _, configs := range manager.configsMap {
+					for _, scrapeConfig := range configs {
 						expectedConfig[scrapeConfig.JobName] = scrapeConfig
 					}
 				}
@@ -389,7 +389,7 @@ func BenchmarkApplyScrapeConfig(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := manager.ApplyConfig(allocatorWatcher.EventSourcePrometheusCR, cfg)
+		err := manager.ApplyConfig(allocatorWatcher.EventSourcePrometheusCR, cfg.ScrapeConfigs)
 		require.NoError(b, err)
 	}
 }


### PR DESCRIPTION
I've made defaults for some options easier to work with by following Go conventions - used string values with an empty string signifying no value, instead of pointers.

I've also made an internal change to target allocator, where it's now clear that we only use scrape configs out of the Prometheus config, and ignore everything else. I'd like to make this more explicit in the future and reject configurations which include anything other than scrape configs.
