### PR TITLE
Use standard label selectors in target allocator config

### DIFF
--- a/.chloggen/feat_ta_monitor-selectors.yaml
+++ b/.chloggen/feat_ta_monitor-selectors.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use standard K8s label selectors for Prometheus CRs in target allocator config
+
+# One or more tracking issues related to the change
+issues: [1907]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This is a breaking change only for users of standalone target allocator. Operator users are unaffected.
+  The operator is still compatible with previous target allocator versions, and will be for the next 3 releases.

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -53,15 +53,15 @@ type Config struct {
 	AllocationStrategy              string                `yaml:"allocation_strategy,omitempty"`
 	FilterStrategy                  string                `yaml:"filter_strategy,omitempty"`
 	PrometheusCR                    PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
-	PodMonitorSelector              map[string]string     `yaml:"pod_monitor_selector,omitempty"`
-	ServiceMonitorSelector          map[string]string     `yaml:"service_monitor_selector,omitempty"`
 	ServiceMonitorNamespaceSelector *metav1.LabelSelector `yaml:"service_monitor_namespace_selector,omitempty"`
 	PodMonitorNamespaceSelector     *metav1.LabelSelector `yaml:"pod_monitor_namespace_selector,omitempty"`
 }
 
 type PrometheusCRConfig struct {
-	Enabled        bool           `yaml:"enabled,omitempty"`
-	ScrapeInterval model.Duration `yaml:"scrape_interval,omitempty"`
+	Enabled                bool                  `yaml:"enabled,omitempty"`
+	PodMonitorSelector     *metav1.LabelSelector `yaml:"pod_monitor_selector,omitempty"`
+	ServiceMonitorSelector *metav1.LabelSelector `yaml:"service_monitor_selector,omitempty"`
+	ScrapeInterval         model.Duration        `yaml:"scrape_interval,omitempty"`
 }
 
 func LoadFromFile(file string, target *Config) error {

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -44,24 +44,24 @@ const (
 )
 
 type Config struct {
-	ListenAddr                      string                `yaml:"listen_addr,omitempty"`
-	KubeConfigFilePath              string                `yaml:"kube_config_file_path,omitempty"`
-	ClusterConfig                   *rest.Config          `yaml:"-"`
-	RootLogger                      logr.Logger           `yaml:"-"`
-	CollectorSelector               *metav1.LabelSelector `yaml:"collector_selector,omitempty"`
-	PromConfig                      *promconfig.Config    `yaml:"config"`
-	AllocationStrategy              string                `yaml:"allocation_strategy,omitempty"`
-	FilterStrategy                  string                `yaml:"filter_strategy,omitempty"`
-	PrometheusCR                    PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
-	ServiceMonitorNamespaceSelector *metav1.LabelSelector `yaml:"service_monitor_namespace_selector,omitempty"`
-	PodMonitorNamespaceSelector     *metav1.LabelSelector `yaml:"pod_monitor_namespace_selector,omitempty"`
+	ListenAddr         string                `yaml:"listen_addr,omitempty"`
+	KubeConfigFilePath string                `yaml:"kube_config_file_path,omitempty"`
+	ClusterConfig      *rest.Config          `yaml:"-"`
+	RootLogger         logr.Logger           `yaml:"-"`
+	CollectorSelector  *metav1.LabelSelector `yaml:"collector_selector,omitempty"`
+	PromConfig         *promconfig.Config    `yaml:"config"`
+	AllocationStrategy string                `yaml:"allocation_strategy,omitempty"`
+	FilterStrategy     string                `yaml:"filter_strategy,omitempty"`
+	PrometheusCR       PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
 }
 
 type PrometheusCRConfig struct {
-	Enabled                bool                  `yaml:"enabled,omitempty"`
-	PodMonitorSelector     *metav1.LabelSelector `yaml:"pod_monitor_selector,omitempty"`
-	ServiceMonitorSelector *metav1.LabelSelector `yaml:"service_monitor_selector,omitempty"`
-	ScrapeInterval         model.Duration        `yaml:"scrape_interval,omitempty"`
+	Enabled                         bool                  `yaml:"enabled,omitempty"`
+	PodMonitorSelector              *metav1.LabelSelector `yaml:"pod_monitor_selector,omitempty"`
+	ServiceMonitorSelector          *metav1.LabelSelector `yaml:"service_monitor_selector,omitempty"`
+	ServiceMonitorNamespaceSelector *metav1.LabelSelector `yaml:"service_monitor_namespace_selector,omitempty"`
+	PodMonitorNamespaceSelector     *metav1.LabelSelector `yaml:"pod_monitor_namespace_selector,omitempty"`
+	ScrapeInterval                  model.Duration        `yaml:"scrape_interval,omitempty"`
 }
 
 func LoadFromFile(file string, target *Config) error {

--- a/cmd/otel-allocator/config/config_test.go
+++ b/cmd/otel-allocator/config/config_test.go
@@ -122,6 +122,16 @@ func TestLoad(t *testing.T) {
 				},
 				FilterStrategy: DefaultFilterStrategy,
 				PrometheusCR: PrometheusCRConfig{
+					PodMonitorSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"release": "test",
+						},
+					},
+					ServiceMonitorSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"release": "test",
+						},
+					},
 					ScrapeInterval: DefaultCRScrapeInterval,
 				},
 				PromConfig: &promconfig.Config{
@@ -159,12 +169,6 @@ func TestLoad(t *testing.T) {
 							},
 						},
 					},
