### PR TITLE
Remove `operator.collector.rewritetargetallocator` feature flag

### DIFF
--- a/.chloggen/chore_remove-ta-rewrite-flag.yaml
+++ b/.chloggen/chore_remove-ta-rewrite-flag.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `operator.collector.rewritetargetallocator` feature flag
+
+# One or more tracking issues related to the change
+issues: [2796]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1alpha1/collector_webhook.go
+++ b/apis/v1alpha1/collector_webhook.go
@@ -32,7 +32,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	ta "github.com/open-telemetry/opentelemetry-operator/internal/manifests/targetallocator/adapters"
 	"github.com/open-telemetry/opentelemetry-operator/internal/rbac"
-	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
 
 var (
@@ -365,7 +364,7 @@ func (c CollectorWebhook) validateTargetAllocatorConfig(ctx context.Context, r *
 	if err != nil {
 		return nil, fmt.Errorf("the OpenTelemetry Spec Prometheus configuration is incorrect, %w", err)
 	}
-	err = ta.ValidatePromConfig(promCfg, r.Spec.TargetAllocator.Enabled, featuregate.EnableTargetAllocatorRewrite.IsEnabled())
+	err = ta.ValidatePromConfig(promCfg, r.Spec.TargetAllocator.Enabled)
 	if err != nil {
 		return nil, fmt.Errorf("the OpenTelemetry Spec Prometheus configuration is incorrect, %w", err)
 	}

--- a/internal/manifests/targetallocator/adapters/config_to_prom_config.go
+++ b/internal/manifests/targetallocator/adapters/config_to_prom_config.go
@@ -15,7 +15,6 @@
 package adapters
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -297,20 +296,12 @@ func AddTAConfigToPromConfig(prometheus map[interface{}]interface{}, taServiceNa
 }
 
 // ValidatePromConfig checks if the prometheus receiver config is valid given other collector-level settings.
-func ValidatePromConfig(config map[interface{}]interface{}, targetAllocatorEnabled bool, targetAllocatorRewriteEnabled bool) error {
+func ValidatePromConfig(config map[interface{}]interface{}, targetAllocatorEnabled bool) error {
+	// TODO: Rethink this validation, now that target allocator rewrite is enabled permanently.
+
 	_, promConfigExists := config["config"]
 
 	if targetAllocatorEnabled {
-		if targetAllocatorRewriteEnabled { // if rewrite is enabled, we will add a target_allocator section during rewrite
-			return nil
-		}
-		_, targetAllocatorExists := config["target_allocator"]
-
-		// otherwise, either the target_allocator or config section needs to be here
-		if !(promConfigExists || targetAllocatorExists) {
-			return errors.New("either target allocator or prometheus config needs to be present")
-		}
-
 		return nil
 	}
 	// if target allocator isn't enabled, we need a config section

--- a/internal/manifests/targetallocator/adapters/config_to_prom_config_test.go
+++ b/internal/manifests/targetallocator/adapters/config_to_prom_config_test.go
@@ -15,7 +15,6 @@
 package adapters_test
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -302,66 +301,53 @@ func TestAddTAConfigToPromConfig(t *testing.T) {
 
 func TestValidatePromConfig(t *testing.T) {
 	testCases := []struct {
-		description                   string
-		config                        map[interface{}]interface{}
-		targetAllocatorEnabled        bool
-		targetAllocatorRewriteEnabled bool
-		expectedError                 error
+		description            string
+		config                 map[interface{}]interface{}
+		targetAllocatorEnabled bool
+		expectedError          error
 	}{
 		{
-			description:                   "target_allocator and rewrite enabled",
-			config:                        map[interface{}]interface{}{},
-			targetAllocatorEnabled:        true,
-			targetAllocatorRewriteEnabled: true,
-			expectedError:                 nil,
+			description:            "target_allocator enabled",
+			config:                 map[interface{}]interface{}{},
+			targetAllocatorEnabled: true,
+			expectedError:          nil,
 		},
 		{
 			description: "target_allocator enabled, target_allocator section present",
 			config: map[interface{}]interface{}{
 				"target_allocator": map[interface{}]interface{}{},
 			},
-			targetAllocatorEnabled:        true,
-			targetAllocatorRewriteEnabled: false,
-			expectedError:                 nil,
+			targetAllocatorEnabled: true,
+			expectedError:          nil,
 		},
 		{
 			description: "target_allocator enabled, config section present",
 			config: map[interface{}]interface{}{
 				"config": map[interface{}]interface{}{},
 			},
-			targetAllocatorEnabled:        true,
-			targetAllocatorRewriteEnabled: false,
-			expectedError:                 nil,
-		},
-		{
-			description:                   "target_allocator enabled, neither section present",
-			config:                        map[interface{}]interface{}{},
-			targetAllocatorEnabled:        true,
-			targetAllocatorRewriteEnabled: false,
-			expectedError:                 errors.New("either target allocator or prometheus config needs to be present"),
+			targetAllocatorEnabled: true,
+			expectedError:          nil,
 		},
 		{
 			description: "target_allocator disabled, config section present",
 			config: map[interface{}]interface{}{
 				"config": map[interface{}]interface{}{},
 			},
-			targetAllocatorEnabled:        false,
-			targetAllocatorRewriteEnabled: false,
-			expectedError:                 nil,
+			targetAllocatorEnabled: false,
+			expectedError:          nil,
 		},
 		{
-			description:                   "target_allocator disabled, config section not present",
-			config:                        map[interface{}]interface{}{},
-			targetAllocatorEnabled:        false,
-			targetAllocatorRewriteEnabled: false,
-			expectedError:                 fmt.Errorf("no %s available as part of the configuration", "prometheusConfig"),
+			description:            "target_allocator disabled, config section not present",
+			config:                 map[interface{}]interface{}{},
+			targetAllocatorEnabled: false,
+			expectedError:          fmt.Errorf("no %s available as part of the configuration", "prometheusConfig"),
 		},
 	}
 
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.description, func(t *testing.T) {
-			err := ta.ValidatePromConfig(testCase.config, testCase.targetAllocatorEnabled, testCase.targetAllocatorRewriteEnabled)
+			err := ta.ValidatePromConfig(testCase.config, testCase.targetAllocatorEnabled)
 			assert.Equal(t, testCase.expectedError, err)
 		})
 	}

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -43,15 +43,6 @@ var (
 		featuregate.WithRegisterDescription("controls whether the operator supports Golang auto-instrumentation"),
 		featuregate.WithRegisterFromVersion("v0.77.0"),
 	)
-	// EnableTargetAllocatorRewrite is the feature gate that controls whether the collector's configuration should
-	// automatically be rewritten when the target allocator is enabled.
-	EnableTargetAllocatorRewrite = featuregate.GlobalRegistry().MustRegister(
-		"operator.collector.rewritetargetallocator",
-		featuregate.StageStable,
-		featuregate.WithRegisterDescription("controls whether the operator should configure the collector's targetAllocator configuration"),
-		featuregate.WithRegisterFromVersion("v0.76.1"),
-		featuregate.WithRegisterToVersion("v0.98.0"),
-	)
 
 	// PrometheusOperatorIsAvailable is the feature gate that enables features associated to the Prometheus Operator.
 	PrometheusOperatorIsAvailable = featuregate.GlobalRegistry().MustRegister(


### PR DESCRIPTION
**Description:**
This feature gate is slated for removal in 0.99.0. 

After merging this, we should rethink how the prometheus config validation should work. It's probably still too strict in some cases the way it is now.

**Link to tracking Issue(s):** #2796 

- Resolves: #2796

**Testing:**
Removed some tests for the non-enabled case.
