### PR TITLE
Drop compatibility with older target allocator versions

### DIFF
--- a/.chloggen/fix_drop-ta-config-backwards-compat.yaml
+++ b/.chloggen/fix_drop-ta-config-backwards-compat.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Drop compatibility with older target allocator versions
+
+# One or more tracking issues related to the change
+issues: [1907]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  We've made a breaking change to the target allocator configuration in 0.93.0. This change removes operator 
+  compatibility with target allocator versions older than that. Users running more recent target allocator versions
+  are unaffected.

--- a/controllers/builder_test.go
+++ b/controllers/builder_test.go
@@ -1372,11 +1372,6 @@ config:
       - __meta_service_name
       target_label: instance
 filter_strategy: relabel-config
-label_selector:
-  app.kubernetes.io/component: opentelemetry-collector
-  app.kubernetes.io/instance: test.test
-  app.kubernetes.io/managed-by: opentelemetry-operator
-  app.kubernetes.io/part-of: opentelemetry
 prometheus_cr:
   pod_monitor_selector: null
   service_monitor_selector: null
@@ -1412,7 +1407,7 @@ prometheus_cr:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "ba38217bad7e399f1210b90a464252159a8c4e17060c246799b8e4cb29a6f18f",
+									"opentelemetry-targetallocator-config/hash": "dd0ff440929239a362ebc85256b89e109d37bd2c77b400bd2039582cbda56be5",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -1771,11 +1766,6 @@ config:
       - __meta_service_name
       target_label: instance
 filter_strategy: relabel-config
-label_selector:
-  app.kubernetes.io/component: opentelemetry-collector
-  app.kubernetes.io/instance: test.test
-  app.kubernetes.io/managed-by: opentelemetry-operator
-  app.kubernetes.io/part-of: opentelemetry
 prometheus_cr:
   pod_monitor_selector: null
   service_monitor_selector: null
@@ -1811,7 +1801,7 @@ prometheus_cr:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "ba38217bad7e399f1210b90a464252159a8c4e17060c246799b8e4cb29a6f18f",
+									"opentelemetry-targetallocator-config/hash": "dd0ff440929239a362ebc85256b89e109d37bd2c77b400bd2039582cbda56be5",
 								},
 							},
 							Spec: corev1.PodSpec{

--- a/controllers/reconcile_test.go
+++ b/controllers/reconcile_test.go
@@ -462,17 +462,9 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 									"app.kubernetes.io/part-of":    "opentelemetry",
 								},
 							}
-							taConfig["label_selector"] = map[string]string{
-								"app.kubernetes.io/instance":   "default.test",
-								"app.kubernetes.io/managed-by": "opentelemetry-operator",
-								"app.kubernetes.io/component":  "opentelemetry-collector",
-								"app.kubernetes.io/part-of":    "opentelemetry",
-							}
 							taConfig["config"] = promConfig["config"]
 							taConfig["allocation_strategy"] = "consistent-hashing"
 							taConfig["filter_strategy"] = "relabel-config"
-							taConfig["pod_monitor_selector"] = map[string]string{}
-							taConfig["service_monitor_selector"] = map[string]string{}
 							taConfig["prometheus_cr"] = map[string]any{
 								"scrape_interval":          "30s",
 								"pod_monitor_selector":     &metav1.LabelSelector{},

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -38,9 +38,6 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	taConfig := make(map[interface{}]interface{})
 	prometheusCRConfig := make(map[interface{}]interface{})
 	taConfig["collector_selector"] = taSpec.CollectorSelector
-	// The below instruction is here for compatibility with the previous target allocator version
-	// TODO: Drop it after 3 more versions
-	taConfig["label_selector"] = taSpec.CollectorSelector.MatchLabels
 
 	// Add scrape configs if present
 	if instance.Spec.ScrapeConfigs != nil {
@@ -62,19 +59,7 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 
 	prometheusCRConfig["service_monitor_selector"] = taSpec.PrometheusCR.ServiceMonitorSelector
 
-	// The below instruction is here for compatibility with the previous target allocator version
-	// TODO: Drop it after 3 more versions
-	if taSpec.PrometheusCR.ServiceMonitorSelector != nil {
-		taConfig["service_monitor_selector"] = &taSpec.PrometheusCR.ServiceMonitorSelector.MatchLabels
-	}
-
 	prometheusCRConfig["pod_monitor_selector"] = taSpec.PrometheusCR.PodMonitorSelector
-
-	// The below instruction is here for compatibility with the previous target allocator version
-	// TODO: Drop it after 3 more versions
-	if taSpec.PrometheusCR.PodMonitorSelector != nil {
-		taConfig["pod_monitor_selector"] = &taSpec.PrometheusCR.PodMonitorSelector.MatchLabels
-	}
 
 	if len(prometheusCRConfig) > 0 {
 		taConfig["prometheus_cr"] = prometheusCRConfig

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -57,11 +57,6 @@ config:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
 filter_strategy: relabel-config
-label_selector:
-  app.kubernetes.io/component: opentelemetry-collector
-  app.kubernetes.io/instance: default.my-instance
-  app.kubernetes.io/managed-by: opentelemetry-operator
-  app.kubernetes.io/part-of: opentelemetry
 prometheus_cr:
   pod_monitor_selector: null
   service_monitor_selector: null
@@ -106,13 +101,6 @@ config:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
 filter_strategy: relabel-config
-label_selector:
-  app.kubernetes.io/component: opentelemetry-collector
-  app.kubernetes.io/instance: default.my-instance
-  app.kubernetes.io/managed-by: opentelemetry-operator
-  app.kubernetes.io/part-of: opentelemetry
-pod_monitor_selector:
-  release: my-instance
 prometheus_cr:
   pod_monitor_selector:
     matchlabels:
@@ -122,8 +110,6 @@ prometheus_cr:
     matchlabels:
       release: my-instance
     matchexpressions: []
-service_monitor_selector:
-  release: my-instance
 `,
 		}
 		targetAllocator := targetAllocatorInstance()
@@ -172,11 +158,6 @@ config:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
 filter_strategy: relabel-config
-label_selector:
-  app.kubernetes.io/component: opentelemetry-collector
-  app.kubernetes.io/instance: default.my-instance
-  app.kubernetes.io/managed-by: opentelemetry-operator
-  app.kubernetes.io/part-of: opentelemetry
 prometheus_cr:
   pod_monitor_selector: null
   scrape_interval: 30s


### PR DESCRIPTION
**Description:** <Describe what has changed.>

We've made a breaking change to the target allocator configuration in 0.93.0. This change removes operator compatibility with target allocator versions older than that.

**Link to tracking Issue(s):** #1907 

**Testing:**
Modified existing tests.
