### PR TITLE
Ensure unique names for ClusterRoles in e2e tests

### DIFF
--- a/tests/e2e-prometheuscr/create-sm-prometheus-exporters/08-install.yaml
+++ b/tests/e2e-prometheuscr/create-sm-prometheus-exporters/08-install.yaml
@@ -8,7 +8,7 @@ automountServiceAccountToken: true
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ta
+  name: create-sm-prometheus
 rules:
 - apiGroups: [""]
   resources:
@@ -60,7 +60,7 @@ rules:
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl create clusterrolebinding simplest-targetallocator-create-sm-prometheus --clusterrole=ta --serviceaccount=create-sm-prometheus:ta
+  - command: kubectl create clusterrolebinding simplest-targetallocator-create-sm-prometheus --clusterrole=create-sm-prometheus --serviceaccount=create-sm-prometheus:ta
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector

--- a/tests/e2e/prometheus-config-validation/00-promreceiver-allocatorconfig.yaml
+++ b/tests/e2e/prometheus-config-validation/00-promreceiver-allocatorconfig.yaml
@@ -7,7 +7,7 @@ automountServiceAccountToken: true
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pod-view
+  name: promreceiver-allocatorconfig
 rules:
 - apiGroups: [""]
   resources: [ "pods", "namespaces" ]
@@ -16,7 +16,7 @@ rules:
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl -n $NAMESPACE create clusterrolebinding default-view-$NAMESPACE --clusterrole=pod-view --serviceaccount=$NAMESPACE:ta
+  - command: kubectl -n $NAMESPACE create clusterrolebinding default-view-$NAMESPACE --clusterrole=promreceiver-allocatorconfig --serviceaccount=$NAMESPACE:ta
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector

--- a/tests/e2e/smoke-targetallocator/00-install.yaml
+++ b/tests/e2e/smoke-targetallocator/00-install.yaml
@@ -7,7 +7,7 @@ automountServiceAccountToken: true
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: pod-view
+  name: smoke-targetallocator
 rules:
 - apiGroups: [""]
   resources: [ "pods", "namespaces" ]
@@ -16,7 +16,7 @@ rules:
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl -n $NAMESPACE create clusterrolebinding default-view-$NAMESPACE --clusterrole=pod-view --serviceaccount=$NAMESPACE:ta
+  - command: kubectl -n $NAMESPACE create clusterrolebinding default-view-$NAMESPACE --clusterrole=smoke-targetallocator --serviceaccount=$NAMESPACE:ta
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: OpenTelemetryCollector


### PR DESCRIPTION
ClusterRoles with the same name in different tests can cause hard to debug test failures due to race conditions. With this fix, all ClusterRoles have unique names.
