### PR TITLE
Use container securityContext for target allocator

### DIFF
--- a/.chloggen/fix-ta-security-context.yaml
+++ b/.chloggen/fix-ta-security-context.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use container securityContext for target allocator
+
+# One or more tracking issues related to the change
+issues: [2490]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is really a bug fix, as the current behaviour is not intended. We've marked it as breaking in case anyone started depending on it.

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -325,7 +325,7 @@ type OpenTelemetryTargetAllocator struct {
 	// SecurityContext configures the container security context for
 	// the targetallocator.
 	// +optional
-	SecurityContext *v1.PodSecurityContext `json:"securityContext,omitempty"`
+	SecurityContext *v1.SecurityContext `json:"securityContext,omitempty"`
 	// TopologySpreadConstraints embedded kubernetes pod configuration option,
 	// controls how pods are spread across your cluster among failure-domains
 	// such as regions, zones, nodes, and other user-defined topology domains

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -976,7 +976,7 @@ func (in *OpenTelemetryTargetAllocator) DeepCopyInto(out *OpenTelemetryTargetAll
 	in.PrometheusCR.DeepCopyInto(&out.PrometheusCR)
 	if in.SecurityContext != nil {
 		in, out := &in.SecurityContext, &out.SecurityContext
-		*out = new(v1.PodSecurityContext)
+		*out = new(v1.SecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.TopologySpreadConstraints != nil {

--- a/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -5285,22 +5285,54 @@ spec:
                     description: SecurityContext configures the container security
                       context for the targetallocator.
                     properties:
-                      fsGroup:
-                        description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1."
-                        format: int64
-                        type: integer
-                      fsGroupChangePolicy:
-                        description: fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod.
+                      allowPrivilegeEscalation:
+                        description: AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges than its parent process. This bool
+                          directly controls if the no_new_privs flag will be set on
+                          the container process.
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths.
                         type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        type: boolean
                       runAsGroup:
                         description: The GID to run the entrypoint of the container
                           process. Uses runtime default if unset. May also be set
-                          in SecurityContext.
+                          in PodSecurityContext.
                         format: int64
                         type: integer
                       runAsNonRoot:
@@ -5310,14 +5342,14 @@ spec:
                       runAsUser:
                         description: The UID to run the entrypoint of the container
                           process. Defaults to user specified in image metadata if
-                          unspecified. May also be set in SecurityContext.
+                          unspecified. May also be set in PodSecurityContext.
                         format: int64
                         type: integer
                       seLinuxOptions:
-                        description: The SELinux context to be applied to all containers.
+                        description: The SELinux context to be applied to the container.
                           If unspecified, the container runtime will allocate a random
                           SELinux context for each container.  May also be set in
-                          SecurityContext.
+                          PodSecurityContext.
                         properties:
                           level:
                             description: Level is SELinux level label that applies
@@ -5337,9 +5369,9 @@ spec:
                             type: string
                         type: object
                       seccompProfile:
-                        description: The seccomp options to use by the containers
-                          in this pod. Note that this field cannot be set when spec.os.name
-                          is windows.
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
                         properties:
                           localhostProfile:
                             description: localhostProfile indicates a profile defined
@@ -5354,38 +5386,10 @@ spec:
                         required:
                         - type
                         type: object
-                      supplementalGroups:
-                        description: A list of groups applied to the first process
-                          run in each container, in addition to the container's primary
-                          GID, the fsGroup (if specified), and group memberships defined
-                          in the container image for th
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      sysctls:
-                        description: Sysctls hold a list of namespaced sysctls used
-                          for the pod. Pods with unsupported sysctls (by the container
-                          runtime) might fail to launch. Note that this field cannot
-                          be set when spec.os.
-                        items:
-                          description: Sysctl defines a kernel parameter to be set
-                          properties:
-                            name:
-                              description: Name of a property to set
-                              type: string
-                            value:
-                              description: Value of a property to set
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
                       windowsOptions:
                         description: The Windows specific settings applied to all
-                          containers. If unspecified, the options within a container's
-                          SecurityContext will be used.
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used.
                         properties:
                           gmsaCredentialSpec:
                             description: GMSACredentialSpec is where the GMSA admission

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -5282,22 +5282,54 @@ spec:
                     description: SecurityContext configures the container security
                       context for the targetallocator.
                     properties:
-                      fsGroup:
-                        description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1."
-                        format: int64
-                        type: integer
-                      fsGroupChangePolicy:
-                        description: fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod.
+                      allowPrivilegeEscalation:
+                        description: AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges than its parent process. This bool
+                          directly controls if the no_new_privs flag will be set on
+                          the container process.
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                        type: object
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false. Note that this field cannot
+                          be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths.
                         type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false. Note that this field cannot be set when
+                          spec.os.name is windows.
+                        type: boolean
                       runAsGroup:
                         description: The GID to run the entrypoint of the container
                           process. Uses runtime default if unset. May also be set
-                          in SecurityContext.
+                          in PodSecurityContext.
                         format: int64
                         type: integer
                       runAsNonRoot:
@@ -5307,14 +5339,14 @@ spec:
                       runAsUser:
                         description: The UID to run the entrypoint of the container
                           process. Defaults to user specified in image metadata if
-                          unspecified. May also be set in SecurityContext.
+                          unspecified. May also be set in PodSecurityContext.
                         format: int64
                         type: integer
                       seLinuxOptions:
-                        description: The SELinux context to be applied to all containers.
+                        description: The SELinux context to be applied to the container.
                           If unspecified, the container runtime will allocate a random
                           SELinux context for each container.  May also be set in
-                          SecurityContext.
+                          PodSecurityContext.
                         properties:
                           level:
                             description: Level is SELinux level label that applies
@@ -5334,9 +5366,9 @@ spec:
                             type: string
                         type: object
                       seccompProfile:
-                        description: The seccomp options to use by the containers
-                          in this pod. Note that this field cannot be set when spec.os.name
-                          is windows.
+                        description: The seccomp options to use by this container.
+                          If seccomp options are provided at both the pod & container
+                          level, the container options override the pod options.
                         properties:
                           localhostProfile:
                             description: localhostProfile indicates a profile defined
@@ -5351,38 +5383,10 @@ spec:
                         required:
                         - type
                         type: object
-                      supplementalGroups:
-                        description: A list of groups applied to the first process
-                          run in each container, in addition to the container's primary
-                          GID, the fsGroup (if specified), and group memberships defined
-                          in the container image for th
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      sysctls:
-                        description: Sysctls hold a list of namespaced sysctls used
-                          for the pod. Pods with unsupported sysctls (by the container
-                          runtime) might fail to launch. Note that this field cannot
-                          be set when spec.os.
-                        items:
-                          description: Sysctl defines a kernel parameter to be set
-                          properties:
-                            name:
-                              description: Name of a property to set
-                              type: string
-                            value:
-                              description: Value of a property to set
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
                       windowsOptions:
                         description: The Windows specific settings applied to all
-                          containers. If unspecified, the options within a container's
-                          SecurityContext will be used.
+                          containers. If unspecified, the options from the PodSecurityContext
+                          will be used.
                         properties:
                           gmsaCredentialSpec:
                             description: GMSACredentialSpec is where the GMSA admission

--- a/internal/manifests/targetallocator/container.go
+++ b/internal/manifests/targetallocator/container.go
@@ -89,14 +89,15 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelem
 
 	envVars = append(envVars, proxy.ReadProxyVarsFromEnv()...)
 	return corev1.Container{
-		Name:           naming.TAContainer(),
-		Image:          image,
-		Ports:          ports,
-		Env:            envVars,
-		VolumeMounts:   volumeMounts,
-		Resources:      otelcol.Spec.TargetAllocator.Resources,
-		Args:           args,
-		LivenessProbe:  livenessProbe,
-		ReadinessProbe: readinessProbe,
+		Name:            naming.TAContainer(),
+		Image:           image,
+		Ports:           ports,
+		Env:             envVars,
+		VolumeMounts:    volumeMounts,
+		Resources:       otelcol.Spec.TargetAllocator.Resources,
+		Args:            args,
+		LivenessProbe:   livenessProbe,
+		ReadinessProbe:  readinessProbe,
+		SecurityContext: otelcol.Spec.TargetAllocator.SecurityContext,
 	}
 }

--- a/internal/manifests/targetallocator/container_test.go
+++ b/internal/manifests/targetallocator/container_test.go
@@ -368,3 +368,26 @@ func TestLivenessProbe(t *testing.T) {
 	// verify
 	assert.Equal(t, expected, c.LivenessProbe)
 }
+
+func TestSecurityContext(t *testing.T) {
+	runAsNonRoot := true
+	securityContext := &corev1.SecurityContext{
+		RunAsNonRoot: &runAsNonRoot,
+	}
+	// prepare
+	otelcol := v1alpha1.OpenTelemetryCollector{
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
+				Enabled:         true,
+				SecurityContext: securityContext,
+			},
+		},
+	}
+	cfg := config.New()
+
+	// test
+	c := Container(cfg, logger, otelcol)
+
+	// verify
+	assert.Equal(t, securityContext, c.SecurityContext)
+}

--- a/internal/manifests/targetallocator/deployment.go
+++ b/internal/manifests/targetallocator/deployment.go
@@ -59,7 +59,6 @@ func Deployment(params manifests.Params) (*appsv1.Deployment, error) {
 					Tolerations:               params.OtelCol.Spec.TargetAllocator.Tolerations,
 					TopologySpreadConstraints: params.OtelCol.Spec.TargetAllocator.TopologySpreadConstraints,
 					Affinity:                  params.OtelCol.Spec.TargetAllocator.Affinity,
-					SecurityContext:           params.OtelCol.Spec.TargetAllocator.SecurityContext,
 				},
 			},
 		},

