### PR TITLE
[chore] Fix flaky target allocator e2e test

### DIFF
--- a/tests/e2e/targetallocator-prometheuscr/00-install.yaml
+++ b/tests/e2e/targetallocator-prometheuscr/00-install.yaml
@@ -104,6 +104,7 @@ spec:
   targetAllocator:
     enabled: true
     serviceAccount: ta
+    scrapeInterval: 1s
     prometheusCR:
       enabled: true
   config: |

--- a/tests/e2e/targetallocator-prometheuscr/01-install.yaml
+++ b/tests/e2e/targetallocator-prometheuscr/01-install.yaml
@@ -13,7 +13,12 @@ spec:
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-collector:9090/metrics | grep "otelcol_exporter_sent_metric_points_total{"
+            - |
+              for i in $(seq 30); do
+                if curl -m 1 -s http://prometheus-cr-collector:9090/metrics | grep "otelcol"; then exit 0; fi
+                sleep 5
+              done
+              exit 1
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
I've made the target allocator Prometheus CR test significantly faster by avoiding restarts in the metrics checking job, checking a metric that is available earlier, and decreasing the scrape interval. All this adds up to the job running 2x as fast.

