### PR TITLE
[autoinstrumentation/nodejs] Update to v0.46.0

### DIFF
--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -11,20 +11,20 @@
     "devDependencies": {
         "copyfiles": "^2.4.1",
         "rimraf": "^5.0.5",
-        "typescript": "^5.4.2"
+        "typescript": "^5.4.5"
     },
     "dependencies": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/auto-instrumentations-node": "0.45.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.49.1",
-        "@opentelemetry/exporter-prometheus": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-        "@opentelemetry/resource-detector-alibaba-cloud": "0.28.7",
-        "@opentelemetry/resource-detector-aws": "1.4.0",
-        "@opentelemetry/resource-detector-container": "0.3.7",
-        "@opentelemetry/resource-detector-gcp": "0.29.7",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-node": "0.49.1"
+        "@opentelemetry/auto-instrumentations-node": "0.46.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.51.0",
+        "@opentelemetry/exporter-prometheus": "0.51.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.0",
+        "@opentelemetry/resource-detector-alibaba-cloud": "0.28.9",
+        "@opentelemetry/resource-detector-aws": "1.4.2",
+        "@opentelemetry/resource-detector-container": "0.3.9",
+        "@opentelemetry/resource-detector-gcp": "0.29.9",
+        "@opentelemetry/resources": "1.24.0",
+        "@opentelemetry/sdk-metrics": "1.24.0",
+        "@opentelemetry/sdk-node": "0.51.0"
     }
 }


### PR DESCRIPTION
Update Node.js Auto Instrumentation to v0.46.0

https://github.com/open-telemetry/opentelemetry-js-contrib/releases/tag/auto-instrumentations-node-v0.46.0