### PR TITLE
[chore] Remove invalid skipped TA test

### DIFF
--- a/cmd/otel-allocator/allocation/least_weighted_test.go
+++ b/cmd/otel-allocator/allocation/least_weighted_test.go
@@ -195,55 +195,6 @@ func TestNoAssignmentToNewCollector(t *testing.T) {
 	assert.Equal(t, newCollector.NumTargets, 0)
 }
 
-func TestSmartCollectorReassignment(t *testing.T) {
-	t.Skip("This test is flaky and fails frequently, see issue 1291")
-	s, _ := New("least-weighted", logger)
-
-	cols := MakeNCollectors(4, 0)
-	s.SetCollectors(cols)
-
-	expectedColLen := len(cols)
-	assert.Len(t, s.Collectors(), expectedColLen)
-
-	for _, i := range cols {
-		assert.NotNil(t, s.Collectors()[i.Name])
-	}
-	initTargets := MakeNNewTargets(6, 0, 0)
-	// test that targets and collectors are added properly
-	s.SetTargets(initTargets)
-
-	// verify
-	expectedTargetLen := len(initTargets)
-	targetItems := s.TargetItems()
-	assert.Len(t, targetItems, expectedTargetLen)
-
-	// assign new set of collectors with the same names
-	newCols := map[string]*Collector{
-		"collector-0": {
-			Name: "collector-0",
-		}, "collector-1": {
-			Name: "collector-1",
-		}, "collector-2": {
-			Name: "collector-2",
-		}, "collector-4": {
-			Name: "collector-4",
-		},
-	}
-	s.SetCollectors(newCols)
-
-	newTargetItems := s.TargetItems()
-	assert.Equal(t, len(targetItems), len(newTargetItems))
-	for key, targetItem := range targetItems {
-		item, ok := newTargetItems[key]
-		assert.True(t, ok, "all target items should be found in new target item list")
-		if targetItem.CollectorName != "collector-3" {
-			assert.Equal(t, targetItem.CollectorName, item.CollectorName)
-		} else {
-			assert.Equal(t, "collector-4", item.CollectorName)
-		}
-	}
-}
-
 // Tests that the delta in number of targets per collector is less than 15% of an even distribution.
 func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 


### PR DESCRIPTION
Resolves #1291. This test was checking behaviour the least-weighted strategy doesn't exhibit. Allocation using this strategy is not stable.

