### PR TITLE
Remove nodejs autoinstrumentation dev dependencies from image

### DIFF
--- a/.chloggen/js-build-remove-dev.yaml
+++ b/.chloggen/js-build-remove-dev.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Remove NodeJS autoinstrumentation dev dependencies to reduce image size"
+
+# One or more tracking issues related to the change
+issues: [2802]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -6,7 +6,7 @@
     "clean": "rimraf build/*",
     "prepare": "npm run compile",
     "compile": "tsc -p .",
-    "postcompile": "copyfiles -f 'build/src/**' build/workspace/ && copyfiles 'node_modules/**' build/workspace/"
+    "postcompile": "copyfiles -f 'build/src/**' build/workspace/ && copyfiles 'node_modules/**' package.json build/workspace/ && npm -C build/workspace prune --omit=dev --no-package-lock"
   },
   "devDependencies": {
     "copyfiles": "^2.4.1",


### PR DESCRIPTION
**Description:**

The autoinstrumentation has several build-time dependencies which aren't necessary for the final image, like typescript. Comparison of builds without typescript, typescript + rimraf, and finally all dev dependencies:

```
$ docker image ls --format 'table {{.Repository}} {{.Tag}} {{.Size}}'
autoinstrumentation-nodejs 60d37e18ce 272MB
autoinstrumentation-nodejs no-ts 208MB
autoinstrumentation-nodejs no-ts-rmrf 201MB
autoinstrumentation-nodejs no-dev 200MB
```

We extend the existing `postcompile` script. After building into `build/workspace`, we `prune` to remove extraneous packages. Doing that requires the `package.json` in the build directory.

**Link to tracking Issue(s):**

- Resolves: #2802 

**Testing:** Locally instrumenting a nodejs application.
