### PR TITLE
[chore] Refactor allocation strategies

### DIFF
--- a/.chloggen/refactor-strategies.yaml
+++ b/.chloggen/refactor-strategies.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Refactor allocation strategies
+
+# One or more tracking issues related to the change
+issues: [2928]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The performance of the per-node strategy was massively improved as part of this change.

--- a/cmd/otel-allocator/allocation/allocator.go
+++ b/cmd/otel-allocator/allocation/allocator.go
@@ -1,0 +1,272 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocation
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/diff"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
+)
+
+type Strategy interface {
+	GetCollectorForTarget(map[string]*Collector, *target.Item) (*Collector, error)
+	SetCollectors(map[string]*Collector)
+	GetName() string
+}
+
+var _ Allocator = &TargetAllocator{}
+
+func newAllocator(log logr.Logger, strategy Strategy, opts ...AllocationOption) Allocator {
+	chAllocator := &TargetAllocator{
+		strategy:                      strategy,
+		collectors:                    make(map[string]*Collector),
+		targetItems:                   make(map[string]*target.Item),
+		targetItemsPerJobPerCollector: make(map[string]map[string]map[string]bool),
+		log:                           log,
+	}
+	for _, opt := range opts {
+		opt(chAllocator)
+	}
+
+	return chAllocator
+}
+
+type TargetAllocator struct {
+	strategy Strategy
+	// m protects consistentHasher, collectors and targetItems for concurrent use.
+	m sync.RWMutex
+
+	// collectors is a map from a Collector's name to a Collector instance
+	// collectorKey -> collector pointer
+	collectors map[string]*Collector
+
+	// targetItems is a map from a target item's hash to the target items allocated state
+	// targetItem hash -> target item pointer
+	targetItems map[string]*target.Item
+
+	// collectorKey -> job -> target item hash -> true
+	targetItemsPerJobPerCollector map[string]map[string]map[string]bool
+
+	log logr.Logger
+
+	filter Filter
+}
+
+// SetFilter sets the filtering hook to use.
+func (t *TargetAllocator) SetFilter(filter Filter) {
+	t.filter = filter
+}
+
+// SetTargets accepts a list of targets that will be used to make
+// load balancing decisions. This method should be called when there are
+// new targets discovered or existing targets are shutdown.
+func (t *TargetAllocator) SetTargets(targets map[string]*target.Item) {
+	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetTargets", perNodeStrategyName))
+	defer timer.ObserveDuration()
+
+	if t.filter != nil {
+		targets = t.filter.Apply(targets)
+	}
+	RecordTargetsKept(targets)
+
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	// Check for target changes
+	targetsDiff := diff.Maps(t.targetItems, targets)
+	// If there are any additions or removals
+	if len(targetsDiff.Additions()) != 0 || len(targetsDiff.Removals()) != 0 {
+		t.handleTargets(targetsDiff)
+	}
+}
+
+// SetCollectors sets the set of collectors with key=collectorName, value=Collector object.
+// This method is called when Collectors are added or removed.
+func (t *TargetAllocator) SetCollectors(collectors map[string]*Collector) {
+	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetCollectors", consistentHashingStrategyName))
+	defer timer.ObserveDuration()
+
+	CollectorsAllocatable.WithLabelValues(consistentHashingStrategyName).Set(float64(len(collectors)))
+	if len(collectors) == 0 {
+		t.log.Info("No collector instances present")
+		return
+	}
+
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	// Check for collector changes
+	collectorsDiff := diff.Maps(t.collectors, collectors)
+	if len(collectorsDiff.Additions()) != 0 || len(collectorsDiff.Removals()) != 0 {
+		t.handleCollectors(collectorsDiff)
+	}
+}
+
+func (t *TargetAllocator) GetTargetsForCollectorAndJob(collector string, job string) []*target.Item {
+	t.m.RLock()
+	defer t.m.RUnlock()
+	if _, ok := t.targetItemsPerJobPerCollector[collector]; !ok {
+		return []*target.Item{}
+	}
+	if _, ok := t.targetItemsPerJobPerCollector[collector][job]; !ok {
+		return []*target.Item{}
+	}
+	targetItemsCopy := make([]*target.Item, len(t.targetItemsPerJobPerCollector[collector][job]))
+	index := 0
+	for targetHash := range t.targetItemsPerJobPerCollector[collector][job] {
+		targetItemsCopy[index] = t.targetItems[targetHash]
+		index++
+	}
+	return targetItemsCopy
+}
+
+// TargetItems returns a shallow copy of the targetItems map.
+func (t *TargetAllocator) TargetItems() map[string]*target.Item {
+	t.m.RLock()
+	defer t.m.RUnlock()
+	targetItemsCopy := make(map[string]*target.Item)
+	for k, v := range t.targetItems {
+		targetItemsCopy[k] = v
+	}
+	return targetItemsCopy
+}
+
+// Collectors returns a shallow copy of the collectors map.
+func (t *TargetAllocator) Collectors() map[string]*Collector {
+	t.m.RLock()
+	defer t.m.RUnlock()
+	collectorsCopy := make(map[string]*Collector)
+	for k, v := range t.collectors {
+		collectorsCopy[k] = v
+	}
+	return collectorsCopy
+}
+
+// handleTargets receives the new and removed targets and reconciles the current state.
+// Any removals are removed from the allocator's targetItems and unassigned from the corresponding collector.
+// Any net-new additions are assigned to the collector on the same node as the target.
+func (t *TargetAllocator) handleTargets(diff diff.Changes[*target.Item]) {
+	// Check for removals
+	for k, item := range t.targetItems {
+		// if the current item is in the removals list
+		if _, ok := diff.Removals()[k]; ok {
+			c, ok := t.collectors[item.CollectorName]
+			if ok {
+				c.NumTargets--
+				TargetsPerCollector.WithLabelValues(item.CollectorName, perNodeStrategyName).Set(float64(c.NumTargets))
+			}
+			delete(t.targetItems, k)
+			delete(t.targetItemsPerJobPerCollector[item.CollectorName][item.JobName], item.Hash())
+		}
+	}
+
+	// Check for additions
+	assignmentErrors := []error{}
+	for k, item := range diff.Additions() {
+		// Do nothing if the item is already there
+		if _, ok := t.targetItems[k]; ok {
+			continue
+		} else {
+			// Add item to item pool and assign a collector
+			err := t.addTargetToTargetItems(item)
+			if err != nil {
+				assignmentErrors = append(assignmentErrors, err)
+			}
+		}
+	}
+
+	// Check for unassigned targets
+	unassignedTargets := len(assignmentErrors)
+	if unassignedTargets > 0 {
+		err := errors.Join(assignmentErrors...)
+		t.log.Info("Could not assign targets for some jobs due to missing node labels", "targets", unassignedTargets, "error", err)
+		TargetsUnassigned.Set(float64(unassignedTargets))
+	}
+}
+
+func (t *TargetAllocator) addTargetToTargetItems(tg *target.Item) error {
+	// Short-circuit if there's no collectors
+	// Check if this is a reassignment, if so, decrement the previous collector's NumTargets
+	if previousColName, ok := t.collectors[tg.CollectorName]; ok {
+		previousColName.NumTargets--
+		delete(t.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName], tg.Hash())
+		TargetsPerCollector.WithLabelValues(previousColName.String(), consistentHashingStrategyName).Set(float64(t.collectors[previousColName.String()].NumTargets))
+	}
+	t.targetItems[tg.Hash()] = tg
+	if len(t.collectors) > 0 {
+		colOwner, err := t.strategy.GetCollectorForTarget(t.collectors, tg)
+		if err != nil {
+			return err
+		}
+		tg.CollectorName = colOwner.Name
+		t.addCollectorTargetItemMapping(tg)
+		t.collectors[colOwner.String()].NumTargets++
+		TargetsPerCollector.WithLabelValues(colOwner.String(), consistentHashingStrategyName).Set(float64(t.collectors[colOwner.String()].NumTargets))
+	}
+	return nil
+}
+
+// addCollectorTargetItemMapping keeps track of which collector has which jobs and targets
+// this allows the allocator to respond without any extra allocations to http calls. The caller of this method
+// has to acquire a lock.
+func (t *TargetAllocator) addCollectorTargetItemMapping(tg *target.Item) {
+	if t.targetItemsPerJobPerCollector[tg.CollectorName] == nil {
+		t.targetItemsPerJobPerCollector[tg.CollectorName] = make(map[string]map[string]bool)
+	}
+	if t.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] == nil {
+		t.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] = make(map[string]bool)
+	}
+	t.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName][tg.Hash()] = true
+}
+
+// handleCollectors receives the new and removed collectors and reconciles the current state.
+// Any removals are removed from the allocator's collectors. New collectors are added to the allocator's collector map.
+// Finally, update all targets' collectors to match the consistent hashing.
+func (t *TargetAllocator) handleCollectors(diff diff.Changes[*Collector]) {
+	// Clear removed collectors
+	for _, k := range diff.Removals() {
+		delete(t.collectors, k.Name)
+		delete(t.targetItemsPerJobPerCollector, k.Name)
+		TargetsPerCollector.WithLabelValues(k.Name, consistentHashingStrategyName).Set(0)
+	}
+	// Insert the new collectors
+	for _, i := range diff.Additions() {
+		t.collectors[i.Name] = NewCollector(i.Name, i.NodeName)
+	}
+
+	// Set collectors on the strategy
+	t.strategy.SetCollectors(t.collectors)
+
+	// Re-Allocate all targets
+	assignmentErrors := []error{}
+	for _, item := range t.targetItems {
+		err := t.addTargetToTargetItems(item)
+		if err != nil {
+			assignmentErrors = append(assignmentErrors, err)
+		}
+	}
+	// Check for unassigned targets
+	unassignedTargets := len(assignmentErrors)
+	if unassignedTargets > 0 {
+		err := errors.Join(assignmentErrors...)
+		t.log.Info("Could not assign targets for some jobs due to missing node labels", "targets", unassignedTargets, "error", err)
+		TargetsUnassigned.Set(float64(unassignedTargets))
+	}
+}

