### PR TITLE
Speed up tests in CI

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -23,6 +23,15 @@ jobs:
       with:
         go-version: "~1.21.1"
 
+    - name: Cache tools
+      uses: actions/cache@v4
+      with:
+        path: bin
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
+
+    - name: Install tools
+      run: make install-tools
+
     - name: "basic checks"
       run: make ci
 
@@ -37,6 +46,15 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: "~1.21.1"
+
+    - name: Cache tools
+      uses: actions/cache@v4
+      with:
+        path: bin
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
+
+    - name: Install tools
+      run: make install-tools
 
     - uses: actions/cache@v4
       with:
@@ -57,6 +75,11 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "~1.21.1"
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,9 +47,6 @@ jobs:
       with:
         go-version: "~1.21.3"
 
-    - name: "install kuttl"
-      run: ./hack/install-kuttl.sh
-
     - name: "run tests"
       env:
         KUBE_VERSION: ${{ matrix.kube-version }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,6 +47,15 @@ jobs:
       with:
         go-version: "~1.21.3"
 
+    - name: Cache tools
+      uses: actions/cache@v4
+      with:
+        path: bin
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
+
+    - name: Install tools
+      run: make install-tools
+
     - name: "run tests"
       env:
         KUBE_VERSION: ${{ matrix.kube-version }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,11 +47,6 @@ jobs:
       with:
         go-version: "~1.21.3"
 
-    - name: Setup kind
-      env:
-        KIND_VERSION: "0.20.0"
-      run: go install sigs.k8s.io/kind@v${KIND_VERSION}
-
     - name: "install kuttl"
       run: ./hack/install-kuttl.sh
 

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -30,6 +30,15 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
+      - name: Cache tools
+        uses: actions/cache@v4
+        with:
+          path: bin
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
+
+      - name: Install tools
+        run: make install-tools
+
       - name: "start kind"
         env:
           KUBE_VERSION: ${{ matrix.kube-version }}

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -27,21 +27,13 @@ jobs:
         with:
           go-version: "~1.21.1"
 
-      - name: Setup kind
-        env:
-          KIND_VERSION: "0.20.0"
-        run: go install sigs.k8s.io/kind@v${KIND_VERSION}
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
-
-      - name: "install kuttl and kind"
-        run: ./hack/install-kuttl.sh
 
       - name: "start kind"
         env:
           KUBE_VERSION: ${{ matrix.kube-version }}
-        run: kind create cluster --config kind-$KUBE_VERSION.yaml
+        run: make start-kind
 
       - name: "wait until cluster is ready"
         run:  kubectl wait --timeout=5m --for=condition=available deployment/coredns -n kube-system

--- a/Makefile
+++ b/Makefile
@@ -356,6 +356,7 @@ cmctl:
 
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 KIND ?= $(LOCALBIN)/kind
+KUTTL ?= $(LOCALBIN)/kubectl-kuttl
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 CHLOGGEN ?= $(LOCALBIN)/chloggen
@@ -365,6 +366,7 @@ KUSTOMIZE_VERSION ?= v5.0.3
 CONTROLLER_TOOLS_VERSION ?= v0.12.0
 GOLANGCI_LINT_VERSION ?= v1.54.0
 KIND_VERSION ?= v0.20.0
+KUTTL_VERSION ?= 0.15.0
 
 
 .PHONY: kustomize
@@ -411,22 +413,7 @@ endef
 
 .PHONY: kuttl
 kuttl:
-ifeq (, $(shell which kubectl-kuttl))
-	echo ${PATH}
-	ls -l /usr/local/bin
-	which kubectl-kuttl
-
-	@{ \
-	set -e ;\
-	echo "" ;\
-	echo "ERROR: kuttl not found." ;\
-	echo "Please check https://kuttl.dev/docs/cli.html for installation instructions and try again." ;\
-	echo "" ;\
-	exit 1 ;\
-	}
-else
-KUTTL=$(shell which kubectl-kuttl)
-endif
+	@KUTTL=$(KUTTL) KUTTL_VERSION=$(KUTTL_VERSION) ./hack/install-kuttl.sh
 
 OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
 .PHONY: operator-sdk

--- a/Makefile
+++ b/Makefile
@@ -368,6 +368,8 @@ GOLANGCI_LINT_VERSION ?= v1.54.0
 KIND_VERSION ?= v0.20.0
 KUTTL_VERSION ?= 0.15.0
 
+.PHONY: install-tools
+install-tools: kustomize golangci-lint kind controller-gen envtest crdoc kuttl kind operator-sdk
 
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
@@ -384,12 +386,12 @@ kind: ## Download kind locally if necessary.
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+	@test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	@test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 CRDOC = $(shell pwd)/bin/crdoc
 .PHONY: crdoc
@@ -412,12 +414,12 @@ rm -rf $$TMP_DIR ;\
 endef
 
 .PHONY: kuttl
-kuttl:
+kuttl: $(LOCALBIN)
 	@KUTTL=$(KUTTL) KUTTL_VERSION=$(KUTTL_VERSION) ./hack/install-kuttl.sh
 
 OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
 .PHONY: operator-sdk
-operator-sdk:
+operator-sdk: $(LOCALBIN)
 	@{ \
 	set -e ;\
 	if (`pwd`/bin/operator-sdk version | grep ${OPERATOR_SDK_VERSION}) > /dev/null 2>&1 ; then \

--- a/Makefile
+++ b/Makefile
@@ -110,11 +110,11 @@ manager: generate fmt vet
 
 # Build target allocator binary
 targetallocator:
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -a -installsuffix cgo -o cmd/otel-allocator/bin/targetallocator_${ARCH} -ldflags "${COMMON_LDFLAGS}" ./cmd/otel-allocator
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -o cmd/otel-allocator/bin/targetallocator_${ARCH} -ldflags "${COMMON_LDFLAGS}" ./cmd/otel-allocator
 
 # Build opamp bridge binary
 operator-opamp-bridge:
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -a -installsuffix cgo -o cmd/operator-opamp-bridge/bin/opampbridge_${ARCH} -ldflags "${COMMON_LDFLAGS}" ./cmd/operator-opamp-bridge
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -o cmd/operator-opamp-bridge/bin/opampbridge_${ARCH} -ldflags "${COMMON_LDFLAGS}" ./cmd/operator-opamp-bridge
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 .PHONY: run

--- a/hack/install-kuttl.sh
+++ b/hack/install-kuttl.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
-sudo curl -Lo /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64
-sudo chmod +x /usr/local/bin/kubectl-kuttl
-export PATH=$PATH:/usr/local/bin
+if (${KUTTL} version | grep ${KUTTL_VERSION}) > /dev/null 2>&1; then
+  exit 0;
+fi
+
+OS=$(go env GOOS)
+ARCH=$(uname -m)
+
+curl -Lo ${KUTTL} https://github.com/kudobuilder/kuttl/releases/download/v${KUTTL_VERSION}/kubectl-kuttl_${KUTTL_VERSION}_${OS}_${ARCH}
+chmod +x ${KUTTL}
+


### PR DESCRIPTION
Speed up tests in the CI via the following changes:

* Avoid unnecessary binary rebuilds of target allocator and opamp bridge. This was probably added to mitigate https://github.com/golang/go/issues/9344, but is not necessary anymore.
* Install kind and kuttl locally via the Makefile.
* Cache tool binaries in the CI

As a result, we save 2-4 minutes per e2e test invocation.

Before:
![Screenshot_20240205_124038](https://github.com/open-telemetry/opentelemetry-operator/assets/93588780/b294f4cc-190b-48dd-a178-0dde73b6a45f)

After:
![Screenshot_20240205_124025](https://github.com/open-telemetry/opentelemetry-operator/assets/93588780/7efc00ef-d3c7-4c81-b29d-374188f508e6)
