### PR TITLE
[autoinstrumentation] Bump go autoinstrumentation to v0.10.0-alpha

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-go/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-go/02-assert.yaml
@@ -19,7 +19,7 @@ spec:
         requests:
           cpu: "50m"
           memory: "32Mi"
-      image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.8.0-alpha
+      image: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go:v0.10.0-alpha
       env:
         - name: OTEL_GO_AUTO_TARGET_EXE
           value: /usr/src/app/productcatalogservice

--- a/versions.txt
+++ b/versions.txt
@@ -30,7 +30,7 @@ autoinstrumentation-python=0.43b0
 autoinstrumentation-dotnet=1.2.0
 
 # Represents the current release of Go instrumentation.
-autoinstrumentation-go=v0.8.0-alpha
+autoinstrumentation-go=v0.10.0-alpha
 
 # Represents the current release of Apache HTTPD instrumentation.
 # Should match autoinstrumentation/apache-httpd/version.txt


### PR DESCRIPTION
**Description:**
Bumps go autoinstrumentation version to v0.10.0-alpha.  Reviewing the changelogs for v0.9.0-alpha and v0.10.0-alpha I dont see anything that needs updated in our code.