### PR TITLE
Opamp Bridge can read env variables on config generation

### DIFF
--- a/.chloggen/bridge-config-env-variables.yaml
+++ b/.chloggen/bridge-config-env-variables.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: opamp bridge
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added env variable parsing to opamp bridge config loading
+
+# One or more tracking issues related to the change
+issues: [2577]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/operator-opamp-bridge/config/config.go
+++ b/cmd/operator-opamp-bridge/config/config.go
@@ -18,7 +18,6 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/oklog/ulid"
 	"io/fs"
 	"net/url"
 	"os"
@@ -26,6 +25,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/oklog/ulid/v2"
 	opampclient "github.com/open-telemetry/opamp-go/client"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/spf13/pflag"

--- a/cmd/operator-opamp-bridge/config/config.go
+++ b/cmd/operator-opamp-bridge/config/config.go
@@ -269,11 +269,11 @@ func LoadFromFile(cfg *Config, configFile string) error {
 	if err != nil {
 		return err
 	}
-	envExpandedYaml := os.ExpandEnv(string(yamlFile))
-	if err = yaml.UnmarshalStrict([]byte(envExpandedYaml), cfg); err != nil {
+	envExpandedYaml := []byte(os.ExpandEnv(string(yamlFile)))
+	if err = yaml.UnmarshalStrict(envExpandedYaml, cfg); err != nil {
 		return fmt.Errorf("error unmarshaling YAML: %w", err)
 	}
-	if err = yaml.Unmarshal(yamlFile, cfg); err != nil {
+	if err = yaml.Unmarshal(envExpandedYaml, cfg); err != nil {
 		return fmt.Errorf("error unmarshaling YAML: %w", err)
 	}
 	return nil

--- a/cmd/operator-opamp-bridge/config/config.go
+++ b/cmd/operator-opamp-bridge/config/config.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/oklog/ulid"
 	"io/fs"
 	"net/url"
 	"os"
@@ -25,7 +26,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/oklog/ulid/v2"
 	opampclient "github.com/open-telemetry/opamp-go/client"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/spf13/pflag"
@@ -268,6 +268,10 @@ func LoadFromFile(cfg *Config, configFile string) error {
 	yamlFile, err := os.ReadFile(configFile)
 	if err != nil {
 		return err
+	}
+	envExpandedYaml := os.ExpandEnv(string(yamlFile))
+	if err = yaml.UnmarshalStrict([]byte(envExpandedYaml), cfg); err != nil {
+		return fmt.Errorf("error unmarshaling YAML: %w", err)
 	}
 	if err = yaml.Unmarshal(yamlFile, cfg); err != nil {
 		return fmt.Errorf("error unmarshaling YAML: %w", err)

--- a/cmd/operator-opamp-bridge/config/config.go
+++ b/cmd/operator-opamp-bridge/config/config.go
@@ -270,9 +270,6 @@ func LoadFromFile(cfg *Config, configFile string) error {
 		return err
 	}
 	envExpandedYaml := []byte(os.ExpandEnv(string(yamlFile)))
-	if err = yaml.UnmarshalStrict(envExpandedYaml, cfg); err != nil {
-		return fmt.Errorf("error unmarshaling YAML: %w", err)
-	}
 	if err = yaml.Unmarshal(envExpandedYaml, cfg); err != nil {
 		return fmt.Errorf("error unmarshaling YAML: %w", err)
 	}

--- a/cmd/operator-opamp-bridge/config/testdata/agentwithheaders.yaml
+++ b/cmd/operator-opamp-bridge/config/testdata/agentwithheaders.yaml
@@ -2,6 +2,8 @@ endpoint: ws://127.0.0.1:4320/v1/opamp
 headers:
   authentication: "access-12345-token"
   my-header-key: "my-header-value"
+  my-env-variable-1: "${MY_ENV_VAR_1}"
+  my-env-variable-2: "$MY_ENV_VAR_2"
 capabilities:
   AcceptsRemoteConfig: true
   ReportsEffectiveConfig: true


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The opamp bridge now substitutes env variables in its yaml config with their respective value from the local environment upon startup

**Link to tracking Issue:** closes #2577

**Testing:** I added a unit test which includes env variables as args and expects that they are parsed into headers according to the updated `agentwithheaders.yaml`

**Documentation:** n/a
