### PR TITLE
fix(targetallocator): support endpointslice (fixes #2718)

### DIFF
--- a/cmd/otel-allocator/allocation/per_node_test.go
+++ b/cmd/otel-allocator/allocation/per_node_test.go
@@ -31,7 +31,7 @@ func TestAllocationPerNode(t *testing.T) {
 	// prepare allocator with initial targets and collectors
 	s, _ := New("per-node", loggerPerNode)
 
-	cols := MakeNCollectors(3, 0)
+	cols := MakeNCollectors(4, 0)
 	s.SetCollectors(cols)
 	firstLabels := model.LabelSet{
 		"test":                            "test1",
@@ -45,14 +45,23 @@ func TestAllocationPerNode(t *testing.T) {
 	thirdLabels := model.LabelSet{
 		"test": "test3",
 	}
+	// endpointslice target kind and name
+	fourthLabels := model.LabelSet{
+		"test": "test4",
+		"__meta_kubernetes_endpointslice_address_target_kind": "Node",
+		"__meta_kubernetes_endpointslice_address_target_name": "node-3",
+	}
+
 	firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstLabels, "")
 	secondTarget := target.NewItem("sample-name", "0.0.0.0:8000", secondLabels, "")
 	thirdTarget := target.NewItem("sample-name", "0.0.0.0:8000", thirdLabels, "")
+	fourthTarget := target.NewItem("sample-name", "0.0.0.0:8000", fourthLabels, "")
 
 	targetList := map[string]*target.Item{
 		firstTarget.Hash():  firstTarget,
 		secondTarget.Hash(): secondTarget,
 		thirdTarget.Hash():  thirdTarget,
+		fourthTarget.Hash(): fourthTarget,
 	}
 
 	// test that targets and collectors are added properly

--- a/cmd/otel-allocator/target/target.go
+++ b/cmd/otel-allocator/target/target.go
@@ -24,11 +24,15 @@ import (
 // nodeLabels are labels that are used to identify the node on which the given
 // target is residing. To learn more about these labels, please refer to:
 // https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config
-var nodeLabels = []model.LabelName{
-	"__meta_kubernetes_pod_node_name",
-	"__meta_kubernetes_node_name",
-	"__meta_kubernetes_endpoint_node_name",
-}
+var (
+	nodeLabels = []model.LabelName{
+		"__meta_kubernetes_pod_node_name",
+		"__meta_kubernetes_node_name",
+		"__meta_kubernetes_endpoint_node_name",
+	}
+	endpointSliceTargetKindLabel model.LabelName = "__meta_kubernetes_endpointslice_address_target_kind"
+	endpointSliceTargetNameLabel model.LabelName = "__meta_kubernetes_endpointslice_address_target_name"
+)
 
 // LinkJSON This package contains common structs and methods that relate to scrape targets.
 type LinkJSON struct {
@@ -55,7 +59,11 @@ func (t *Item) GetNodeName() string {
 		}
 	}
 
-	return ""
+	if val := t.Labels[endpointSliceTargetKindLabel]; val != "Node" {
+		return ""
+	}
+
+	return string(t.Labels[endpointSliceTargetNameLabel])
 }
 
 // NewItem Creates a new target item.


### PR DESCRIPTION
**Description:** <Describe what has changed.>

The standard setup for collecting kubelet metrics, using a service with no selector to point at each node, results in targets without the `__meta_kubernetes_endpoint_node_name` label, instead it includes:

```yaml
labels:
  "__meta_kubernetes_endpointslice_address_target_kind": "Node"
  "__meta_kubernetes_endpointslice_address_target_name": "mynode"
```

This update handles this situation.

**Link to tracking Issue(s):** 
- Resolves: #2718

**Testing:**
Unit tests added

**Documentation:**
None needed (this is a fix to existing functionality)
