### PR TITLE
Promote @swiatekm-sumo to maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,7 +769,6 @@ Approvers ([@open-telemetry/operator-approvers](https://github.com/orgs/open-tel
 - [Benedikt Bongartz](https://github.com/frzifus), Red Hat
 - [Tyler Helmuth](https://github.com/TylerHelmuth), Honeycomb
 - [Yuri Oliveira Sa](https://github.com/yuriolisa), Red Hat
-- [Mikołaj Świątek](https://github.com/swiatekm-sumo), Sumo Logic
 
 Emeritus Approvers:
 
@@ -789,6 +788,7 @@ Target Allocator Maintainers ([@open-telemetry/operator-ta-maintainers](https://
 Maintainers ([@open-telemetry/operator-maintainers](https://github.com/orgs/open-telemetry/teams/operator-maintainers)):
 
 - [Jacob Aronoff](https://github.com/jaronoff97), Lightstep
+- [Mikołaj Świątek](https://github.com/swiatekm-sumo), Sumo Logic
 - [Pavol Loffay](https://github.com/pavolloffay), Red Hat
 - [Vineeth Pothulapati](https://github.com/VineethReddy02), Timescale
 


### PR DESCRIPTION
I'd like to propose promoting me to maintainer. I've been an active contributor in this project for over a year, and an Approver for most of that time, as well as a prolific SIG meeting participant. My original area of interest was the target allocator (https://github.com/open-telemetry/opentelemetry-operator/pull/1889 https://github.com/open-telemetry/opentelemetry-operator/pull/1923 https://github.com/open-telemetry/opentelemetry-operator/pull/2189), but I've also improved both the local dev experience (https://github.com/open-telemetry/opentelemetry-operator/pull/2317 https://github.com/open-telemetry/opentelemetry-operator/pull/2774 https://github.com/open-telemetry/opentelemetry-operator/pull/2654) and the CI (https://github.com/open-telemetry/opentelemetry-operator/pull/2595 https://github.com/open-telemetry/opentelemetry-operator/pull/2479 https://github.com/open-telemetry/opentelemetry-operator/pull/2289). I'm also involved in the ongoing development of v1beta1 CRDs (https://github.com/open-telemetry/opentelemetry-operator/pull/2516 https://github.com/open-telemetry/opentelemetry-operator/pull/2565).

I also try to be responsive in our Slack channels and in issues opened by users.

You can find the full list of my contributions and issues [here](https://github.com/open-telemetry/opentelemetry-operator/issues?q=author%3Aswiatekm-sumo+).

I'd be happy to help out more.

CC @open-telemetry/operator-maintainers 
