### PR TITLE
Skip unknown fields in target allocator config

### DIFF
--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -119,7 +119,7 @@ func unmarshal(cfg *Config, configFile string) error {
 	if err != nil {
 		return err
 	}
-	if err = yaml.UnmarshalStrict(yamlFile, cfg); err != nil {
+	if err = yaml.Unmarshal(yamlFile, cfg); err != nil {
 		return fmt.Errorf("error unmarshaling YAML: %w", err)
 	}
 	return nil

--- a/cmd/otel-allocator/config/testdata/no_config.yaml
+++ b/cmd/otel-allocator/config/testdata/no_config.yaml
@@ -1,0 +1,2 @@
+# this is some random data to check if we skip unknown fields instead of rejecting them
+some_key: some_value


### PR DESCRIPTION
Unmarshal the target allocator config in non-strict mode, which makes it ignore fields it doesn't know, as opposed to erroring on them. This will make it easier for us to change target allocator configuration while preserving backwards compatibilty - see #2466 for example.

I don't think this is worth calling out in the changelog, but I can add an entry if anyone feels strongly about it.
