### PR TITLE
Clean up signatures

### DIFF
--- a/controllers/builder_test.go
+++ b/controllers/builder_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/require"
+	go_yaml "gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -33,6 +34,7 @@ import (
 	colfeaturegate "go.opentelemetry.io/collector/featuregate"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
@@ -73,7 +75,7 @@ var (
 )
 
 func TestBuildCollector(t *testing.T) {
-	var goodConfig = `receivers:
+	var goodConfigYaml = `receivers:
   examplereceiver:
     endpoint: "0.0.0.0:12345"
 exporters:
@@ -84,9 +86,13 @@ service:
       receivers: [examplereceiver]
       exporters: [logging]
 `
+
+	goodConfig := v1alpha2.Config{}
+	err := go_yaml.Unmarshal([]byte(goodConfigYaml), &goodConfig)
+	require.NoError(t, err)
 	one := int32(1)
 	type args struct {
-		instance v1alpha1.OpenTelemetryCollector
+		instance v1alpha2.OpenTelemetryCollector
 	}
 	tests := []struct {
 		name    string
@@ -97,16 +103,18 @@ service:
 		{
 			name: "base case",
 			args: args{
-				instance: v1alpha1.OpenTelemetryCollector{
+				instance: v1alpha2.OpenTelemetryCollector{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test",
 						Namespace: "test",
 					},
-					Spec: v1alpha1.OpenTelemetryCollectorSpec{
-						Replicas: &one,
-						Mode:     "deployment",
-						Image:    "test",
-						Config:   goodConfig,
+					Spec: v1alpha2.OpenTelemetryCollectorSpec{
+						OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+							Image:    "test",
+							Replicas: &one,
+						},
+						Mode:   "deployment",
+						Config: goodConfig,
 					},
 				},
 			},
@@ -334,17 +342,19 @@ service:
 		{
 			name: "ingress",
 			args: args{
-				instance: v1alpha1.OpenTelemetryCollector{
+				instance: v1alpha2.OpenTelemetryCollector{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test",
 						Namespace: "test",
 					},
-					Spec: v1alpha1.OpenTelemetryCollectorSpec{
-						Replicas: &one,
-						Mode:     "deployment",
-						Image:    "test",
-						Ingress: v1alpha1.Ingress{
-							Type:     v1alpha1.IngressTypeNginx,
+					Spec: v1alpha2.OpenTelemetryCollectorSpec{
+						OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+							Image:    "test",
+							Replicas: &one,
+						},
+						Mode: "deployment",
+						Ingress: v1alpha2.Ingress{
+							Type:     v1alpha2.IngressTypeNginx,
 							Hostname: "example.com",
 							Annotations: map[string]string{
 								"something": "true",
@@ -617,17 +627,19 @@ service:
 		{
 			name: "specified service account case",
 			args: args{
-				instance: v1alpha1.OpenTelemetryCollector{
+				instance: v1alpha2.OpenTelemetryCollector{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test",
 						Namespace: "test",
 					},
-					Spec: v1alpha1.OpenTelemetryCollectorSpec{
-						Replicas:       &one,
-						Mode:           "deployment",
-						Image:          "test",
-						Config:         goodConfig,
-						ServiceAccount: "my-special-sa",
+					Spec: v1alpha2.OpenTelemetryCollectorSpec{
+						OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+							Image:          "test",
+							Replicas:       &one,
+							ServiceAccount: "my-special-sa",
+						},
+						Mode:   "deployment",
+						Config: goodConfig,
 					},
 				},
 			},
@@ -1083,7 +1095,7 @@ endpoint: ws://opamp-server:4320/v1/opamp
 }
 
 func TestBuildTargetAllocator(t *testing.T) {
-	var goodConfig = `
+	var goodConfigYaml = `
 receivers:
   prometheus:
     config:
@@ -1108,9 +1120,13 @@ service:
       receivers: [prometheus]
       exporters: [logging]
 `
+
+	goodConfig := v1alpha2.Config{}
+	err := go_yaml.Unmarshal([]byte(goodConfigYaml), &goodConfig)
+	require.NoError(t, err)
 	one := int32(1)
 	type args struct {
-		instance v1alpha1.OpenTelemetryCollector
+		instance v1alpha2.OpenTelemetryCollector
 	}
 	tests := []struct {
 		name         string
@@ -1122,16 +1138,18 @@ service:
 		{
 			name: "base case",
 			args: args{
-				instance: v1alpha1.OpenTelemetryCollector{
+				instance: v1alpha2.OpenTelemetryCollector{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test",
 						Namespace: "test",
 					},
-					Spec: v1alpha1.OpenTelemetryCollectorSpec{
-						Replicas: &one,
-						Mode:     "statefulset",
-						Image:    "test",
-						Config:   goodConfig,
+					Spec: v1alpha2.OpenTelemetryCollectorSpec{
+						OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+							Image:    "test",
+							Replicas: &one,
+						},
+						Mode:   "statefulset",
+						Config: goodConfig,
 						TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 							Enabled:        true,
 							FilterStrategy: "relabel-config",
@@ -1516,16 +1534,18 @@ prometheus_cr:
 		{
 			name: "enable metrics case",
 			args: args{
-				instance: v1alpha1.OpenTelemetryCollector{
+				instance: v1alpha2.OpenTelemetryCollector{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test",
 						Namespace: "test",
 					},
-					Spec: v1alpha1.OpenTelemetryCollectorSpec{
-						Replicas: &one,
-						Mode:     "statefulset",
-						Image:    "test",
-						Config:   goodConfig,
+					Spec: v1alpha2.OpenTelemetryCollectorSpec{
+						OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+							Image:    "test",
+							Replicas: &one,
+						},
+						Mode:   "statefulset",
+						Config: goodConfig,
 						TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 							Enabled: true,
 							PrometheusCR: v1alpha1.OpenTelemetryTargetAllocatorPrometheusCR{

--- a/controllers/opentelemetrycollector_controller.go
+++ b/controllers/opentelemetrycollector_controller.go
@@ -134,8 +134,10 @@ func (r *OpenTelemetryCollectorReconciler) Reconcile(ctx context.Context, req ct
 	if buildErr != nil {
 		return ctrl.Result{}, buildErr
 	}
-	err = reconcileDesiredObjects(ctx, r.Client, log, &params.OtelCol, params.Scheme, desiredObjects...)
-	return collectorStatus.HandleReconcileStatus(ctx, log, params, err)
+	// TODO: https://github.com/open-telemetry/opentelemetry-operator/issues/2620
+	// TODO: Change &instance to use params.OtelCol
+	err = reconcileDesiredObjects(ctx, r.Client, log, &instance, params.Scheme, desiredObjects...)
+	return collectorStatus.HandleReconcileStatus(ctx, log, params, instance, err)
 }
 
 // SetupWithManager tells the manager what our controller is interested in.

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -215,51 +215,44 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func paramsWithMode(mode v1alpha1.Mode) manifests.Params {
+func paramsWithMode(mode v1alpha1.Mode) v1alpha1.OpenTelemetryCollector {
 	replicas := int32(2)
 	return paramsWithModeAndReplicas(mode, replicas)
 }
 
-func paramsWithModeAndReplicas(mode v1alpha1.Mode, replicas int32) manifests.Params {
+func paramsWithModeAndReplicas(mode v1alpha1.Mode, replicas int32) v1alpha1.OpenTelemetryCollector {
 	configYAML, err := os.ReadFile("testdata/test.yaml")
 	if err != nil {
 		fmt.Printf("Error getting yaml file: %v", err)
 	}
-	return manifests.Params{
-		Config: config.New(config.WithCollectorImage(defaultCollectorImage), config.WithTargetAllocatorImage(defaultTaAllocationImage)),
-		Client: k8sClient,
-		OtelCol: v1alpha1.OpenTelemetryCollector{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "opentelemetry.io",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: "default",
-			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{
-				Image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.47.0",
-				Ports: []v1.ServicePort{{
-					Name: "web",
-					Port: 80,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 80,
-					},
-					NodePort: 0,
-				}},
-				Replicas: &replicas,
-				Config:   string(configYAML),
-				Mode:     mode,
-			},
+	return v1alpha1.OpenTelemetryCollector{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "opentelemetry.io",
+			APIVersion: "v1",
 		},
-		Scheme:   testScheme,
-		Log:      logger,
-		Recorder: record.NewFakeRecorder(10),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.47.0",
+			Ports: []v1.ServicePort{{
+				Name: "web",
+				Port: 80,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 80,
+				},
+				NodePort: 0,
+			}},
+			Replicas: &replicas,
+			Config:   string(configYAML),
+			Mode:     mode,
+		},
 	}
 }
 
-func newParams(taContainerImage string, file string) (manifests.Params, error) {
+func newParams(taContainerImage string, file string) (v1alpha1.OpenTelemetryCollector, error) {
 	replicas := int32(1)
 	var configYAML []byte
 	var err error
@@ -270,95 +263,76 @@ func newParams(taContainerImage string, file string) (manifests.Params, error) {
 		configYAML, err = os.ReadFile(file)
 	}
 	if err != nil {
-		return manifests.Params{}, fmt.Errorf("Error getting yaml file: %w", err)
+		return v1alpha1.OpenTelemetryCollector{}, fmt.Errorf("Error getting yaml file: %w", err)
 	}
-
-	cfg := config.New(config.WithCollectorImage(defaultCollectorImage), config.WithTargetAllocatorImage(defaultTaAllocationImage))
-
-	return manifests.Params{
-		Config: cfg,
-		Client: k8sClient,
-		OtelCol: v1alpha1.OpenTelemetryCollector{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "opentelemetry.io",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: "default",
-			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{
-				Mode: v1alpha1.ModeStatefulSet,
-				Ports: []v1.ServicePort{{
-					Name: "web",
-					Port: 80,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 80,
-					},
-					NodePort: 0,
-				}},
-				TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
-					Enabled: true,
-					Image:   taContainerImage,
-				},
-				Replicas: &replicas,
-				Config:   string(configYAML),
-			},
+	return v1alpha1.OpenTelemetryCollector{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "opentelemetry.io",
+			APIVersion: "v1",
 		},
-		Scheme: testScheme,
-		Log:    logger,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Mode: v1alpha1.ModeStatefulSet,
+			Ports: []v1.ServicePort{{
+				Name: "web",
+				Port: 80,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 80,
+				},
+				NodePort: 0,
+			}},
+			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
+				Enabled: true,
+				Image:   taContainerImage,
+			},
+			Replicas: &replicas,
+			Config:   string(configYAML),
+		},
 	}, nil
 }
 
-func paramsWithHPA(minReps, maxReps int32) manifests.Params {
+func paramsWithHPA(minReps, maxReps int32) v1alpha1.OpenTelemetryCollector {
 	configYAML, err := os.ReadFile("testdata/test.yaml")
 	if err != nil {
 		fmt.Printf("Error getting yaml file: %v", err)
 	}
-
 	cpuUtilization := int32(90)
 
-	configuration := config.New(config.WithCollectorImage(defaultCollectorImage), config.WithTargetAllocatorImage(defaultTaAllocationImage))
-
-	return manifests.Params{
-		Config: configuration,
-		Client: k8sClient,
-		OtelCol: v1alpha1.OpenTelemetryCollector{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "opentelemetry.io",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "hpatest",
-				Namespace: "default",
-				UID:       instanceUID,
-			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{
-				Ports: []v1.ServicePort{{
-					Name: "web",
-					Port: 80,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 80,
-					},
-					NodePort: 0,
-				}},
-				Config: string(configYAML),
-				Autoscaler: &v1alpha1.AutoscalerSpec{
-					MinReplicas:          &minReps,
-					MaxReplicas:          &maxReps,
-					TargetCPUUtilization: &cpuUtilization,
+	return v1alpha1.OpenTelemetryCollector{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "opentelemetry.io",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hpatest",
+			Namespace: "default",
+			UID:       instanceUID,
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Ports: []v1.ServicePort{{
+				Name: "web",
+				Port: 80,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 80,
 				},
+				NodePort: 0,
+			}},
+			Config: string(configYAML),
+			Autoscaler: &v1alpha1.AutoscalerSpec{
+				MinReplicas:          &minReps,
+				MaxReplicas:          &maxReps,
+				TargetCPUUtilization: &cpuUtilization,
 			},
 		},
-		Scheme:   testScheme,
-		Log:      logger,
-		Recorder: record.NewFakeRecorder(10),
 	}
 }
 
-func paramsWithPolicy(minAvailable, maxUnavailable int32) manifests.Params {
+func paramsWithPolicy(minAvailable, maxUnavailable int32) v1alpha1.OpenTelemetryCollector {
 	configYAML, err := os.ReadFile("testdata/test.yaml")
 	if err != nil {
 		fmt.Printf("Error getting yaml file: %v", err)
@@ -387,36 +361,29 @@ func paramsWithPolicy(minAvailable, maxUnavailable int32) manifests.Params {
 		}
 	}
 
-	return manifests.Params{
-		Config: configuration,
-		Client: k8sClient,
-		OtelCol: v1alpha1.OpenTelemetryCollector{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "opentelemetry.io",
-				APIVersion: "v1",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "policytest",
-				Namespace: "default",
-				UID:       instanceUID,
-			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{
-				Ports: []v1.ServicePort{{
-					Name: "web",
-					Port: 80,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 80,
-					},
-					NodePort: 0,
-				}},
-				Config:              string(configYAML),
-				PodDisruptionBudget: pdb,
-			},
+	return v1alpha1.OpenTelemetryCollector{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "opentelemetry.io",
+			APIVersion: "v1",
 		},
-		Scheme:   testScheme,
-		Log:      logger,
-		Recorder: record.NewFakeRecorder(10),
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policytest",
+			Namespace: "default",
+			UID:       instanceUID,
+		},
+		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Ports: []v1.ServicePort{{
+				Name: "web",
+				Port: 80,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 80,
+				},
+				NodePort: 0,
+			}},
+			Config:              string(configYAML),
+			PodDisruptionBudget: pdb,
+		},
 	}
 }
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -215,12 +216,12 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func paramsWithMode(mode v1alpha1.Mode) v1alpha1.OpenTelemetryCollector {
+func testCollectorWithMode(mode v1alpha1.Mode) v1alpha1.OpenTelemetryCollector {
 	replicas := int32(2)
-	return paramsWithModeAndReplicas(mode, replicas)
+	return testCollectorWithModeAndReplicas(mode, replicas)
 }
 
-func paramsWithModeAndReplicas(mode v1alpha1.Mode, replicas int32) v1alpha1.OpenTelemetryCollector {
+func testCollectorWithModeAndReplicas(mode v1alpha1.Mode, replicas int32) v1alpha1.OpenTelemetryCollector {
 	configYAML, err := os.ReadFile("testdata/test.yaml")
 	if err != nil {
 		fmt.Printf("Error getting yaml file: %v", err)
@@ -252,7 +253,16 @@ func paramsWithModeAndReplicas(mode v1alpha1.Mode, replicas int32) v1alpha1.Open
 	}
 }
 
-func newParams(taContainerImage string, file string) (v1alpha1.OpenTelemetryCollector, error) {
+func testCollectorAssertNoErr(t *testing.T, taContainerImage string, file string) v1alpha1.OpenTelemetryCollector {
+	p, err := testCollectorWithConfigFile(taContainerImage, file)
+	assert.NoError(t, err)
+	if len(taContainerImage) == 0 {
+		p.Spec.TargetAllocator.Enabled = false
+	}
+	return p
+}
+
+func testCollectorWithConfigFile(taContainerImage string, file string) (v1alpha1.OpenTelemetryCollector, error) {
 	replicas := int32(1)
 	var configYAML []byte
 	var err error
@@ -295,7 +305,7 @@ func newParams(taContainerImage string, file string) (v1alpha1.OpenTelemetryColl
 	}, nil
 }
 
-func paramsWithHPA(minReps, maxReps int32) v1alpha1.OpenTelemetryCollector {
+func testCollectorWithHPA(minReps, maxReps int32) v1alpha1.OpenTelemetryCollector {
 	configYAML, err := os.ReadFile("testdata/test.yaml")
 	if err != nil {
 		fmt.Printf("Error getting yaml file: %v", err)
@@ -332,7 +342,7 @@ func paramsWithHPA(minReps, maxReps int32) v1alpha1.OpenTelemetryCollector {
 	}
 }
 
-func paramsWithPolicy(minAvailable, maxUnavailable int32) v1alpha1.OpenTelemetryCollector {
+func testCollectorWithPDB(minAvailable, maxUnavailable int32) v1alpha1.OpenTelemetryCollector {
 	configYAML, err := os.ReadFile("testdata/test.yaml")
 	if err != nil {
 		fmt.Printf("Error getting yaml file: %v", err)

--- a/internal/manifests/collector/adapters/config_to_ports.go
+++ b/internal/manifests/collector/adapters/config_to_ports.go
@@ -160,6 +160,7 @@ func ConfigToMetricsPort(logger logr.Logger, config map[interface{}]interface{})
 	type cfg struct {
 		Service serviceCfg
 	}
+
 	var cOut cfg
 	err := mapstructure.Decode(config, &cOut)
 	if err != nil {

--- a/internal/manifests/collector/collector.go
+++ b/internal/manifests/collector/collector.go
@@ -17,7 +17,7 @@ package collector
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
@@ -31,15 +31,15 @@ func Build(params manifests.Params) ([]client.Object, error) {
 	var resourceManifests []client.Object
 	var manifestFactories []manifests.K8sManifestFactory
 	switch params.OtelCol.Spec.Mode {
-	case v1alpha1.ModeDeployment:
+	case v1alpha2.ModeDeployment:
 		manifestFactories = append(manifestFactories, manifests.Factory(Deployment))
 		manifestFactories = append(manifestFactories, manifests.Factory(PodDisruptionBudget))
-	case v1alpha1.ModeStatefulSet:
+	case v1alpha2.ModeStatefulSet:
 		manifestFactories = append(manifestFactories, manifests.Factory(StatefulSet))
 		manifestFactories = append(manifestFactories, manifests.Factory(PodDisruptionBudget))
-	case v1alpha1.ModeDaemonSet:
+	case v1alpha2.ModeDaemonSet:
 		manifestFactories = append(manifestFactories, manifests.Factory(DaemonSet))
-	case v1alpha1.ModeSidecar:
+	case v1alpha2.ModeSidecar:
 		params.Log.V(5).Info("not building sidecar...")
 	}
 	manifestFactories = append(manifestFactories, []manifests.K8sManifestFactory{
@@ -53,7 +53,7 @@ func Build(params manifests.Params) ([]client.Object, error) {
 	}...)
 
 	if params.OtelCol.Spec.Observability.Metrics.EnableMetrics && featuregate.PrometheusOperatorIsAvailable.IsEnabled() {
-		if params.OtelCol.Spec.Mode == v1alpha1.ModeSidecar {
+		if params.OtelCol.Spec.Mode == v1alpha2.ModeSidecar {
 			manifestFactories = append(manifestFactories, manifests.Factory(PodMonitor))
 		} else {
 			manifestFactories = append(manifestFactories, manifests.Factory(ServiceMonitor))

--- a/internal/manifests/collector/configmap.go
+++ b/internal/manifests/collector/configmap.go
@@ -18,21 +18,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/internal/api/convert"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
-	otelCol, err := convert.V1Alpha1to2(params.OtelCol)
-	if err != nil {
-		return nil, err
-	}
-	name := naming.ConfigMap(otelCol.Name)
-	labels := manifestutils.Labels(otelCol.ObjectMeta, name, otelCol.Spec.Image, ComponentOpenTelemetryCollector, []string{})
+	name := naming.ConfigMap(params.OtelCol.Name)
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, []string{})
 
-	replacedConf, err := ReplaceConfig(otelCol)
+	replacedConf, err := ReplaceConfig(params.OtelCol)
 	if err != nil {
 		params.Log.V(2).Info("failed to update prometheus config to use sharded targets: ", "err", err)
 		return nil, err
@@ -41,9 +36,9 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   otelCol.Namespace,
+			Namespace:   params.OtelCol.Namespace,
 			Labels:      labels,
-			Annotations: otelCol.Annotations,
+			Annotations: params.OtelCol.Annotations,
 		},
 		Data: map[string]string{
 			"collector.yaml": replacedConf,

--- a/internal/manifests/collector/daemonset.go
+++ b/internal/manifests/collector/daemonset.go
@@ -19,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/internal/api/convert"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
@@ -27,32 +26,28 @@ import (
 
 // DaemonSet builds the deployment for the given instance.
 func DaemonSet(params manifests.Params) (*appsv1.DaemonSet, error) {
-	otelCol, err := convert.V1Alpha1to2(params.OtelCol)
-	if err != nil {
-		return nil, err
-	}
-	name := naming.Collector(otelCol.Name)
-	labels := manifestutils.Labels(otelCol.ObjectMeta, name, otelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
+	name := naming.Collector(params.OtelCol.Name)
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
 
-	annotations, err := Annotations(otelCol)
+	annotations, err := Annotations(params.OtelCol)
 	if err != nil {
 		return nil, err
 	}
-	podAnnotations, err := PodAnnotations(otelCol)
+	podAnnotations, err := PodAnnotations(params.OtelCol)
 	if err != nil {
 		return nil, err
 	}
 
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        naming.Collector(otelCol.Name),
-			Namespace:   otelCol.Namespace,
+			Name:        naming.Collector(params.OtelCol.Name),
+			Namespace:   params.OtelCol.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: manifestutils.SelectorLabels(otelCol.ObjectMeta, ComponentOpenTelemetryCollector),
+				MatchLabels: manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, ComponentOpenTelemetryCollector),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -60,21 +55,21 @@ func DaemonSet(params manifests.Params) (*appsv1.DaemonSet, error) {
 					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName:    ServiceAccountName(otelCol),
+					ServiceAccountName:    ServiceAccountName(params.OtelCol),
 					InitContainers:        params.OtelCol.Spec.InitContainers,
-					Containers:            append(params.OtelCol.Spec.AdditionalContainers, Container(params.Config, params.Log, otelCol, true)),
-					Volumes:               Volumes(params.Config, otelCol),
-					Tolerations:           otelCol.Spec.Tolerations,
-					NodeSelector:          otelCol.Spec.NodeSelector,
-					HostNetwork:           otelCol.Spec.HostNetwork,
-					ShareProcessNamespace: &otelCol.Spec.ShareProcessNamespace,
-					DNSPolicy:             getDNSPolicy(otelCol),
+					Containers:            append(params.OtelCol.Spec.AdditionalContainers, Container(params.Config, params.Log, params.OtelCol, true)),
+					Volumes:               Volumes(params.Config, params.OtelCol),
+					Tolerations:           params.OtelCol.Spec.Tolerations,
+					NodeSelector:          params.OtelCol.Spec.NodeSelector,
+					HostNetwork:           params.OtelCol.Spec.HostNetwork,
+					ShareProcessNamespace: &params.OtelCol.Spec.ShareProcessNamespace,
+					DNSPolicy:             getDNSPolicy(params.OtelCol),
 					SecurityContext:       params.OtelCol.Spec.PodSecurityContext,
 					PriorityClassName:     params.OtelCol.Spec.PriorityClassName,
 					Affinity:              params.OtelCol.Spec.Affinity,
 				},
 			},
-			UpdateStrategy: params.OtelCol.Spec.UpdateStrategy,
+			UpdateStrategy: params.OtelCol.Spec.DaemonSetUpdateStrategy,
 		},
 	}, nil
 }

--- a/internal/manifests/collector/daemonset_test.go
+++ b/internal/manifests/collector/daemonset_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	. "github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
@@ -34,13 +34,15 @@ func TestDaemonSetNewDefault(t *testing.T) {
 	// prepare
 	params := manifests.Params{
 		Config: config.New(),
-		OtelCol: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha2.OpenTelemetryCollector{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-instance",
 				Namespace: "my-namespace",
 			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{
-				Tolerations: testTolerationValues,
+			Spec: v1alpha2.OpenTelemetryCollectorSpec{
+				OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+					Tolerations: testTolerationValues,
+				},
 			},
 		},
 		Log: logger,
@@ -96,12 +98,12 @@ func TestDaemonSetNewDefault(t *testing.T) {
 func TestDaemonsetHostNetwork(t *testing.T) {
 	params1 := manifests.Params{
 		Config: config.New(),
-		OtelCol: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha2.OpenTelemetryCollector{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-instance",
 				Namespace: "my-namespace",
 			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{},
+			Spec: v1alpha2.OpenTelemetryCollectorSpec{},
 		},
 		Log: logger,
 	}
@@ -114,13 +116,15 @@ func TestDaemonsetHostNetwork(t *testing.T) {
 	// verify custom
 	params2 := manifests.Params{
 		Config: config.New(),
-		OtelCol: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha2.OpenTelemetryCollector{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "my-instance",
 				Namespace: "my-namespace",
 			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{
-				HostNetwork: true,
+			Spec: v1alpha2.OpenTelemetryCollectorSpec{
+				OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+					HostNetwork: true,
+				},
 			},
 		},
 		Log: logger,
@@ -134,12 +138,14 @@ func TestDaemonsetHostNetwork(t *testing.T) {
 func TestDaemonsetPodAnnotations(t *testing.T) {
 	// prepare
 	testPodAnnotationValues := map[string]string{"annotation-key": "annotation-value"}
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			PodAnnotations: testPodAnnotationValues,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				PodAnnotations: testPodAnnotationValues,
+			},
 		},
 	}
 	cfg := config.New()
@@ -176,15 +182,17 @@ func TestDaemonstPodSecurityContext(t *testing.T) {
 	runAsUser := int64(1337)
 	runasGroup := int64(1338)
 
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			PodSecurityContext: &v1.PodSecurityContext{
-				RunAsNonRoot: &runAsNonRoot,
-				RunAsUser:    &runAsUser,
-				RunAsGroup:   &runasGroup,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				PodSecurityContext: &v1.PodSecurityContext{
+					RunAsNonRoot: &runAsNonRoot,
+					RunAsUser:    &runAsUser,
+					RunAsGroup:   &runasGroup,
+				},
 			},
 		},
 	}
@@ -211,12 +219,12 @@ func TestDaemonsetFilterLabels(t *testing.T) {
 		"app.foo.bar": "1",
 	}
 
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "my-instance",
 			Labels: excludedLabels,
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{},
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{},
 	}
 
 	cfg := config.New(config.WithLabelFilters([]string{"foo*", "app.*.bar"}))
@@ -238,7 +246,7 @@ func TestDaemonsetFilterLabels(t *testing.T) {
 
 func TestDaemonSetNodeSelector(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -258,14 +266,16 @@ func TestDaemonSetNodeSelector(t *testing.T) {
 	assert.Empty(t, d1.Spec.Template.Spec.NodeSelector)
 
 	// Test nodeSelector
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-nodeselector",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			HostNetwork: true,
-			NodeSelector: map[string]string{
-				"node-key": "node-value",
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				HostNetwork: true,
+				NodeSelector: map[string]string{
+					"node-key": "node-value",
+				},
 			},
 		},
 	}
@@ -284,7 +294,7 @@ func TestDaemonSetNodeSelector(t *testing.T) {
 }
 
 func TestDaemonSetPriorityClassName(t *testing.T) {
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -304,12 +314,14 @@ func TestDaemonSetPriorityClassName(t *testing.T) {
 
 	priorityClassName := "test-class"
 
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-priortyClassName",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			PriorityClassName: priorityClassName,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				PriorityClassName: priorityClassName,
+			},
 		},
 	}
 
@@ -327,7 +339,7 @@ func TestDaemonSetPriorityClassName(t *testing.T) {
 }
 
 func TestDaemonSetAffinity(t *testing.T) {
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -345,12 +357,14 @@ func TestDaemonSetAffinity(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, d1.Spec.Template.Spec.Affinity)
 
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-priortyClassName",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			Affinity: testAffinityValue,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				Affinity: testAffinityValue,
+			},
 		},
 	}
 
@@ -370,15 +384,17 @@ func TestDaemonSetAffinity(t *testing.T) {
 
 func TestDaemonSetInitContainer(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-namespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			InitContainers: []v1.Container{
-				{
-					Name: "test",
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				InitContainers: []v1.Container{
+					{
+						Name: "test",
+					},
 				},
 			},
 		},
@@ -404,15 +420,17 @@ func TestDaemonSetInitContainer(t *testing.T) {
 
 func TestDaemonSetAdditionalContainer(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-namespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			AdditionalContainers: []v1.Container{
-				{
-					Name: "test",
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				AdditionalContainers: []v1.Container{
+					{
+						Name: "test",
+					},
 				},
 			},
 		},
@@ -439,13 +457,13 @@ func TestDaemonSetAdditionalContainer(t *testing.T) {
 
 func TestDaemonSetDefaultUpdateStrategy(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-namespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			DaemonSetUpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 				Type: "RollingUpdate",
 				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
 					MaxSurge:       &intstr.IntOrString{Type: intstr.Int, IntVal: int32(1)},
@@ -474,13 +492,13 @@ func TestDaemonSetDefaultUpdateStrategy(t *testing.T) {
 
 func TestDaemonSetOnDeleteUpdateStrategy(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-namespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			DaemonSetUpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 				Type: "OnDelete",
 				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
 					MaxSurge:       &intstr.IntOrString{Type: intstr.Int, IntVal: int32(1)},
@@ -510,11 +528,11 @@ func TestDaemonSetOnDeleteUpdateStrategy(t *testing.T) {
 func TestDaemonsetShareProcessNamespace(t *testing.T) {
 	params1 := manifests.Params{
 		Config: config.New(),
-		OtelCol: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha2.OpenTelemetryCollector{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-instance",
 			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{},
+			Spec: v1alpha2.OpenTelemetryCollectorSpec{},
 		},
 		Log: logger,
 	}
@@ -526,12 +544,14 @@ func TestDaemonsetShareProcessNamespace(t *testing.T) {
 	// verify custom
 	params2 := manifests.Params{
 		Config: config.New(),
-		OtelCol: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha2.OpenTelemetryCollector{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-instance-with-shareprocessnamespace",
 			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{
-				ShareProcessNamespace: true,
+			Spec: v1alpha2.OpenTelemetryCollectorSpec{
+				OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+					ShareProcessNamespace: true,
+				},
 			},
 		},
 		Log: logger,

--- a/internal/manifests/collector/deployment.go
+++ b/internal/manifests/collector/deployment.go
@@ -19,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/internal/api/convert"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
@@ -27,19 +26,15 @@ import (
 
 // Deployment builds the deployment for the given instance.
 func Deployment(params manifests.Params) (*appsv1.Deployment, error) {
-	otelCol, err := convert.V1Alpha1to2(params.OtelCol)
-	if err != nil {
-		return nil, err
-	}
-	name := naming.Collector(otelCol.Name)
-	labels := manifestutils.Labels(otelCol.ObjectMeta, name, otelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
+	name := naming.Collector(params.OtelCol.Name)
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
 
-	annotations, err := Annotations(otelCol)
+	annotations, err := Annotations(params.OtelCol)
 	if err != nil {
 		return nil, err
 	}
 
-	podAnnotations, err := PodAnnotations(otelCol)
+	podAnnotations, err := PodAnnotations(params.OtelCol)
 	if err != nil {
 		return nil, err
 	}
@@ -47,36 +42,36 @@ func Deployment(params manifests.Params) (*appsv1.Deployment, error) {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   otelCol.Namespace,
+			Namespace:   params.OtelCol.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: otelCol.Spec.Replicas,
+			Replicas: params.OtelCol.Spec.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: manifestutils.SelectorLabels(otelCol.ObjectMeta, ComponentOpenTelemetryCollector),
+				MatchLabels: manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, ComponentOpenTelemetryCollector),
 			},
-			Strategy: otelCol.Spec.DeploymentUpdateStrategy,
+			Strategy: params.OtelCol.Spec.DeploymentUpdateStrategy,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
 					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName:            ServiceAccountName(otelCol),
-					InitContainers:                otelCol.Spec.InitContainers,
-					Containers:                    append(otelCol.Spec.AdditionalContainers, Container(params.Config, params.Log, otelCol, true)),
-					Volumes:                       Volumes(params.Config, otelCol),
-					DNSPolicy:                     getDNSPolicy(otelCol),
-					HostNetwork:                   otelCol.Spec.HostNetwork,
-					ShareProcessNamespace:         &otelCol.Spec.ShareProcessNamespace,
-					Tolerations:                   otelCol.Spec.Tolerations,
-					NodeSelector:                  otelCol.Spec.NodeSelector,
-					SecurityContext:               otelCol.Spec.PodSecurityContext,
-					PriorityClassName:             otelCol.Spec.PriorityClassName,
-					Affinity:                      otelCol.Spec.Affinity,
-					TerminationGracePeriodSeconds: otelCol.Spec.TerminationGracePeriodSeconds,
-					TopologySpreadConstraints:     otelCol.Spec.TopologySpreadConstraints,
+					ServiceAccountName:            ServiceAccountName(params.OtelCol),
+					InitContainers:                params.OtelCol.Spec.InitContainers,
+					Containers:                    append(params.OtelCol.Spec.AdditionalContainers, Container(params.Config, params.Log, params.OtelCol, true)),
+					Volumes:                       Volumes(params.Config, params.OtelCol),
+					DNSPolicy:                     getDNSPolicy(params.OtelCol),
+					HostNetwork:                   params.OtelCol.Spec.HostNetwork,
+					ShareProcessNamespace:         &params.OtelCol.Spec.ShareProcessNamespace,
+					Tolerations:                   params.OtelCol.Spec.Tolerations,
+					NodeSelector:                  params.OtelCol.Spec.NodeSelector,
+					SecurityContext:               params.OtelCol.Spec.PodSecurityContext,
+					PriorityClassName:             params.OtelCol.Spec.PriorityClassName,
+					Affinity:                      params.OtelCol.Spec.Affinity,
+					TerminationGracePeriodSeconds: params.OtelCol.Spec.TerminationGracePeriodSeconds,
+					TopologySpreadConstraints:     params.OtelCol.Spec.TopologySpreadConstraints,
 				},
 			},
 		},

--- a/internal/manifests/collector/deployment_test.go
+++ b/internal/manifests/collector/deployment_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	. "github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
@@ -71,13 +71,15 @@ var testTopologySpreadConstraintValue = []v1.TopologySpreadConstraint{
 
 func TestDeploymentNewDefault(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-namespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			Tolerations: testTolerationValues,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				Tolerations: testTolerationValues,
+			},
 		},
 	}
 	cfg := config.New()
@@ -138,12 +140,14 @@ func TestDeploymentNewDefault(t *testing.T) {
 func TestDeploymentPodAnnotations(t *testing.T) {
 	// prepare
 	testPodAnnotationValues := map[string]string{"annotation-key": "annotation-value"}
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			PodAnnotations: testPodAnnotationValues,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				PodAnnotations: testPodAnnotationValues,
+			},
 		},
 	}
 	cfg := config.New()
@@ -180,15 +184,17 @@ func TestDeploymenttPodSecurityContext(t *testing.T) {
 	runAsUser := int64(1337)
 	runasGroup := int64(1338)
 
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			PodSecurityContext: &v1.PodSecurityContext{
-				RunAsNonRoot: &runAsNonRoot,
-				RunAsUser:    &runAsUser,
-				RunAsGroup:   &runasGroup,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				PodSecurityContext: &v1.PodSecurityContext{
+					RunAsNonRoot: &runAsNonRoot,
+					RunAsUser:    &runAsUser,
+					RunAsGroup:   &runasGroup,
+				},
 			},
 		},
 	}
@@ -210,11 +216,11 @@ func TestDeploymenttPodSecurityContext(t *testing.T) {
 }
 
 func TestDeploymentUpdateStrategy(t *testing.T) {
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			DeploymentUpdateStrategy: appsv1.DeploymentStrategy{
 				Type: "RollingUpdate",
 				RollingUpdate: &appsv1.RollingUpdateDeployment{
@@ -243,7 +249,7 @@ func TestDeploymentUpdateStrategy(t *testing.T) {
 
 func TestDeploymentHostNetwork(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -264,12 +270,14 @@ func TestDeploymentHostNetwork(t *testing.T) {
 	assert.Equal(t, d1.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirst)
 
 	// Test hostNetwork=true
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-hostnetwork",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			HostNetwork: true,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				HostNetwork: true,
+			},
 		},
 	}
 
@@ -293,12 +301,12 @@ func TestDeploymentFilterLabels(t *testing.T) {
 		"app.foo.bar": "1",
 	}
 
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "my-instance",
 			Labels: excludedLabels,
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{},
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{},
 	}
 
 	cfg := config.New(config.WithLabelFilters([]string{"foo*", "app.*.bar"}))
@@ -320,7 +328,7 @@ func TestDeploymentFilterLabels(t *testing.T) {
 
 func TestDeploymentNodeSelector(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -340,14 +348,16 @@ func TestDeploymentNodeSelector(t *testing.T) {
 	assert.Empty(t, d1.Spec.Template.Spec.NodeSelector)
 
 	// Test nodeSelector
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-nodeselector",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			HostNetwork: true,
-			NodeSelector: map[string]string{
-				"node-key": "node-value",
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				HostNetwork: true,
+				NodeSelector: map[string]string{
+					"node-key": "node-value",
+				},
 			},
 		},
 	}
@@ -366,7 +376,7 @@ func TestDeploymentNodeSelector(t *testing.T) {
 }
 
 func TestDeploymentPriorityClassName(t *testing.T) {
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -386,12 +396,14 @@ func TestDeploymentPriorityClassName(t *testing.T) {
 
 	priorityClassName := "test-class"
 
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-priortyClassName",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			PriorityClassName: priorityClassName,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				PriorityClassName: priorityClassName,
+			},
 		},
 	}
 
@@ -409,7 +421,7 @@ func TestDeploymentPriorityClassName(t *testing.T) {
 }
 
 func TestDeploymentAffinity(t *testing.T) {
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -427,12 +439,14 @@ func TestDeploymentAffinity(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, d1.Spec.Template.Spec.Affinity)
 
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-priortyClassName",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			Affinity: testAffinityValue,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				Affinity: testAffinityValue,
+			},
 		},
 	}
 
@@ -451,7 +465,7 @@ func TestDeploymentAffinity(t *testing.T) {
 }
 
 func TestDeploymentTerminationGracePeriodSeconds(t *testing.T) {
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -471,12 +485,14 @@ func TestDeploymentTerminationGracePeriodSeconds(t *testing.T) {
 
 	gracePeriodSec := int64(60)
 
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-terminationGracePeriodSeconds",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			TerminationGracePeriodSeconds: &gracePeriodSec,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				TerminationGracePeriodSeconds: &gracePeriodSec,
+			},
 		},
 	}
 
@@ -496,15 +512,17 @@ func TestDeploymentTerminationGracePeriodSeconds(t *testing.T) {
 
 func TestDeploymentSetInitContainer(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-namespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			InitContainers: []v1.Container{
-				{
-					Name: "test",
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				InitContainers: []v1.Container{
+					{
+						Name: "test",
+					},
 				},
 			},
 		},
@@ -530,7 +548,7 @@ func TestDeploymentSetInitContainer(t *testing.T) {
 
 func TestDeploymentTopologySpreadConstraints(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -549,12 +567,14 @@ func TestDeploymentTopologySpreadConstraints(t *testing.T) {
 	assert.Empty(t, d1.Spec.Template.Spec.TopologySpreadConstraints)
 
 	// Test TopologySpreadConstraints
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-topologyspreadconstraint",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			TopologySpreadConstraints: testTopologySpreadConstraintValue,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				TopologySpreadConstraints: testTopologySpreadConstraintValue,
+			},
 		},
 	}
 
@@ -575,15 +595,17 @@ func TestDeploymentTopologySpreadConstraints(t *testing.T) {
 
 func TestDeploymentAdditionalContainers(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-namespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			AdditionalContainers: []v1.Container{
-				{
-					Name: "test",
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				AdditionalContainers: []v1.Container{
+					{
+						Name: "test",
+					},
 				},
 			},
 		},
@@ -610,7 +632,7 @@ func TestDeploymentAdditionalContainers(t *testing.T) {
 
 func TestDeploymentShareProcessNamespace(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -629,12 +651,14 @@ func TestDeploymentShareProcessNamespace(t *testing.T) {
 	assert.False(t, *d1.Spec.Template.Spec.ShareProcessNamespace)
 
 	// Test hostNetwork=true
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-with-shareprocessnamespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			ShareProcessNamespace: true,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				ShareProcessNamespace: true,
+			},
 		},
 	}
 

--- a/internal/manifests/collector/horizontalpodautoscaler_test.go
+++ b/internal/manifests/collector/horizontalpodautoscaler_test.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
@@ -81,14 +80,16 @@ func TestHPA(t *testing.T) {
 				configuration := config.New()
 				params := manifests.Params{
 					Config: configuration,
-					OtelCol: v1alpha1.OpenTelemetryCollector{
+					OtelCol: v1alpha2.OpenTelemetryCollector{
 						ObjectMeta: otelcol.ObjectMeta,
-						Spec: v1alpha1.OpenTelemetryCollectorSpec{
-							MinReplicas: otelcol.Spec.OpenTelemetryCommonFields.Autoscaler.MinReplicas,
-							MaxReplicas: otelcol.Spec.OpenTelemetryCommonFields.Autoscaler.MaxReplicas,
-							Autoscaler: &v1alpha1.AutoscalerSpec{
-								TargetCPUUtilization:    otelcol.Spec.OpenTelemetryCommonFields.Autoscaler.TargetCPUUtilization,
-								TargetMemoryUtilization: otelcol.Spec.OpenTelemetryCommonFields.Autoscaler.TargetMemoryUtilization,
+						Spec: v1alpha2.OpenTelemetryCollectorSpec{
+							OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+								Autoscaler: &v1alpha2.AutoscalerSpec{
+									MinReplicas:             otelcol.Spec.Autoscaler.MinReplicas,
+									MaxReplicas:             otelcol.Spec.Autoscaler.MaxReplicas,
+									TargetCPUUtilization:    otelcol.Spec.OpenTelemetryCommonFields.Autoscaler.TargetCPUUtilization,
+									TargetMemoryUtilization: otelcol.Spec.OpenTelemetryCommonFields.Autoscaler.TargetMemoryUtilization,
+								},
 							},
 						},
 					},

--- a/internal/manifests/collector/poddisruptionbudget.go
+++ b/internal/manifests/collector/poddisruptionbudget.go
@@ -18,33 +18,28 @@ import (
 	policyV1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/internal/api/convert"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 func PodDisruptionBudget(params manifests.Params) (*policyV1.PodDisruptionBudget, error) {
-	otelCol, err := convert.V1Alpha1to2(params.OtelCol)
-	if err != nil {
-		return nil, err
-	}
 	// defaulting webhook should always set this, but if unset then return nil.
-	if otelCol.Spec.PodDisruptionBudget == nil {
+	if params.OtelCol.Spec.PodDisruptionBudget == nil {
 		params.Log.Info("pdb field is unset in Spec, skipping podDisruptionBudget creation")
 		return nil, nil
 	}
 
-	name := naming.Collector(otelCol.Name)
-	labels := manifestutils.Labels(otelCol.ObjectMeta, name, otelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
-	annotations, err := Annotations(otelCol)
+	name := naming.Collector(params.OtelCol.Name)
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
+	annotations, err := Annotations(params.OtelCol)
 	if err != nil {
 		return nil, err
 	}
 
 	objectMeta := metav1.ObjectMeta{
-		Name:        naming.PodDisruptionBudget(otelCol.Name),
-		Namespace:   otelCol.Namespace,
+		Name:        naming.PodDisruptionBudget(params.OtelCol.Name),
+		Namespace:   params.OtelCol.Namespace,
 		Labels:      labels,
 		Annotations: annotations,
 	}
@@ -52,8 +47,8 @@ func PodDisruptionBudget(params manifests.Params) (*policyV1.PodDisruptionBudget
 	return &policyV1.PodDisruptionBudget{
 		ObjectMeta: objectMeta,
 		Spec: policyV1.PodDisruptionBudgetSpec{
-			MinAvailable:   otelCol.Spec.PodDisruptionBudget.MinAvailable,
-			MaxUnavailable: otelCol.Spec.PodDisruptionBudget.MaxUnavailable,
+			MinAvailable:   params.OtelCol.Spec.PodDisruptionBudget.MinAvailable,
+			MaxUnavailable: params.OtelCol.Spec.PodDisruptionBudget.MaxUnavailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: objectMeta.Labels,
 			},

--- a/internal/manifests/collector/poddisruptionbudget_test.go
+++ b/internal/manifests/collector/poddisruptionbudget_test.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	. "github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
@@ -65,7 +65,7 @@ func TestPDB(t *testing.T) {
 		},
 	}
 
-	otelcols := []v1alpha1.OpenTelemetryCollector{
+	otelcols := []v1alpha2.OpenTelemetryCollector{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-instance",
@@ -76,7 +76,7 @@ func TestPDB(t *testing.T) {
 	for _, otelcol := range otelcols {
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				otelcol.Spec.PodDisruptionBudget = &v1alpha1.PodDisruptionBudgetSpec{
+				otelcol.Spec.PodDisruptionBudget = &v1alpha2.PodDisruptionBudgetSpec{
 					MinAvailable:   test.MinAvailable,
 					MaxUnavailable: test.MaxUnavailable,
 				}

--- a/internal/manifests/collector/podmonitor.go
+++ b/internal/manifests/collector/podmonitor.go
@@ -22,7 +22,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/adapters"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
@@ -39,7 +39,7 @@ func PodMonitor(params manifests.Params) (*monitoringv1.PodMonitor, error) {
 	}
 	var pm monitoringv1.PodMonitor
 
-	if params.OtelCol.Spec.Mode != v1alpha1.ModeSidecar {
+	if params.OtelCol.Spec.Mode != v1alpha2.ModeSidecar {
 		return nil, nil
 	}
 
@@ -77,8 +77,14 @@ func PodMonitor(params manifests.Params) (*monitoringv1.PodMonitor, error) {
 	return &pm, nil
 }
 
-func metricsEndpointsFromConfig(logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) []monitoringv1.PodMetricsEndpoint {
-	config, err := adapters.ConfigFromString(otelcol.Spec.Config)
+func metricsEndpointsFromConfig(logger logr.Logger, otelcol v1alpha2.OpenTelemetryCollector) []monitoringv1.PodMetricsEndpoint {
+	// TODO: https://github.com/open-telemetry/opentelemetry-operator/issues/2603
+	cfgStr, err := otelcol.Spec.Config.Yaml()
+	if err != nil {
+		logger.V(2).Error(err, "Error while marshalling to YAML")
+		return []monitoringv1.PodMetricsEndpoint{}
+	}
+	config, err := adapters.ConfigFromString(cfgStr)
 	if err != nil {
 		logger.V(2).Error(err, "Error while parsing the configuration")
 		return []monitoringv1.PodMetricsEndpoint{}

--- a/internal/manifests/collector/podmonitor.go
+++ b/internal/manifests/collector/podmonitor.go
@@ -81,7 +81,7 @@ func metricsEndpointsFromConfig(logger logr.Logger, otelcol v1alpha2.OpenTelemet
 	// TODO: https://github.com/open-telemetry/opentelemetry-operator/issues/2603
 	cfgStr, err := otelcol.Spec.Config.Yaml()
 	if err != nil {
-		logger.V(2).Error(err, "Error while marshalling to YAML")
+		logger.V(2).Error(err, "Error while marshaling to YAML")
 		return []monitoringv1.PodMetricsEndpoint{}
 	}
 	config, err := adapters.ConfigFromString(cfgStr)

--- a/internal/manifests/collector/podmonitor_test.go
+++ b/internal/manifests/collector/podmonitor_test.go
@@ -16,17 +16,16 @@ package collector
 
 import (
 	"fmt"
+	"testing"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 
 	"github.com/stretchr/testify/assert"
-
-	"testing"
 )
 
 func sidecarParams() manifests.Params {
-	return paramsWithMode(v1alpha1.ModeSidecar)
+	return paramsWithMode(v1alpha2.ModeSidecar)
 }
 
 func TestDesiredPodMonitors(t *testing.T) {
@@ -46,7 +45,7 @@ func TestDesiredPodMonitors(t *testing.T) {
 
 	params, err = newParams("", "testdata/prometheus-exporter.yaml")
 	assert.NoError(t, err)
-	params.OtelCol.Spec.Mode = v1alpha1.ModeSidecar
+	params.OtelCol.Spec.Mode = v1alpha2.ModeSidecar
 	params.OtelCol.Spec.Observability.Metrics.EnableMetrics = true
 	actual, err = PodMonitor(params)
 	assert.NoError(t, err)

--- a/internal/manifests/collector/route_test.go
+++ b/internal/manifests/collector/route_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
@@ -36,10 +36,10 @@ func TestDesiredRoutes(t *testing.T) {
 		params := manifests.Params{
 			Config: config.Config{},
 			Log:    logger,
-			OtelCol: v1alpha1.OpenTelemetryCollector{
-				Spec: v1alpha1.OpenTelemetryCollectorSpec{
-					Ingress: v1alpha1.Ingress{
-						Type: v1alpha1.IngressType("unknown"),
+			OtelCol: v1alpha2.OpenTelemetryCollector{
+				Spec: v1alpha2.OpenTelemetryCollectorSpec{
+					Ingress: v1alpha2.Ingress{
+						Type: v1alpha2.IngressType("unknown"),
 					},
 				},
 			},
@@ -50,39 +50,17 @@ func TestDesiredRoutes(t *testing.T) {
 		assert.Nil(t, actual)
 	})
 
-	t.Run("should return nil unable to parse config", func(t *testing.T) {
-		params := manifests.Params{
-			Config: config.Config{},
-			Log:    logger,
-			OtelCol: v1alpha1.OpenTelemetryCollector{
-				Spec: v1alpha1.OpenTelemetryCollectorSpec{
-					Config: "!!!",
-					Ingress: v1alpha1.Ingress{
-						Type: v1alpha1.IngressTypeRoute,
-						Route: v1alpha1.OpenShiftRoute{
-							Termination: v1alpha1.TLSRouteTerminationTypeInsecure,
-						},
-					},
-				},
-			},
-		}
-
-		actual, err := Routes(params)
-		assert.Nil(t, actual)
-		assert.ErrorContains(t, err, "could not convert config json to v1alpha2.Config")
-	})
-
 	t.Run("should return nil unable to parse receiver ports", func(t *testing.T) {
 		params := manifests.Params{
 			Config: config.Config{},
 			Log:    logger,
-			OtelCol: v1alpha1.OpenTelemetryCollector{
-				Spec: v1alpha1.OpenTelemetryCollectorSpec{
-					Config: "---",
-					Ingress: v1alpha1.Ingress{
-						Type: v1alpha1.IngressTypeRoute,
-						Route: v1alpha1.OpenShiftRoute{
-							Termination: v1alpha1.TLSRouteTerminationTypeInsecure,
+			OtelCol: v1alpha2.OpenTelemetryCollector{
+				Spec: v1alpha2.OpenTelemetryCollectorSpec{
+					Config: v1alpha2.Config{},
+					Ingress: v1alpha2.Ingress{
+						Type: v1alpha2.IngressTypeRoute,
+						Route: v1alpha2.OpenShiftRoute{
+							Termination: v1alpha2.TLSRouteTerminationTypeInsecure,
 						},
 					},
 				},
@@ -106,12 +84,12 @@ func TestDesiredRoutes(t *testing.T) {
 		}
 
 		params.OtelCol.Namespace = ns
-		params.OtelCol.Spec.Ingress = v1alpha1.Ingress{
-			Type:        v1alpha1.IngressTypeRoute,
+		params.OtelCol.Spec.Ingress = v1alpha2.Ingress{
+			Type:        v1alpha2.IngressTypeRoute,
 			Hostname:    hostname,
 			Annotations: map[string]string{"some.key": "some.value"},
-			Route: v1alpha1.OpenShiftRoute{
-				Termination: v1alpha1.TLSRouteTerminationTypeInsecure,
+			Route: v1alpha2.OpenShiftRoute{
+				Termination: v1alpha2.TLSRouteTerminationTypeInsecure,
 			},
 		}
 
@@ -156,11 +134,11 @@ func TestDesiredRoutes(t *testing.T) {
 		}
 
 		params.OtelCol.Namespace = "test"
-		params.OtelCol.Spec.Ingress = v1alpha1.Ingress{
+		params.OtelCol.Spec.Ingress = v1alpha2.Ingress{
 			Hostname: "example.com",
-			Type:     v1alpha1.IngressTypeRoute,
-			Route: v1alpha1.OpenShiftRoute{
-				Termination: v1alpha1.TLSRouteTerminationTypeInsecure,
+			Type:     v1alpha2.IngressTypeRoute,
+			Route: v1alpha2.OpenShiftRoute{
+				Termination: v1alpha2.TLSRouteTerminationTypeInsecure,
 			},
 		}
 
@@ -178,10 +156,10 @@ func TestDesiredRoutes(t *testing.T) {
 		}
 
 		params.OtelCol.Namespace = "test"
-		params.OtelCol.Spec.Ingress = v1alpha1.Ingress{
-			Type: v1alpha1.IngressTypeRoute,
-			Route: v1alpha1.OpenShiftRoute{
-				Termination: v1alpha1.TLSRouteTerminationTypeInsecure,
+		params.OtelCol.Spec.Ingress = v1alpha2.Ingress{
+			Type: v1alpha2.IngressTypeRoute,
+			Route: v1alpha2.OpenShiftRoute{
+				Termination: v1alpha2.TLSRouteTerminationTypeInsecure,
 			},
 		}
 

--- a/internal/manifests/collector/service_test.go
+++ b/internal/manifests/collector/service_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 )
 
@@ -99,11 +99,8 @@ func TestDesiredService(t *testing.T) {
 		params := manifests.Params{
 			Config: config.Config{},
 			Log:    logger,
-			OtelCol: v1alpha1.OpenTelemetryCollector{
-				Spec: v1alpha1.OpenTelemetryCollectorSpec{Config: `receivers:
-      test:
-        protocols:
-          unknown:`},
+			OtelCol: v1alpha2.OpenTelemetryCollector{
+				Spec: v1alpha2.OpenTelemetryCollectorSpec{Config: v1alpha2.Config{}},
 			},
 		}
 
@@ -141,7 +138,7 @@ func TestDesiredService(t *testing.T) {
 
 		params := deploymentParams()
 
-		params.OtelCol.Spec.Ingress.Type = v1alpha1.IngressTypeRoute
+		params.OtelCol.Spec.Ingress.Type = v1alpha2.IngressTypeRoute
 		actual, err := Service(params)
 
 		ports := append(params.OtelCol.Spec.Ports, jaegerPort)
@@ -160,7 +157,7 @@ func TestDesiredService(t *testing.T) {
 			Port:        14250,
 			AppProtocol: &grpc,
 		}
-		p := paramsWithMode(v1alpha1.ModeDaemonSet)
+		p := paramsWithMode(v1alpha2.ModeDaemonSet)
 		ports := append(p.OtelCol.Spec.Ports, jaegerPorts)
 		expected := serviceWithInternalTrafficPolicy("test-collector", ports, v1.ServiceInternalTrafficPolicyLocal)
 
@@ -170,20 +167,6 @@ func TestDesiredService(t *testing.T) {
 		assert.Equal(t, expected, *actual)
 	})
 
-	t.Run("should return nil unable to parse config", func(t *testing.T) {
-		params := manifests.Params{
-			Config: config.Config{},
-			Log:    logger,
-			OtelCol: v1alpha1.OpenTelemetryCollector{
-				Spec: v1alpha1.OpenTelemetryCollectorSpec{Config: `!!!`},
-			},
-		}
-
-		actual, err := Service(params)
-		assert.ErrorContains(t, err, "could not convert config json to v1alpha2.Config")
-		assert.Nil(t, actual)
-
-	})
 }
 
 func TestHeadlessService(t *testing.T) {
@@ -216,11 +199,20 @@ func TestMonitoringService(t *testing.T) {
 			Port: 9090,
 		}}
 		params := deploymentParams()
-		params.OtelCol.Spec.Config = `service:
-    telemetry:
-        metrics:
-            level: detailed
-            address: 0.0.0.0:9090`
+		params.OtelCol.Spec.Config = v1alpha2.Config{
+			Service: v1alpha2.Service{
+				Telemetry: &v1alpha2.AnyConfig{
+					Object: map[string]interface{}{
+						"service": map[string]interface{}{
+							"metrics": map[string]interface{}{
+								"level":   "detailed",
+								"address": "0.0.0.0:9090",
+							},
+						},
+					},
+				},
+			},
+		}
 
 		actual, err := MonitoringService(params)
 		assert.NoError(t, err)

--- a/internal/manifests/collector/service_test.go
+++ b/internal/manifests/collector/service_test.go
@@ -203,11 +203,9 @@ func TestMonitoringService(t *testing.T) {
 			Service: v1alpha2.Service{
 				Telemetry: &v1alpha2.AnyConfig{
 					Object: map[string]interface{}{
-						"service": map[string]interface{}{
-							"metrics": map[string]interface{}{
-								"level":   "detailed",
-								"address": "0.0.0.0:9090",
-							},
+						"metrics": map[string]interface{}{
+							"level":   "detailed",
+							"address": "0.0.0.0:9090",
 						},
 					},
 				},

--- a/internal/manifests/collector/serviceaccount.go
+++ b/internal/manifests/collector/serviceaccount.go
@@ -19,7 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
-	"github.com/open-telemetry/opentelemetry-operator/internal/api/convert"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
@@ -36,23 +35,19 @@ func ServiceAccountName(instance v1alpha2.OpenTelemetryCollector) string {
 
 // ServiceAccount returns the service account for the given instance.
 func ServiceAccount(params manifests.Params) (*corev1.ServiceAccount, error) {
-	otelCol, err := convert.V1Alpha1to2(params.OtelCol)
-	if err != nil {
-		return nil, err
-	}
-	if otelCol.Spec.ServiceAccount != "" {
+	if params.OtelCol.Spec.ServiceAccount != "" {
 		return nil, nil
 	}
 
-	name := naming.ServiceAccount(otelCol.Name)
-	labels := manifestutils.Labels(otelCol.ObjectMeta, name, otelCol.Spec.Image, ComponentOpenTelemetryCollector, []string{})
+	name := naming.ServiceAccount(params.OtelCol.Name)
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, []string{})
 
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   otelCol.Namespace,
+			Namespace:   params.OtelCol.Namespace,
 			Labels:      labels,
-			Annotations: otelCol.Annotations,
+			Annotations: params.OtelCol.Annotations,
 		},
 	}, nil
 }

--- a/internal/manifests/collector/servicemonitor.go
+++ b/internal/manifests/collector/servicemonitor.go
@@ -22,7 +22,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/adapters"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
@@ -39,7 +39,7 @@ func ServiceMonitor(params manifests.Params) (*monitoringv1.ServiceMonitor, erro
 	}
 	var sm monitoringv1.ServiceMonitor
 
-	if params.OtelCol.Spec.Mode == v1alpha1.ModeSidecar {
+	if params.OtelCol.Spec.Mode == v1alpha2.ModeSidecar {
 		return nil, nil
 	}
 	sm = monitoringv1.ServiceMonitor{
@@ -73,8 +73,14 @@ func ServiceMonitor(params manifests.Params) (*monitoringv1.ServiceMonitor, erro
 	return &sm, nil
 }
 
-func endpointsFromConfig(logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) []monitoringv1.Endpoint {
-	c, err := adapters.ConfigFromString(otelcol.Spec.Config)
+func endpointsFromConfig(logger logr.Logger, otelcol v1alpha2.OpenTelemetryCollector) []monitoringv1.Endpoint {
+	// TODO: https://github.com/open-telemetry/opentelemetry-operator/issues/2603
+	cfgStr, err := otelcol.Spec.Config.Yaml()
+	if err != nil {
+		logger.V(2).Error(err, "Error while marshalling to YAML")
+		return []monitoringv1.Endpoint{}
+	}
+	c, err := adapters.ConfigFromString(cfgStr)
 	if err != nil {
 		logger.V(2).Error(err, "Error while parsing the configuration")
 		return []monitoringv1.Endpoint{}

--- a/internal/manifests/collector/servicemonitor.go
+++ b/internal/manifests/collector/servicemonitor.go
@@ -77,7 +77,7 @@ func endpointsFromConfig(logger logr.Logger, otelcol v1alpha2.OpenTelemetryColle
 	// TODO: https://github.com/open-telemetry/opentelemetry-operator/issues/2603
 	cfgStr, err := otelcol.Spec.Config.Yaml()
 	if err != nil {
-		logger.V(2).Error(err, "Error while marshalling to YAML")
+		logger.V(2).Error(err, "Error while marshaling to YAML")
 		return []monitoringv1.Endpoint{}
 	}
 	c, err := adapters.ConfigFromString(cfgStr)

--- a/internal/manifests/collector/statefulset_test.go
+++ b/internal/manifests/collector/statefulset_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	. "github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
@@ -33,14 +33,16 @@ import (
 
 func TestStatefulSetNewDefault(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-namespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			Mode:        "statefulset",
-			Tolerations: testTolerationValues,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			Mode: "statefulset",
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				Tolerations: testTolerationValues,
+			},
 		},
 	}
 	cfg := config.New()
@@ -107,13 +109,15 @@ func TestStatefulSetNewDefault(t *testing.T) {
 func TestStatefulSetReplicas(t *testing.T) {
 	// prepare
 	replicaInt := int32(3)
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			Mode:     "statefulset",
-			Replicas: &replicaInt,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			Mode: "statefulset",
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				Replicas: &replicaInt,
+			},
 		},
 	}
 	cfg := config.New()
@@ -134,23 +138,25 @@ func TestStatefulSetReplicas(t *testing.T) {
 
 func TestStatefulSetVolumeClaimTemplates(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			Mode: "statefulset",
-			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "added-volume",
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					AccessModes: []corev1.PersistentVolumeAccessMode{"ReadWriteOnce"},
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{"storage": resource.MustParse("1Gi")},
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "added-volume",
 					},
-				},
-			}},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{"ReadWriteOnce"},
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{"storage": resource.MustParse("1Gi")},
+						},
+					},
+				}},
+			},
 		},
 	}
 	cfg := config.New()
@@ -178,12 +184,14 @@ func TestStatefulSetVolumeClaimTemplates(t *testing.T) {
 func TestStatefulSetPodAnnotations(t *testing.T) {
 	// prepare
 	testPodAnnotationValues := map[string]string{"annotation-key": "annotation-value"}
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			PodAnnotations: testPodAnnotationValues,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				PodAnnotations: testPodAnnotationValues,
+			},
 		},
 	}
 	cfg := config.New()
@@ -218,15 +226,17 @@ func TestStatefulSetPodSecurityContext(t *testing.T) {
 	runAsUser := int64(1337)
 	runasGroup := int64(1338)
 
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			PodSecurityContext: &v1.PodSecurityContext{
-				RunAsNonRoot: &runAsNonRoot,
-				RunAsUser:    &runAsUser,
-				RunAsGroup:   &runasGroup,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				PodSecurityContext: &v1.PodSecurityContext{
+					RunAsNonRoot: &runAsNonRoot,
+					RunAsUser:    &runAsUser,
+					RunAsGroup:   &runasGroup,
+				},
 			},
 		},
 	}
@@ -249,7 +259,7 @@ func TestStatefulSetPodSecurityContext(t *testing.T) {
 
 func TestStatefulSetHostNetwork(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -270,12 +280,14 @@ func TestStatefulSetHostNetwork(t *testing.T) {
 	assert.Equal(t, d1.Spec.Template.Spec.DNSPolicy, v1.DNSClusterFirst)
 
 	// Test hostNetwork=true
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-hostnetwork",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			HostNetwork: true,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				HostNetwork: true,
+			},
 		},
 	}
 
@@ -299,12 +311,12 @@ func TestStatefulSetFilterLabels(t *testing.T) {
 		"app.foo.bar": "1",
 	}
 
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "my-instance",
 			Labels: excludedLabels,
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{},
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{},
 	}
 
 	cfg := config.New(config.WithLabelFilters([]string{"foo*", "app.*.bar"}))
@@ -326,7 +338,7 @@ func TestStatefulSetFilterLabels(t *testing.T) {
 
 func TestStatefulSetNodeSelector(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -346,14 +358,16 @@ func TestStatefulSetNodeSelector(t *testing.T) {
 	assert.Empty(t, d1.Spec.Template.Spec.NodeSelector)
 
 	// Test nodeSelector
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-nodeselector",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			HostNetwork: true,
-			NodeSelector: map[string]string{
-				"node-key": "node-value",
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				HostNetwork: true,
+				NodeSelector: map[string]string{
+					"node-key": "node-value",
+				},
 			},
 		},
 	}
@@ -372,7 +386,7 @@ func TestStatefulSetNodeSelector(t *testing.T) {
 }
 
 func TestStatefulSetPriorityClassName(t *testing.T) {
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -392,12 +406,14 @@ func TestStatefulSetPriorityClassName(t *testing.T) {
 
 	priorityClassName := "test-class"
 
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-priortyClassName",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			PriorityClassName: priorityClassName,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				PriorityClassName: priorityClassName,
+			},
 		},
 	}
 
@@ -415,7 +431,7 @@ func TestStatefulSetPriorityClassName(t *testing.T) {
 }
 
 func TestStatefulSetAffinity(t *testing.T) {
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -433,12 +449,14 @@ func TestStatefulSetAffinity(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, sts1.Spec.Template.Spec.Affinity)
 
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-priortyClassName",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			Affinity: testAffinityValue,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				Affinity: testAffinityValue,
+			},
 		},
 	}
 
@@ -458,15 +476,17 @@ func TestStatefulSetAffinity(t *testing.T) {
 
 func TestStatefulSetInitContainer(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-namespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			InitContainers: []v1.Container{
-				{
-					Name: "test",
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				InitContainers: []v1.Container{
+					{
+						Name: "test",
+					},
 				},
 			},
 		},
@@ -492,7 +512,7 @@ func TestStatefulSetInitContainer(t *testing.T) {
 
 func TestStatefulSetTopologySpreadConstraints(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -511,12 +531,14 @@ func TestStatefulSetTopologySpreadConstraints(t *testing.T) {
 	assert.Empty(t, s1.Spec.Template.Spec.TopologySpreadConstraints)
 
 	// Test TopologySpreadConstraints
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-topologyspreadconstraint",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			TopologySpreadConstraints: testTopologySpreadConstraintValue,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				TopologySpreadConstraints: testTopologySpreadConstraintValue,
+			},
 		},
 	}
 
@@ -538,15 +560,17 @@ func TestStatefulSetTopologySpreadConstraints(t *testing.T) {
 
 func TestStatefulSetAdditionalContainers(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-namespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			AdditionalContainers: []v1.Container{
-				{
-					Name: "test",
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				AdditionalContainers: []v1.Container{
+					{
+						Name: "test",
+					},
 				},
 			},
 		},
@@ -573,7 +597,7 @@ func TestStatefulSetAdditionalContainers(t *testing.T) {
 
 func TestStatefulSetShareProcessNamespace(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -592,12 +616,14 @@ func TestStatefulSetShareProcessNamespace(t *testing.T) {
 	assert.False(t, *d1.Spec.Template.Spec.ShareProcessNamespace)
 
 	// Test shareProcessNamespace=true
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-with-shareprocessnamespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			ShareProcessNamespace: true,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				ShareProcessNamespace: true,
+			},
 		},
 	}
 

--- a/internal/manifests/collector/suite_test.go
+++ b/internal/manifests/collector/suite_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	go_yaml "gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -26,6 +27,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
@@ -42,18 +44,23 @@ const (
 )
 
 func deploymentParams() manifests.Params {
-	return paramsWithMode(v1alpha1.ModeDeployment)
+	return paramsWithMode(v1alpha2.ModeDeployment)
 }
 
-func paramsWithMode(mode v1alpha1.Mode) manifests.Params {
+func paramsWithMode(mode v1alpha2.Mode) manifests.Params {
 	replicas := int32(2)
 	configYAML, err := os.ReadFile("testdata/test.yaml")
 	if err != nil {
 		fmt.Printf("Error getting yaml file: %v", err)
 	}
+	cfg := v1alpha2.Config{}
+	err = go_yaml.Unmarshal(configYAML, &cfg)
+	if err != nil {
+		fmt.Printf("Error unmarshalling YAML: %v", err)
+	}
 	return manifests.Params{
 		Config: config.New(config.WithCollectorImage(defaultCollectorImage), config.WithTargetAllocatorImage(defaultTaAllocationImage)),
-		OtelCol: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha2.OpenTelemetryCollector{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "opentelemetry.io",
 				APIVersion: "v1",
@@ -63,20 +70,23 @@ func paramsWithMode(mode v1alpha1.Mode) manifests.Params {
 				Namespace: "default",
 				UID:       instanceUID,
 			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{
-				Image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.47.0",
-				Ports: []v1.ServicePort{{
-					Name: "web",
-					Port: 80,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 80,
-					},
-					NodePort: 0,
-				}},
-				Replicas: &replicas,
-				Config:   string(configYAML),
-				Mode:     mode,
+			Spec: v1alpha2.OpenTelemetryCollectorSpec{
+				OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+
+					Image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.47.0",
+					Ports: []v1.ServicePort{{
+						Name: "web",
+						Port: 80,
+						TargetPort: intstr.IntOrString{
+							Type:   intstr.Int,
+							IntVal: 80,
+						},
+						NodePort: 0,
+					}},
+					Replicas: &replicas,
+				},
+				Config: cfg,
+				Mode:   mode,
 			},
 		},
 		Log:      logger,
@@ -95,7 +105,13 @@ func newParams(taContainerImage string, file string) (manifests.Params, error) {
 		configYAML, err = os.ReadFile(file)
 	}
 	if err != nil {
-		return manifests.Params{}, fmt.Errorf("Error getting yaml file: %w", err)
+		return manifests.Params{}, fmt.Errorf("error getting yaml file: %w", err)
+	}
+
+	colCfg := v1alpha2.Config{}
+	err = go_yaml.Unmarshal(configYAML, &colCfg)
+	if err != nil {
+		return manifests.Params{}, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
 	cfg := config.New(
@@ -106,7 +122,7 @@ func newParams(taContainerImage string, file string) (manifests.Params, error) {
 
 	return manifests.Params{
 		Config: cfg,
-		OtelCol: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha2.OpenTelemetryCollector{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "opentelemetry.io",
 				APIVersion: "v1",
@@ -116,23 +132,26 @@ func newParams(taContainerImage string, file string) (manifests.Params, error) {
 				Namespace: "default",
 				UID:       instanceUID,
 			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{
-				Mode: v1alpha1.ModeStatefulSet,
-				Ports: []v1.ServicePort{{
-					Name: "web",
-					Port: 80,
-					TargetPort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 80,
-					},
-					NodePort: 0,
-				}},
+			Spec: v1alpha2.OpenTelemetryCollectorSpec{
+				OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+					Ports: []v1.ServicePort{{
+						Name: "web",
+						Port: 80,
+						TargetPort: intstr.IntOrString{
+							Type:   intstr.Int,
+							IntVal: 80,
+						},
+						NodePort: 0,
+					}},
+
+					Replicas: &replicas,
+				},
+				Mode: v1alpha2.ModeStatefulSet,
 				TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 					Enabled: true,
 					Image:   taContainerImage,
 				},
-				Replicas: &replicas,
-				Config:   string(configYAML),
+				Config: colCfg,
 			},
 		},
 		Log: logger,

--- a/internal/manifests/params.go
+++ b/internal/manifests/params.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 )
 
@@ -30,7 +31,7 @@ type Params struct {
 	Recorder    record.EventRecorder
 	Scheme      *runtime.Scheme
 	Log         logr.Logger
-	OtelCol     v1alpha1.OpenTelemetryCollector
+	OtelCol     v1alpha2.OpenTelemetryCollector
 	OpAMPBridge v1alpha1.OpAMPBridge
 	Config      config.Config
 }

--- a/internal/manifests/targetallocator/annotations.go
+++ b/internal/manifests/targetallocator/annotations.go
@@ -20,13 +20,13 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 )
 
 const configMapHashAnnotationKey = "opentelemetry-targetallocator-config/hash"
 
 // Annotations returns the annotations for the TargetAllocator Pod.
-func Annotations(instance v1alpha1.OpenTelemetryCollector, configMap *v1.ConfigMap) map[string]string {
+func Annotations(instance v1alpha2.OpenTelemetryCollector, configMap *v1.ConfigMap) map[string]string {
 	// Make a copy of PodAnnotations to be safe
 	annotations := make(map[string]string, len(instance.Spec.PodAnnotations))
 	for key, value := range instance.Spec.PodAnnotations {

--- a/internal/manifests/targetallocator/annotations_test.go
+++ b/internal/manifests/targetallocator/annotations_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
@@ -57,7 +58,7 @@ func TestConfigMapHash(t *testing.T) {
 
 func TestInvalidConfigNoHash(t *testing.T) {
 	instance := collectorInstance()
-	instance.Spec.Config = ""
+	instance.Spec.Config = v1alpha2.Config{}
 	annotations := Annotations(instance, nil)
 	require.NotContains(t, annotations, configMapHashAnnotationKey)
 }

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -34,10 +34,15 @@ const (
 func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	name := naming.TAConfigMap(params.OtelCol.Name)
 	labels := Labels(params.OtelCol, name)
+	// TODO: https://github.com/open-telemetry/opentelemetry-operator/issues/2603
+	cfgStr, err := params.OtelCol.Spec.Config.Yaml()
+	if err != nil {
+		return &corev1.ConfigMap{}, err
+	}
 
 	// Collector supports environment variable substitution, but the TA does not.
 	// TA ConfigMap should have a single "$", as it does not support env var substitution
-	prometheusReceiverConfig, err := adapters.UnescapeDollarSignsInPromConfig(params.OtelCol.Spec.Config)
+	prometheusReceiverConfig, err := adapters.UnescapeDollarSignsInPromConfig(cfgStr)
 	if err != nil {
 		return &corev1.ConfigMap{}, err
 	}

--- a/internal/manifests/targetallocator/container.go
+++ b/internal/manifests/targetallocator/container.go
@@ -20,13 +20,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 // Container builds a container for the given TargetAllocator.
-func Container(cfg config.Config, logger logr.Logger, otelcol v1alpha1.OpenTelemetryCollector) corev1.Container {
+func Container(cfg config.Config, logger logr.Logger, otelcol v1alpha2.OpenTelemetryCollector) corev1.Container {
 	image := otelcol.Spec.TargetAllocator.Image
 	if len(image) == 0 {
 		image = cfg.TargetAllocatorImage()

--- a/internal/manifests/targetallocator/container_test.go
+++ b/internal/manifests/targetallocator/container_test.go
@@ -26,6 +26,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
@@ -34,7 +35,7 @@ var logger = logf.Log.WithName("unit-tests")
 
 func TestContainerNewDefault(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{}
+	otelcol := v1alpha2.OpenTelemetryCollector{}
 	cfg := config.New(config.WithTargetAllocatorImage("default-image"))
 
 	// test
@@ -46,8 +47,8 @@ func TestContainerNewDefault(t *testing.T) {
 
 func TestContainerWithImageOverridden(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+	otelcol := v1alpha2.OpenTelemetryCollector{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Enabled: true,
 				Image:   "overridden-image",
@@ -65,8 +66,8 @@ func TestContainerWithImageOverridden(t *testing.T) {
 
 func TestContainerPorts(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+	otelcol := v1alpha2.OpenTelemetryCollector{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Enabled: true,
 				Image:   "default-image",
@@ -86,8 +87,8 @@ func TestContainerPorts(t *testing.T) {
 
 func TestContainerVolumes(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+	otelcol := v1alpha2.OpenTelemetryCollector{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Enabled: true,
 				Image:   "default-image",
@@ -105,8 +106,8 @@ func TestContainerVolumes(t *testing.T) {
 }
 
 func TestContainerResourceRequirements(t *testing.T) {
-	otelcol := v1alpha1.OpenTelemetryCollector{
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+	otelcol := v1alpha2.OpenTelemetryCollector{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -143,8 +144,8 @@ func TestContainerResourceRequirements(t *testing.T) {
 
 func TestContainerHasEnvVars(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+	otelcol := v1alpha2.OpenTelemetryCollector{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Enabled: true,
 				Env: []corev1.EnvVar{
@@ -228,8 +229,8 @@ func TestContainerHasProxyEnvVars(t *testing.T) {
 	defer os.Unsetenv("NO_PROXY")
 
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+	otelcol := v1alpha2.OpenTelemetryCollector{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Enabled: true,
 				Env: []corev1.EnvVar{
@@ -254,8 +255,8 @@ func TestContainerHasProxyEnvVars(t *testing.T) {
 
 func TestContainerDoesNotOverrideEnvVars(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+	otelcol := v1alpha2.OpenTelemetryCollector{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Enabled: true,
 				Env: []corev1.EnvVar{
@@ -320,8 +321,8 @@ func TestContainerDoesNotOverrideEnvVars(t *testing.T) {
 	assert.Equal(t, expected, c)
 }
 func TestReadinessProbe(t *testing.T) {
-	otelcol := v1alpha1.OpenTelemetryCollector{
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+	otelcol := v1alpha2.OpenTelemetryCollector{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Enabled: true,
 			},
@@ -345,8 +346,8 @@ func TestReadinessProbe(t *testing.T) {
 }
 func TestLivenessProbe(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+	otelcol := v1alpha2.OpenTelemetryCollector{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Enabled: true,
 			},
@@ -375,8 +376,8 @@ func TestSecurityContext(t *testing.T) {
 		RunAsNonRoot: &runAsNonRoot,
 	}
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+	otelcol := v1alpha2.OpenTelemetryCollector{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Enabled:         true,
 				SecurityContext: securityContext,

--- a/internal/manifests/targetallocator/deployment_test.go
+++ b/internal/manifests/targetallocator/deployment_test.go
@@ -20,10 +20,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	go_yaml "gopkg.in/yaml.v3"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
@@ -77,7 +79,7 @@ var testSecurityContextValue = &v1.PodSecurityContext{
 
 func TestDeploymentSecurityContext(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -97,11 +99,11 @@ func TestDeploymentSecurityContext(t *testing.T) {
 	assert.Empty(t, d1.Spec.Template.Spec.SecurityContext)
 
 	// Test SecurityContext
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-securitycontext",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				PodSecurityContext: testSecurityContextValue,
 			},
@@ -174,19 +176,26 @@ func TestDeploymentPodAnnotations(t *testing.T) {
 	assert.Subset(t, ds.Spec.Template.Annotations, testPodAnnotationValues)
 }
 
-func collectorInstance() v1alpha1.OpenTelemetryCollector {
+func collectorInstance() v1alpha2.OpenTelemetryCollector {
 	configYAML, err := os.ReadFile("testdata/test.yaml")
 	if err != nil {
 		fmt.Printf("Error getting yaml file: %v", err)
 	}
-	return v1alpha1.OpenTelemetryCollector{
+	cfg := v1alpha2.Config{}
+	err = go_yaml.Unmarshal(configYAML, &cfg)
+	if err != nil {
+		fmt.Printf("Error unmarshalling YAML: %v", err)
+	}
+	return v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "default",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			Image:  "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.47.0",
-			Config: string(configYAML),
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				Image: "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.47.0",
+			},
+			Config: cfg,
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Image:          "ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-targetallocator:0.47.0",
 				FilterStrategy: "relabel-config",
@@ -197,7 +206,7 @@ func collectorInstance() v1alpha1.OpenTelemetryCollector {
 
 func TestDeploymentNodeSelector(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -215,11 +224,11 @@ func TestDeploymentNodeSelector(t *testing.T) {
 	assert.Empty(t, d1.Spec.Template.Spec.NodeSelector)
 
 	// Test nodeSelector
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-nodeselector",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				NodeSelector: map[string]string{
 					"node-key": "node-value",
@@ -242,7 +251,7 @@ func TestDeploymentNodeSelector(t *testing.T) {
 }
 func TestDeploymentAffinity(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -260,11 +269,11 @@ func TestDeploymentAffinity(t *testing.T) {
 	assert.Empty(t, d1.Spec.Template.Spec.Affinity)
 
 	// Test affinity
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-affinity",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Affinity: testAffinityValue,
 			},
@@ -286,7 +295,7 @@ func TestDeploymentAffinity(t *testing.T) {
 
 func TestDeploymentTolerations(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -304,11 +313,11 @@ func TestDeploymentTolerations(t *testing.T) {
 	assert.Empty(t, d1.Spec.Template.Spec.Tolerations)
 
 	// Test Tolerations
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-toleration",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				Tolerations: testTolerationValues,
 			},
@@ -330,7 +339,7 @@ func TestDeploymentTolerations(t *testing.T) {
 
 func TestDeploymentTopologySpreadConstraints(t *testing.T) {
 	// Test default
-	otelcol1 := v1alpha1.OpenTelemetryCollector{
+	otelcol1 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -349,11 +358,11 @@ func TestDeploymentTopologySpreadConstraints(t *testing.T) {
 	assert.Empty(t, d1.Spec.Template.Spec.TopologySpreadConstraints)
 
 	// Test TopologySpreadConstraints
-	otelcol2 := v1alpha1.OpenTelemetryCollector{
+	otelcol2 := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance-topologyspreadconstraint",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				TopologySpreadConstraints: testTopologySpreadConstraintValue,
 			},

--- a/internal/manifests/targetallocator/labels.go
+++ b/internal/manifests/targetallocator/labels.go
@@ -15,18 +15,18 @@
 package targetallocator
 
 import (
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 // Labels return the common labels to all TargetAllocator objects that are part of a managed OpenTelemetryCollector.
-func Labels(instance v1alpha1.OpenTelemetryCollector, name string) map[string]string {
+func Labels(instance v1alpha2.OpenTelemetryCollector, name string) map[string]string {
 	return manifestutils.Labels(instance.ObjectMeta, name, instance.Spec.TargetAllocator.Image, ComponentOpenTelemetryTargetAllocator, nil)
 }
 
 // SelectorLabels return the selector labels for Target Allocator Pods.
-func SelectorLabels(instance v1alpha1.OpenTelemetryCollector) map[string]string {
+func SelectorLabels(instance v1alpha2.OpenTelemetryCollector) map[string]string {
 	selectorLabels := manifestutils.SelectorLabels(instance.ObjectMeta, ComponentOpenTelemetryTargetAllocator)
 	// TargetAllocator uses the name label as well for selection
 	// This is inconsistent with the Collector, but changing is a somewhat painful breaking change

--- a/internal/manifests/targetallocator/labels_test.go
+++ b/internal/manifests/targetallocator/labels_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
@@ -31,7 +31,7 @@ const (
 
 func TestLabelsCommonSet(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -50,7 +50,7 @@ func TestLabelsCommonSet(t *testing.T) {
 
 func TestLabelsPropagateDown(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				"myapp":                  "mycomponent",
@@ -70,7 +70,7 @@ func TestLabelsPropagateDown(t *testing.T) {
 
 func TestSelectorLabels(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/internal/manifests/targetallocator/poddisruptionbudget_test.go
+++ b/internal/manifests/targetallocator/poddisruptionbudget_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
@@ -66,11 +67,11 @@ var tests = []test{
 func TestPDBWithValidStrategy(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			otelcol := v1alpha1.OpenTelemetryCollector{
+			otelcol := v1alpha2.OpenTelemetryCollector{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-instance",
 				},
-				Spec: v1alpha1.OpenTelemetryCollectorSpec{
+				Spec: v1alpha2.OpenTelemetryCollectorSpec{
 					TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 						PodDisruptionBudget: &v1alpha1.PodDisruptionBudgetSpec{
 							MinAvailable:   test.MinAvailable,
@@ -100,11 +101,11 @@ func TestPDBWithValidStrategy(t *testing.T) {
 func TestPDBWithNotValidStrategy(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			otelcol := v1alpha1.OpenTelemetryCollector{
+			otelcol := v1alpha2.OpenTelemetryCollector{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-instance",
 				},
-				Spec: v1alpha1.OpenTelemetryCollectorSpec{
+				Spec: v1alpha2.OpenTelemetryCollectorSpec{
 					TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 						PodDisruptionBudget: &v1alpha1.PodDisruptionBudgetSpec{
 							MinAvailable:   test.MinAvailable,
@@ -129,11 +130,11 @@ func TestPDBWithNotValidStrategy(t *testing.T) {
 }
 
 func TestNoPDB(t *testing.T) {
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				AllocationStrategy: v1alpha1.OpenTelemetryTargetAllocatorAllocationStrategyLeastWeighted,
 			},

--- a/internal/manifests/targetallocator/serviceaccount.go
+++ b/internal/manifests/targetallocator/serviceaccount.go
@@ -18,14 +18,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
-
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 )
 
 // ServiceAccountName returns the name of the existing or self-provisioned service account to use for the given instance.
-func ServiceAccountName(instance v1alpha1.OpenTelemetryCollector) string {
+func ServiceAccountName(instance v1alpha2.OpenTelemetryCollector) string {
 	if len(instance.Spec.TargetAllocator.ServiceAccount) == 0 {
 		return naming.TargetAllocatorServiceAccount(instance.Name)
 	}

--- a/internal/manifests/targetallocator/serviceaccount_test.go
+++ b/internal/manifests/targetallocator/serviceaccount_test.go
@@ -22,12 +22,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
 func TestServiceAccountDefaultName(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
@@ -42,11 +43,11 @@ func TestServiceAccountDefaultName(t *testing.T) {
 
 func TestServiceAccountOverrideName(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 				ServiceAccount: "my-special-sa",
 			},
@@ -62,7 +63,7 @@ func TestServiceAccountOverrideName(t *testing.T) {
 
 func TestServiceAccountDefault(t *testing.T) {
 	params := manifests.Params{
-		OtelCol: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha2.OpenTelemetryCollector{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-instance",
 			},
@@ -86,11 +87,11 @@ func TestServiceAccountDefault(t *testing.T) {
 
 func TestServiceAccountOverride(t *testing.T) {
 	params := manifests.Params{
-		OtelCol: v1alpha1.OpenTelemetryCollector{
+		OtelCol: v1alpha2.OpenTelemetryCollector{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-instance",
 			},
-			Spec: v1alpha1.OpenTelemetryCollectorSpec{
+			Spec: v1alpha2.OpenTelemetryCollectorSpec{
 				TargetAllocator: v1alpha1.OpenTelemetryTargetAllocator{
 					ServiceAccount: "my-special-sa",
 				},

--- a/internal/manifests/targetallocator/servicemonitor_test.go
+++ b/internal/manifests/targetallocator/servicemonitor_test.go
@@ -20,7 +20,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 
@@ -28,14 +28,16 @@ import (
 )
 
 func TestDesiredServiceMonitors(t *testing.T) {
-	otelcol := v1alpha1.OpenTelemetryCollector{
+	otelcol := v1alpha2.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-namespace",
 		},
-		Spec: v1alpha1.OpenTelemetryCollectorSpec{
-			Mode:        v1alpha1.ModeStatefulSet,
-			Tolerations: testTolerationValues,
+		Spec: v1alpha2.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1alpha2.OpenTelemetryCommonFields{
+				Tolerations: testTolerationValues,
+			},
+			Mode: v1alpha2.ModeStatefulSet,
 		},
 	}
 	cfg := config.New()

--- a/internal/manifests/targetallocator/volume.go
+++ b/internal/manifests/targetallocator/volume.go
@@ -17,13 +17,13 @@ package targetallocator
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 // Volumes builds the volumes for the given instance, including the config map volume.
-func Volumes(cfg config.Config, otelcol v1alpha1.OpenTelemetryCollector) []corev1.Volume {
+func Volumes(cfg config.Config, otelcol v1alpha2.OpenTelemetryCollector) []corev1.Volume {
 	volumes := []corev1.Volume{{
 		Name: naming.TAConfigMapVolume(),
 		VolumeSource: corev1.VolumeSource{

--- a/internal/manifests/targetallocator/volume_test.go
+++ b/internal/manifests/targetallocator/volume_test.go
@@ -19,14 +19,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha2"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 func TestVolumeNewDefault(t *testing.T) {
 	// prepare
-	otelcol := v1alpha1.OpenTelemetryCollector{}
+	otelcol := v1alpha2.OpenTelemetryCollector{}
 	cfg := config.New()
 
 	// test


### PR DESCRIPTION
**Description:** 
This PR cleans up all the places that need to convert the v1alpha1 type to the v1alpha2 by minimizing the calls to the conversion function. Other than the type changes all over, the main thing that changed is the tests which previously built a whole params object, which really only needed to build a collector object.

**Link to tracking Issue:** closes https://github.com/open-telemetry/opentelemetry-operator/issues/2592

**Testing:** unit testing

**Documentation:** N/A