-				},
-				PodMonitorSelector: map[string]string{
-					"release": "test",
-				},
-				ServiceMonitorSelector: map[string]string{
-					"release": "test",
 				},
 			},
 			wantErr: assert.NoError,

--- a/cmd/otel-allocator/config/testdata/pod_service_selector_test.yaml
+++ b/cmd/otel-allocator/config/testdata/pod_service_selector_test.yaml
@@ -2,10 +2,13 @@ collector_selector:
   matchlabels:
     app.kubernetes.io/instance: default.test
     app.kubernetes.io/managed-by: opentelemetry-operator
-pod_monitor_selector:
-  release: test
-service_monitor_selector:
-  release: test
+prometheus_cr:
+  pod_monitor_selector:
+    matchlabels:
+      release: test
+  service_monitor_selector:
+    matchlabels:
+      release: test
 config:
   scrape_configs:
     - job_name: prometheus

--- a/cmd/otel-allocator/watcher/promOperator.go
+++ b/cmd/otel-allocator/watcher/promOperator.go
@@ -76,8 +76,8 @@ func NewPrometheusCRWatcher(ctx context.Context, logger logr.Logger, cfg allocat
 				ScrapeInterval:                  monitoringv1.Duration(cfg.PrometheusCR.ScrapeInterval.String()),
 				ServiceMonitorSelector:          cfg.PrometheusCR.ServiceMonitorSelector,
 				PodMonitorSelector:              cfg.PrometheusCR.PodMonitorSelector,
-				ServiceMonitorNamespaceSelector: cfg.ServiceMonitorNamespaceSelector,
-				PodMonitorNamespaceSelector:     cfg.PodMonitorNamespaceSelector,
+				ServiceMonitorNamespaceSelector: cfg.PrometheusCR.ServiceMonitorNamespaceSelector,
+				PodMonitorNamespaceSelector:     cfg.PrometheusCR.PodMonitorNamespaceSelector,
 			},
 		},
 	}
@@ -112,8 +112,8 @@ func NewPrometheusCRWatcher(ctx context.Context, logger logr.Logger, cfg allocat
 		eventInterval:                   minEventInterval,
 		configGenerator:                 generator,
 		kubeConfigPath:                  cfg.KubeConfigFilePath,
-		podMonitorNamespaceSelector:     cfg.PodMonitorNamespaceSelector,
-		serviceMonitorNamespaceSelector: cfg.ServiceMonitorNamespaceSelector,
+		podMonitorNamespaceSelector:     cfg.PrometheusCR.PodMonitorNamespaceSelector,
+		serviceMonitorNamespaceSelector: cfg.PrometheusCR.ServiceMonitorNamespaceSelector,
 		resourceSelector:                resourceSelector,
 		store:                           store,
 	}, nil

