### PR TITLE
Generate target allocator manifests from TargetAllocator CR

### DIFF
--- a/controllers/builder_test.go
+++ b/controllers/builder_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
 
@@ -1350,6 +1351,7 @@ collector_selector:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
+  matchexpressions: []
 config:
   scrape_configs:
   - job_name: example
@@ -1408,7 +1410,7 @@ prometheus_cr:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "59307aaa5652c8723f7803aa2d2b631389d1a0267444a4a8dc559878b5c4aa2c",
+									"opentelemetry-targetallocator-config/hash": "ba38217bad7e399f1210b90a464252159a8c4e17060c246799b8e4cb29a6f18f",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -1747,6 +1749,7 @@ collector_selector:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
+  matchexpressions: []
 config:
   scrape_configs:
   - job_name: example
@@ -1805,7 +1808,7 @@ prometheus_cr:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "59307aaa5652c8723f7803aa2d2b631389d1a0267444a4a8dc559878b5c4aa2c",
+									"opentelemetry-targetallocator-config/hash": "ba38217bad7e399f1210b90a464252159a8c4e17060c246799b8e4cb29a6f18f",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -1972,10 +1975,13 @@ prometheus_cr:
 				Config:  cfg,
 				OtelCol: tt.args.instance,
 			}
+			targetAllocator, err := collector.TargetAllocator(params)
+			require.NoError(t, err)
+			params.TargetAllocator = *targetAllocator
 			if len(tt.featuregates) > 0 {
 				fg := strings.Join(tt.featuregates, ",")
 				flagset := featuregate.Flags(colfeaturegate.GlobalRegistry())
-				if err := flagset.Set(featuregate.FeatureGatesFlag, fg); err != nil {
+				if err = flagset.Set(featuregate.FeatureGatesFlag, fg); err != nil {
 					t.Errorf("featuregate setting error = %v", err)
 					return
 				}

--- a/controllers/reconcile_test.go
+++ b/controllers/reconcile_test.go
@@ -451,8 +451,8 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 							assert.NoError(t, err)
 
 							taConfig := make(map[interface{}]interface{})
-							taConfig["collector_selector"] = map[string]any{
-								"matchlabels": map[string]string{
+							taConfig["collector_selector"] = metav1.LabelSelector{
+								MatchLabels: map[string]string{
 									"app.kubernetes.io/instance":   "default.test",
 									"app.kubernetes.io/managed-by": "opentelemetry-operator",
 									"app.kubernetes.io/component":  "opentelemetry-collector",

--- a/internal/manifests/targetallocator/annotations.go
+++ b/internal/manifests/targetallocator/annotations.go
@@ -26,7 +26,7 @@ import (
 const configMapHashAnnotationKey = "opentelemetry-targetallocator-config/hash"
 
 // Annotations returns the annotations for the TargetAllocator Pod.
-func Annotations(instance v1beta1.OpenTelemetryCollector, configMap *v1.ConfigMap) map[string]string {
+func Annotations(instance v1beta1.TargetAllocator, configMap *v1.ConfigMap) map[string]string {
 	// Make a copy of PodAnnotations to be safe
 	annotations := make(map[string]string, len(instance.Spec.PodAnnotations))
 	for key, value := range instance.Spec.PodAnnotations {

--- a/internal/manifests/targetallocator/annotations_test.go
+++ b/internal/manifests/targetallocator/annotations_test.go
@@ -23,13 +23,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
 func TestPodAnnotations(t *testing.T) {
-	instance := collectorInstance()
+	instance := targetAllocatorInstance()
 	instance.Spec.PodAnnotations = map[string]string{
 		"key": "value",
 	}
@@ -39,26 +38,27 @@ func TestPodAnnotations(t *testing.T) {
 
 func TestConfigMapHash(t *testing.T) {
 	cfg := config.New()
-	instance := collectorInstance()
+	collector := collectorInstance()
+	targetAllocator := targetAllocatorInstance()
 	params := manifests.Params{
-		OtelCol: instance,
-		Config:  cfg,
-		Log:     logr.Discard(),
+		OtelCol:         collector,
+		TargetAllocator: targetAllocator,
+		Config:          cfg,
+		Log:             logr.Discard(),
 	}
 	expectedConfigMap, err := ConfigMap(params)
 	require.NoError(t, err)
 	expectedConfig := expectedConfigMap.Data[targetAllocatorFilename]
 	require.NotEmpty(t, expectedConfig)
 	expectedHash := sha256.Sum256([]byte(expectedConfig))
-	annotations := Annotations(instance, expectedConfigMap)
+	annotations := Annotations(targetAllocator, expectedConfigMap)
 	require.Contains(t, annotations, configMapHashAnnotationKey)
 	cmHash := annotations[configMapHashAnnotationKey]
 	assert.Equal(t, fmt.Sprintf("%x", expectedHash), cmHash)
 }
 
 func TestInvalidConfigNoHash(t *testing.T) {
-	instance := collectorInstance()
-	instance.Spec.Config = v1beta1.Config{}
+	instance := targetAllocatorInstance()
 	annotations := Annotations(instance, nil)
 	require.NotContains(t, annotations, configMapHashAnnotationKey)
 }

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -21,9 +21,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/targetallocator/adapters"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
@@ -32,61 +29,50 @@ const (
 )
 
 func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
-	name := naming.TAConfigMap(params.OtelCol.Name)
-	labels := Labels(params.OtelCol, name)
-	// TODO: https://github.com/open-telemetry/opentelemetry-operator/issues/2603
-	cfgStr, err := params.OtelCol.Spec.Config.Yaml()
-	if err != nil {
-		return &corev1.ConfigMap{}, err
-	}
-
-	// Collector supports environment variable substitution, but the TA does not.
-	// TA ConfigMap should have a single "$", as it does not support env var substitution
-	prometheusReceiverConfig, err := adapters.UnescapeDollarSignsInPromConfig(cfgStr)
-	if err != nil {
-		return &corev1.ConfigMap{}, err
-	}
+	instance := params.TargetAllocator
+	name := naming.TAConfigMap(instance.Name)
+	labels := Labels(instance, name)
+	taSpec := instance.Spec
 
 	taConfig := make(map[interface{}]interface{})
 	prometheusCRConfig := make(map[interface{}]interface{})
-	collectorSelectorLabels := manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, collector.ComponentOpenTelemetryCollector)
-	taConfig["collector_selector"] = map[string]any{
-		"matchlabels": collectorSelectorLabels,
-	}
+	taConfig["collector_selector"] = taSpec.CollectorSelector
 	// The below instruction is here for compatibility with the previous target allocator version
 	// TODO: Drop it after 3 more versions
-	taConfig["label_selector"] = collectorSelectorLabels
-	// We only take the "config" from the returned object, if it's present
-	if prometheusConfig, ok := prometheusReceiverConfig["config"]; ok {
-		taConfig["config"] = prometheusConfig
+	taConfig["label_selector"] = taSpec.CollectorSelector.MatchLabels
+
+	// Add scrape configs if present
+	if instance.Spec.ScrapeConfigs != nil {
+		taConfig["config"] = map[string]interface{}{
+			"scrape_configs": instance.Spec.ScrapeConfigs,
+		}
 	}
 
-	if len(params.OtelCol.Spec.TargetAllocator.AllocationStrategy) > 0 {
-		taConfig["allocation_strategy"] = params.OtelCol.Spec.TargetAllocator.AllocationStrategy
+	if len(taSpec.AllocationStrategy) > 0 {
+		taConfig["allocation_strategy"] = taSpec.AllocationStrategy
 	} else {
 		taConfig["allocation_strategy"] = v1beta1.TargetAllocatorAllocationStrategyConsistentHashing
 	}
+	taConfig["filter_strategy"] = taSpec.FilterStrategy
 
-	taConfig["filter_strategy"] = params.OtelCol.Spec.TargetAllocator.FilterStrategy
-
-	if params.OtelCol.Spec.TargetAllocator.PrometheusCR.ScrapeInterval.Size() > 0 {
-		prometheusCRConfig["scrape_interval"] = params.OtelCol.Spec.TargetAllocator.PrometheusCR.ScrapeInterval.Duration
+	if taSpec.PrometheusCR.ScrapeInterval.Size() > 0 {
+		prometheusCRConfig["scrape_interval"] = taSpec.PrometheusCR.ScrapeInterval.Duration
 	}
 
-	prometheusCRConfig["service_monitor_selector"] = params.OtelCol.Spec.TargetAllocator.PrometheusCR.ServiceMonitorSelector
+	prometheusCRConfig["service_monitor_selector"] = taSpec.PrometheusCR.ServiceMonitorSelector
 
 	// The below instruction is here for compatibility with the previous target allocator version
 	// TODO: Drop it after 3 more versions
-	if params.OtelCol.Spec.TargetAllocator.PrometheusCR.ServiceMonitorSelector != nil {
-		taConfig["service_monitor_selector"] = &params.OtelCol.Spec.TargetAllocator.PrometheusCR.ServiceMonitorSelector.MatchLabels
+	if taSpec.PrometheusCR.ServiceMonitorSelector != nil {
+		taConfig["service_monitor_selector"] = &taSpec.PrometheusCR.ServiceMonitorSelector.MatchLabels
 	}
 
-	prometheusCRConfig["pod_monitor_selector"] = params.OtelCol.Spec.TargetAllocator.PrometheusCR.PodMonitorSelector
+	prometheusCRConfig["pod_monitor_selector"] = taSpec.PrometheusCR.PodMonitorSelector
 
 	// The below instruction is here for compatibility with the previous target allocator version
 	// TODO: Drop it after 3 more versions
-	if params.OtelCol.Spec.TargetAllocator.PrometheusCR.PodMonitorSelector != nil {
-		taConfig["pod_monitor_selector"] = &params.OtelCol.Spec.TargetAllocator.PrometheusCR.PodMonitorSelector.MatchLabels
+	if taSpec.PrometheusCR.PodMonitorSelector != nil {
+		taConfig["pod_monitor_selector"] = &taSpec.PrometheusCR.PodMonitorSelector.MatchLabels
 	}
 
 	if len(prometheusCRConfig) > 0 {
@@ -101,9 +87,9 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   params.OtelCol.Namespace,
+			Namespace:   instance.Namespace,
 			Labels:      labels,
-			Annotations: params.OtelCol.Annotations,
+			Annotations: instance.Annotations,
 		},
 		Data: map[string]string{
 			targetAllocatorFilename: string(taConfigYAML),

--- a/internal/manifests/targetallocator/container.go
+++ b/internal/manifests/targetallocator/container.go
@@ -26,8 +26,8 @@ import (
 )
 
 // Container builds a container for the given TargetAllocator.
-func Container(cfg config.Config, logger logr.Logger, otelcol v1beta1.OpenTelemetryCollector) corev1.Container {
-	image := otelcol.Spec.TargetAllocator.Image
+func Container(cfg config.Config, logger logr.Logger, instance v1beta1.TargetAllocator) corev1.Container {
+	image := instance.Spec.Image
 	if len(image) == 0 {
 		image = cfg.TargetAllocatorImage()
 	}
@@ -44,8 +44,8 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1beta1.OpenTeleme
 		MountPath: "/conf",
 	}}
 
-	var envVars = otelcol.Spec.TargetAllocator.Env
-	if otelcol.Spec.TargetAllocator.Env == nil {
+	var envVars = instance.Spec.Env
+	if envVars == nil {
 		envVars = []corev1.EnvVar{}
 	}
 
@@ -67,7 +67,7 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1beta1.OpenTeleme
 	}
 
 	var args []string
-	if otelcol.Spec.TargetAllocator.PrometheusCR.Enabled {
+	if instance.Spec.PrometheusCR.Enabled {
 		args = append(args, "--enable-prometheus-cr-watcher")
 	}
 	readinessProbe := &corev1.Probe{
@@ -94,10 +94,10 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1beta1.OpenTeleme
 		Ports:           ports,
 		Env:             envVars,
 		VolumeMounts:    volumeMounts,
-		Resources:       otelcol.Spec.TargetAllocator.Resources,
+		Resources:       instance.Spec.Resources,
 		Args:            args,
 		LivenessProbe:   livenessProbe,
 		ReadinessProbe:  readinessProbe,
-		SecurityContext: otelcol.Spec.TargetAllocator.SecurityContext,
+		SecurityContext: instance.Spec.SecurityContext,
 	}
 }

--- a/internal/manifests/targetallocator/container_test.go
+++ b/internal/manifests/targetallocator/container_test.go
@@ -34,11 +34,11 @@ var logger = logf.Log.WithName("unit-tests")
 
 func TestContainerNewDefault(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{}
+	targetAllocator := v1beta1.TargetAllocator{}
 	cfg := config.New(config.WithTargetAllocatorImage("default-image"))
 
 	// test
-	c := Container(cfg, logger, otelcol)
+	c := Container(cfg, logger, targetAllocator)
 
 	// verify
 	assert.Equal(t, "default-image", c.Image)
@@ -46,18 +46,17 @@ func TestContainerNewDefault(t *testing.T) {
 
 func TestContainerWithImageOverridden(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-				Enabled: true,
-				Image:   "overridden-image",
+	targetAllocator := v1beta1.TargetAllocator{
+		Spec: v1beta1.TargetAllocatorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+				Image: "overridden-image",
 			},
 		},
 	}
 	cfg := config.New(config.WithTargetAllocatorImage("default-image"))
 
 	// test
-	c := Container(cfg, logger, otelcol)
+	c := Container(cfg, logger, targetAllocator)
 
 	// verify
 	assert.Equal(t, "overridden-image", c.Image)
@@ -65,18 +64,11 @@ func TestContainerWithImageOverridden(t *testing.T) {
 
 func TestContainerPorts(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-				Enabled: true,
-				Image:   "default-image",
-			},
-		},
-	}
+	targetAllocator := v1beta1.TargetAllocator{}
 	cfg := config.New()
 
 	// test
-	c := Container(cfg, logger, otelcol)
+	c := Container(cfg, logger, targetAllocator)
 
 	// verify
 	assert.Len(t, c.Ports, 1)
@@ -86,18 +78,11 @@ func TestContainerPorts(t *testing.T) {
 
 func TestContainerVolumes(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-				Enabled: true,
-				Image:   "default-image",
-			},
-		},
-	}
+	targetAllocator := v1beta1.TargetAllocator{}
 	cfg := config.New()
 
 	// test
-	c := Container(cfg, logger, otelcol)
+	c := Container(cfg, logger, targetAllocator)
 
 	// verify
 	assert.Len(t, c.VolumeMounts, 1)
@@ -105,9 +90,9 @@ func TestContainerVolumes(t *testing.T) {
 }
 
 func TestContainerResourceRequirements(t *testing.T) {
-	otelcol := v1beta1.OpenTelemetryCollector{
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
+	targetAllocator := v1beta1.TargetAllocator{
+		Spec: v1beta1.TargetAllocatorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -134,7 +119,7 @@ func TestContainerResourceRequirements(t *testing.T) {
 		},
 	}
 	// test
-	c := Container(cfg, logger, otelcol)
+	c := Container(cfg, logger, targetAllocator)
 	resourcesValues := c.Resources
 
 	// verify
@@ -143,10 +128,9 @@ func TestContainerResourceRequirements(t *testing.T) {
 
 func TestContainerHasEnvVars(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-				Enabled: true,
+	targetAllocator := v1beta1.TargetAllocator{
+		Spec: v1beta1.TargetAllocatorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
 				Env: []corev1.EnvVar{
 					{
 						Name:  "TEST_ENV",
@@ -216,7 +200,7 @@ func TestContainerHasEnvVars(t *testing.T) {
 	}
 
 	// test
-	c := Container(cfg, logger, otelcol)
+	c := Container(cfg, logger, targetAllocator)
 
 	// verify
 	assert.Equal(t, expected, c)
@@ -228,10 +212,9 @@ func TestContainerHasProxyEnvVars(t *testing.T) {
 	defer os.Unsetenv("NO_PROXY")
 
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-				Enabled: true,
+	targetAllocator := v1beta1.TargetAllocator{
+		Spec: v1beta1.TargetAllocatorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
 				Env: []corev1.EnvVar{
 					{
 						Name:  "TEST_ENV",
@@ -244,7 +227,7 @@ func TestContainerHasProxyEnvVars(t *testing.T) {
 	cfg := config.New(config.WithTargetAllocatorImage("default-image"))
 
 	// test
-	c := Container(cfg, logger, otelcol)
+	c := Container(cfg, logger, targetAllocator)
 
 	// verify
 	require.Len(t, c.Env, 4)
@@ -254,10 +237,9 @@ func TestContainerHasProxyEnvVars(t *testing.T) {
 
 func TestContainerDoesNotOverrideEnvVars(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-				Enabled: true,
+	targetAllocator := v1beta1.TargetAllocator{
+		Spec: v1beta1.TargetAllocatorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
 				Env: []corev1.EnvVar{
 					{
 						Name:  "OTELCOL_NAMESPACE",
@@ -314,19 +296,13 @@ func TestContainerDoesNotOverrideEnvVars(t *testing.T) {
 	}
 
 	// test
-	c := Container(cfg, logger, otelcol)
+	c := Container(cfg, logger, targetAllocator)
 
 	// verify
 	assert.Equal(t, expected, c)
 }
 func TestReadinessProbe(t *testing.T) {
-	otelcol := v1beta1.OpenTelemetryCollector{
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-				Enabled: true,
-			},
-		},
-	}
+	targetAllocator := v1beta1.TargetAllocator{}
 	cfg := config.New()
 	expected := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
@@ -338,20 +314,14 @@ func TestReadinessProbe(t *testing.T) {
 	}
 
 	// test
-	c := Container(cfg, logger, otelcol)
+	c := Container(cfg, logger, targetAllocator)
 
 	// verify
 	assert.Equal(t, expected, c.ReadinessProbe)
 }
 func TestLivenessProbe(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-				Enabled: true,
-			},
-		},
-	}
+	targetAllocator := v1beta1.TargetAllocator{}
 	cfg := config.New()
 	expected := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
@@ -363,7 +333,7 @@ func TestLivenessProbe(t *testing.T) {
 	}
 
 	// test
-	c := Container(cfg, logger, otelcol)
+	c := Container(cfg, logger, targetAllocator)
 
 	// verify
 	assert.Equal(t, expected, c.LivenessProbe)
@@ -375,10 +345,9 @@ func TestSecurityContext(t *testing.T) {
 		RunAsNonRoot: &runAsNonRoot,
 	}
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-				Enabled:         true,
+	targetAllocator := v1beta1.TargetAllocator{
+		Spec: v1beta1.TargetAllocatorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
 				SecurityContext: securityContext,
 			},
 		},
@@ -386,7 +355,7 @@ func TestSecurityContext(t *testing.T) {
 	cfg := config.New()
 
 	// test
-	c := Container(cfg, logger, otelcol)
+	c := Container(cfg, logger, targetAllocator)
 
 	// verify
 	assert.Equal(t, securityContext, c.SecurityContext)

--- a/internal/manifests/targetallocator/deployment.go
+++ b/internal/manifests/targetallocator/deployment.go
@@ -25,26 +25,26 @@ import (
 
 // Deployment builds the deployment for the given instance.
 func Deployment(params manifests.Params) (*appsv1.Deployment, error) {
-	name := naming.TargetAllocator(params.OtelCol.Name)
-	labels := Labels(params.OtelCol, name)
+	name := naming.TargetAllocator(params.TargetAllocator.Name)
+	labels := Labels(params.TargetAllocator, name)
 
 	configMap, err := ConfigMap(params)
 	if err != nil {
 		params.Log.Info("failed to construct target allocator config map for annotations")
 		configMap = nil
 	}
-	annotations := Annotations(params.OtelCol, configMap)
+	annotations := Annotations(params.TargetAllocator, configMap)
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: params.OtelCol.Namespace,
+			Namespace: params.TargetAllocator.Namespace,
 			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: params.OtelCol.Spec.TargetAllocator.Replicas,
+			Replicas: params.TargetAllocator.Spec.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: SelectorLabels(params.OtelCol),
+				MatchLabels: SelectorLabels(params.TargetAllocator),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -52,14 +52,14 @@ func Deployment(params manifests.Params) (*appsv1.Deployment, error) {
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName:        ServiceAccountName(params.OtelCol),
-					Containers:                []corev1.Container{Container(params.Config, params.Log, params.OtelCol)},
-					Volumes:                   Volumes(params.Config, params.OtelCol),
-					NodeSelector:              params.OtelCol.Spec.TargetAllocator.NodeSelector,
-					Tolerations:               params.OtelCol.Spec.TargetAllocator.Tolerations,
-					TopologySpreadConstraints: params.OtelCol.Spec.TargetAllocator.TopologySpreadConstraints,
-					Affinity:                  params.OtelCol.Spec.TargetAllocator.Affinity,
-					SecurityContext:           params.OtelCol.Spec.TargetAllocator.PodSecurityContext,
+					ServiceAccountName:        ServiceAccountName(params.TargetAllocator),
+					Containers:                []corev1.Container{Container(params.Config, params.Log, params.TargetAllocator)},
+					Volumes:                   Volumes(params.Config, params.TargetAllocator),
+					NodeSelector:              params.TargetAllocator.Spec.NodeSelector,
+					Tolerations:               params.TargetAllocator.Spec.Tolerations,
+					TopologySpreadConstraints: params.TargetAllocator.Spec.TopologySpreadConstraints,
+					Affinity:                  params.TargetAllocator.Spec.Affinity,
+					SecurityContext:           params.TargetAllocator.Spec.PodSecurityContext,
 				},
 			},
 		},

--- a/internal/manifests/targetallocator/labels.go
+++ b/internal/manifests/targetallocator/labels.go
@@ -21,12 +21,12 @@ import (
 )
 
 // Labels return the common labels to all TargetAllocator objects that are part of a managed OpenTelemetryCollector.
-func Labels(instance v1beta1.OpenTelemetryCollector, name string) map[string]string {
-	return manifestutils.Labels(instance.ObjectMeta, name, instance.Spec.TargetAllocator.Image, ComponentOpenTelemetryTargetAllocator, nil)
+func Labels(instance v1beta1.TargetAllocator, name string) map[string]string {
+	return manifestutils.Labels(instance.ObjectMeta, name, instance.Spec.Image, ComponentOpenTelemetryTargetAllocator, nil)
 }
 
 // SelectorLabels return the selector labels for Target Allocator Pods.
-func SelectorLabels(instance v1beta1.OpenTelemetryCollector) map[string]string {
+func SelectorLabels(instance v1beta1.TargetAllocator) map[string]string {
 	selectorLabels := manifestutils.SelectorLabels(instance.ObjectMeta, ComponentOpenTelemetryTargetAllocator)
 
 	// TargetAllocator uses the name label as well for selection

--- a/internal/manifests/targetallocator/labels_test.go
+++ b/internal/manifests/targetallocator/labels_test.go
@@ -31,7 +31,7 @@ const (
 
 func TestLabelsCommonSet(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
+	allocator := v1beta1.TargetAllocator{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -39,7 +39,7 @@ func TestLabelsCommonSet(t *testing.T) {
 	}
 
 	// test
-	labels := Labels(otelcol, name)
+	labels := Labels(allocator, name)
 	assert.Equal(t, "opentelemetry-operator", labels["app.kubernetes.io/managed-by"])
 	assert.Equal(t, "my-ns.my-instance", labels["app.kubernetes.io/instance"])
 	assert.Equal(t, "opentelemetry", labels["app.kubernetes.io/part-of"])
@@ -50,7 +50,7 @@ func TestLabelsCommonSet(t *testing.T) {
 
 func TestLabelsPropagateDown(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
+	allocator := v1beta1.TargetAllocator{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				"myapp":                  "mycomponent",
@@ -60,8 +60,8 @@ func TestLabelsPropagateDown(t *testing.T) {
 	}
 
 	// test
-	labels := Labels(otelcol, name)
-	selectorLabels := SelectorLabels(otelcol)
+	labels := Labels(allocator, name)
+	selectorLabels := SelectorLabels(allocator)
 
 	// verify
 	assert.Len(t, labels, 7)
@@ -72,7 +72,7 @@ func TestLabelsPropagateDown(t *testing.T) {
 
 func TestSelectorLabels(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
+	otelcol := v1beta1.TargetAllocator{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/internal/manifests/targetallocator/poddisruptionbudget.go
+++ b/internal/manifests/targetallocator/poddisruptionbudget.go
@@ -27,7 +27,7 @@ import (
 
 func PodDisruptionBudget(params manifests.Params) (*policyV1.PodDisruptionBudget, error) {
 	// defaulting webhook should set this if the strategy is compatible, but if unset then return nil.
-	if params.OtelCol.Spec.TargetAllocator.PodDisruptionBudget == nil {
+	if params.TargetAllocator.Spec.PodDisruptionBudget == nil {
 		params.Log.Info("pdb field is unset in Spec, skipping podDisruptionBudget creation")
 		return nil, nil
 	}
@@ -35,19 +35,19 @@ func PodDisruptionBudget(params manifests.Params) (*policyV1.PodDisruptionBudget
 	// defaulter doesn't set PodDisruptionBudget if the strategy isn't valid,
 	// if PodDisruptionBudget != nil and stategy isn't correct, users have set
 	// it wrongly
-	if params.OtelCol.Spec.TargetAllocator.AllocationStrategy != v1beta1.TargetAllocatorAllocationStrategyConsistentHashing {
+	if params.TargetAllocator.Spec.AllocationStrategy != v1beta1.TargetAllocatorAllocationStrategyConsistentHashing {
 		params.Log.V(4).Info("current allocation strategy not compatible, skipping podDisruptionBudget creation")
 		return nil, fmt.Errorf("target allocator pdb has been configured but the allocation strategy isn't not compatible")
 	}
 
-	name := naming.TAPodDisruptionBudget(params.OtelCol.Name)
-	labels := Labels(params.OtelCol, name)
+	name := naming.TAPodDisruptionBudget(params.TargetAllocator.Name)
+	labels := Labels(params.TargetAllocator, name)
 
-	annotations := Annotations(params.OtelCol, nil)
+	annotations := Annotations(params.TargetAllocator, nil)
 
 	objectMeta := metav1.ObjectMeta{
 		Name:        name,
-		Namespace:   params.OtelCol.Namespace,
+		Namespace:   params.TargetAllocator.Namespace,
 		Labels:      labels,
 		Annotations: annotations,
 	}
@@ -55,10 +55,10 @@ func PodDisruptionBudget(params manifests.Params) (*policyV1.PodDisruptionBudget
 	return &policyV1.PodDisruptionBudget{
 		ObjectMeta: objectMeta,
 		Spec: policyV1.PodDisruptionBudgetSpec{
-			MinAvailable:   params.OtelCol.Spec.TargetAllocator.PodDisruptionBudget.MinAvailable,
-			MaxUnavailable: params.OtelCol.Spec.TargetAllocator.PodDisruptionBudget.MaxUnavailable,
+			MinAvailable:   params.TargetAllocator.Spec.PodDisruptionBudget.MinAvailable,
+			MaxUnavailable: params.TargetAllocator.Spec.PodDisruptionBudget.MaxUnavailable,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: SelectorLabels(params.OtelCol),
+				MatchLabels: SelectorLabels(params.TargetAllocator),
 			},
 		},
 	}, nil

--- a/internal/manifests/targetallocator/poddisruptionbudget_test.go
+++ b/internal/manifests/targetallocator/poddisruptionbudget_test.go
@@ -66,25 +66,25 @@ var tests = []test{
 func TestPDBWithValidStrategy(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			otelcol := v1beta1.OpenTelemetryCollector{
+			targetAllocator := v1beta1.TargetAllocator{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-instance",
 				},
-				Spec: v1beta1.OpenTelemetryCollectorSpec{
-					TargetAllocator: v1beta1.TargetAllocatorEmbedded{
+				Spec: v1beta1.TargetAllocatorSpec{
+					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
 						PodDisruptionBudget: &v1beta1.PodDisruptionBudgetSpec{
 							MinAvailable:   test.MinAvailable,
 							MaxUnavailable: test.MaxUnavailable,
 						},
-						AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
 					},
+					AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
 				},
 			}
 			configuration := config.New()
 			pdb, err := PodDisruptionBudget(manifests.Params{
-				Log:     logger,
-				Config:  configuration,
-				OtelCol: otelcol,
+				Log:             logger,
+				Config:          configuration,
+				TargetAllocator: targetAllocator,
 			})
 
 			// verify
@@ -100,25 +100,25 @@ func TestPDBWithValidStrategy(t *testing.T) {
 func TestPDBWithNotValidStrategy(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			otelcol := v1beta1.OpenTelemetryCollector{
+			targetAllocator := v1beta1.TargetAllocator{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-instance",
 				},
-				Spec: v1beta1.OpenTelemetryCollectorSpec{
-					TargetAllocator: v1beta1.TargetAllocatorEmbedded{
+				Spec: v1beta1.TargetAllocatorSpec{
+					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
 						PodDisruptionBudget: &v1beta1.PodDisruptionBudgetSpec{
 							MinAvailable:   test.MinAvailable,
 							MaxUnavailable: test.MaxUnavailable,
 						},
-						AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyLeastWeighted,
 					},
+					AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyLeastWeighted,
 				},
 			}
 			configuration := config.New()
 			pdb, err := PodDisruptionBudget(manifests.Params{
-				Log:     logger,
-				Config:  configuration,
-				OtelCol: otelcol,
+				Log:             logger,
+				Config:          configuration,
+				TargetAllocator: targetAllocator,
 			})
 
 			// verify
@@ -129,21 +129,16 @@ func TestPDBWithNotValidStrategy(t *testing.T) {
 }
 
 func TestNoPDB(t *testing.T) {
-	otelcol := v1beta1.OpenTelemetryCollector{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-instance",
-		},
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-				AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyLeastWeighted,
-			},
+	targetAllocator := v1beta1.TargetAllocator{
+		Spec: v1beta1.TargetAllocatorSpec{
+			AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyLeastWeighted,
 		},
 	}
 	configuration := config.New()
 	pdb, err := PodDisruptionBudget(manifests.Params{
-		Log:     logger,
-		Config:  configuration,
-		OtelCol: otelcol,
+		Log:             logger,
+		Config:          configuration,
+		TargetAllocator: targetAllocator,
 	})
 
 	// verify

--- a/internal/manifests/targetallocator/service.go
+++ b/internal/manifests/targetallocator/service.go
@@ -24,15 +24,15 @@ import (
 )
 
 func Service(params manifests.Params) *corev1.Service {
-	name := naming.TAService(params.OtelCol.Name)
-	labels := Labels(params.OtelCol, name)
+	name := naming.TAService(params.TargetAllocator.Name)
+	labels := Labels(params.TargetAllocator, name)
 
-	selector := SelectorLabels(params.OtelCol)
+	selector := SelectorLabels(params.TargetAllocator)
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      naming.TAService(params.OtelCol.Name),
-			Namespace: params.OtelCol.Namespace,
+			Name:      naming.TAService(params.TargetAllocator.Name),
+			Namespace: params.TargetAllocator.Namespace,
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{

--- a/internal/manifests/targetallocator/service_test.go
+++ b/internal/manifests/targetallocator/service_test.go
@@ -26,13 +26,13 @@ import (
 )
 
 func TestServicePorts(t *testing.T) {
-	otelcol := collectorInstance()
+	targetAllocator := targetAllocatorInstance()
 	cfg := config.New()
 
 	params := manifests.Params{
-		OtelCol: otelcol,
-		Config:  cfg,
-		Log:     logger,
+		TargetAllocator: targetAllocator,
+		Config:          cfg,
+		Log:             logger,
 	}
 
 	ports := []v1.ServicePort{{Name: "targetallocation", Port: 80, TargetPort: intstr.FromString("http")}}

--- a/internal/manifests/targetallocator/serviceaccount.go
+++ b/internal/manifests/targetallocator/serviceaccount.go
@@ -24,29 +24,29 @@ import (
 )
 
 // ServiceAccountName returns the name of the existing or self-provisioned service account to use for the given instance.
-func ServiceAccountName(instance v1beta1.OpenTelemetryCollector) string {
-	if len(instance.Spec.TargetAllocator.ServiceAccount) == 0 {
+func ServiceAccountName(instance v1beta1.TargetAllocator) string {
+	if len(instance.Spec.ServiceAccount) == 0 {
 		return naming.TargetAllocatorServiceAccount(instance.Name)
 	}
 
-	return instance.Spec.TargetAllocator.ServiceAccount
+	return instance.Spec.ServiceAccount
 }
 
 // ServiceAccount returns the service account for the given instance.
 func ServiceAccount(params manifests.Params) *corev1.ServiceAccount {
-	if len(params.OtelCol.Spec.TargetAllocator.ServiceAccount) > 0 {
+	if len(params.TargetAllocator.Spec.ServiceAccount) > 0 {
 		return nil
 	}
 
-	name := naming.TargetAllocatorServiceAccount(params.OtelCol.Name)
-	labels := Labels(params.OtelCol, name)
+	name := naming.TargetAllocatorServiceAccount(params.TargetAllocator.Name)
+	labels := Labels(params.TargetAllocator, name)
 
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   params.OtelCol.Namespace,
+			Namespace:   params.TargetAllocator.Namespace,
 			Labels:      labels,
-			Annotations: params.OtelCol.Annotations,
+			Annotations: params.TargetAllocator.Annotations,
 		},
 	}
 }

--- a/internal/manifests/targetallocator/serviceaccount_test.go
+++ b/internal/manifests/targetallocator/serviceaccount_test.go
@@ -27,14 +27,14 @@ import (
 
 func TestServiceAccountDefaultName(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
+	targetAllocator := v1beta1.TargetAllocator{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
 	}
 
 	// test
-	saName := ServiceAccountName(otelcol)
+	saName := ServiceAccountName(targetAllocator)
 
 	// verify
 	assert.Equal(t, "my-instance-targetallocator", saName)
@@ -42,19 +42,19 @@ func TestServiceAccountDefaultName(t *testing.T) {
 
 func TestServiceAccountOverrideName(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{
+	targetAllocator := v1beta1.TargetAllocator{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-instance",
 		},
-		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
+		Spec: v1beta1.TargetAllocatorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
 				ServiceAccount: "my-special-sa",
 			},
 		},
 	}
 
 	// test
-	sa := ServiceAccountName(otelcol)
+	sa := ServiceAccountName(targetAllocator)
 
 	// verify
 	assert.Equal(t, "my-special-sa", sa)
@@ -62,7 +62,7 @@ func TestServiceAccountOverrideName(t *testing.T) {
 
 func TestServiceAccountDefault(t *testing.T) {
 	params := manifests.Params{
-		OtelCol: v1beta1.OpenTelemetryCollector{
+		TargetAllocator: v1beta1.TargetAllocator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-instance",
 			},
@@ -72,26 +72,26 @@ func TestServiceAccountDefault(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "my-instance-targetallocator",
 			Namespace:   params.OtelCol.Namespace,
-			Labels:      Labels(params.OtelCol, "my-instance-targetallocator"),
+			Labels:      Labels(params.TargetAllocator, "my-instance-targetallocator"),
 			Annotations: params.OtelCol.Annotations,
 		},
 	}
 
-	saName := ServiceAccountName(params.OtelCol)
+	saName := ServiceAccountName(params.TargetAllocator)
 	sa := ServiceAccount(params)
 
-	assert.Equal(t, sa.Name, saName)
+	assert.Equal(t, saName, sa.Name)
 	assert.Equal(t, expected, sa)
 }
 
 func TestServiceAccountOverride(t *testing.T) {
 	params := manifests.Params{
-		OtelCol: v1beta1.OpenTelemetryCollector{
+		TargetAllocator: v1beta1.TargetAllocator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-instance",
 			},
-			Spec: v1beta1.OpenTelemetryCollectorSpec{
-				TargetAllocator: v1beta1.TargetAllocatorEmbedded{
+			Spec: v1beta1.TargetAllocatorSpec{
+				OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
 					ServiceAccount: "my-special-sa",
 				},
 			},

--- a/internal/manifests/targetallocator/servicemonitor.go
+++ b/internal/manifests/targetallocator/servicemonitor.go
@@ -25,7 +25,7 @@ import (
 // ServiceMonitor returns the service monitor for the given instance.
 func ServiceMonitor(params manifests.Params) *monitoringv1.ServiceMonitor {
 	name := naming.TargetAllocator(params.OtelCol.Name)
-	labels := Labels(params.OtelCol, name)
+	labels := Labels(params.TargetAllocator, name)
 
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
@@ -44,7 +44,7 @@ func ServiceMonitor(params manifests.Params) *monitoringv1.ServiceMonitor {
 				MatchNames: []string{params.OtelCol.Namespace},
 			},
 			Selector: metav1.LabelSelector{
-				MatchLabels: SelectorLabels(params.OtelCol),
+				MatchLabels: SelectorLabels(params.TargetAllocator),
 			},
 		},
 	}

--- a/internal/manifests/targetallocator/targetallocator.go
+++ b/internal/manifests/targetallocator/targetallocator.go
@@ -39,7 +39,7 @@ func Build(params manifests.Params) ([]client.Object, error) {
 		manifests.Factory(PodDisruptionBudget),
 	}
 
-	if params.OtelCol.Spec.TargetAllocator.Observability.Metrics.EnableMetrics && featuregate.PrometheusOperatorIsAvailable.IsEnabled() {
+	if params.TargetAllocator.Spec.Observability.Metrics.EnableMetrics && featuregate.PrometheusOperatorIsAvailable.IsEnabled() {
 		resourceFactories = append(resourceFactories, manifests.FactoryWithoutError(ServiceMonitor))
 	}
 

--- a/internal/manifests/targetallocator/volume.go
+++ b/internal/manifests/targetallocator/volume.go
@@ -23,12 +23,12 @@ import (
 )
 
 // Volumes builds the volumes for the given instance, including the config map volume.
-func Volumes(cfg config.Config, otelcol v1beta1.OpenTelemetryCollector) []corev1.Volume {
+func Volumes(cfg config.Config, instance v1beta1.TargetAllocator) []corev1.Volume {
 	volumes := []corev1.Volume{{
 		Name: naming.TAConfigMapVolume(),
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{Name: naming.TAConfigMap(otelcol.Name)},
+				LocalObjectReference: corev1.LocalObjectReference{Name: naming.TAConfigMap(instance.Name)},
 				Items: []corev1.KeyToPath{
 					{
 						Key:  cfg.TargetAllocatorConfigMapEntry(),

--- a/internal/manifests/targetallocator/volume_test.go
+++ b/internal/manifests/targetallocator/volume_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestVolumeNewDefault(t *testing.T) {
 	// prepare
-	otelcol := v1beta1.OpenTelemetryCollector{}
+	otelcol := v1beta1.TargetAllocator{}
 	cfg := config.New()
 
 	// test

--- a/internal/naming/main.go
+++ b/internal/naming/main.go
@@ -21,8 +21,8 @@ func ConfigMap(otelcol string) string {
 }
 
 // TAConfigMap returns the name for the config map used in the TargetAllocator.
-func TAConfigMap(otelcol string) string {
-	return DNSName(Truncate("%s-targetallocator", 63, otelcol))
+func TAConfigMap(targetAllocator string) string {
+	return DNSName(Truncate("%s-targetallocator", 63, targetAllocator))
 }
 
 // OpAMPBridgeConfigMap builds the name for the config map used in the OpAMPBridge containers.


### PR DESCRIPTION
Use our internally converted TargetAllocator CR for manifest generation. This is a purely internal change that will make introduction of the TA CR easier, similar to https://github.com/open-telemetry/opentelemetry-operator/pull/2532.
