### PR TITLE
opamp bridge configmap: use manifestutils.Labels() logic to set version label

### DIFF
--- a/.chloggen/opampbridge-version-label.yaml
+++ b/.chloggen/opampbridge-version-label.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: opamp bridge
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix opamp bridge configmap "app.kubernetes.io/version" label to be generated in the same way as other resource version labels
+
+# One or more tracking issues related to the change
+issues: [2583]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/opampbridge/configmap.go
+++ b/internal/manifests/opampbridge/configmap.go
@@ -18,8 +18,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"strings"
-
 	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
@@ -33,14 +31,7 @@ const (
 
 func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	name := naming.OpAMPBridgeConfigMap(params.OpAMPBridge.Name)
-	version := strings.Split(params.OpAMPBridge.Spec.Image, ":")
 	labels := manifestutils.Labels(params.OpAMPBridge.ObjectMeta, name, params.OpAMPBridge.Spec.Image, ComponentOpAMPBridge, []string{})
-
-	if len(version) > 1 {
-		labels["app.kubernetes.io/version"] = version[len(version)-1]
-	} else {
-		labels["app.kubernetes.io/version"] = "latest"
-	}
 
 	config := make(map[interface{}]interface{})
 

--- a/internal/manifests/opampbridge/configmap_test.go
+++ b/internal/manifests/opampbridge/configmap_test.go
@@ -26,20 +26,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDesiredConfigMap(t *testing.T) {
-	expectedLables := map[string]string{
+func expectedLabels() map[string]string {
+	return map[string]string{
 		"app.kubernetes.io/managed-by": "opentelemetry-operator",
 		"app.kubernetes.io/instance":   "my-namespace.my-instance",
 		"app.kubernetes.io/part-of":    "opentelemetry",
 		"app.kubernetes.io/version":    "0.69.0",
+		"app.kubernetes.io/component":  "opentelemetry-opamp-bridge",
+		"app.kubernetes.io/name":       "my-instance-opamp-bridge",
 	}
+}
 
-	t.Run("should return expected opamp-bridge config map", func(t *testing.T) {
-		expectedLables["app.kubernetes.io/component"] = "opentelemetry-opamp-bridge"
-		expectedLables["app.kubernetes.io/name"] = "my-instance-opamp-bridge"
-
-		expectedData := map[string]string{
-			"remoteconfiguration.yaml": `capabilities:
+func TestDesiredConfigMap(t *testing.T) {
+	data := map[string]string{
+		"remoteconfiguration.yaml": `capabilities:
   AcceptsOpAMPConnectionSettings: true
   AcceptsOtherConnectionSettings: true
   AcceptsRemoteConfig: true
@@ -62,46 +62,72 @@ endpoint: ws://opamp-server:4320/v1/opamp
 headers:
   authorization: access-12345-token
 `}
-
-		opampBridge := v1alpha1.OpAMPBridge{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-instance",
-				Namespace: "my-namespace",
+	tests := []struct {
+		description    string
+		image          string
+		expectedLabels func() map[string]string
+		expectedData   map[string]string
+	}{
+		{
+			description:    "should return expected opamp-bridge config map",
+			image:          "ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:0.69.0",
+			expectedLabels: expectedLabels,
+			expectedData:   data,
+		},
+		{
+			description: "should return expected opamp-bridge config map, sha256 image",
+			image:       "ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:main@sha256:00738c3a6bca8f143995c9c89fd0c1976784d9785ea394fcdfe580fb18754e1e",
+			expectedLabels: func() map[string]string {
+				ls := expectedLabels()
+				ls["app.kubernetes.io/version"] = "main"
+				return ls
 			},
-			Spec: v1alpha1.OpAMPBridgeSpec{
-				Image:    "ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:0.69.0",
-				Endpoint: "ws://opamp-server:4320/v1/opamp",
-				Headers:  map[string]string{"authorization": "access-12345-token"},
-				Capabilities: map[v1alpha1.OpAMPBridgeCapability]bool{
-					v1alpha1.OpAMPBridgeCapabilityReportsStatus:                  true,
-					v1alpha1.OpAMPBridgeCapabilityAcceptsRemoteConfig:            true,
-					v1alpha1.OpAMPBridgeCapabilityReportsEffectiveConfig:         true,
-					v1alpha1.OpAMPBridgeCapabilityReportsOwnTraces:               true,
-					v1alpha1.OpAMPBridgeCapabilityReportsOwnMetrics:              true,
-					v1alpha1.OpAMPBridgeCapabilityReportsOwnLogs:                 true,
-					v1alpha1.OpAMPBridgeCapabilityAcceptsOpAMPConnectionSettings: true,
-					v1alpha1.OpAMPBridgeCapabilityAcceptsOtherConnectionSettings: true,
-					v1alpha1.OpAMPBridgeCapabilityAcceptsRestartCommand:          true,
-					v1alpha1.OpAMPBridgeCapabilityReportsHealth:                  true,
-					v1alpha1.OpAMPBridgeCapabilityReportsRemoteConfig:            true,
+			expectedData: data,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			opampBridge := v1alpha1.OpAMPBridge{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-instance",
+					Namespace: "my-namespace",
 				},
-				ComponentsAllowed: map[string][]string{"receivers": {"otlp"}, "processors": {"memory_limiter"}, "exporters": {"logging"}},
-			},
-		}
+				Spec: v1alpha1.OpAMPBridgeSpec{
+					Image:    tc.image,
+					Endpoint: "ws://opamp-server:4320/v1/opamp",
+					Headers:  map[string]string{"authorization": "access-12345-token"},
+					Capabilities: map[v1alpha1.OpAMPBridgeCapability]bool{
+						v1alpha1.OpAMPBridgeCapabilityReportsStatus:                  true,
+						v1alpha1.OpAMPBridgeCapabilityAcceptsRemoteConfig:            true,
+						v1alpha1.OpAMPBridgeCapabilityReportsEffectiveConfig:         true,
+						v1alpha1.OpAMPBridgeCapabilityReportsOwnTraces:               true,
+						v1alpha1.OpAMPBridgeCapabilityReportsOwnMetrics:              true,
+						v1alpha1.OpAMPBridgeCapabilityReportsOwnLogs:                 true,
+						v1alpha1.OpAMPBridgeCapabilityAcceptsOpAMPConnectionSettings: true,
+						v1alpha1.OpAMPBridgeCapabilityAcceptsOtherConnectionSettings: true,
+						v1alpha1.OpAMPBridgeCapabilityAcceptsRestartCommand:          true,
+						v1alpha1.OpAMPBridgeCapabilityReportsHealth:                  true,
+						v1alpha1.OpAMPBridgeCapabilityReportsRemoteConfig:            true,
+					},
+					ComponentsAllowed: map[string][]string{"receivers": {"otlp"}, "processors": {"memory_limiter"}, "exporters": {"logging"}},
+				},
+			}
 
-		cfg := config.New()
+			cfg := config.New()
 
-		params := manifests.Params{
-			Config:      cfg,
-			OpAMPBridge: opampBridge,
-			Log:         logger,
-		}
+			params := manifests.Params{
+				Config:      cfg,
+				OpAMPBridge: opampBridge,
+				Log:         logger,
+			}
 
-		actual, err := ConfigMap(params)
-		assert.NoError(t, err)
+			actual, err := ConfigMap(params)
+			assert.NoError(t, err)
 
-		assert.Equal(t, "my-instance-opamp-bridge", actual.Name)
-		assert.Equal(t, expectedLables, actual.Labels)
-		assert.Equal(t, expectedData, actual.Data)
-	})
+			assert.Equal(t, "my-instance-opamp-bridge", actual.Name)
+			assert.Equal(t, tc.expectedLabels(), actual.Labels)
+			assert.Equal(t, tc.expectedData, actual.Data)
+		})
+	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fixing a bug where the version label for the opamp bridge config map is too long.  We had custom logic for the config map that was overriding the version label being set by `manifestutils.Labels()`:
https://github.com/open-telemetry/opentelemetry-operator/blob/be172d96401b328176dea0c3d60e2c546d0caf5c/internal/manifests/manifestutils/labels.go#L52-L65

I removed the custom logic and added a unit test for this use case.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #2583

**Testing:** <Describe what testing was performed and which tests were added.>
I refactored the unit tests a bit to include this use case and make the test table driven.

**Documentation:** <Describe the documentation added.>
None