### PR TITLE
Added new Log Enconder Config

### DIFF
--- a/.chloggen/customized-log-encoder.yaml
+++ b/.chloggen/customized-log-encoder.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enabling new Logs Enconder Configuration parameters.
+
+# One or more tracking issues related to the change
+issues: [268]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/DEBUG.md
+++ b/DEBUG.md
@@ -1,0 +1,34 @@
+# Debug tips to the OpenTelemetry Operator
+
+A tip during a troubleshooting process is always welcome. Therefore, we prepared this documentation to help you identify possible issues and improve the application's reliability.
+
+## Customizing Logs Output
+By the default the Operator's log format is console like you can see below:
+```bash
+2024-05-06T11:55:11+02:00	INFO	setup	Prometheus CRDs are installed, adding to scheme.
+2024-05-06T11:55:11+02:00	INFO	setup	Openshift CRDs are not installed, skipping adding to scheme.
+2024-05-06T11:55:11+02:00	INFO	setup	the env var WATCH_NAMESPACE isn't set, watching all namespaces
+2024-05-06T11:55:11+02:00	INFO	Webhooks are disabled, operator is running an unsupported mode	{"ENABLE_WEBHOOKS": "false"}
+2024-05-06T11:55:11+02:00	INFO	setup	starting manager
+```
+
+If it is necessary to customize the log format, so you can use one of the following parameters:
+- `--zap-devel`:                                        Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default false)
+- `--zap-encoder`:                               Zap log encoding (one of 'json' or 'console')
+- `--zap-log-level`                              Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
+- `--zap-stacktrace-level`                        Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
+- `--zap-time-encoding`                   Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
+- The following parameters are effective only if the `--zap-encoder=json`:
+  - `zap-message-key`: The message key to be used in the customized Log Encoder
+  - `zap-level-key`: The level key to be used in the customized Log Encoder
+  - `zap-time-key`: The time key to be used in the customized Log Encoder
+  - `zap-level-format`: The level format to be used in the customized Log Encoder
+
+Running the Operator with the parameters `--zap-encoder=json`, `--zap-message-key="msg"`, `zap-level-key="severity"`,`zap-time-key="timestamp"`,`zap-level-format="uppercase"` you should see the following output:
+```bash
+{"severity":"INFO","timestamp":"2024-05-07T16:23:35+02:00","logger":"setup","msg":"Prometheus CRDs are installed, adding to scheme."}
+{"severity":"INFO","timestamp":"2024-05-07T16:23:35+02:00","logger":"setup","msg":"Openshift CRDs are not installed, skipping adding to scheme."}
+{"severity":"INFO","timestamp":"2024-05-07T16:23:35+02:00","logger":"setup","msg":"the env var WATCH_NAMESPACE isn't set, watching all namespaces"}
+{"severity":"INFO","timestamp":"2024-05-07T16:23:35+02:00","msg":"Webhooks are disabled, operator is running an unsupported mode","ENABLE_WEBHOOKS":"false"}
+{"severity":"INFO","timestamp":"2024-05-07T16:23:35+02:00","logger":"setup","msg":"starting manager"}
+```

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -262,22 +262,3 @@ func WithEncodeLevelFormat(s string) zapcore.LevelEncoder {
 		return zapcore.CapitalLevelEncoder
 	}
 }
-
-func WithEncodeTimeFormat(s string) zapcore.TimeEncoder {
-	switch s {
-	case "iso8601":
-		return zapcore.ISO8601TimeEncoder
-	case "epochmillis":
-		return zapcore.EpochMillisTimeEncoder
-	case "epochnannos":
-		return zapcore.EpochNanosTimeEncoder
-	case "epoch":
-		return zapcore.EpochTimeEncoder
-	case "rfc3339nano":
-		return zapcore.RFC3339NanoTimeEncoder
-	case "rfc3339":
-		return zapcore.RFC3339TimeEncoder
-	default:
-		return zapcore.ISO8601TimeEncoder
-	}
-}

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
@@ -251,5 +252,32 @@ func WithAnnotationFilters(annotationFilters []string) Option {
 			filters = append(filters, result.String())
 		}
 		o.annotationsFilter = filters
+	}
+}
+
+func WithEncodeLevelFormat(s string) zapcore.LevelEncoder {
+	if s == "lowercase" {
+		return zapcore.LowercaseLevelEncoder
+	} else {
+		return zapcore.CapitalLevelEncoder
+	}
+}
+
+func WithEncodeTimeFormat(s string) zapcore.TimeEncoder {
+	switch s {
+	case "iso8601":
+		return zapcore.ISO8601TimeEncoder
+	case "epochmillis":
+		return zapcore.EpochMillisTimeEncoder
+	case "epochnannos":
+		return zapcore.EpochNanosTimeEncoder
+	case "epoch":
+		return zapcore.EpochTimeEncoder
+	case "rfc3339nano":
+		return zapcore.RFC3339NanoTimeEncoder
+	case "rfc3339":
+		return zapcore.RFC3339TimeEncoder
+	default:
+		return zapcore.ISO8601TimeEncoder
 	}
 }

