### PR TITLE
[Chore] Update test to use multiarch image.

### DIFF
--- a/tests/e2e/smoke-pod-labels/00-assert.yaml
+++ b/tests/e2e/smoke-pod-labels/00-assert.yaml
@@ -1,12 +1,28 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: testlabel-collector
   labels:
     app.kubernetes.io/component: opentelemetry-collector
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/name: testlabel-collector
     app.kubernetes.io/part-of: opentelemetry
-    app.kubernetes.io/version: a0c6dea261b3d794971c23c5665173a39f0ce2aa09b9d88b753bd46776d7b05
+    app.kubernetes.io/version: 0.94.0
+  name: testlabel-collector
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: testlabel-collector
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: 0.94.0
 status:
+  availableReplicas: 1
   readyReplicas: 1
+  replicas: 1

--- a/tests/e2e/smoke-pod-labels/00-install.yaml
+++ b/tests/e2e/smoke-pod-labels/00-install.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: testlabel
 spec:
-  image: otel/opentelemetry-collector-contrib@sha256:a0c6dea261b3d794971c23c5665173a39f0ce2aa09b9d88b753bd46776d7b05b
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.94.0
   config: |
     receivers:
       otlp:


### PR DESCRIPTION
**Description:**

Fix smoke-pod-labels test case to use multiarch collector image so that we can run the test on non-amd64 clusters. 

**Testing:** 

Tested on a ARM cluster.

--- PASS: kuttl (17.78s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/smoke-pod-labels (12.73s)
PASS