### PR TITLE
Fix target allocator readiness check

### DIFF
--- a/.chloggen/fix_load-initial-servicemonitors.yaml
+++ b/.chloggen/fix_load-initial-servicemonitors.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix target allocator readiness check
+
+# One or more tracking issues related to the change
+issues: [2903]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -149,7 +149,7 @@ func main() {
 	runGroup.Add(
 		func() error {
 			// Initial loading of the config file's scrape config
-			if cfg.PromConfig != nil {
+			if cfg.PromConfig != nil && len(cfg.PromConfig.ScrapeConfigs) > 0 {
 				err = targetDiscoverer.ApplyConfig(allocatorWatcher.EventSourceConfigMap, cfg.PromConfig.ScrapeConfigs)
 				if err != nil {
 					setupLog.Error(err, "Unable to apply initial configuration")

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -111,6 +111,17 @@ func main() {
 			setupLog.Error(err, "Can't start the prometheus watcher")
 			os.Exit(1)
 		}
+		// apply the initial configuration
+		promConfig, loadErr := promWatcher.LoadConfig(ctx)
+		if loadErr != nil {
+			setupLog.Error(err, "Can't load initial Prometheus configuration from Prometheus CRs")
+			os.Exit(1)
+		}
+		loadErr = targetDiscoverer.ApplyConfig(allocatorWatcher.EventSourcePrometheusCR, promConfig.ScrapeConfigs)
+		if loadErr != nil {
+			setupLog.Error(err, "Can't load initial scrape targets from Prometheus CRs")
+			os.Exit(1)
+		}
 		runGroup.Add(
 			func() error {
 				promWatcherErr := promWatcher.Watch(eventChan, errChan)

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -40,7 +40,7 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	taConfig["collector_selector"] = taSpec.CollectorSelector
 
 	// Add scrape configs if present
-	if instance.Spec.ScrapeConfigs != nil {
+	if instance.Spec.ScrapeConfigs != nil && len(instance.Spec.ScrapeConfigs) > 0 {
 		taConfig["config"] = map[string]interface{}{
 			"scrape_configs": instance.Spec.ScrapeConfigs,
 		}

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/00-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/00-install.yaml
@@ -155,16 +155,5 @@ spec:
     enabled: true
     prometheusCR:
       enabled: true
-    scrapeInterval: 1s
+      scrapeInterval: 1s
     serviceAccount: ta
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: prometheus-cr
-spec:
-  endpoints:
-  - port: monitoring
-  selector:
-    matchLabels:
-      app.kubernetes.io/managed-by: opentelemetry-operator

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/01-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/01-install.yaml
@@ -1,4 +1,15 @@
 ---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prometheus-cr
+spec:
+  endpoints:
+    - port: monitoring
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: opentelemetry-operator
+---
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
**Description:**
The target allocator readiness check is broken in two ways:
* The target allocator doesn't do an initial load of targets from Prometheus CRs. So if there aren't any CRs, no targets are generated.
* If there are no scrape configs, but there is an empty scrape configs array, targets are loaded from these, and the target allocator becomes ready even though it shouldn't be.

This PR fixes both of these issues by:

* Loading targets from Prometheus CRs at startup.
* Not loading targets from scrape configs if there aren't any.
* For good measure, the target allocator config now doesn't even have the prometheus configuration section if there aren't any scrape targets.

**Link to tracking Issue(s):** #2903 

- Resolves: #2903 

**Testing:**
I changed an integration test with only Prometheus CR enabled to run without any actual CRs created initially.

