### PR TITLE
Set a timeout of 300s for all e2e tests

### DIFF
--- a/kuttl-test-autoscale.yaml
+++ b/kuttl-test-autoscale.yaml
@@ -3,4 +3,4 @@ kind: TestSuite
 artifactsDir: ./tests/_build/artifacts/
 testDirs:
   - ./tests/e2e-autoscale/
-timeout: 150
+timeout: 300

--- a/kuttl-test-multi-instr.yaml
+++ b/kuttl-test-multi-instr.yaml
@@ -3,4 +3,4 @@ kind: TestSuite
 artifactsDir: ./tests/_build/artifacts/
 testDirs:
   - ./tests/e2e-multi-instrumentation/
-timeout: 150
+timeout: 300

--- a/kuttl-test-openshift.yaml
+++ b/kuttl-test-openshift.yaml
@@ -3,4 +3,4 @@ kind: TestSuite
 startKIND: false
 testDirs:
   - ./tests/e2e-openshift/
-timeout: 150
+timeout: 300

--- a/kuttl-test-pdb.yaml
+++ b/kuttl-test-pdb.yaml
@@ -3,4 +3,4 @@ kind: TestSuite
 artifactsDir: ./tests/_build/artifacts/
 testDirs:
   - ./tests/e2e-pdb/
-timeout: 150
+timeout: 300

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -3,5 +3,5 @@ kind: TestSuite
 artifactsDir: ./tests/_build/artifacts/
 testDirs:
   - ./tests/e2e/
-timeout: 150
+timeout: 300
 parallel: 4


### PR DESCRIPTION
We don't really lose much by having the same timeout for all test suites. It looks like we can sometimes have delays due to namespace deletion - this change should help with those.