### PR TITLE
Fix nil pointer in opamp bridge generateCollectorHealth

### DIFF
--- a/cmd/operator-opamp-bridge/agent/agent.go
+++ b/cmd/operator-opamp-bridge/agent/agent.go
@@ -163,8 +163,14 @@ func (agent *Agent) generateCollectorHealth(selectorLabels map[string]string, na
 		if item.Status.Phase != "Running" {
 			healthy = false
 		}
+		var startTime int64
+		if item.Status.StartTime != nil {
+			startTime = item.Status.StartTime.UnixNano()
+		} else {
+			healthy = false
+		}
 		healthMap[key.String()] = &protobufs.ComponentHealth{
-			StartTimeUnixNano:  uint64(item.Status.StartTime.UnixNano()),
+			StartTimeUnixNano:  uint64(startTime),
 			StatusTimeUnixNano: uint64(agent.clock.Now().UnixNano()),
 			Status:             string(item.Status.Phase),
 			Healthy:            healthy,


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fixes a bug in the opamp bridge where a nil start time for a pod would lead to a nil pointer panic. This PR sets the starttime to 0 and healthy to false if this occurs

**Link to tracking Issue:** n/a

**Testing:** updated unit tests to include a case that checks when this field is nil

**Documentation:** n/a
