### PR TITLE
[chore] .NET OTel AutoInstrumentation - multistage docker image build

### DIFF
--- a/autoinstrumentation/dotnet/Dockerfile
+++ b/autoinstrumentation/dotnet/Dockerfile
@@ -14,7 +14,7 @@
 #  - For auto-instrumentation by container injection, the Linux command cp is
 #    used and must be availabe in the image.
 
-FROM busybox
+FROM busybox as downloader
 
 ARG version
 
@@ -27,3 +27,7 @@ RUN unzip opentelemetry-dotnet-instrumentation-linux-glibc.zip &&\
     unzip opentelemetry-dotnet-instrumentation-linux-musl.zip "linux-musl-x64/*" -d . &&\
     rm opentelemetry-dotnet-instrumentation-linux-glibc.zip opentelemetry-dotnet-instrumentation-linux-musl.zip &&\
     chmod -R go+r .
+
+FROM busybox
+
+COPY --from=downloader /autoinstrumentation /autoinstrumentation


### PR DESCRIPTION
**Description:** Change the way how the .NET OTel auto docker image is build.
It reduces image size by 16 of 57 to 41 mb.
Final layer does not contain zip files.

**Link to tracking Issue(s):** N/A

- Resolves: N/A

**Testing:** Compare images build by the new and old way.

**Documentation:** N/A