--- a/cmd/otel-allocator/watcher/promOperator.go
+++ b/cmd/otel-allocator/watcher/promOperator.go
@@ -73,13 +73,9 @@ func NewPrometheusCRWatcher(ctx context.Context, logger logr.Logger, cfg allocat
 	prom := &monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				ScrapeInterval: monitoringv1.Duration(cfg.PrometheusCR.ScrapeInterval.String()),
-				ServiceMonitorSelector: &metav1.LabelSelector{
-					MatchLabels: cfg.ServiceMonitorSelector,
-				},
-				PodMonitorSelector: &metav1.LabelSelector{
-					MatchLabels: cfg.PodMonitorSelector,
-				},
+				ScrapeInterval:                  monitoringv1.Duration(cfg.PrometheusCR.ScrapeInterval.String()),
+				ServiceMonitorSelector:          cfg.PrometheusCR.ServiceMonitorSelector,
+				PodMonitorSelector:              cfg.PrometheusCR.PodMonitorSelector,
 				ServiceMonitorNamespaceSelector: cfg.ServiceMonitorNamespaceSelector,
 				PodMonitorNamespaceSelector:     cfg.PodMonitorNamespaceSelector,
 			},

--- a/cmd/otel-allocator/watcher/promOperator_test.go
+++ b/cmd/otel-allocator/watcher/promOperator_test.go
@@ -669,10 +669,10 @@ func TestLoadConfig(t *testing.T) {
 				PrometheusCR: allocatorconfig.PrometheusCRConfig{
 					ServiceMonitorSelector: &metav1.LabelSelector{},
 					PodMonitorSelector:     &metav1.LabelSelector{},
-				},
-				ServiceMonitorNamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"label1": "label1",
+					ServiceMonitorNamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label1": "label1",
+						},
 					},
 				},
 			},
@@ -737,10 +737,10 @@ func TestLoadConfig(t *testing.T) {
 				PrometheusCR: allocatorconfig.PrometheusCRConfig{
 					ServiceMonitorSelector: &metav1.LabelSelector{},
 					PodMonitorSelector:     &metav1.LabelSelector{},
-				},
-				PodMonitorNamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"label1": "label1",
+					PodMonitorNamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label1": "label1",
+						},
 					},
 				},
 			},
@@ -838,10 +838,10 @@ func TestNamespaceLabelUpdate(t *testing.T) {
 		PrometheusCR: allocatorconfig.PrometheusCRConfig{
 			ServiceMonitorSelector: &metav1.LabelSelector{},
 			PodMonitorSelector:     &metav1.LabelSelector{},
-		},
-		PodMonitorNamespaceSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"label1": "label1",
+			PodMonitorNamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"label1": "label1",
+				},
 			},
 		},
 	}
@@ -1059,8 +1059,8 @@ func getTestPrometheusCRWatcher(t *testing.T, svcMonitors []*monitoringv1.Servic
 				ScrapeInterval:                  monitoringv1.Duration("30s"),
 				ServiceMonitorSelector:          cfg.PrometheusCR.ServiceMonitorSelector,
 				PodMonitorSelector:              cfg.PrometheusCR.PodMonitorSelector,
-				ServiceMonitorNamespaceSelector: cfg.ServiceMonitorNamespaceSelector,
-				PodMonitorNamespaceSelector:     cfg.PodMonitorNamespaceSelector,
+				ServiceMonitorNamespaceSelector: cfg.PrometheusCR.ServiceMonitorNamespaceSelector,
+				PodMonitorNamespaceSelector:     cfg.PrometheusCR.PodMonitorNamespaceSelector,
 			},
 		},
 	}
@@ -1097,8 +1097,8 @@ func getTestPrometheusCRWatcher(t *testing.T, svcMonitors []*monitoringv1.Servic
 		nsInformer:                      nsMonInf,
 		stopChannel:                     make(chan struct{}),
 		configGenerator:                 generator,
-		podMonitorNamespaceSelector:     cfg.PodMonitorNamespaceSelector,
-		serviceMonitorNamespaceSelector: cfg.ServiceMonitorNamespaceSelector,
+		podMonitorNamespaceSelector:     cfg.PrometheusCR.PodMonitorNamespaceSelector,
+		serviceMonitorNamespaceSelector: cfg.PrometheusCR.ServiceMonitorNamespaceSelector,
 		resourceSelector:                resourceSelector,
 		store:                           store,
 	}, source

