### PR TITLE
bump all dependencies to trigger release for dependency updates in autoinstrumentation/nodejs

### DIFF
--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "copyfiles": "^2.4.1",
-    "rimraf": "^3.0.2",
-    "typescript": "^4.4.4"
+    "rimraf": "^5.0.5",
+    "typescript": "^5.4.2"
   },
   "dependencies": {
     "@opentelemetry/api": "1.7.0",

--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -14,17 +14,17 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/auto-instrumentations-node": "0.43.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.46.0",
-    "@opentelemetry/exporter-prometheus": "0.46.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",
-    "@opentelemetry/resource-detector-alibaba-cloud": "0.28.4",
-    "@opentelemetry/resource-detector-aws": "1.3.4",
-    "@opentelemetry/resource-detector-container": "0.3.4",
-    "@opentelemetry/resource-detector-gcp": "0.29.4",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-metrics": "1.19.0",
-    "@opentelemetry/sdk-node": "0.46.0"
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.49.1",
+    "@opentelemetry/exporter-prometheus": "0.49.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
+    "@opentelemetry/resource-detector-alibaba-cloud": "0.28.7",
+    "@opentelemetry/resource-detector-aws": "1.4.0",
+    "@opentelemetry/resource-detector-container": "0.3.7",
+    "@opentelemetry/resource-detector-gcp": "0.29.7",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-metrics": "1.22.0",
+    "@opentelemetry/sdk-node": "0.49.1"
   }
 }


### PR DESCRIPTION
**Description:**
Bump NodeJS dependencies

**Link to tracking Issue(s):**

- To trigger release of for #2622, main change done in #2745

**Testing:**
* Tests for #2622 are included in the https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1953 of the updated library
* all the `dependencies` that affect the runtime are semver minor or patch-level, so shouldn't break consumers
* changes in `devDependencies` contain also semver major-level, but those are not included in runtime, so shouldn't break consumers.