### PR TITLE
bump `@opentelemetry/auto-instrumentations-node` to allow enabling only selected instrumentations via env

### DIFF
--- a/.chloggen/2622-bump-autoinstrumentation-nodejs-to-allow-disabling-instrumentations-via-env.yaml
+++ b/.chloggen/2622-bump-autoinstrumentation-nodejs-to-allow-disabling-instrumentations-via-env.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Bump NodeJS autoinstrumentations dependency to a version that supports enabling selected instrumentations via environment variable."
+
+# One or more tracking issues related to the change
+issues: [2622]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  See [the documentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node#usage-auto-instrumentation) for details.
+  Usage example: `export OTEL_NODE_ENABLED_INSTRUMENTATIONS="http,nestjs-core"`.

--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/auto-instrumentations-node": "0.40.2",
+    "@opentelemetry/auto-instrumentations-node": "0.43.0",
     "@opentelemetry/exporter-metrics-otlp-grpc": "0.46.0",
     "@opentelemetry/exporter-prometheus": "0.46.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",


### PR DESCRIPTION
**Description:**
* Updated only @opentelemetry/auto-instrumentations-node version, so it would contain [PR that allows enabling selected instrumentations via environment variable](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1953).
* **Motivation**: [application startup is super-slow when all instrumentations are enabled](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1953#issuecomment-1961107798)

**Link to tracking Issue(s):**
- Resolves: #2622 (but allows enabling/disabling any instrumentation, not just fs instrumentation)

**Testing:**
* Tests are included in the [PR](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1953) of the updated library
    * The change is backwards compatible - all instrumentations are still enabled by default

**Documentation:**
Usage example: `export OTEL_NODE_ENABLED_INSTRUMENTATIONS="http,nestjs-core"`.
See [the documentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node#usage-auto-instrumentation) for details.

