### PR TITLE
Add missing annotation to TargetAllocator ScrapeConfigs field

### DIFF
--- a/apis/v1beta1/targetallocator_types.go
+++ b/apis/v1beta1/targetallocator_types.go
@@ -78,6 +78,7 @@ type TargetAllocatorSpec struct {
 	// For the exact format, see https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config.
 	// +optional
 	// +listType=atomic
+	// +kubebuilder:pruning:PreserveUnknownFields
 	ScrapeConfigs []AnyConfig `json:"scrapeConfigs,omitempty"`
 	// PrometheusCR defines the configuration for the retrieval of PrometheusOperator CRDs ( servicemonitor.monitoring.coreos.com/v1 and podmonitor.monitoring.coreos.com/v1 ).
 	// +optional

--- a/config/crd/bases/opentelemetry.io_targetallocators.yaml
+++ b/config/crd/bases/opentelemetry.io_targetallocators.yaml
@@ -2322,6 +2322,7 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+                x-kubernetes-preserve-unknown-fields: true
               securityContext:
                 properties:
                   allowPrivilegeEscalation:


### PR DESCRIPTION
Without this annotation, we get no data at all, as it's all discarded during serialization.
