### PR TITLE
Move operator.observability.prometheus to be beta

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,8 +34,6 @@ jobs:
          - e2e-multi-instrumentation
          - e2e-metadata-filters
        include:
-         - group: e2e-prometheuscr
-           setup: "prepare-e2e-with-featuregates"
          - group: e2e-multi-instrumentation
            setup: "add-operator-arg OPERATOR_ARG=--enable-multi-instrumentation prepare-e2e"
          - group: e2e-metadata-filters

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,7 @@ jobs:
          - e2e-metadata-filters
        include:
          - group: e2e-prometheuscr
-           setup: "prepare-e2e-with-featuregates FEATUREGATES=+operator.observability.prometheus"
+           setup: "prepare-e2e-with-featuregates"
          - group: e2e-multi-instrumentation
            setup: "add-operator-arg OPERATOR_ARG=--enable-multi-instrumentation prepare-e2e"
          - group: e2e-metadata-filters

--- a/controllers/builder_test.go
+++ b/controllers/builder_test.go
@@ -53,10 +53,6 @@ var (
 )
 
 var (
-	prometheusFeatureGate = featuregate.PrometheusOperatorIsAvailable.ID()
-)
-
-var (
 	opampbridgeSelectorLabels = map[string]string{
 		"app.kubernetes.io/managed-by": "opentelemetry-operator",
 		"app.kubernetes.io/part-of":    "opentelemetry",
@@ -1946,7 +1942,7 @@ prometheus_cr:
 					},
 					Spec: monitoringv1.ServiceMonitorSpec{
 						Endpoints: []monitoringv1.Endpoint{
-							monitoringv1.Endpoint{Port: "targetallocation"},
+							{Port: "targetallocation"},
 						},
 						Selector: v1.LabelSelector{
 							MatchLabels: map[string]string{
@@ -1964,7 +1960,7 @@ prometheus_cr:
 				},
 			},
 			wantErr:      false,
-			featuregates: []string{prometheusFeatureGate},
+			featuregates: []string{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -67,7 +67,7 @@ var (
 	// PrometheusOperatorIsAvailable is the feature gate that enables features associated to the Prometheus Operator.
 	PrometheusOperatorIsAvailable = featuregate.GlobalRegistry().MustRegister(
 		"operator.observability.prometheus",
-		featuregate.StageAlpha,
+		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("enables features associated to the Prometheus Operator"),
 		featuregate.WithRegisterFromVersion("v0.82.0"),
 	)


### PR DESCRIPTION
**Description:** Move the operator.observability.prometheus flag to beta. This flag has been in alpha for plenty long.

**Link to tracking Issue(s):** n/a

**Testing:** e2e

**Documentation:** n/a
