### PR TITLE
Draft: Add check for watch_namespace before mutating Pod

### DIFF
--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -59,6 +59,7 @@ type Config struct {
 	openshiftRoutesAvailability         openshift.RoutesAvailability
 	labelsFilter                        []string
 	annotationsFilter                   []string
+	namespaces                          []string
 }
 
 // New constructs a new configuration based on the given options.
@@ -101,6 +102,7 @@ func New(opts ...Option) Config {
 		autoInstrumentationNginxImage:       o.autoInstrumentationNginxImage,
 		labelsFilter:                        o.labelsFilter,
 		annotationsFilter:                   o.annotationsFilter,
+		namespaces:                          o.namespaces,
 	}
 }
 
@@ -224,4 +226,9 @@ func (c *Config) LabelsFilter() []string {
 // AnnotationsFilter Returns the filters converted to regex strings used to filter out unwanted labels from propagations.
 func (c *Config) AnnotationsFilter() []string {
 	return c.annotationsFilter
+}
+
+// Namespaces Returns the namespaces to be watched.
+func (c *Config) Namespaces() []string {
+	return c.namespaces
 }

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -54,6 +54,7 @@ type options struct {
 	openshiftRoutesAvailability         openshift.RoutesAvailability
 	labelsFilter                        []string
 	annotationsFilter                   []string
+	namespaces                          []string
 }
 
 func WithAutoDetect(a autodetect.AutoDetect) Option {
@@ -223,5 +224,11 @@ func WithAnnotationFilters(annotationFilters []string) Option {
 			filters = append(filters, result.String())
 		}
 		o.annotationsFilter = filters
+	}
+}
+
+func WithNamespaces(namespaces []string) Option {
+	return func(o *options) {
+		o.namespaces = namespaces
 	}
 }

--- a/internal/webhook/podmutation/webhookhandler.go
+++ b/internal/webhook/podmutation/webhookhandler.go
@@ -18,14 +18,15 @@ package podmutation
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"slices"
+
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"slices"
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 )

--- a/main.go
+++ b/main.go
@@ -19,11 +19,12 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"runtime"
 	"strings"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"

--- a/tests/e2e-watch-namespace/00-install-collector.yaml
+++ b/tests/e2e-watch-namespace/00-install-collector.yaml
@@ -1,0 +1,24 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: deployment
+  namespace: opentelemetry-operator-system
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+
+    exporters:
+      debug:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]
+  mode: deployment

--- a/tests/e2e-watch-namespace/00-install-instrumentation.yaml
+++ b/tests/e2e-watch-namespace/00-install-instrumentation.yaml
@@ -1,0 +1,8 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: deployment
+  namespace: opentelemetry-operator-system
+spec:
+  exporter:
+    endpoint: http://deployment-collector.opentelemetry-operator-system:4317

--- a/tests/e2e-watch-namespace/01-deployment.yaml
+++ b/tests/e2e-watch-namespace/01-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deploy
+spec:
+  selector:
+    matchLabels:
+      app: my-deploy
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: my-deploy
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "opentelemetry-operator-system/deployment"
+    spec:
+      containers:
+      - name: myapp
+        image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-java:main

--- a/tests/e2e-watch-namespace/not-watch-ns/01-assert.yaml
+++ b/tests/e2e-watch-namespace/not-watch-ns/01-assert.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    instrumentation.opentelemetry.io/inject-java: "opentelemetry-operator-system/deployment"
+  labels:
+    app: my-deploy
+spec:
+  (initContainers == null): true
+  (length(containers)): 1
+  containers:
+    - name: myapp
+      (env == null): true
+

--- a/tests/e2e-watch-namespace/not-watch-ns/chainsaw-test.yaml
+++ b/tests/e2e-watch-namespace/not-watch-ns/chainsaw-test.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: not-watch-ns
+spec:
+  namespace: not-watch-ns
+  steps:
+    - name: step-00
+      skipDelete: true
+      try:
+        # when running in parallel it seems to conflict a bit on both tests creating the collector
+        # opentelemetrycollectors.opentelemetry.io "deployment" already exists
+        - sleep:
+            duration: 5s
+
+        - apply:
+            file: ../00-install-collector.yaml
+        - apply:
+            file: ../00-install-instrumentation.yaml
+        # wait not working :-(
+        - sleep:
+            duration: 10s
+    # Deployment
+    - name: step-01
+      try:
+        - apply:
+            file: ../01-deployment.yaml
+        - assert:
+            timeout: 60s
+            file: 01-assert.yaml
+      catch:
+        - podLogs:
+            selector: app=my-deploy