--- a/main.go
+++ b/main.go
@@ -136,7 +136,6 @@ func main() {
 		encodeMessageKey                 string
 		encodeLevelKey                   string
 		encodeTimeKey                    string
-		encodeTimeFormat                 string
 		encodeLevelFormat                string
 	)
 
@@ -174,21 +173,17 @@ func main() {
 	pflag.StringVar(&encodeMessageKey, "log-message-key", "message", "The message key to be used in the customized Log Encoder")
 	pflag.StringVar(&encodeLevelKey, "log-level-key", "level", "The level key to be used in the customized Log Encoder")
 	pflag.StringVar(&encodeTimeKey, "log-time-key", "timestamp", "The time key to be used in the customized Log Encoder")
-	pflag.StringVar(&encodeTimeFormat, "log-time-format", "iso8601", "The time format to be used in the customized Log Encoder")
 	pflag.StringVar(&encodeLevelFormat, "log-level-format", "uppercase", "The level format to be used in the customized Log Encoder")
 	pflag.Parse()
 
 	if custLogEncoder {
-		var encCfg = zapcore.EncoderConfig{
-			MessageKey: encodeMessageKey,
-			LevelKey:   encodeLevelKey,
-			TimeKey:    encodeTimeKey,
-		}
-		encCfg.EncodeTime = config.WithEncodeTimeFormat(encodeTimeFormat)
-		encCfg.EncodeLevel = config.WithEncodeLevelFormat(encodeLevelFormat)
-		encoder := zapcore.NewJSONEncoder(encCfg)
-		opts.Encoder = encoder
+		opts.EncoderConfigOptions = append(opts.EncoderConfigOptions, func(ec *zapcore.EncoderConfig) {
+			ec.MessageKey = encodeMessageKey
+			ec.LevelKey = encodeLevelKey
+			ec.TimeKey = encodeTimeKey
+		})
 	}
+
 	logger := zap.New(zap.UseFlagOptions(&opts))
 	ctrl.SetLogger(logger)
 
@@ -223,7 +218,6 @@ func main() {
 		"log-message-key", encodeMessageKey,
 		"log-level-key", encodeLevelKey,
 		"log-time-key", encodeTimeKey,
-		"log-time-format", encodeTimeFormat,
 		"log-level-format", encodeLevelFormat,
 	)
 

--- a/main.go
+++ b/main.go
@@ -174,7 +174,6 @@ func main() {
 	pflag.StringVar(&encodeLevelFormat, "zap-level-format", "uppercase", "The level format to be used in the customized Log Encoder")
 	pflag.Parse()
 
-	
 	opts.EncoderConfigOptions = append(opts.EncoderConfigOptions, func(ec *zapcore.EncoderConfig) {
 		ec.MessageKey = encodeMessageKey
 		ec.LevelKey = encodeLevelKey

--- a/main.go
+++ b/main.go
@@ -132,7 +132,6 @@ func main() {
 		annotationsFilter                []string
 		webhookPort                      int
 		tlsOpt                           tlsConfig
-		custLogEncoder                   bool
 		encodeMessageKey                 string
 		encodeLevelKey                   string
 		encodeTimeKey                    string
@@ -169,21 +168,19 @@ func main() {
 	pflag.IntVar(&webhookPort, "webhook-port", 9443, "The port the webhook endpoint binds to.")
 	pflag.StringVar(&tlsOpt.minVersion, "tls-min-version", "VersionTLS12", "Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.")
 	pflag.StringSliceVar(&tlsOpt.cipherSuites, "tls-cipher-suites", nil, "Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used")
-	pflag.BoolVar(&custLogEncoder, "enable-customized-log-encoder", false, "Enable the use of a customized Json Log Encoder")
 	pflag.StringVar(&encodeMessageKey, "zap-message-key", "message", "The message key to be used in the customized Log Encoder")
 	pflag.StringVar(&encodeLevelKey, "zap-level-key", "level", "The level key to be used in the customized Log Encoder")
 	pflag.StringVar(&encodeTimeKey, "zap-time-key", "timestamp", "The time key to be used in the customized Log Encoder")
 	pflag.StringVar(&encodeLevelFormat, "zap-level-format", "uppercase", "The level format to be used in the customized Log Encoder")
 	pflag.Parse()
 
-	if custLogEncoder {
-		opts.EncoderConfigOptions = append(opts.EncoderConfigOptions, func(ec *zapcore.EncoderConfig) {
-			ec.MessageKey = encodeMessageKey
-			ec.LevelKey = encodeLevelKey
-			ec.TimeKey = encodeTimeKey
-			ec.EncodeLevel = config.WithEncodeLevelFormat(encodeLevelFormat)
-		})
-	}
+	
+	opts.EncoderConfigOptions = append(opts.EncoderConfigOptions, func(ec *zapcore.EncoderConfig) {
+		ec.MessageKey = encodeMessageKey
+		ec.LevelKey = encodeLevelKey
+		ec.TimeKey = encodeTimeKey
+		ec.EncodeLevel = config.WithEncodeLevelFormat(encodeLevelFormat)
+	})
 
 	logger := zap.New(zap.UseFlagOptions(&opts))
 	ctrl.SetLogger(logger)
@@ -215,7 +212,6 @@ func main() {
 		"enable-nginx-instrumentation", enableNginxInstrumentation,
 		"enable-nodejs-instrumentation", enableNodeJSInstrumentation,
 		"enable-java-instrumentation", enableJavaInstrumentation,
-		"enable-customized-log-encoder", custLogEncoder,
 		"zap-message-key", encodeMessageKey,
 		"zap-level-key", encodeLevelKey,
 		"zap-time-key", encodeTimeKey,

--- a/main.go
+++ b/main.go
@@ -181,6 +181,7 @@ func main() {
 			ec.MessageKey = encodeMessageKey
 			ec.LevelKey = encodeLevelKey
 			ec.TimeKey = encodeTimeKey
+			ec.EncodeLevel = config.WithEncodeLevelFormat(encodeLevelFormat)
 		})
 	}
 

--- a/main.go
+++ b/main.go
@@ -170,10 +170,10 @@ func main() {
 	pflag.StringVar(&tlsOpt.minVersion, "tls-min-version", "VersionTLS12", "Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.")
 	pflag.StringSliceVar(&tlsOpt.cipherSuites, "tls-cipher-suites", nil, "Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used")
 	pflag.BoolVar(&custLogEncoder, "enable-customized-log-encoder", false, "Enable the use of a customized Json Log Encoder")
-	pflag.StringVar(&encodeMessageKey, "log-message-key", "message", "The message key to be used in the customized Log Encoder")
-	pflag.StringVar(&encodeLevelKey, "log-level-key", "level", "The level key to be used in the customized Log Encoder")
-	pflag.StringVar(&encodeTimeKey, "log-time-key", "timestamp", "The time key to be used in the customized Log Encoder")
-	pflag.StringVar(&encodeLevelFormat, "log-level-format", "uppercase", "The level format to be used in the customized Log Encoder")
+	pflag.StringVar(&encodeMessageKey, "zap-message-key", "message", "The message key to be used in the customized Log Encoder")
+	pflag.StringVar(&encodeLevelKey, "zap-level-key", "level", "The level key to be used in the customized Log Encoder")
+	pflag.StringVar(&encodeTimeKey, "zap-time-key", "timestamp", "The time key to be used in the customized Log Encoder")
+	pflag.StringVar(&encodeLevelFormat, "zap-level-format", "uppercase", "The level format to be used in the customized Log Encoder")
 	pflag.Parse()
 
 	if custLogEncoder {
@@ -216,10 +216,10 @@ func main() {
 		"enable-nodejs-instrumentation", enableNodeJSInstrumentation,
 		"enable-java-instrumentation", enableJavaInstrumentation,
 		"enable-customized-log-encoder", custLogEncoder,
-		"log-message-key", encodeMessageKey,
-		"log-level-key", encodeLevelKey,
-		"log-time-key", encodeTimeKey,
-		"log-level-format", encodeLevelFormat,
+		"zap-message-key", encodeMessageKey,
+		"zap-level-key", encodeLevelKey,
+		"zap-time-key", encodeTimeKey,
+		"zap-level-format", encodeLevelFormat,
 	)
 
 	restConfig := ctrl.GetConfigOrDie()


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Added 5 new parameters to enable a customized JSON log Encoder: 
`--enable-customized-log-encoder` = It will enable the feature to set customized `keys` and `formats` to the logs, otherwise, the operator will use the zap-devel config. 
`--log-message-key` = It will replace the Key of the Message field (e.g. "msg") 
`--log-level-key` = It will replace the Key of the Level field (e.g. "severity")
`--log-time-key`= It will replace the Key of the Time field (e.g. "timestamp")
`--log-time-format` = It will replace the Format of the Time field (e.g. "epoch", "epochmillis", "epochnano", "iso8601", "rfc3339" or "rfc3339nano")
`--log-level-format` = It will replace the Format of the Level field (e.g. "uppercase", "lowercase")

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #268 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
