### PR TITLE
Fix flaky target allocator tests

### DIFF
--- a/tests/e2e-targetallocator/targetallocator-features/00-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-features/00-install.yaml
@@ -7,7 +7,7 @@ automountServiceAccountToken: true
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pod-view
+  name: targetallocator-features
 rules:
 - apiGroups: [""]
   resources: [ "pods", "namespaces" ]
@@ -19,7 +19,7 @@ rules:
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl -n $NAMESPACE create clusterrolebinding default-view-$NAMESPACE --clusterrole=pod-view --serviceaccount=$NAMESPACE:ta
+  - command: kubectl -n $NAMESPACE create clusterrolebinding default-view-$NAMESPACE --clusterrole=targetallocator-features --serviceaccount=$NAMESPACE:ta
   # Annotate the namespace to allow the application to run using an specific group and user in OpenShift
   # https://docs.openshift.com/dedicated/authentication/managing-security-context-constraints.html
   # This annotation has no effect in Kubernetes

--- a/tests/e2e-targetallocator/targetallocator-kubernetessd/00-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-kubernetessd/00-install.yaml
@@ -13,7 +13,7 @@ automountServiceAccountToken: true
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ta
+  name: targetallocator-kubernetessd
 rules:
 - apiGroups: [""]
   resources:
@@ -58,7 +58,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: collector
+  name: collector-kubernetessd
 rules:
 - apiGroups: [""]
   resources:
@@ -84,8 +84,8 @@ rules:
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create clusterrolebinding ta-$NAMESPACE --clusterrole=ta --serviceaccount=$NAMESPACE:ta
-  - command: kubectl create clusterrolebinding collector-$NAMESPACE --clusterrole=collector --serviceaccount=$NAMESPACE:collector
+  - command: kubectl create clusterrolebinding ta-$NAMESPACE --clusterrole=targetallocator-kubernetessd --serviceaccount=$NAMESPACE:ta
+  - command: kubectl create clusterrolebinding collector-$NAMESPACE --clusterrole=collector-kubernetessd --serviceaccount=$NAMESPACE:collector
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector

--- a/tests/e2e-targetallocator/targetallocator-kubernetessd/01-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-kubernetessd/01-install.yaml
@@ -13,7 +13,12 @@ spec:
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-kubernetessd-collector:9090/metrics | grep "kubelet_running_pods{"
+            - |
+              for i in $(seq 30); do
+                if curl -m 1 -s http://prometheus-kubernetessd-collector:9090/metrics | grep "kubelet_running_pods"; then exit 0; fi
+                sleep 5
+              done
+              exit 1
 ---
 apiVersion: batch/v1
 kind: Job

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/00-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/00-install.yaml
@@ -13,7 +13,7 @@ automountServiceAccountToken: true
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ta
+  name: targetallocator-prometheuscr
 rules:
 - apiGroups: [""]
   resources:
@@ -65,7 +65,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: collector
+  name: collector-prometheuscr
 rules:
 - apiGroups: [""]
   resources:
@@ -92,8 +92,8 @@ rules:
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create clusterrolebinding ta-$NAMESPACE --clusterrole=ta --serviceaccount=$NAMESPACE:ta
-  - command: kubectl create clusterrolebinding collector-$NAMESPACE --clusterrole=collector --serviceaccount=$NAMESPACE:collector
+  - command: kubectl create clusterrolebinding ta-$NAMESPACE --clusterrole=targetallocator-prometheuscr --serviceaccount=$NAMESPACE:ta
+  - command: kubectl create clusterrolebinding collector-$NAMESPACE --clusterrole=collector-prometheuscr --serviceaccount=$NAMESPACE:collector
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector

--- a/tests/e2e/prometheus-config-validation/00-promreceiver-allocatorconfig.yaml
+++ b/tests/e2e/prometheus-config-validation/00-promreceiver-allocatorconfig.yaml
@@ -27,8 +27,6 @@ spec:
   targetAllocator:
     enabled: true
     serviceAccount: ta
-    prometheusCR:
-      enabled: true
 
   config: |
     receivers:

--- a/tests/e2e/smoke-targetallocator/00-install.yaml
+++ b/tests/e2e/smoke-targetallocator/00-install.yaml
@@ -27,8 +27,6 @@ spec:
   targetAllocator:
     enabled: true
     serviceAccount: ta
-    prometheusCR:
-      enabled: true
   config: |
     receivers:
       jaeger:


### PR DESCRIPTION
We had a race condition where concurrently running tests used the same ClusterRole name with different RBAC permissions.