--- a/internal/manifests/targetallocator/deployment_test.go
+++ b/internal/manifests/targetallocator/deployment_test.go
@@ -67,62 +67,6 @@ var testAffinityValue = &v1.Affinity{
 	},
 }
 
-var runAsUser int64 = 1000
-var runAsGroup int64 = 1000
-
-var testSecurityContextValue = &v1.PodSecurityContext{
-	RunAsUser:  &runAsUser,
-	RunAsGroup: &runAsGroup,
-}
-
-func TestDeploymentSecurityContext(t *testing.T) {
-	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-instance",
-		},
-	}
-
-	cfg := config.New()
-
-	params1 := manifests.Params{
-		OtelCol: otelcol1,
-		Config:  cfg,
-		Log:     logger,
-	}
-	d1, err := Deployment(params1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Empty(t, d1.Spec.Template.Spec.SecurityContext)
-
-	// Test SecurityContext
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-instance-securitycontext",
-		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
-				SecurityContext: testSecurityContextValue,
-			},
-		},
-	}
-
-	cfg = config.New()
-
-	params2 := manifests.Params{
-		OtelCol: otelcol2,
-		Config:  cfg,
-		Log:     logger,
-	}
-
-	d2, err := Deployment(params2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, *testSecurityContextValue, *d2.Spec.Template.Spec.SecurityContext)
-}
-
 func TestDeploymentNewDefault(t *testing.T) {
 	// prepare
 	otelcol := collectorInstance()

--- a/tests/e2e/targetallocator-features/00-assert.yaml
+++ b/tests/e2e/targetallocator-features/00-assert.yaml
@@ -56,8 +56,6 @@ spec:
                     operator: In
                     values:
                       - "true"
-      securityContext:
-        runAsUser: 1000
       containers:
         - name: ta-container
           args:
@@ -79,6 +77,10 @@ spec:
             failureThreshold: 3
             timeoutSeconds: 1
             periodSeconds: 10
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 3000
+            privileged: true
           livenessProbe:
             httpGet:
               path: /livez

--- a/tests/e2e/targetallocator-features/00-install.yaml
+++ b/tests/e2e/targetallocator-features/00-install.yaml
@@ -51,7 +51,7 @@ spec:
     securityContext:
       runAsUser: 1000
       runAsGroup: 3000
-      fsGroup: 3000
+      privileged: true
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
**Description:**
The target allocator CR `securityContext` field is currently the Pod Security Context. This change makes it the container security context, as originally intended. 

**Link to tracking Issue:** #2490 

**Testing:**
Added a unit test and modified an E2E test to specifically check fields unique to the container security context.
