### PR TITLE
Cache tools with go version

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -20,6 +20,7 @@ jobs:
 
     - name: Set up Go
       uses: actions/setup-go@v5
+      id: setup-go
       with:
         go-version: "~1.21.1"
 
@@ -27,7 +28,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: bin
-        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
 
     - name: Install tools
       run: make install-tools
@@ -49,9 +50,10 @@ jobs:
 
     - name: Cache tools
       uses: actions/cache@v4
+      id: setup-go
       with:
         path: bin
-        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
 
     - name: Install tools
       run: make install-tools

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -44,13 +44,14 @@ jobs:
       uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v5
+      id: setup-go
       with:
         go-version: "~1.21.3"
-    - name: Cache tools
+    - name: gache tools
       uses: actions/cache@v4
       with:
         path: bin
-        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
     - name: Install chainsaw
       uses: kyverno/action-install-chainsaw@v0.1.8
     - name: Install tools

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,7 +47,7 @@ jobs:
       id: setup-go
       with:
         go-version: "~1.21.3"
-    - name: gache tools
+    - name: Cache tools
       uses: actions/cache@v4
       with:
         path: bin

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v5
+        id: setup-go
         with:
           go-version: "~1.21.1"
 
@@ -34,7 +35,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bin
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
 
       - name: Install tools
         run: make install-tools


### PR DESCRIPTION
The caching of tools should take into account the go version. 

For instance this job https://github.com/open-telemetry/opentelemetry-operator/actions/runs/8249577251/job/22562259975 should pass. But it's failing because it's using tools from cache with golang 1.22 that was reverted.



