### PR TITLE
Increase PDB test timeout to 150s

### DIFF
--- a/kuttl-test-pdb.yaml
+++ b/kuttl-test-pdb.yaml
@@ -3,4 +3,4 @@ kind: TestSuite
 artifactsDir: ./tests/_build/artifacts/
 testDirs:
   - ./tests/e2e-pdb/
-timeout: 30
+timeout: 150


### PR DESCRIPTION
It looks like this test can time out sometimes because deleting the namespace can take a bit of time. We don't really gain anything from having this lower, as we always need to wait for all these test suites, and each runs concurrently.

