### PR TITLE
Only add to scheme when prometheus is available

### DIFF
--- a/.chloggen/disable-looking-for-podmonitor-servicemonitor-when-not-needed.yaml
+++ b/.chloggen/disable-looking-for-podmonitor-servicemonitor-when-not-needed.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: collector
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: resolves a problem for trying to use a scheme that isn't present.
+note: Introduces ability to detect presence of Prometheus CRDs to dynamically add to scheme to prevent startup issues.
 
 # One or more tracking issues related to the change
 issues: [2180]

--- a/.chloggen/disable-looking-for-podmonitor-servicemonitor-when-not-needed.yaml
+++ b/.chloggen/disable-looking-for-podmonitor-servicemonitor-when-not-needed.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: resolves a problem for trying to use a scheme that isn't present.
+
+# One or more tracking issues related to the change
+issues: [2180]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/controllers/opampbridge_controller_test.go
+++ b/controllers/opampbridge_controller_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/controllers"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 )
 
@@ -43,6 +44,9 @@ var opampBridgeLogger = logf.Log.WithName("opamp-bridge-controller-unit-tests")
 var opampBridgeMockAutoDetector = &mockAutoDetect{
 	OpenShiftRoutesAvailabilityFunc: func() (openshift.RoutesAvailability, error) {
 		return openshift.RoutesAvailable, nil
+	},
+	PrometheusCRsAvailabilityFunc: func() (prometheus.Availability, error) {
+		return prometheus.Available, nil
 	},
 }
 