--- a/cmd/otel-allocator/allocation/allocator.go
+++ b/cmd/otel-allocator/allocation/allocator.go
@@ -193,7 +193,7 @@ func (a *allocator) handleTargets(diff diff.Changes[*target.Item]) {
 	unassignedTargets := len(assignmentErrors)
 	if unassignedTargets > 0 {
 		err := errors.Join(assignmentErrors...)
-		a.log.Info("Could not assign targets for some jobs due to missing node labels", "targets", unassignedTargets, "error", err)
+		a.log.Info("Could not assign targets for some jobs", "targets", unassignedTargets, "error", err)
 		TargetsUnassigned.Set(float64(unassignedTargets))
 	}
 }
@@ -212,7 +212,7 @@ func (a *allocator) addTargetToTargetItems(tg *target.Item) error {
 	// Check if this is a reassignment, if so, unassign first
 	// note: The ordering here is important, we want to determine the new assignment before unassigning, because
 	// the strategy might make use of previous assignment information
-	if _, ok := a.collectors[tg.CollectorName]; ok {
+	if _, ok := a.collectors[tg.CollectorName]; ok && tg.CollectorName != "" {
 		a.unassignTargetItem(tg)
 	}
 
@@ -304,7 +304,7 @@ func (a *allocator) handleCollectors(diff diff.Changes[*Collector]) {
 	unassignedTargets := len(assignmentErrors)
 	if unassignedTargets > 0 {
 		err := errors.Join(assignmentErrors...)
-		a.log.Info("Could not assign targets for some jobs due to missing node labels", "targets", unassignedTargets, "error", err)
+		a.log.Info("Could not assign targets for some jobs", "targets", unassignedTargets, "error", err)
 		TargetsUnassigned.Set(float64(unassignedTargets))
 	}
 }

--- a/cmd/otel-allocator/allocation/allocator.go
+++ b/cmd/otel-allocator/allocation/allocator.go
@@ -25,6 +25,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 )
 
+/*
+	Target Allocator will serve on an HTTP server exposing /jobs/<job_id>/targets
+	The targets are allocated using the least connection method
+	Target Allocator will need information about the collectors in order to set the URLs
+	Keep a Map of what each collector currently holds and update it based on new scrape target updates
+*/
+
 type Strategy interface {
 	GetCollectorForTarget(map[string]*Collector, *target.Item) (*Collector, error)
 	SetCollectors(map[string]*Collector)
@@ -184,6 +191,7 @@ func (t *TargetAllocator) handleTargets(diff diff.Changes[*target.Item]) {
 		if _, ok := t.targetItems[k]; ok {
 			continue
 		} else {
+			item.CollectorName = ""
 			// Add item to item pool and assign a collector
 			err := t.addTargetToTargetItems(item)
 			if err != nil {

--- a/cmd/otel-allocator/allocation/allocator.go
+++ b/cmd/otel-allocator/allocation/allocator.go
@@ -277,7 +277,7 @@ func (a *allocator) addCollectorTargetItemMapping(tg *target.Item) {
 
 // handleCollectors receives the new and removed collectors and reconciles the current state.
 // Any removals are removed from the allocator's collectors. New collectors are added to the allocator's collector map.
-// Finally, update all targets' collectors to match the consistent hashing.
+// Finally, update all targets' collector assignments.
 func (a *allocator) handleCollectors(diff diff.Changes[*Collector]) {
 	// Clear removed collectors
 	for _, k := range diff.Removals() {

--- a/cmd/otel-allocator/allocation/allocator_test.go
+++ b/cmd/otel-allocator/allocation/allocator_test.go
@@ -1,0 +1,148 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocation
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
+)
+
+func TestSetCollectors(t *testing.T) {
+	RunForAllStrategies(t, func(t *testing.T, allocator Allocator) {
+		cols := MakeNCollectors(3, 0)
+		allocator.SetCollectors(cols)
+
+		expectedColLen := len(cols)
+		collectors := allocator.Collectors()
+		assert.Len(t, collectors, expectedColLen)
+
+		for _, i := range cols {
+			assert.NotNil(t, collectors[i.Name])
+		}
+	})
+}
+
+func TestSetTargets(t *testing.T) {
+	RunForAllStrategies(t, func(t *testing.T, allocator Allocator) {
+		targets := MakeNNewTargetsWithEmptyCollectors(3, 0)
+		allocator.SetTargets(targets)
+
+		expectedTargetLen := len(targets)
+		actualTargets := allocator.TargetItems()
+		assert.Len(t, actualTargets, expectedTargetLen)
+	})
+}
+
+func TestCanSetSingleTarget(t *testing.T) {
+	RunForAllStrategies(t, func(t *testing.T, allocator Allocator) {
+		cols := MakeNCollectors(3, 0)
+		targets := MakeNNewTargetsWithEmptyCollectors(1, 3)
+		allocator.SetCollectors(cols)
+		allocator.SetTargets(targets)
+		actualTargetItems := allocator.TargetItems()
+		assert.Len(t, actualTargetItems, 1)
+		for _, item := range actualTargetItems {
+			assert.NotEmpty(t, item.CollectorName)
+		}
+	})
+}
+
+func TestCanSetTargetsBeforeCollectors(t *testing.T) {
+	RunForAllStrategies(t, func(t *testing.T, allocator Allocator) {
+		cols := MakeNCollectors(3, 0)
+		targets := MakeNNewTargetsWithEmptyCollectors(1, 3)
+		allocator.SetTargets(targets)
+		allocator.SetCollectors(cols)
+		actualTargetItems := allocator.TargetItems()
+		assert.Len(t, actualTargetItems, 1)
+		for _, item := range actualTargetItems {
+			assert.NotEmpty(t, item.CollectorName)
+		}
+	})
+}
+
+func TestAddingAndRemovingTargets(t *testing.T) {
+	RunForAllStrategies(t, func(t *testing.T, allocator Allocator) {
+		cols := MakeNCollectors(3, 0)
+		allocator.SetCollectors(cols)
+
+		initTargets := MakeNNewTargets(6, 3, 0)
+
+		// test that targets and collectors are added properly
+		allocator.SetTargets(initTargets)
+
+		// verify
+		expectedTargetLen := len(initTargets)
+		assert.Len(t, allocator.TargetItems(), expectedTargetLen)
+
+		// prepare second round of targets
+		tar := MakeNNewTargets(4, 3, 0)
+
+		// test that fewer targets are found - removed
+		allocator.SetTargets(tar)
+
+		// verify
+		targetItems := allocator.TargetItems()
+		expectedNewTargetLen := len(tar)
+		assert.Len(t, targetItems, expectedNewTargetLen)
+
+		// verify results map
+		for _, i := range tar {
+			_, ok := targetItems[i.Hash()]
+			assert.True(t, ok)
+		}
+	})
+
+}
+
+// Tests that two targets with the same target url and job name but different label set are both added.
+func TestAllocationCollision(t *testing.T) {
+	RunForAllStrategies(t, func(t *testing.T, allocator Allocator) {
+
+		cols := MakeNCollectors(3, 0)
+		allocator.SetCollectors(cols)
+		firstLabels := model.LabelSet{
+			"test": "test1",
+		}
+		secondLabels := model.LabelSet{
+			"test": "test2",
+		}
+		firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstLabels, "")
+		secondTarget := target.NewItem("sample-name", "0.0.0.0:8000", secondLabels, "")
+
+		targetList := map[string]*target.Item{
+			firstTarget.Hash():  firstTarget,
+			secondTarget.Hash(): secondTarget,
+		}
+
+		// test that targets and collectors are added properly
+		allocator.SetTargets(targetList)
+
+		// verify
+		targetItems := allocator.TargetItems()
+		expectedTargetLen := len(targetList)
+		assert.Len(t, targetItems, expectedTargetLen)
+
+		// verify results map
+		for _, i := range targetList {
+			_, ok := targetItems[i.Hash()]
+			assert.True(t, ok)
+		}
+	})
+}

--- a/cmd/otel-allocator/allocation/consistent_hashing.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing.go
@@ -72,10 +72,13 @@ func (s *consistentHashingStrategy) GetCollectorForTarget(collectors map[string]
 func (s *consistentHashingStrategy) SetCollectors(collectors map[string]*Collector) {
 	// we simply recreate the hasher with the new member set
 	// this isn't any more expensive than doing a diff and then applying the change
-	members := []consistent.Member{}
+	var members []consistent.Member
 
-	for _, collector := range collectors {
-		members = append(members, collector)
+	if len(collectors) > 0 {
+		members = make([]consistent.Member, 0, len(collectors))
+		for _, collector := range collectors {
+			members = append(members, collector)
+		}
 	}
 
 	s.consistentHasher = consistent.New(members, s.config)

--- a/cmd/otel-allocator/allocation/consistent_hashing.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing.go
@@ -15,19 +15,14 @@
 package allocation
 
 import (
+	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/buraksezer/consistent"
 	"github.com/cespare/xxhash/v2"
-	"github.com/go-logr/logr"
-	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/diff"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 )
-
-var _ Allocator = &consistentHashingAllocator{}
 
 const consistentHashingStrategyName = "consistent-hashing"
 
@@ -37,29 +32,14 @@ func (h hasher) Sum64(data []byte) uint64 {
 	return xxhash.Sum64(data)
 }
 
-type consistentHashingAllocator struct {
-	// m protects consistentHasher, collectors and targetItems for concurrent use.
-	m sync.RWMutex
+var _ Strategy = &consistentHashingStrategy{}
 
+type consistentHashingStrategy struct {
+	config           consistent.Config
 	consistentHasher *consistent.Consistent
-
-	// collectors is a map from a Collector's name to a Collector instance
-	// collectorKey -> collector pointer
-	collectors map[string]*Collector
-
-	// targetItems is a map from a target item's hash to the target items allocated state
-	// targetItem hash -> target item pointer
-	targetItems map[string]*target.Item
-
-	// collectorKey -> job -> target item hash -> true
-	targetItemsPerJobPerCollector map[string]map[string]map[string]bool
-
-	log logr.Logger
-
-	filter Filter
 }
 
-func newConsistentHashingAllocator(log logr.Logger, opts ...AllocationOption) Allocator {
+func newConsistentHashingStrategy() Strategy {
 	config := consistent.Config{
 		PartitionCount:    1061,
 		ReplicationFactor: 5,
@@ -67,228 +47,37 @@ func newConsistentHashingAllocator(log logr.Logger, opts ...AllocationOption) Al
 		Hasher:            hasher{},
 	}
 	consistentHasher := consistent.New(nil, config)
-	chAllocator := &consistentHashingAllocator{
-		consistentHasher:              consistentHasher,
-		collectors:                    make(map[string]*Collector),
-		targetItems:                   make(map[string]*target.Item),
-		targetItemsPerJobPerCollector: make(map[string]map[string]map[string]bool),
-		log:                           log,
+	chStrategy := &consistentHashingStrategy{
+		consistentHasher: consistentHasher,
+		config:           config,
 	}
-	for _, opt := range opts {
-		opt(chAllocator)
-	}
-
-	return chAllocator
+	return chStrategy
 }
 
-// SetFilter sets the filtering hook to use.
-func (c *consistentHashingAllocator) SetFilter(filter Filter) {
-	c.filter = filter
+func (s *consistentHashingStrategy) GetName() string {
+	return consistentHashingStrategyName
 }
 
-// addCollectorTargetItemMapping keeps track of which collector has which jobs and targets
-// this allows the allocator to respond without any extra allocations to http calls. The caller of this method
-// has to acquire a lock.
-func (c *consistentHashingAllocator) addCollectorTargetItemMapping(tg *target.Item) {
-	if c.targetItemsPerJobPerCollector[tg.CollectorName] == nil {
-		c.targetItemsPerJobPerCollector[tg.CollectorName] = make(map[string]map[string]bool)
+func (s *consistentHashingStrategy) GetCollectorForTarget(collectors map[string]*Collector, item *target.Item) (*Collector, error) {
+	hashKey := strings.Join(item.TargetURL, "")
+	member := s.consistentHasher.LocateKey([]byte(hashKey))
+	collectorName := member.String()
+	collector, ok := collectors[collectorName]
+	if !ok {
+		return nil, fmt.Errorf("unknown collector %s", collectorName)
 	}
-	if c.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] == nil {
-		c.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] = make(map[string]bool)
-	}
-	c.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName][tg.Hash()] = true
+	return collector, nil
 }
 
-// addTargetToTargetItems assigns a target to the collector based on its hash and adds it to the allocator's targetItems
-// This method is called from within SetTargets and SetCollectors, which acquire the needed lock.
-// This is only called after the collectors are cleared or when a new target has been found in the tempTargetMap.
-// INVARIANT: c.collectors must have at least 1 collector set.
-// NOTE: by not creating a new target item, there is the potential for a race condition where we modify this target
-// item while it's being encoded by the server JSON handler.
-func (c *consistentHashingAllocator) addTargetToTargetItems(tg *target.Item) {
-	// Check if this is a reassignment, if so, decrement the previous collector's NumTargets
-	if previousColName, ok := c.collectors[tg.CollectorName]; ok {
-		previousColName.NumTargets--
-		delete(c.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName], tg.Hash())
-		TargetsPerCollector.WithLabelValues(previousColName.String(), consistentHashingStrategyName).Set(float64(c.collectors[previousColName.String()].NumTargets))
-	}
-	colOwner := c.consistentHasher.LocateKey([]byte(strings.Join(tg.TargetURL, "")))
-	tg.CollectorName = colOwner.String()
-	c.targetItems[tg.Hash()] = tg
-	c.addCollectorTargetItemMapping(tg)
-	c.collectors[colOwner.String()].NumTargets++
-	TargetsPerCollector.WithLabelValues(colOwner.String(), consistentHashingStrategyName).Set(float64(c.collectors[colOwner.String()].NumTargets))
-}
+func (s *consistentHashingStrategy) SetCollectors(collectors map[string]*Collector) {
+	// we simply recreate the hasher with the new member set
+	// this isn't any more expensive than doing a diff and then applying the change
+	members := []consistent.Member{}
 
-// handleTargets receives the new and removed targets and reconciles the current state.
-// Any removals are removed from the allocator's targetItems and unassigned from the corresponding collector.
-// Any net-new additions are assigned to the next available collector.
-func (c *consistentHashingAllocator) handleTargets(diff diff.Changes[*target.Item]) {
-	// Check for removals
-	for k, item := range c.targetItems {
-		// if the current item is in the removals list
-		if _, ok := diff.Removals()[k]; ok {
-			col := c.collectors[item.CollectorName]
-			col.NumTargets--
-			delete(c.targetItems, k)
-			delete(c.targetItemsPerJobPerCollector[item.CollectorName][item.JobName], item.Hash())
-			TargetsPerCollector.WithLabelValues(item.CollectorName, consistentHashingStrategyName).Set(float64(col.NumTargets))
-		}
+	for _, collector := range collectors {
+		members = append(members, collector)
 	}
 
-	// Check for additions
-	for k, item := range diff.Additions() {
-		// Do nothing if the item is already there
-		if _, ok := c.targetItems[k]; ok {
-			continue
-		} else {
-			// Add item to item pool and assign a collector
-			c.addTargetToTargetItems(item)
-		}
-	}
-}
+	s.consistentHasher = consistent.New(members, s.config)
 
-// handleCollectors receives the new and removed collectors and reconciles the current state.
-// Any removals are removed from the allocator's collectors. New collectors are added to the allocator's collector map.
-// Finally, update all targets' collectors to match the consistent hashing.
-func (c *consistentHashingAllocator) handleCollectors(diff diff.Changes[*Collector]) {
-	// Clear removed collectors
-	for _, k := range diff.Removals() {
-		delete(c.collectors, k.Name)
-		delete(c.targetItemsPerJobPerCollector, k.Name)
-		c.consistentHasher.Remove(k.Name)
-		TargetsPerCollector.WithLabelValues(k.Name, consistentHashingStrategyName).Set(0)
-	}
-	// Insert the new collectors
-	for _, i := range diff.Additions() {
-		c.collectors[i.Name] = NewCollector(i.Name, i.NodeName)
-		c.consistentHasher.Add(c.collectors[i.Name])
-	}
-
-	// Re-Allocate all targets
-	for _, item := range c.targetItems {
-		c.addTargetToTargetItems(item)
-	}
-}
-
-// SetTargets accepts a list of targets that will be used to make
-// load balancing decisions. This method should be called when there are
-// new targets discovered or existing targets are shutdown.
-func (c *consistentHashingAllocator) SetTargets(targets map[string]*target.Item) {
-	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetTargets", consistentHashingStrategyName))
-	defer timer.ObserveDuration()
-
-	if c.filter != nil {
-		targets = c.filter.Apply(targets)
-	}
-	RecordTargetsKept(targets)
-
-	c.m.Lock()
-	defer c.m.Unlock()
-
-	if len(c.collectors) == 0 {
-		c.log.Info("No collector instances present, saving targets to allocate to collector(s)")
-		// If there were no targets discovered previously, assign this as the new set of target items
-		if len(c.targetItems) == 0 {
-			c.log.Info("Not discovered any targets previously, saving targets found to the targetItems set")
-			for k, item := range targets {
-				c.targetItems[k] = item
-			}
-		} else {
-			// If there were previously discovered targets, add or remove accordingly
-			targetsDiffEmptyCollectorSet := diff.Maps(c.targetItems, targets)
-
-			// Check for additions
-			if len(targetsDiffEmptyCollectorSet.Additions()) > 0 {
-				c.log.Info("New targets discovered, adding new targets to the targetItems set")
-				for k, item := range targetsDiffEmptyCollectorSet.Additions() {
-					// Do nothing if the item is already there
-					if _, ok := c.targetItems[k]; ok {
-						continue
-					} else {
-						// Add item to item pool
-						c.targetItems[k] = item
-					}
-				}
-			}
-
-			// Check for deletions
-			if len(targetsDiffEmptyCollectorSet.Removals()) > 0 {
-				c.log.Info("Targets removed, Removing targets from the targetItems set")
-				for k := range targetsDiffEmptyCollectorSet.Removals() {
-					// Delete item from target items
-					delete(c.targetItems, k)
-				}
-			}
-		}
-		return
-	}
-	// Check for target changes
-	targetsDiff := diff.Maps(c.targetItems, targets)
-	// If there are any additions or removals
-	if len(targetsDiff.Additions()) != 0 || len(targetsDiff.Removals()) != 0 {
-		c.handleTargets(targetsDiff)
-	}
-}
-
-// SetCollectors sets the set of collectors with key=collectorName, value=Collector object.
-// This method is called when Collectors are added or removed.
-func (c *consistentHashingAllocator) SetCollectors(collectors map[string]*Collector) {
-	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetCollectors", consistentHashingStrategyName))
-	defer timer.ObserveDuration()
-
-	CollectorsAllocatable.WithLabelValues(consistentHashingStrategyName).Set(float64(len(collectors)))
-	if len(collectors) == 0 {
-		c.log.Info("No collector instances present")
-		return
-	}
-
-	c.m.Lock()
-	defer c.m.Unlock()
-
-	// Check for collector changes
-	collectorsDiff := diff.Maps(c.collectors, collectors)
-	if len(collectorsDiff.Additions()) != 0 || len(collectorsDiff.Removals()) != 0 {
-		c.handleCollectors(collectorsDiff)
-	}
-}
-
-func (c *consistentHashingAllocator) GetTargetsForCollectorAndJob(collector string, job string) []*target.Item {
-	c.m.RLock()
-	defer c.m.RUnlock()
-	if _, ok := c.targetItemsPerJobPerCollector[collector]; !ok {
-		return []*target.Item{}
-	}
-	if _, ok := c.targetItemsPerJobPerCollector[collector][job]; !ok {
-		return []*target.Item{}
-	}
-	targetItemsCopy := make([]*target.Item, len(c.targetItemsPerJobPerCollector[collector][job]))
-	index := 0
-	for targetHash := range c.targetItemsPerJobPerCollector[collector][job] {
-		targetItemsCopy[index] = c.targetItems[targetHash]
-		index++
-	}
-	return targetItemsCopy
-}
-
-// TargetItems returns a shallow copy of the targetItems map.
-func (c *consistentHashingAllocator) TargetItems() map[string]*target.Item {
-	c.m.RLock()
-	defer c.m.RUnlock()
-	targetItemsCopy := make(map[string]*target.Item)
-	for k, v := range c.targetItems {
-		targetItemsCopy[k] = v
-	}
-	return targetItemsCopy
-}
-
-// Collectors returns a shallow copy of the collectors map.
-func (c *consistentHashingAllocator) Collectors() map[string]*Collector {
-	c.m.RLock()
-	defer c.m.RUnlock()
-	collectorsCopy := make(map[string]*Collector)
-	for k, v := range c.collectors {
-		collectorsCopy[k] = v
-	}
-	return collectorsCopy
 }

--- a/cmd/otel-allocator/allocation/consistent_hashing_test.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestCanSetSingleTarget(t *testing.T) {
 	cols := MakeNCollectors(3, 0)
-	c := newAllocator(logger, newConsistentHashingStrategy())
+	c, _ := New("consistent-hashing", logger)
 	c.SetCollectors(cols)
 	c.SetTargets(MakeNNewTargets(1, 3, 0))
 	actualTargetItems := c.TargetItems()
@@ -38,7 +38,7 @@ func TestRelativelyEvenDistribution(t *testing.T) {
 	cols := MakeNCollectors(numCols, 0)
 	var expectedPerCollector = float64(numItems / numCols)
 	expectedDelta := (expectedPerCollector * 1.5) - expectedPerCollector
-	c := newAllocator(logger, newConsistentHashingStrategy())
+	c, _ := New("consistent-hashing", logger)
 	c.SetCollectors(cols)
 	c.SetTargets(MakeNNewTargets(numItems, 0, 0))
 	actualTargetItems := c.TargetItems()
@@ -52,7 +52,7 @@ func TestRelativelyEvenDistribution(t *testing.T) {
 
 func TestFullReallocation(t *testing.T) {
 	cols := MakeNCollectors(10, 0)
-	c := newAllocator(logger, newConsistentHashingStrategy())
+	c, _ := New("consistent-hashing", logger)
 	c.SetCollectors(cols)
 	c.SetTargets(MakeNNewTargets(10000, 10, 0))
 	actualTargetItems := c.TargetItems()
@@ -77,7 +77,7 @@ func TestNumRemapped(t *testing.T) {
 	numFinalCols := 16
 	expectedDelta := float64((numFinalCols - numInitialCols) * (numItems / numFinalCols))
 	cols := MakeNCollectors(numInitialCols, 0)
-	c := newAllocator(logger, newConsistentHashingStrategy())
+	c, _ := New("consistent-hashing", logger)
 	c.SetCollectors(cols)
 	c.SetTargets(MakeNNewTargets(numItems, numInitialCols, 0))
 	actualTargetItems := c.TargetItems()
@@ -106,7 +106,7 @@ func TestNumRemapped(t *testing.T) {
 
 func TestTargetsWithNoCollectorsConsistentHashing(t *testing.T) {
 
-	c := newAllocator(logger, newConsistentHashingStrategy())
+	c, _ := New("consistent-hashing", logger)
 
 	// Adding 10 new targets
 	numItems := 10

--- a/cmd/otel-allocator/allocation/consistent_hashing_test.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestCanSetSingleTarget(t *testing.T) {
 	cols := MakeNCollectors(3, 0)
-	c := newConsistentHashingAllocator(logger)
+	c := newAllocator(logger, newConsistentHashingStrategy())
 	c.SetCollectors(cols)
 	c.SetTargets(MakeNNewTargets(1, 3, 0))
 	actualTargetItems := c.TargetItems()
@@ -38,7 +38,7 @@ func TestRelativelyEvenDistribution(t *testing.T) {
 	cols := MakeNCollectors(numCols, 0)
 	var expectedPerCollector = float64(numItems / numCols)
 	expectedDelta := (expectedPerCollector * 1.5) - expectedPerCollector
-	c := newConsistentHashingAllocator(logger)
+	c := newAllocator(logger, newConsistentHashingStrategy())
 	c.SetCollectors(cols)
 	c.SetTargets(MakeNNewTargets(numItems, 0, 0))
 	actualTargetItems := c.TargetItems()
@@ -52,7 +52,7 @@ func TestRelativelyEvenDistribution(t *testing.T) {
 
 func TestFullReallocation(t *testing.T) {
 	cols := MakeNCollectors(10, 0)
-	c := newConsistentHashingAllocator(logger)
+	c := newAllocator(logger, newConsistentHashingStrategy())
 	c.SetCollectors(cols)
 	c.SetTargets(MakeNNewTargets(10000, 10, 0))
 	actualTargetItems := c.TargetItems()
@@ -77,7 +77,7 @@ func TestNumRemapped(t *testing.T) {
 	numFinalCols := 16
 	expectedDelta := float64((numFinalCols - numInitialCols) * (numItems / numFinalCols))
 	cols := MakeNCollectors(numInitialCols, 0)
-	c := newConsistentHashingAllocator(logger)
+	c := newAllocator(logger, newConsistentHashingStrategy())
 	c.SetCollectors(cols)
 	c.SetTargets(MakeNNewTargets(numItems, numInitialCols, 0))
 	actualTargetItems := c.TargetItems()
@@ -106,7 +106,7 @@ func TestNumRemapped(t *testing.T) {
 
 func TestTargetsWithNoCollectorsConsistentHashing(t *testing.T) {
 
-	c := newConsistentHashingAllocator(logger)
+	c := newAllocator(logger, newConsistentHashingStrategy())
 
 	// Adding 10 new targets
 	numItems := 10

--- a/cmd/otel-allocator/allocation/consistent_hashing_test.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing_test.go
@@ -20,18 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCanSetSingleTarget(t *testing.T) {
-	cols := MakeNCollectors(3, 0)
-	c, _ := New("consistent-hashing", logger)
-	c.SetCollectors(cols)
-	c.SetTargets(MakeNNewTargets(1, 3, 0))
-	actualTargetItems := c.TargetItems()
-	assert.Len(t, actualTargetItems, 1)
-	for _, item := range actualTargetItems {
-		assert.Equal(t, "collector-0", item.CollectorName)
-	}
-}
-
 func TestRelativelyEvenDistribution(t *testing.T) {
 	numCols := 15
 	numItems := 10000

--- a/cmd/otel-allocator/allocation/least_weighted.go
+++ b/cmd/otel-allocator/allocation/least_weighted.go
@@ -34,6 +34,7 @@ func (s *leastWeightedStrategy) GetName() string {
 
 func (s *leastWeightedStrategy) GetCollectorForTarget(collectors map[string]*Collector, item *target.Item) (*Collector, error) {
 	// if a collector is already assigned, do nothing
+	// TODO: track this in a separate map
 	if item.CollectorName != "" {
 		if col, ok := collectors[item.CollectorName]; ok {
 			return col, nil

--- a/cmd/otel-allocator/allocation/least_weighted.go
+++ b/cmd/otel-allocator/allocation/least_weighted.go
@@ -15,98 +15,33 @@
 package allocation
 
 import (
-	"sync"
-
-	"github.com/go-logr/logr"
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/diff"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 )
 
-var _ Allocator = &leastWeightedAllocator{}
-
 const leastWeightedStrategyName = "least-weighted"
 
-/*
-	Target Allocator will serve on an HTTP server exposing /jobs/<job_id>/targets
-	The targets are allocated using the least connection method
-	Target Allocator will need information about the collectors in order to set the URLs
-	Keep a Map of what each collector currently holds and update it based on new scrape target updates
-*/
+var _ Strategy = &leastWeightedStrategy{}
 
-// leastWeightedAllocator makes decisions to distribute work among
-// a number of OpenTelemetry collectors based on the number of targets.
-// Users need to call SetTargets when they have new targets in their
-// clusters and call SetCollectors when the collectors have changed.
-type leastWeightedAllocator struct {
-	// m protects collectors and targetItems for concurrent use.
-	m sync.RWMutex
-	// collectors is a map from a Collector's name to a Collector instance
-	collectors map[string]*Collector
-	// targetItems is a map from a target item's hash to the target items allocated state
-	targetItems map[string]*target.Item
+type leastWeightedStrategy struct{}
 
-	// collectorKey -> job -> target item hash -> true
-	targetItemsPerJobPerCollector map[string]map[string]map[string]bool
-
-	log logr.Logger
-
-	filter Filter
+func newleastWeightedStrategy() Strategy {
+	return &leastWeightedStrategy{}
 }
 
-// SetFilter sets the filtering hook to use.
-func (allocator *leastWeightedAllocator) SetFilter(filter Filter) {
-	allocator.filter = filter
+func (s *leastWeightedStrategy) GetName() string {
+	return leastWeightedStrategyName
 }
 
-func (allocator *leastWeightedAllocator) GetTargetsForCollectorAndJob(collector string, job string) []*target.Item {
-	allocator.m.RLock()
-	defer allocator.m.RUnlock()
-	if _, ok := allocator.targetItemsPerJobPerCollector[collector]; !ok {
-		return []*target.Item{}
+func (s *leastWeightedStrategy) GetCollectorForTarget(collectors map[string]*Collector, item *target.Item) (*Collector, error) {
+	// if a collector is already assigned, do nothing
+	if item.CollectorName != "" {
+		if col, ok := collectors[item.CollectorName]; ok {
+			return col, nil
+		}
 	}
-	if _, ok := allocator.targetItemsPerJobPerCollector[collector][job]; !ok {
-		return []*target.Item{}
-	}
-	targetItemsCopy := make([]*target.Item, len(allocator.targetItemsPerJobPerCollector[collector][job]))
-	index := 0
-	for targetHash := range allocator.targetItemsPerJobPerCollector[collector][job] {
-		targetItemsCopy[index] = allocator.targetItems[targetHash]
-		index++
-	}
-	return targetItemsCopy
-}
 
-// TargetItems returns a shallow copy of the targetItems map.
-func (allocator *leastWeightedAllocator) TargetItems() map[string]*target.Item {
-	allocator.m.RLock()
-	defer allocator.m.RUnlock()
-	targetItemsCopy := make(map[string]*target.Item)
-	for k, v := range allocator.targetItems {
-		targetItemsCopy[k] = v
-	}
-	return targetItemsCopy
-}
-
-// Collectors returns a shallow copy of the collectors map.
-func (allocator *leastWeightedAllocator) Collectors() map[string]*Collector {
-	allocator.m.RLock()
-	defer allocator.m.RUnlock()
-	collectorsCopy := make(map[string]*Collector)
-	for k, v := range allocator.collectors {
-		collectorsCopy[k] = v
-	}
-	return collectorsCopy
-}
-
-// findNextCollector finds the next collector with fewer number of targets.
-// This method is called from within SetTargets and SetCollectors, whose caller
-// acquires the needed lock. This method assumes there are is at least 1 collector set.
-// INVARIANT: allocator.collectors must have at least 1 collector set.
-func (allocator *leastWeightedAllocator) findNextCollector() *Collector {
 	var col *Collector
-	for _, v := range allocator.collectors {
+	for _, v := range collectors {
 		// If the initial collector is empty, set the initial collector to the first element of map
 		if col == nil {
 			col = v
@@ -114,192 +49,7 @@ func (allocator *leastWeightedAllocator) findNextCollector() *Collector {
 			col = v
 		}
 	}
-	return col
+	return col, nil
 }
 
-// addCollectorTargetItemMapping keeps track of which collector has which jobs and targets
-// this allows the allocator to respond without any extra allocations to http calls. The caller of this method
-// has to acquire a lock.
-func (allocator *leastWeightedAllocator) addCollectorTargetItemMapping(tg *target.Item) {
-	if allocator.targetItemsPerJobPerCollector[tg.CollectorName] == nil {
-		allocator.targetItemsPerJobPerCollector[tg.CollectorName] = make(map[string]map[string]bool)
-	}
-	if allocator.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] == nil {
-		allocator.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] = make(map[string]bool)
-	}
-	allocator.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName][tg.Hash()] = true
-}
-
-// addTargetToTargetItems assigns a target to the next available collector and adds it to the allocator's targetItems
-// This method is called from within SetTargets and SetCollectors, which acquire the needed lock.
-// This is only called after the collectors are cleared or when a new target has been found in the tempTargetMap.
-// INVARIANT: allocator.collectors must have at least 1 collector set.
-// NOTE: by not creating a new target item, there is the potential for a race condition where we modify this target
-// item while it's being encoded by the server JSON handler.
-func (allocator *leastWeightedAllocator) addTargetToTargetItems(tg *target.Item) {
-	chosenCollector := allocator.findNextCollector()
-	tg.CollectorName = chosenCollector.Name
-	allocator.targetItems[tg.Hash()] = tg
-	allocator.addCollectorTargetItemMapping(tg)
-	chosenCollector.NumTargets++
-	TargetsPerCollector.WithLabelValues(chosenCollector.Name, leastWeightedStrategyName).Set(float64(chosenCollector.NumTargets))
-}
-
-// handleTargets receives the new and removed targets and reconciles the current state.
-// Any removals are removed from the allocator's targetItems and unassigned from the corresponding collector.
-// Any net-new additions are assigned to the next available collector.
-func (allocator *leastWeightedAllocator) handleTargets(diff diff.Changes[*target.Item]) {
-	// Check for removals
-	for k, item := range allocator.targetItems {
-		// if the current item is in the removals list
-		if _, ok := diff.Removals()[k]; ok {
-			c := allocator.collectors[item.CollectorName]
-			c.NumTargets--
-			delete(allocator.targetItems, k)
-			delete(allocator.targetItemsPerJobPerCollector[item.CollectorName][item.JobName], item.Hash())
-			TargetsPerCollector.WithLabelValues(item.CollectorName, leastWeightedStrategyName).Set(float64(c.NumTargets))
-		}
-	}
-
-	// Check for additions
-	for k, item := range diff.Additions() {
-		// Do nothing if the item is already there
-		if _, ok := allocator.targetItems[k]; ok {
-			continue
-		} else {
-			// Add item to item pool and assign a collector
-			allocator.addTargetToTargetItems(item)
-		}
-	}
-}
-
-// handleCollectors receives the new and removed collectors and reconciles the current state.
-// Any removals are removed from the allocator's collectors. New collectors are added to the allocator's collector map.
-// Finally, any targets of removed collectors are reallocated to the next available collector.
-func (allocator *leastWeightedAllocator) handleCollectors(diff diff.Changes[*Collector]) {
-	// Clear removed collectors
-	for _, k := range diff.Removals() {
-		delete(allocator.collectors, k.Name)
-		delete(allocator.targetItemsPerJobPerCollector, k.Name)
-		TargetsPerCollector.WithLabelValues(k.Name, leastWeightedStrategyName).Set(0)
-	}
-
-	// If previously there were no collector instances present, allocate the previous set of saved targets to the new collectors
-	allocateTargets := false
-	if len(allocator.collectors) == 0 && len(allocator.targetItems) > 0 {
-		allocateTargets = true
-	}
-	// Insert the new collectors
-	for _, i := range diff.Additions() {
-		allocator.collectors[i.Name] = NewCollector(i.Name, i.NodeName)
-	}
-	if allocateTargets {
-		for _, item := range allocator.targetItems {
-			allocator.addTargetToTargetItems(item)
-		}
-	}
-
-	// Re-Allocate targets of the removed collectors
-	for _, item := range allocator.targetItems {
-		if _, ok := diff.Removals()[item.CollectorName]; ok {
-			allocator.addTargetToTargetItems(item)
-		}
-	}
-}
-
-// SetTargets accepts a list of targets that will be used to make
-// load balancing decisions. This method should be called when there are
-// new targets discovered or existing targets are shutdown.
-func (allocator *leastWeightedAllocator) SetTargets(targets map[string]*target.Item) {
-	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetTargets", leastWeightedStrategyName))
-	defer timer.ObserveDuration()
-
-	if allocator.filter != nil {
-		targets = allocator.filter.Apply(targets)
-	}
-	RecordTargetsKept(targets)
-
-	allocator.m.Lock()
-	defer allocator.m.Unlock()
-
-	if len(allocator.collectors) == 0 {
-		allocator.log.Info("No collector instances present, saving targets to allocate to collector(s)")
-		// If there were no targets discovered previously, assign this as the new set of target items
-		if len(allocator.targetItems) == 0 {
-			allocator.log.Info("Not discovered any targets previously, saving targets found to the targetItems set")
-			for k, item := range targets {
-				allocator.targetItems[k] = item
-			}
-		} else {
-			// If there were previously discovered targets, add or remove accordingly
-			targetsDiffEmptyCollectorSet := diff.Maps(allocator.targetItems, targets)
-
-			// Check for additions
-			if len(targetsDiffEmptyCollectorSet.Additions()) > 0 {
-				allocator.log.Info("New targets discovered, adding new targets to the targetItems set")
-				for k, item := range targetsDiffEmptyCollectorSet.Additions() {
-					// Do nothing if the item is already there
-					if _, ok := allocator.targetItems[k]; ok {
-						continue
-					} else {
-						// Add item to item pool
-						allocator.targetItems[k] = item
-					}
-				}
-			}
-
-			// Check for deletions
-			if len(targetsDiffEmptyCollectorSet.Removals()) > 0 {
-				allocator.log.Info("Targets removed, Removing targets from the targetItems set")
-				for k := range targetsDiffEmptyCollectorSet.Removals() {
-					// Delete item from target items
-					delete(allocator.targetItems, k)
-				}
-			}
-		}
-		return
-	}
-	// Check for target changes
-	targetsDiff := diff.Maps(allocator.targetItems, targets)
-	// If there are any additions or removals
-	if len(targetsDiff.Additions()) != 0 || len(targetsDiff.Removals()) != 0 {
-		allocator.handleTargets(targetsDiff)
-	}
-}
-
-// SetCollectors sets the set of collectors with key=collectorName, value=Collector object.
-// This method is called when Collectors are added or removed.
-func (allocator *leastWeightedAllocator) SetCollectors(collectors map[string]*Collector) {
-	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetCollectors", leastWeightedStrategyName))
-	defer timer.ObserveDuration()
-
-	CollectorsAllocatable.WithLabelValues(leastWeightedStrategyName).Set(float64(len(collectors)))
-	if len(collectors) == 0 {
-		allocator.log.Info("No collector instances present")
-		return
-	}
-
-	allocator.m.Lock()
-	defer allocator.m.Unlock()
-
-	// Check for collector changes
-	collectorsDiff := diff.Maps(allocator.collectors, collectors)
-	if len(collectorsDiff.Additions()) != 0 || len(collectorsDiff.Removals()) != 0 {
-		allocator.handleCollectors(collectorsDiff)
-	}
-}
-
-func newLeastWeightedAllocator(log logr.Logger, opts ...AllocationOption) Allocator {
-	lwAllocator := &leastWeightedAllocator{
-		log:                           log,
-		collectors:                    make(map[string]*Collector),
-		targetItems:                   make(map[string]*target.Item),
-		targetItemsPerJobPerCollector: make(map[string]map[string]map[string]bool),
-	}
-
-	for _, opt := range opts {
-		opt(lwAllocator)
-	}
-
-	return lwAllocator
-}
+func (s *leastWeightedStrategy) SetCollectors(_ map[string]*Collector) {}

--- a/cmd/otel-allocator/allocation/least_weighted_test.go
+++ b/cmd/otel-allocator/allocation/least_weighted_test.go
@@ -20,99 +20,11 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 )
 
 var logger = logf.Log.WithName("unit-tests")
-
-func TestSetCollectors(t *testing.T) {
-	s, _ := New("least-weighted", logger)
-
-	cols := MakeNCollectors(3, 0)
-	s.SetCollectors(cols)
-
-	expectedColLen := len(cols)
-	collectors := s.Collectors()
-	assert.Len(t, collectors, expectedColLen)
-
-	for _, i := range cols {
-		assert.NotNil(t, collectors[i.Name])
-	}
-}
-
-func TestAddingAndRemovingTargets(t *testing.T) {
-	// prepare allocator with initial targets and collectors
-	s, _ := New("least-weighted", logger)
-
-	cols := MakeNCollectors(3, 0)
-	s.SetCollectors(cols)
-
-	initTargets := MakeNNewTargets(6, 3, 0)
-
-	// test that targets and collectors are added properly
-	s.SetTargets(initTargets)
-
-	// verify
-	expectedTargetLen := len(initTargets)
-	assert.Len(t, s.TargetItems(), expectedTargetLen)
-
-	// prepare second round of targets
-	tar := MakeNNewTargets(4, 3, 0)
-
-	// test that fewer targets are found - removed
-	s.SetTargets(tar)
-
-	// verify
-	targetItems := s.TargetItems()
-	expectedNewTargetLen := len(tar)
-	assert.Len(t, targetItems, expectedNewTargetLen)
-
-	// verify results map
-	for _, i := range tar {
-		_, ok := targetItems[i.Hash()]
-		assert.True(t, ok)
-	}
-}
-
-// Tests that two targets with the same target url and job name but different label set are both added.
-func TestAllocationCollision(t *testing.T) {
-	// prepare allocator with initial targets and collectors
-	s, _ := New("least-weighted", logger)
-
-	cols := MakeNCollectors(3, 0)
-	s.SetCollectors(cols)
-	firstLabels := model.LabelSet{
-		"test": "test1",
-	}
-	secondLabels := model.LabelSet{
-		"test": "test2",
-	}
-	firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstLabels, "")
-	secondTarget := target.NewItem("sample-name", "0.0.0.0:8000", secondLabels, "")
-
-	targetList := map[string]*target.Item{
-		firstTarget.Hash():  firstTarget,
-		secondTarget.Hash(): secondTarget,
-	}
-
-	// test that targets and collectors are added properly
-	s.SetTargets(targetList)
-
-	// verify
-	targetItems := s.TargetItems()
-	expectedTargetLen := len(targetList)
-	assert.Len(t, targetItems, expectedTargetLen)
-
-	// verify results map
-	for _, i := range targetList {
-		_, ok := targetItems[i.Hash()]
-		assert.True(t, ok)
-	}
-}
 
 func TestNoCollectorReassignment(t *testing.T) {
 	s, _ := New("least-weighted", logger)

--- a/cmd/otel-allocator/allocation/least_weighted_test.go
+++ b/cmd/otel-allocator/allocation/least_weighted_test.go
@@ -104,7 +104,7 @@ func TestNoAssignmentToNewCollector(t *testing.T) {
 
 	// new collector should have no targets
 	newCollector := s.Collectors()[newColName]
-	assert.Equal(t, newCollector.NumTargets, 0)
+	assert.Equal(t, 0, newCollector.NumTargets)
 }
 
 // Tests that the delta in number of targets per collector is less than 15% of an even distribution.

--- a/cmd/otel-allocator/allocation/per_node.go
+++ b/cmd/otel-allocator/allocation/per_node.go
@@ -15,228 +15,43 @@
 package allocation
 
 import (
-	"sync"
+	"fmt"
 
-	"github.com/go-logr/logr"
-	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/diff"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 )
 
-var _ Allocator = &perNodeAllocator{}
-
 const perNodeStrategyName = "per-node"
 
-// perNodeAllocator makes decisions to distribute work among
-// a number of OpenTelemetry collectors based on the node on which
-// the collector is running. This allocator should be used only when
-// collectors are running as daemon set (agent) on each node.
-// Users need to call SetTargets when they have new targets in their
-// clusters and call SetCollectors when the collectors have changed.
-type perNodeAllocator struct {
-	// m protects collectors and targetItems for concurrent use.
-	m sync.RWMutex
-	// collectors is a map from a Collector's node name to a Collector instance
-	collectors map[string]*Collector
-	// targetItems is a map from a target item's hash to the target items allocated state
-	targetItems map[string]*target.Item
+var _ Strategy = &perNodeStrategy{}
 
-	// collectorKey -> job -> target item hash -> true
-	targetItemsPerJobPerCollector map[string]map[string]map[string]bool
-
-	log logr.Logger
-
-	filter Filter
+type perNodeStrategy struct {
+	collectorByNode map[string]*Collector
 }
 
-// SetCollectors sets the set of collectors with key=collectorName, value=Collector object.
-// This method is called when Collectors are added or removed.
-func (allocator *perNodeAllocator) SetCollectors(collectors map[string]*Collector) {
-	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetCollectors", perNodeStrategyName))
-	defer timer.ObserveDuration()
-
-	CollectorsAllocatable.WithLabelValues(perNodeStrategyName).Set(float64(len(collectors)))
-	if len(collectors) == 0 {
-		allocator.log.Info("No collector instances present")
-		return
-	}
-
-	allocator.m.Lock()
-	defer allocator.m.Unlock()
-
-	// Check for collector changes
-	collectorsDiff := diff.Maps(allocator.collectors, collectors)
-	if len(collectorsDiff.Additions()) != 0 || len(collectorsDiff.Removals()) != 0 {
-		for _, k := range allocator.collectors {
-			delete(allocator.collectors, k.NodeName)
-			delete(allocator.targetItemsPerJobPerCollector, k.Name)
-			TargetsPerCollector.WithLabelValues(k.Name, perNodeStrategyName).Set(0)
-		}
-
-		for _, k := range collectors {
-			allocator.collectors[k.NodeName] = NewCollector(k.Name, k.NodeName)
-		}
-
-		// Re-allocate any already existing targets.
-		for _, item := range allocator.targetItems {
-			allocator.addTargetToTargetItems(item)
-		}
+func newPerNodeStrategy() Strategy {
+	return &perNodeStrategy{
+		collectorByNode: make(map[string]*Collector),
 	}
 }
 
-// SetTargets accepts a list of targets that will be used to make
-// load balancing decisions. This method should be called when there are
-// new targets discovered or existing targets are shutdown.
-func (allocator *perNodeAllocator) SetTargets(targets map[string]*target.Item) {
-	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetTargets", perNodeStrategyName))
-	defer timer.ObserveDuration()
-
-	if allocator.filter != nil {
-		targets = allocator.filter.Apply(targets)
-	}
-	RecordTargetsKept(targets)
-
-	allocator.m.Lock()
-	defer allocator.m.Unlock()
-
-	// Check for target changes
-	targetsDiff := diff.Maps(allocator.targetItems, targets)
-	// If there are any additions or removals
-	if len(targetsDiff.Additions()) != 0 || len(targetsDiff.Removals()) != 0 {
-		allocator.handleTargets(targetsDiff)
-	}
+func (s *perNodeStrategy) GetName() string {
+	return perNodeStrategyName
 }
 
-// handleTargets receives the new and removed targets and reconciles the current state.
-// Any removals are removed from the allocator's targetItems and unassigned from the corresponding collector.
-// Any net-new additions are assigned to the collector on the same node as the target.
-func (allocator *perNodeAllocator) handleTargets(diff diff.Changes[*target.Item]) {
-	// Check for removals
-	for k, item := range allocator.targetItems {
-		// if the current item is in the removals list
-		if _, ok := diff.Removals()[k]; ok {
-			c, ok := allocator.collectors[item.GetNodeName()]
-			if ok {
-				c.NumTargets--
-				TargetsPerCollector.WithLabelValues(item.CollectorName, perNodeStrategyName).Set(float64(c.NumTargets))
-			}
-			delete(allocator.targetItems, k)
-			delete(allocator.targetItemsPerJobPerCollector[item.CollectorName][item.JobName], item.Hash())
-		}
-	}
-
-	// Check for additions
-	var unassignedTargets int
-	for k, item := range diff.Additions() {
-		// Do nothing if the item is already there
-		if _, ok := allocator.targetItems[k]; ok {
-			continue
-		} else {
-			// Add item to item pool and assign a collector
-			collectorAssigned := allocator.addTargetToTargetItems(item)
-			if !collectorAssigned {
-				unassignedTargets++
-			}
-		}
-	}
-
-	// Check for unassigned targets
-	if unassignedTargets > 0 {
-		allocator.log.Info("Could not assign targets for some jobs due to missing node labels", "targets", unassignedTargets)
-		TargetsUnassigned.Set(float64(unassignedTargets))
-	}
-}
-
-// addTargetToTargetItems assigns a target to the  collector and adds it to the allocator's targetItems
-// This method is called from within SetTargets and SetCollectors, which acquire the needed lock.
-// This is only called after the collectors are cleared or when a new target has been found in the tempTargetMap.
-// Also, any targets that cannot be assigned to a collector, due to no matching node name, will remain unassigned. These
-// targets are still "silently" added to the targetItems map, to make sure they exist if collector for a node is added
-// later and to prevent them from being reported as unassigned on each new target items setting.
-func (allocator *perNodeAllocator) addTargetToTargetItems(tg *target.Item) bool {
-	allocator.targetItems[tg.Hash()] = tg
-	chosenCollector, ok := allocator.collectors[tg.GetNodeName()]
+func (s *perNodeStrategy) GetCollectorForTarget(collectors map[string]*Collector, item *target.Item) (*Collector, error) {
+	targetNodeName := item.GetNodeName()
+	collector, ok := s.collectorByNode[targetNodeName]
 	if !ok {
-		allocator.log.V(2).Info("Couldn't find a collector for the target item", "item", tg, "collectors", allocator.collectors)
-		return false
+		return nil, fmt.Errorf("could not find collector for node %s", targetNodeName)
 	}
-	tg.CollectorName = chosenCollector.Name
-	allocator.addCollectorTargetItemMapping(tg)
-	chosenCollector.NumTargets++
-	TargetsPerCollector.WithLabelValues(chosenCollector.Name, perNodeStrategyName).Set(float64(chosenCollector.NumTargets))
-	return true
+	return collectors[collector.Name], nil
 }
 
-// addCollectorTargetItemMapping keeps track of which collector has which jobs and targets
-// this allows the allocator to respond without any extra allocations to http calls. The caller of this method
-// has to acquire a lock.
-func (allocator *perNodeAllocator) addCollectorTargetItemMapping(tg *target.Item) {
-	if allocator.targetItemsPerJobPerCollector[tg.CollectorName] == nil {
-		allocator.targetItemsPerJobPerCollector[tg.CollectorName] = make(map[string]map[string]bool)
+func (s *perNodeStrategy) SetCollectors(collectors map[string]*Collector) {
+	clear(s.collectorByNode)
+	for _, collector := range collectors {
+		if collector.NodeName != "" {
+			s.collectorByNode[collector.NodeName] = collector
+		}
 	}
-	if allocator.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] == nil {
-		allocator.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] = make(map[string]bool)
-	}
-	allocator.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName][tg.Hash()] = true
-}
-
-// TargetItems returns a shallow copy of the targetItems map.
-func (allocator *perNodeAllocator) TargetItems() map[string]*target.Item {
-	allocator.m.RLock()
-	defer allocator.m.RUnlock()
-	targetItemsCopy := make(map[string]*target.Item)
-	for k, v := range allocator.targetItems {
-		targetItemsCopy[k] = v
-	}
-	return targetItemsCopy
-}
-
-// Collectors returns a shallow copy of the collectors map.
-func (allocator *perNodeAllocator) Collectors() map[string]*Collector {
-	allocator.m.RLock()
-	defer allocator.m.RUnlock()
-	collectorsCopy := make(map[string]*Collector)
-	for k, v := range allocator.collectors {
-		collectorsCopy[k] = v
-	}
-	return collectorsCopy
-}
-
-func (allocator *perNodeAllocator) GetTargetsForCollectorAndJob(collector string, job string) []*target.Item {
-	allocator.m.RLock()
-	defer allocator.m.RUnlock()
-	if _, ok := allocator.targetItemsPerJobPerCollector[collector]; !ok {
-		return []*target.Item{}
-	}
-	if _, ok := allocator.targetItemsPerJobPerCollector[collector][job]; !ok {
-		return []*target.Item{}
-	}
-	targetItemsCopy := make([]*target.Item, len(allocator.targetItemsPerJobPerCollector[collector][job]))
-	index := 0
-	for targetHash := range allocator.targetItemsPerJobPerCollector[collector][job] {
-		targetItemsCopy[index] = allocator.targetItems[targetHash]
-		index++
-	}
-	return targetItemsCopy
-}
-
-// SetFilter sets the filtering hook to use.
-func (allocator *perNodeAllocator) SetFilter(filter Filter) {
-	allocator.filter = filter
-}
-
-func newPerNodeAllocator(log logr.Logger, opts ...AllocationOption) Allocator {
-	pnAllocator := &perNodeAllocator{
-		log:                           log,
-		collectors:                    make(map[string]*Collector),
-		targetItems:                   make(map[string]*target.Item),
-		targetItemsPerJobPerCollector: make(map[string]map[string]map[string]bool),
-	}
-
-	for _, opt := range opts {
-		opt(pnAllocator)
-	}
-
-	return pnAllocator
 }

--- a/cmd/otel-allocator/allocation/per_node_test.go
+++ b/cmd/otel-allocator/allocation/per_node_test.go
@@ -128,7 +128,7 @@ func TestTargetsWithNoCollectorsPerNode(t *testing.T) {
 	assert.Len(t, actualCollectors, numCols)
 	// Based on lable all targets should be assigned to node-0
 	for name, ac := range actualCollectors {
-		if name == "node-0" {
+		if name == "collector-0" {
 			assert.Equal(t, 6, ac.NumTargets)
 		} else {
 			assert.Equal(t, 0, ac.NumTargets)

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -131,7 +131,9 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	err = Register(consistentHashingStrategyName, newConsistentHashingAllocator)
+	err = Register(consistentHashingStrategyName, func(log logr.Logger, opts ...AllocationOption) Allocator {
+		return newAllocator(log, newConsistentHashingStrategy(), opts...)
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -127,7 +127,9 @@ func NewCollector(name, node string) *Collector {
 }
 
 func init() {
-	err := Register(leastWeightedStrategyName, newLeastWeightedAllocator)
+	err := Register(leastWeightedStrategyName, func(log logr.Logger, opts ...AllocationOption) Allocator {
+		return newAllocator(log, newleastWeightedStrategy(), opts...)
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -137,7 +137,9 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	err = Register(perNodeStrategyName, newPerNodeAllocator)
+	err = Register(perNodeStrategyName, func(log logr.Logger, opts ...AllocationOption) Allocator {
+		return newAllocator(log, newPerNodeStrategy(), opts...)
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -103,6 +103,15 @@ type Allocator interface {
 	SetFilter(filter Filter)
 }
 
+type Strategy interface {
+	GetCollectorForTarget(map[string]*Collector, *target.Item) (*Collector, error)
+	// SetCollectors exists for strategies where changing the collector set is potentially an expensive operation.
+	// The caller must guarantee that the collectors map passed in GetCollectorForTarget is consistent with the latest
+	// SetCollectors call. Strategies which don't need this information can just ignore it.
+	SetCollectors(map[string]*Collector)
+	GetName() string
+}
+
 var _ consistent.Member = Collector{}
 
 // Collector Creates a struct that holds Collector information.

--- a/cmd/otel-allocator/allocation/testutils.go
+++ b/cmd/otel-allocator/allocation/testutils.go
@@ -12,13 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Note: These utilities are used by other packages, which is why they're defined in a non-test file.
+
 package allocation
 
 import (
 	"fmt"
 	"strconv"
+	"testing"
 
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 )
@@ -69,4 +74,16 @@ func MakeNNewTargetsWithEmptyCollectors(n int, startingIndex int) map[string]*ta
 		toReturn[newTarget.Hash()] = newTarget
 	}
 	return toReturn
+}
+
+func RunForAllStrategies(t *testing.T, f func(t *testing.T, allocator Allocator)) {
+	allocatorNames := GetRegisteredAllocatorNames()
+	logger := logf.Log.WithName("unit-tests")
+	for _, allocatorName := range allocatorNames {
+		t.Run(allocatorName, func(t *testing.T) {
+			allocator, err := New(allocatorName, logger)
+			require.NoError(t, err)
+			f(t, allocator)
+		})
+	}
 }


### PR DESCRIPTION
Allocation strategies are currently messy and duplicate a lot of logic. This is an attempt at making them more DRY.

* Factored out the bookkeeping into a new Allocator struct. It keeps track of targets, collectors, allocation, metrics, etc.
* Added a new Strategy interface that strategies need to implement. Right now, the minimum needed is just a method that takes a collector map and a target, and returns the assigned collector.
* Added some generic allocator tests that run for all strategies.

I'm not entirely happy with the end result, and I've left some TODOs in the code I'd like to address in a follow-up. I haven't included those changes in this PR in the interest of keeping it simpler.