--- a/cmd/otel-allocator/watcher/promOperator_test.go
+++ b/cmd/otel-allocator/watcher/promOperator_test.go
@@ -88,7 +88,12 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 			},
-			cfg: allocatorconfig.Config{},
+			cfg: allocatorconfig.Config{
+				PrometheusCR: allocatorconfig.PrometheusCRConfig{
+					ServiceMonitorSelector: &metav1.LabelSelector{},
+					PodMonitorSelector:     &metav1.LabelSelector{},
+				},
+			},
 			want: &promconfig.Config{
 				ScrapeConfigs: []*promconfig.ScrapeConfig{
 					{
@@ -171,7 +176,12 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 			},
-			cfg: allocatorconfig.Config{},
+			cfg: allocatorconfig.Config{
+				PrometheusCR: allocatorconfig.PrometheusCRConfig{
+					ServiceMonitorSelector: &metav1.LabelSelector{},
+					PodMonitorSelector:     &metav1.LabelSelector{},
+				},
+			},
 			want: &promconfig.Config{
 				GlobalConfig: promconfig.GlobalConfig{},
 				ScrapeConfigs: []*promconfig.ScrapeConfig{
@@ -232,7 +242,12 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 			},
-			cfg: allocatorconfig.Config{},
+			cfg: allocatorconfig.Config{
+				PrometheusCR: allocatorconfig.PrometheusCRConfig{
+					ServiceMonitorSelector: &metav1.LabelSelector{},
+					PodMonitorSelector:     &metav1.LabelSelector{},
+				},
+			},
 			want: &promconfig.Config{
 				GlobalConfig: promconfig.GlobalConfig{},
 				ScrapeConfigs: []*promconfig.ScrapeConfig{
@@ -322,7 +337,12 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 			},
-			cfg: allocatorconfig.Config{},
+			cfg: allocatorconfig.Config{
+				PrometheusCR: allocatorconfig.PrometheusCRConfig{
+					ServiceMonitorSelector: &metav1.LabelSelector{},
+					PodMonitorSelector:     &metav1.LabelSelector{},
+				},
+			},
 			want: &promconfig.Config{
 				ScrapeConfigs: []*promconfig.ScrapeConfig{
 					{
@@ -424,7 +444,12 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 			},
-			cfg: allocatorconfig.Config{},
+			cfg: allocatorconfig.Config{
+				PrometheusCR: allocatorconfig.PrometheusCRConfig{
+					ServiceMonitorSelector: &metav1.LabelSelector{},
+					PodMonitorSelector:     &metav1.LabelSelector{},
+				},
+			},
 			want: &promconfig.Config{
 				ScrapeConfigs: []*promconfig.ScrapeConfig{
 					{
@@ -506,8 +531,12 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 			cfg: allocatorconfig.Config{
-				ServiceMonitorSelector: map[string]string{
-					"testsvc": "testsvc",
+				PrometheusCR: allocatorconfig.PrometheusCRConfig{
+					ServiceMonitorSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"testsvc": "testsvc",
+						},
+					},
 				},
 			},
 			want: &promconfig.Config{
@@ -571,8 +600,12 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 			cfg: allocatorconfig.Config{
-				PodMonitorSelector: map[string]string{
-					"testpod": "testpod",
+				PrometheusCR: allocatorconfig.PrometheusCRConfig{
+					PodMonitorSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"testpod": "testpod",
+						},
+					},
 				},
 			},
 			want: &promconfig.Config{
@@ -633,6 +666,10 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 			cfg: allocatorconfig.Config{
+				PrometheusCR: allocatorconfig.PrometheusCRConfig{
+					ServiceMonitorSelector: &metav1.LabelSelector{},
+					PodMonitorSelector:     &metav1.LabelSelector{},
+				},
 				ServiceMonitorNamespaceSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"label1": "label1",
@@ -697,6 +734,10 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 			cfg: allocatorconfig.Config{
+				PrometheusCR: allocatorconfig.PrometheusCRConfig{
+					ServiceMonitorSelector: &metav1.LabelSelector{},
+					PodMonitorSelector:     &metav1.LabelSelector{},
+				},
 				PodMonitorNamespaceSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"label1": "label1",
@@ -794,6 +835,10 @@ func TestNamespaceLabelUpdate(t *testing.T) {
 	}
 
 	cfg := allocatorconfig.Config{
+		PrometheusCR: allocatorconfig.PrometheusCRConfig{
+			ServiceMonitorSelector: &metav1.LabelSelector{},
+			PodMonitorSelector:     &metav1.LabelSelector{},
+		},
 		PodMonitorNamespaceSelector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				"label1": "label1",
@@ -1011,13 +1056,9 @@ func getTestPrometheusCRWatcher(t *testing.T, svcMonitors []*monitoringv1.Servic
 	prom := &monitoringv1.Prometheus{
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				ScrapeInterval: monitoringv1.Duration("30s"),
-				ServiceMonitorSelector: &metav1.LabelSelector{
-					MatchLabels: cfg.ServiceMonitorSelector,
-				},
-				PodMonitorSelector: &metav1.LabelSelector{
-					MatchLabels: cfg.PodMonitorSelector,
-				},
+				ScrapeInterval:                  monitoringv1.Duration("30s"),
+				ServiceMonitorSelector:          cfg.PrometheusCR.ServiceMonitorSelector,
+				PodMonitorSelector:              cfg.PrometheusCR.PodMonitorSelector,
 				ServiceMonitorNamespaceSelector: cfg.ServiceMonitorNamespaceSelector,
 				PodMonitorNamespaceSelector:     cfg.PodMonitorNamespaceSelector,
 			},

--- a/controllers/builder_test.go
+++ b/controllers/builder_test.go
@@ -1352,6 +1352,13 @@ label_selector:
   app.kubernetes.io/instance: test.test
   app.kubernetes.io/managed-by: opentelemetry-operator
   app.kubernetes.io/part-of: opentelemetry
+prometheus_cr:
+  pod_monitor_selector:
+    matchlabels: {}
+    matchexpressions: []
+  service_monitor_selector:
+    matchlabels: {}
+    matchexpressions: []
 `,
 					},
 				},
@@ -1384,7 +1391,7 @@ label_selector:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "bf084cbbdcb09d03a40ad2352e0869ccf75d01f5dec977938b94d5a3239ea491",
+									"opentelemetry-targetallocator-config/hash": "51477b182d2c9e7c0db27a2cbc9c7d35b24895b1cf0774d51a41b8d1753696ed",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -1744,6 +1751,13 @@ label_selector:
   app.kubernetes.io/instance: test.test
   app.kubernetes.io/managed-by: opentelemetry-operator
   app.kubernetes.io/part-of: opentelemetry
+prometheus_cr:
+  pod_monitor_selector:
+    matchlabels: {}
+    matchexpressions: []
+  service_monitor_selector:
+    matchlabels: {}
+    matchexpressions: []
 `,
 					},
 				},
@@ -1776,7 +1790,7 @@ label_selector:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "bf084cbbdcb09d03a40ad2352e0869ccf75d01f5dec977938b94d5a3239ea491",
+									"opentelemetry-targetallocator-config/hash": "51477b182d2c9e7c0db27a2cbc9c7d35b24895b1cf0774d51a41b8d1753696ed",
 								},
 							},
 							Spec: corev1.PodSpec{

--- a/controllers/reconcile_test.go
+++ b/controllers/reconcile_test.go
@@ -460,8 +460,10 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 							taConfig["config"] = promConfig["config"]
 							taConfig["allocation_strategy"] = "consistent-hashing"
 							taConfig["filter_strategy"] = "relabel-config"
-							taConfig["prometheus_cr"] = map[string]string{
-								"scrape_interval": "30s",
+							taConfig["prometheus_cr"] = map[string]any{
+								"scrape_interval":          "30s",
+								"pod_monitor_selector":     &metav1.LabelSelector{},
+								"service_monitor_selector": &metav1.LabelSelector{},
 							}
 							taConfigYAML, _ := yaml.Marshal(taConfig)
 							assert.Equal(t, string(taConfigYAML), actual.Data["targetallocator.yaml"])

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -68,10 +68,20 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 		prometheusCRConfig["scrape_interval"] = params.OtelCol.Spec.TargetAllocator.PrometheusCR.ScrapeInterval.Duration
 	}
 
+	prometheusCRConfig["service_monitor_selector"] = &metav1.LabelSelector{
+		MatchLabels: params.OtelCol.Spec.TargetAllocator.PrometheusCR.ServiceMonitorSelector,
+	}
+	// The below instruction is here for compatibility with the previous target allocator version
+	// TODO: Drop it after 3 more versions
 	if params.OtelCol.Spec.TargetAllocator.PrometheusCR.ServiceMonitorSelector != nil {
 		taConfig["service_monitor_selector"] = &params.OtelCol.Spec.TargetAllocator.PrometheusCR.ServiceMonitorSelector
 	}
 
+	prometheusCRConfig["pod_monitor_selector"] = &metav1.LabelSelector{
+		MatchLabels: params.OtelCol.Spec.TargetAllocator.PrometheusCR.PodMonitorSelector,
+	}
+	// The below instruction is here for compatibility with the previous target allocator version
+	// TODO: Drop it after 3 more versions
 	if params.OtelCol.Spec.TargetAllocator.PrometheusCR.PodMonitorSelector != nil {
 		taConfig["pod_monitor_selector"] = &params.OtelCol.Spec.TargetAllocator.PrometheusCR.PodMonitorSelector
 	}

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -60,6 +60,13 @@ label_selector:
   app.kubernetes.io/instance: default.my-instance
   app.kubernetes.io/managed-by: opentelemetry-operator
   app.kubernetes.io/part-of: opentelemetry
+prometheus_cr:
+  pod_monitor_selector:
+    matchlabels: {}
+    matchexpressions: []
+  service_monitor_selector:
+    matchlabels: {}
+    matchexpressions: []
 `,
 		}
 		instance := collectorInstance()
@@ -105,6 +112,15 @@ label_selector:
   app.kubernetes.io/part-of: opentelemetry
 pod_monitor_selector:
   release: my-instance
+prometheus_cr:
+  pod_monitor_selector:
+    matchlabels:
+      release: my-instance
+    matchexpressions: []
+  service_monitor_selector:
+    matchlabels:
+      release: my-instance
+    matchexpressions: []
 service_monitor_selector:
   release: my-instance
 `,
@@ -157,7 +173,13 @@ label_selector:
   app.kubernetes.io/managed-by: opentelemetry-operator
   app.kubernetes.io/part-of: opentelemetry
 prometheus_cr:
+  pod_monitor_selector:
+    matchlabels: {}
+    matchexpressions: []
   scrape_interval: 30s
+  service_monitor_selector:
+    matchlabels: {}
+    matchexpressions: []
 `,
 		}
 


### PR DESCRIPTION
**Description:**
Use standard label selectors in target allocator config instead of plain maps. This is a step towards resolving #1907 in `v1alpha2` CRs, by using these selectors in the CRDs themselves as well.

I'd wanted to keep backwards compatibility with older target allocator versions to make upgrades easier, so I couldn't simply change the types of existing config fields. Instead, I decided to move all of these fields under the `prometheus_cr` section in the configuration, which imo is the more intuitive location for it anyway.

There's also a difference in semantics between our current `v1alpha1` CRD and standard behaviour for these selectors that I needed to handle. For selectors:

* a `nil` selector means "select nothing", which is also the default in prometheus-operator CRs
* an empty `{}` selector means "select everything"
* a selector with actual labels or expressions works as expected

However, for the label maps in our `v1alpha1` CRD, an empty or nil map means "select everything". As a result, I needed to make sure we put an empty selector in the configuration in that case. This is the reason they appear in the modified test code. In `v1alpha2`, we can change this behaviour to match prometheus-operator.

**Link to tracking Issue:** #1907

**Testing:**
Modified existing unit tests. Existing E2E tests cover the functionality.

