### PR TITLE
[chore] Automate adding release notes to the release

### DIFF
--- a/.ci/create-release-github.sh
+++ b/.ci/create-release-github.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
-OPERATOR_VERSION=$(git describe --tags)
+NOTES_FILE=/tmp/notes.md
+OPERATOR_VERSION=$(git describe --tags --abbrev=0)
+PREVIOUS_OPERATOR_VERSION=$(git describe --tags --abbrev=0 "${OPERATOR_VERSION}^")
+# Note: Changelog headers don't have the `v` prefix, so we need to drop the first letter in the sed expression below
+sed -n "/${OPERATOR_VERSION:1}/,/${PREVIOUS_OPERATOR_VERSION:1}/{/${PREVIOUS_OPERATOR_VERSION:1}/!p;}" CHANGELOG.md >${NOTES_FILE}
 
 gh config set prompt disabled
 gh release create \
     -t "Release ${OPERATOR_VERSION}" \
+    --notes-file ${NOTES_FILE} \
     "${OPERATOR_VERSION}" \
     'dist/opentelemetry-operator.yaml#Installation manifest for Kubernetes'


### PR DESCRIPTION
Automatically add release notes to the release generated by the CI. This is done in a very simple way, by using sed to cut out the relevant lines from the changelog based on current and previous release tags. Here's a release I generated using this script: https://github.com/swiatekm-sumo/opentelemetry-operator/releases/tag/v0.94.0.
