### PR TITLE
[chore] switch to using debug exporter in tests

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,15 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
+  newTag: 0.96.0-32-gdcf3579
+patches:
+- patch: '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--target-allocator-image=ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.96.0-32-gdcf3579"}]'
+  target:
+    kind: Deployment
+- patch: '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--operator-opamp-bridge-image=ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:v0.96.0-32-gdcf3579"}]'
+  target:
+    kind: Deployment

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,15 +1,2 @@
 resources:
 - manager.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-images:
-- name: controller
-  newName: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-  newTag: 0.96.0-32-gdcf3579
-patches:
-- patch: '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--target-allocator-image=ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.96.0-32-gdcf3579"}]'
-  target:
-    kind: Deployment
-- patch: '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--operator-opamp-bridge-image=ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:v0.96.0-32-gdcf3579"}]'
-  target:
-    kind: Deployment

--- a/tests/e2e/multiple-configmaps/00-install.yaml
+++ b/tests/e2e/multiple-configmaps/00-install.yaml
@@ -33,11 +33,11 @@ spec:
           http:
 
     exporters:
-      logging:
+      debug:
 
     service:
       pipelines:
         traces:
           receivers: [otlp]
           processors: []
-          exporters: [logging]
+          exporters: [debug]

--- a/tests/e2e/smoke-pod-labels/00-install.yaml
+++ b/tests/e2e/smoke-pod-labels/00-install.yaml
@@ -20,11 +20,11 @@ spec:
         timeout: 10s
 
     exporters:
-      logging:
+      debug:
 
     service:
       pipelines:
         traces:
           receivers: [otlp]
           processors: []
-          exporters: [logging]
+          exporters: [debug]


### PR DESCRIPTION
**Description:** 
Logging exporter is deprecated, switches to use the debug exporter

**Link to tracking Issue(s):** 

Unblocks https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1154