--- a/tests/e2e-watch-namespace/watch-ns/01-assert.yaml
+++ b/tests/e2e-watch-namespace/watch-ns/01-assert.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    instrumentation.opentelemetry.io/inject-java: "opentelemetry-operator-system/deployment"
+  labels:
+    app: my-deploy
+spec:
+  initContainers:
+    - name: opentelemetry-auto-instrumentation-java
+      (volumeMounts[?name == 'opentelemetry-auto-instrumentation-java']):
+        - name: opentelemetry-auto-instrumentation-java
+          mountPath: /otel-auto-instrumentation-java
+  (containers[?name == 'myapp']):
+  - name: myapp
+    env:
+    - name: OTEL_NODE_IP
+    - name: OTEL_POD_IP
+    - name: JAVA_TOOL_OPTIONS
+    - name: OTEL_SERVICE_NAME
+      value: my-deploy
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://deployment-collector.opentelemetry-operator-system:4317
+    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+    - name: OTEL_RESOURCE_ATTRIBUTES
+    (volumeMounts[?name == 'opentelemetry-auto-instrumentation-java']):
+      - name: opentelemetry-auto-instrumentation-java
+        mountPath: /otel-auto-instrumentation-java
+  (volumes[?name == 'opentelemetry-auto-instrumentation-java']):
+    - name: opentelemetry-auto-instrumentation-java
+      emptyDir: {}

--- a/tests/e2e-watch-namespace/watch-ns/chainsaw-test.yaml
+++ b/tests/e2e-watch-namespace/watch-ns/chainsaw-test.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: watch-ns
+spec:
+  namespace: watch-ns
+  steps:
+    - name: step-00
+      skipDelete: true
+      try:
+        - apply:
+            file: ../00-install-collector.yaml
+        - apply:
+            file: ../00-install-instrumentation.yaml
+        # wait not working :-(
+        - sleep:
+            duration: 10s
+#        - command:
+#            entrypoint: kubectl
+#            args:
+#              - wait
+#              - pods
+#              - --for
+#              - condition=Ready="true"
+#              - -l
+#              - app.kubernetes.io/name=deployment-collector
+#              - -n
+#              - opentelemetry-operator-system
+#              - --timeout
+#              - 10s
+##              - 1m
+#              - -v
+#              - '8'
+#        - wait:
+#            resource: pods
+#            selector: 'app.kubernetes.io/name=deployment-collector'
+#            timeout: 10s
+#            namespace: opentelemetry-operator-system
+#            for:
+#              condition:
+#                name: Ready
+#                value: 'true'
+    # Deployment
+    - name: step-01
+      try:
+        - apply:
+            file: ../01-deployment.yaml
+        - assert:
+            timeout: 60s
+            file: 01-assert.yaml
+      catch:
+        - podLogs:
+            selector: app=my-deploy


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

We have a scenario where in some environment (e.g. dev) the same helm chart is deployed across many different personal namespaces. While we keep the exact same helm chart config all around we were using the `WATCH_NAMESPACES` env var to restrict the operator to only a few namespaces that were relevant.

However, we noticed that the operator was still trying to get other namespaces and failing with them because it was not in the list of watched (cache key). This was leaving the pod with instrumentation that seemed incomplete.


Stack message:

```
{"level":"error","ts":"2024-02-23T07:19:40Z","msg":"failed to get replicaset","replicaset":"...","namespace":"..","error":"unable to get:.../... because of unknown namespace for the cache","stacktrace":"github.com/open-telemetry/opentelemetry-operator/pkg/instrumentation.(*sdkInjector).addParentResourceLabels
pkg/instrumentation/sdk.go:481
github.com/open-telemetry/opentelemetry-operator/pkg/instrumentation.(*sdkInjector).createResourceMap
pkg/instrumentation/sdk.go:448
github.com/open-telemetry/opentelemetry-operator/pkg/instrumentation.(*sdkInjector).injectCommonSDKConfig
pkg/instrumentation/sdk.go:255
github.com/open-telemetry/opentelemetry-operator/pkg/instrumentation.(*sdkInjector).inject
pkg/instrumentation/sdk.go:74
github.com/open-telemetry/opentelemetry-operator/pkg/instrumentation.(*instPodMutator).Mutate
pkg/instrumentation/podmutator.go:360
github.com/open-telemetry/opentelemetry-operator/internal/webhook/podmutation.(*podMutationWebhook).Handle
internal/webhook/podmutation/webhookhandler.go:92
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle
/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.0/pkg/webhook/admission/webhook.go:169
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP
/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.0/pkg/webhook/admission/http.go:119
sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics.InstrumentedHook.InstrumentHandlerInFlight.func1
/home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.18.0/prometheus/promhttp/instrument_server.go:60
net/http.HandlerFunc.ServeHTTP
/opt/hostedtoolcache/go/1.21.6/x64/src/net/http/server.go:2136
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1
/home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.18.0/prometheus/promhttp/instrument_server.go:147
net/http.HandlerFunc.ServeHTTP
/opt/hostedtoolcache/go/1.21.6/x64/src/net/http/server.go:2136
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2
/home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.18.0/prometheus/promhttp/instrument_server.go:109
net/http.HandlerFunc.ServeHTTP
/opt/hostedtoolcache/go/1.21.6/x64/src/net/http/server.go:2136
net/http.(*ServeMux).ServeHTTP
/opt/hostedtoolcache/go/1.21.6/x64/src/net/http/server.go:2514
net/http.serverHandler.ServeHTTP
/opt/hostedtoolcache/go/1.21.6/x64/src/net/http/server.go:2938
net/http.(*conn).serve
/opt/hostedtoolcache/go/1.21.6/x64/src/net/http/server.go:2009"}

```

In this PR we will start to check the watch_namespaces before trying to mutate the pods.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/2668

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
