### PR TITLE
ci: create release based on changes to versions.txt

### DIFF
--- a/.ci/create-release-github.sh
+++ b/.ci/create-release-github.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
 NOTES_FILE=/tmp/notes.md
-OPERATOR_VERSION=$(git describe --tags --abbrev=0)
-PREVIOUS_OPERATOR_VERSION=$(git describe --tags --abbrev=0 "${OPERATOR_VERSION}^")
-# Note: Changelog headers don't have the `v` prefix, so we need to drop the first letter in the sed expression below
-sed -n "/${OPERATOR_VERSION:1}/,/${PREVIOUS_OPERATOR_VERSION:1}/{/${PREVIOUS_OPERATOR_VERSION:1}/!p;}" CHANGELOG.md >${NOTES_FILE}
+# Note: We expect the versions to not have the `v` prefix here
+sed -n "/${DESIRED_VERSION}/,/${CURRENT_VERSION}/{/${CURRENT_VERSION}/!p;}" CHANGELOG.md >${NOTES_FILE}
 
 gh config set prompt disabled
 gh release create \
-    -t "Release ${OPERATOR_VERSION}" \
+    -t "Release v${DESIRED_VERSION}" \
     --notes-file ${NOTES_FILE} \
-    "${OPERATOR_VERSION}" \
+    --draft \
+    "v${DESIRED_VERSION}" \
     'dist/opentelemetry-operator.yaml#Installation manifest for Kubernetes'

--- a/.github/workflows/publish-operator-hub.yaml
+++ b/.github/workflows/publish-operator-hub.yaml
@@ -1,0 +1,21 @@
+name: "Publish release on operator hub"
+on:
+  release:
+    types: [published]
+
+jobs:
+  operator-hub-prod-release:
+    uses: ./.github/workflows/reusable-operator-hub-release.yaml
+    with:
+      org: redhat-openshift-ecosystem
+      repo: community-operators-prod
+    secrets:
+      OPENTELEMETRYBOT_GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+
+  operator-hub-community-release:
+    uses: ./.github/workflows/reusable-operator-hub-release.yaml
+    with:
+      org: k8s-operatorhub
+      repo: community-operators
+    secrets:
+      OPENTELEMETRYBOT_GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,21 +1,45 @@
-name: "Prepare the release"
+name: "Create the release"
 on:
   push:
-    tags: [ 'v*' ]
+    branches:
+      - 'release/**'
+      - 'main'
+    paths:
+      - 'versions.txt'
 
 jobs:
+  get-versions:
+    runs-on: ubuntu-22.04
+    outputs:
+      current_version: ${{ steps.get-versions.outputs.current_version }}
+      desired_version: ${{ steps.get-versions.outputs.desired_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: "Get versions from versions.txt"
+        id: get-versions
+        run: |
+          echo "desired_version=$(grep -v '#' versions.txt | grep operator= | awk -F= '{print $2}')" >> $GITHUB_OUTPUT
+          echo "current_version=$(git describe --tags --abbrev=0 | sed 's/^v//')" >> $GITHUB_OUTPUT
+
   release:
     runs-on: ubuntu-22.04
+    needs: get-versions
+    if: needs.get-versions.outputs.desired_version != needs.get-versions.outputs.current_version
+    env:
+      CURRENT_VERSION: ${{ needs.get-versions.outputs.current_version }}
+      DESIRED_VERSION: ${{ needs.get-versions.outputs.desired_version }}
     steps:
+    - uses: actions/checkout@v4
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: "~1.21.1"
 
-    - uses: actions/checkout@v4
-
     - name: "generate release resources"
-      run: make release-artifacts IMG_PREFIX="ghcr.io/open-telemetry/opentelemetry-operator"
+      run: make release-artifacts IMG_PREFIX="ghcr.io/open-telemetry/opentelemetry-operator" VERSION=${DESIRED_VERSION}
 
     - name: "create the release in GitHub"
       env:
@@ -24,23 +48,4 @@ jobs:
 
     - name: "refresh go proxy module info on release"
       run: |
-        OPERATOR_VERSION=$(git describe --tags)
-        curl https://proxy.golang.org/github.com/open-telemetry/opentelemetry-operator/@v/${OPERATOR_VERSION}.info
-
-  operator-hub-prod-release:
-    needs: release
-    uses: ./.github/workflows/reusable-operator-hub-release.yaml
-    with:
-      org: redhat-openshift-ecosystem
-      repo: community-operators-prod
-    secrets:
-      OPENTELEMETRYBOT_GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
-
-  operator-hub-community-release:
-    needs: release
-    uses: ./.github/workflows/reusable-operator-hub-release.yaml
-    with:
-      org: k8s-operatorhub
-      repo: community-operators
-    secrets:
-      OPENTELEMETRYBOT_GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+        curl https://proxy.golang.org/github.com/open-telemetry/opentelemetry-operator/@v/${DESIRED_VERSION}.info

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,8 +15,7 @@ Steps to release a new version of the OpenTelemetry Operator:
 3. Update release schedule table, by moving the current release manager to the end of the table with updated release version.
 3. Add the changes to the changelog by running `make chlog-update VERSION=$VERSION`.
 3. Check the OpenTelemetry Collector's changelog and ensure migration steps are present in `pkg/collector/upgrade`
-3. Once the changes above are merged and available in `main`, one of the maintainers will tag the release.
-3. The GitHub Workflow will take it from here, creating a GitHub release with the generated artifacts (manifests) and publishing the images.
+3. Once the changes above are merged and available in `main`, a draft release will be automatically created. Publish it once the release workflows all complete. 
 3. Update the operator version in the Helm Chart, as per the [release guide](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/CONTRIBUTING.md)
 3. The GitHub Workflow, submits two pull requests to the Operator hub repositories. Make sure the pull requests are approved and merged.
    - `community-operators-prod` is used by OLM on OpenShift. Example: [`operator-framework/community-operators-prod`](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/494)


### PR DESCRIPTION
Automatically create a draft release if the latest tagged version and the version from versions.txt don't match. This changes the release workflow dependencies a bit.

Right now we have:
* Create release job is triggered on tag.
* When it succeeds, the operatorhub publishing job runs in the same workflow.
* All the other jobs are independently triggered on tag.

After this change:
* Create release is triggered on changes to `version.txt` in `main`.
* If needed, it creates a draft release and tag.
* Other jobs are triggered by the tag.
* Once the release manager publishes the release, this triggers the operatorhub publishing workflow.
