### PR TITLE
Quiets some SUPER noisy logs

### DIFF
--- a/internal/manifests/collector/horizontalpodautoscaler.go
+++ b/internal/manifests/collector/horizontalpodautoscaler.go
@@ -44,7 +44,7 @@ func HorizontalPodAutoscaler(params manifests.Params) (*autoscalingv2.Horizontal
 
 	// defaulting webhook should always set this, but if unset then return nil.
 	if params.OtelCol.Spec.Autoscaler == nil {
-		params.Log.Info("hpa field is unset in Spec, skipping autoscaler creation")
+		params.Log.V(4).Info("hpa field is unset in Spec, skipping autoscaler creation")
 		return nil, nil
 	}
 

--- a/pkg/instrumentation/upgrade/upgrade.go
+++ b/pkg/instrumentation/upgrade/upgrade.go
@@ -117,10 +117,10 @@ func (u *InstrumentationUpgrade) ManagedInstances(ctx context.Context) error {
 
 func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instrumentation) *v1alpha1.Instrumentation {
 	upgraded := inst.DeepCopy()
-	for annotation, config := range u.defaultAnnotationToConfig {
+	for annotation, instCfg := range u.defaultAnnotationToConfig {
 		autoInst := upgraded.Annotations[annotation]
 		if autoInst != "" {
-			if config.enabled {
+			if instCfg.enabled {
 				switch annotation {
 				case constants.AnnotationDefaultAutoInstrumentationApacheHttpd:
 					if inst.Spec.ApacheHttpd.Image == autoInst {
@@ -144,8 +144,7 @@ func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instru
 					}
 				}
 			} else {
-				u.Logger.Error(nil, "autoinstrumentation not enabled for this language", "flag", config.id)
-				u.Recorder.Event(upgraded, "Warning", "InstrumentationUpgradeRejected", fmt.Sprintf("support for is not enabled for %s", config.id))
+				u.Logger.V(4).Info("autoinstrumentation not enabled for this language", "flag", instCfg.id)
 			}
 		}
 	}
@@ -177,8 +176,7 @@ func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instru
 					}
 				}
 			} else {
-				u.Logger.Error(nil, "autoinstrumentation not enabled for this language", "flag", gate.ID())
-				u.Recorder.Event(upgraded, "Warning", "InstrumentationUpgradeRejected", fmt.Sprintf("support for is not enabled for %s", gate.ID()))
+				u.Logger.V(4).Info("autoinstrumentation not enabled for this language", "flag", gate.ID())
 			}
 		}
 	}


