### PR TITLE
fix: Add /metrics non-resource URL to rbac

### DIFF
--- a/internal/manifests/collector/parser/processor/processor_k8sattributes.go
+++ b/internal/manifests/collector/parser/processor/processor_k8sattributes.go
@@ -62,6 +62,10 @@ func (o *K8sAttributesParser) GetRBACRules() []rbacv1.PolicyRule {
 			Resources: []string{"replicasets"},
 			Verbs:     []string{"get", "watch", "list"},
 		},
+		{
+			NonResourceURLs: []string{"/metrics"},
+			Verbs:           []string{"get"},
+		},
 	}
 
 	extractCfg, ok := o.config["extract"]

--- a/internal/manifests/collector/parser/processor/processor_k8sattributes_test.go
+++ b/internal/manifests/collector/parser/processor/processor_k8sattributes_test.go
@@ -45,6 +45,10 @@ func TestK8sAttributesRBAC(t *testing.T) {
 					Resources: []string{"replicasets"},
 					Verbs:     []string{"get", "watch", "list"},
 				},
+				{
+					NonResourceURLs: []string{"/metrics"},
+					Verbs:           []string{"get"},
+				},
 			},
 		},
 		{
@@ -66,6 +70,10 @@ func TestK8sAttributesRBAC(t *testing.T) {
 					APIGroups: []string{"apps"},
 					Resources: []string{"replicasets"},
 					Verbs:     []string{"get", "watch", "list"},
+				},
+				{
+					NonResourceURLs: []string{"/metrics"},
+					Verbs:           []string{"get"},
 				},
 				{
 					APIGroups: []string{""},


### PR DESCRIPTION
**Description:** Add the /metrics non-resource URL to the OTEL collector RBAC

By adding this non-resource URL to the RBAC, it becomes possible for an OTEL collector to scrape authenticated endpoints such as control plane components.