--- a/controllers/opentelemetrycollector_controller.go
+++ b/controllers/opentelemetrycollector_controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
@@ -80,7 +81,7 @@ func (r *OpenTelemetryCollectorReconciler) findOtelOwnedObjects(ctx context.Cont
 	for i := range hpaList.Items {
 		ownedObjects[hpaList.Items[i].GetUID()] = &hpaList.Items[i]
 	}
-	if featuregate.PrometheusOperatorIsAvailable.IsEnabled() {
+	if featuregate.PrometheusOperatorIsAvailable.IsEnabled() && r.config.PrometheusCRAvailability() == prometheus.Available {
 		servicemonitorList := &monitoringv1.ServiceMonitorList{}
 		err = r.List(ctx, servicemonitorList, listOps)
 		if err != nil {
@@ -249,7 +250,7 @@ func (r *OpenTelemetryCollectorReconciler) SetupWithManager(mgr ctrl.Manager) er
 		builder.Owns(&rbacv1.ClusterRole{})
 	}
 
-	if featuregate.PrometheusOperatorIsAvailable.IsEnabled() {
+	if featuregate.PrometheusOperatorIsAvailable.IsEnabled() && r.config.PrometheusCRAvailability() == prometheus.Available {
 		builder.Owns(&monitoringv1.ServiceMonitor{})
 		builder.Owns(&monitoringv1.PodMonitor{})
 	}

--- a/controllers/reconcile_test.go
+++ b/controllers/reconcile_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/controllers"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	ta "github.com/open-telemetry/opentelemetry-operator/internal/manifests/targetallocator/adapters"
@@ -556,6 +557,7 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 					config.WithCollectorImage("default-collector"),
 					config.WithTargetAllocatorImage("default-ta-allocator"),
 					config.WithOpenShiftRoutesAvailability(openshift.RoutesAvailable),
+					config.WithPrometheusCRAvailability(prometheus.Available),
 				),
 			})
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/testdata"
@@ -92,6 +93,14 @@ var _ autodetect.AutoDetect = (*mockAutoDetect)(nil)
 
 type mockAutoDetect struct {
 	OpenShiftRoutesAvailabilityFunc func() (openshift.RoutesAvailability, error)
+	PrometheusCRsAvailabilityFunc   func() (prometheus.Availability, error)
+}
+
+func (m *mockAutoDetect) PrometheusCRsAvailability() (prometheus.Availability, error) {
+	if m.PrometheusCRsAvailabilityFunc != nil {
+		return m.PrometheusCRsAvailabilityFunc()
+	}
+	return prometheus.NotAvailable, nil
 }
 
 func (m *mockAutoDetect) OpenShiftRoutesAvailability() (openshift.RoutesAvailability, error) {

--- a/internal/autodetect/prometheus/operator.go
+++ b/internal/autodetect/prometheus/operator.go
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+// Availability represents what CRDs are available from the prometheus operator
+type Availability int
+
+const (
+	// NotAvailable represents the monitoring.coreos.com is not available.
+	NotAvailable Availability = iota
+
+	// Available represents the monitoring.coreos.com is available.
+	Available
+)
+
+func (p Availability) String() string {
+	return [...]string{"NotAvailable", "Available"}[p]
+}

--- a/internal/autodetect/prometheus/operator.go
+++ b/internal/autodetect/prometheus/operator.go
@@ -14,7 +14,7 @@
 
 package prometheus
 
-// Availability represents what CRDs are available from the prometheus operator
+// Availability represents what CRDs are available from the prometheus operator.
 type Availability int
 
 const (

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 )
 
@@ -52,6 +53,7 @@ type options struct {
 	targetAllocatorImage                string
 	operatorOpAMPBridgeImage            string
 	openshiftRoutesAvailability         openshift.RoutesAvailability
+	prometheusCRAvailability            prometheus.Availability
 	labelsFilter                        []string
 	annotationsFilter                   []string
 }
@@ -177,6 +179,12 @@ func WithAutoInstrumentationNginxImage(s string) Option {
 func WithOpenShiftRoutesAvailability(os openshift.RoutesAvailability) Option {
 	return func(o *options) {
 		o.openshiftRoutesAvailability = os
+	}
+}
+
+func WithPrometheusCRAvailability(pcrd prometheus.Availability) Option {
+	return func(o *options) {
+		o.prometheusCRAvailability = pcrd
 	}
 }
 

--- a/internal/manifests/collector/podmonitor.go
+++ b/internal/manifests/collector/podmonitor.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/adapters"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
@@ -32,6 +33,12 @@ import (
 func PodMonitor(params manifests.Params) (*monitoringv1.PodMonitor, error) {
 	if !params.OtelCol.Spec.Observability.Metrics.EnableMetrics {
 		params.Log.V(2).Info("Metrics disabled for this OTEL Collector",
+			"params.OtelCol.name", params.OtelCol.Name,
+			"params.OtelCol.namespace", params.OtelCol.Namespace,
+		)
+		return nil, nil
+	} else if params.Config.PrometheusCRAvailability() == prometheus.NotAvailable {
+		params.Log.V(1).Info("Cannot enable PodMonitor when prometheus CRDs are unavailable",
 			"params.OtelCol.name", params.OtelCol.Name,
 			"params.OtelCol.namespace", params.OtelCol.Namespace,
 		)

--- a/internal/manifests/collector/podmonitor_test.go
+++ b/internal/manifests/collector/podmonitor_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
+	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 
 	"github.com/stretchr/testify/assert"
@@ -71,4 +73,14 @@ func TestDesiredPodMonitorsWithPrometheus(t *testing.T) {
 		"app.kubernetes.io/component":  "opentelemetry-collector",
 	}
 	assert.Equal(t, expectedSelectorLabels, actual.Spec.Selector.MatchLabels)
+}
+
+func TestDesiredPodMonitorsPrometheusNotAvailable(t *testing.T) {
+	params, err := newParams("", "testdata/prometheus-exporter.yaml", config.WithPrometheusCRAvailability(prometheus.NotAvailable))
+	assert.NoError(t, err)
+	params.OtelCol.Spec.Mode = v1beta1.ModeSidecar
+	params.OtelCol.Spec.Observability.Metrics.EnableMetrics = true
+	actual, err := PodMonitor(params)
+	assert.NoError(t, err)
+	assert.Nil(t, actual)
 }

--- a/internal/manifests/collector/servicemonitor.go
+++ b/internal/manifests/collector/servicemonitor.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/adapters"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
@@ -32,6 +33,12 @@ import (
 func ServiceMonitor(params manifests.Params) (*monitoringv1.ServiceMonitor, error) {
 	if !params.OtelCol.Spec.Observability.Metrics.EnableMetrics {
 		params.Log.V(2).Info("Metrics disabled for this OTEL Collector",
+			"params.OtelCol.name", params.OtelCol.Name,
+			"params.OtelCol.namespace", params.OtelCol.Namespace,
+		)
+		return nil, nil
+	} else if params.Config.PrometheusCRAvailability() == prometheus.NotAvailable {
+		params.Log.V(1).Info("Cannot enable ServiceMonitor when prometheus CRDs are unavailable",
 			"params.OtelCol.name", params.OtelCol.Name,
 			"params.OtelCol.namespace", params.OtelCol.Namespace,
 		)

--- a/internal/manifests/collector/servicemonitor_test.go
+++ b/internal/manifests/collector/servicemonitor_test.go
@@ -19,6 +19,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
+	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 )
 
 func TestDesiredServiceMonitors(t *testing.T) {
@@ -65,4 +68,13 @@ func TestDesiredServiceMonitorsWithPrometheus(t *testing.T) {
 		"operator.opentelemetry.io/collector-monitoring-service": "Exists",
 	}
 	assert.Equal(t, expectedSelectorLabels, actual.Spec.Selector.MatchLabels)
+}
+
+func TestDesiredServiceMonitorsPrometheusNotAvailable(t *testing.T) {
+	params, err := newParams("", "testdata/prometheus-exporter.yaml", config.WithPrometheusCRAvailability(prometheus.NotAvailable))
+	assert.NoError(t, err)
+	params.OtelCol.Spec.Observability.Metrics.EnableMetrics = true
+	actual, err := ServiceMonitor(params)
+	assert.NoError(t, err)
+	assert.Nil(t, actual)
 }

--- a/main.go
+++ b/main.go
@@ -74,10 +74,17 @@ type tlsConfig struct {
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(otelv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(routev1.AddToScheme(scheme))
-	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	utilruntime.Must(networkingv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
+	// accept errors for the following custom resources:
+	err := monitoringv1.AddToScheme(scheme)
+	if err != nil {
+		setupLog.Error(err, "failed to add prometheus CRDs")
+	}
+	err = routev1.Install(scheme)
+	if err != nil {
+		setupLog.Error(err, "failed to add openshift CRDs")
+	}
 }
 
 // stringFlagOrEnv defines a string flag which can be set by an environment variable.

--- a/main.go
+++ b/main.go
@@ -224,10 +224,16 @@ func main() {
 	}
 	// Only add these to the scheme if they are available
 	if cfg.PrometheusCRAvailability() == prometheus.Available {
+		setupLog.Info("Prometheus CRDs are installed, adding to scheme.")
 		utilruntime.Must(monitoringv1.AddToScheme(scheme))
+	} else {
+		setupLog.Info("Prometheus CRDs are not installed, skipping adding to scheme.")
 	}
 	if cfg.OpenShiftRoutesAvailability() == openshift.RoutesAvailable {
+		setupLog.Info("Openshift CRDs are installed, adding to scheme.")
 		utilruntime.Must(routev1.Install(scheme))
+	} else {
+		setupLog.Info("Openshift CRDs are not installed, skipping adding to scheme.")
 	}
 
 	var namespaces map[string]cache.Config


### PR DESCRIPTION
**Description:** Changes the prometheus operator integration to fail by logging (rather than panicking) and as a result only allowing the creation of prometheus resources when it is safe to do so.

**Link to tracking Issue(s):**

- Resolves: #2810 

**Testing:** unit tests, e2e testing, local confirmation

**Documentation:** n/a