### PR DESCRIPTION
**Description:** 
This PR puts more things into debug logs where they were providing no value to users. The logs and events for autoinstrumentation were particularly noisy – a user doesn't really care if we need to upgrade something that isn't enabled. We just end up crowding logs and events for autoinstrumentation with garbage:
```
{"level":"error","ts":"2024-04-04T19:45:02Z","logger":"instrumentation-upgrade","msg":"autoinstrumentation not enabled for this language","flag":"enable-nginx-instrumentation","stacktrace":"github.com/open-telemetry/opentelemetry-operator/pkg/instrumentation/upgrade.(*InstrumentationUpgrade).upgrade\n\t/Users/jacob.aronoff/workspace/playground/opentelemetry-operator/pkg/instrumentation/upgrade/upgrade.go:147\ngithub.com/open-telemetry/opentelemetry-operator/pkg/instrumentation/upgrade.(*InstrumentationUpgrade).ManagedInstances\n\t/Users/jacob.aronoff/workspace/playground/opentelemetry-operator/pkg/instrumentation/upgrade/upgrade.go:102\nmain.addDependencies.func2\n\t/Users/jacob.aronoff/workspace/playground/opentelemetry-operator/main.go:381\nsigs.k8s.io/controller-runtime/pkg/manager.RunnableFunc.Start\n\t/Users/jacob.aronoff/workspace/playground/opentelemetry-operator/vendor/sigs.k8s.io/controller-runtime/pkg/manager/manager.go:301\nsigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1\n\t/Users/jacob.aronoff/workspace/playground/opentelemetry-operator/vendor/sigs.k8s.io/controller-runtime/pkg/manager/runnable_group.go:223"}
{"level":"error","ts":"2024-04-04T19:45:02Z","logger":"instrumentation-upgrade","msg":"autoinstrumentation not enabled for this language","flag":"operator.autoinstrumentation.go","stacktrace":"github.com/open-telemetry/opentelemetry-operator/pkg/instrumentation/upgrade.(*InstrumentationUpgrade).upgrade\n\t/Users/jacob.aronoff/workspace/playground/opentelemetry-operator/pkg/instrumentation/upgrade/upgrade.go:180\ngithub.com/open-telemetry/opentelemetry-operator/pkg/instrumentation/upgrade.(*InstrumentationUpgrade).ManagedInstances\n\t/Users/jacob.aronoff/workspace/playground/opentelemetry-operator/pkg/instrumentation/upgrade/upgrade.go:102\nmain.addDependencies.func2\n\t/Users/jacob.aronoff/workspace/playground/opentelemetry-operator/main.go:381\nsigs.k8s.io/controller-runtime/pkg/manager.RunnableFunc.Start\n\t/Users/jacob.aronoff/workspace/playground/opentelemetry-operator/vendor/sigs.k8s.io/controller-runtime/pkg/manager/manager.go:301\nsigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1\n\t/Users/jacob.aronoff/workspace/playground/opentelemetry-operator/vendor/sigs.k8s.io/controller-runtime/pkg/manager/runnable_group.go:223"}
```
```
Events:
  Type     Reason                          Age    From                    Message
  ----     ------                          ----   ----                    -------
  Warning  InstrumentationUpgradeRejected  56m    opentelemetry-operator  support for is not enabled for enable-nginx-instrumentation
  Warning  InstrumentationUpgradeRejected  56m    opentelemetry-operator  support for is not enabled for operator.autoinstrumentation.go
  Warning  InstrumentationUpgradeRejected  50m    opentelemetry-operator  support for is not enabled for enable-nginx-instrumentation
  Warning  InstrumentationUpgradeRejected  50m    opentelemetry-operator  support for is not enabled for operator.autoinstrumentation.go
  Warning  InstrumentationUpgradeRejected  42m    opentelemetry-operator  support for is not enabled for enable-nginx-instrumentation
  Warning  InstrumentationUpgradeRejected  42m    opentelemetry-operator  support for is not enabled for operator.autoinstrumentation.go
  Warning  InstrumentationUpgradeRejected  30m    opentelemetry-operator  support for is not enabled for enable-nginx-instrumentation
  Warning  InstrumentationUpgradeRejected  30m    opentelemetry-operator  support for is not enabled for operator.autoinstrumentation.go
  Warning  InstrumentationUpgradeRejected  26m    opentelemetry-operator  support for is not enabled for enable-nginx-instrumentation
  Warning  InstrumentationUpgradeRejected  26m    opentelemetry-operator  support for is not enabled for operator.autoinstrumentation.go
  Warning  InstrumentationUpgradeRejected  21m    opentelemetry-operator  support for is not enabled for enable-nginx-instrumentation
  Warning  InstrumentationUpgradeRejected  21m    opentelemetry-operator  support for is not enabled for operator.autoinstrumentation.go
  Warning  InstrumentationUpgradeRejected  18m    opentelemetry-operator  support for is not enabled for enable-nginx-instrumentation
  Warning  InstrumentationUpgradeRejected  18m    opentelemetry-operator  support for is not enabled for operator.autoinstrumentation.go
  Warning  InstrumentationUpgradeRejected  13m    opentelemetry-operator  support for is not enabled for enable-nginx-instrumentation
  Warning  InstrumentationUpgradeRejected  13m    opentelemetry-operator  support for is not enabled for operator.autoinstrumentation.go
  Warning  InstrumentationUpgradeRejected  8m47s  opentelemetry-operator  support for is not enabled for enable-nginx-instrumentation
  Warning  InstrumentationUpgradeRejected  8m47s  opentelemetry-operator  support for is not enabled for operator.autoinstrumentation.go
  Warning  InstrumentationUpgradeRejected  5m35s  opentelemetry-operator  support for is not enabled for enable-nginx-instrumentation
  Warning  InstrumentationUpgradeRejected  5m35s  opentelemetry-operator  support for is not enabled for operator.autoinstrumentation.go
```

**Link to tracking Issue(s):** n/a

**Testing:** logs

**Documentation:** n/a
