### PR TITLE
opamp bridge - set healthy bool at collector pool level

### DIFF
--- a/.chloggen/add-collector-pool-healthy.yaml
+++ b/.chloggen/add-collector-pool-healthy.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: opamp
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add healthy field at collector pool level in opamp bridge heartbeat
+
+# One or more tracking issues related to the change
+issues: [2936]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/operator-opamp-bridge/agent/agent.go
+++ b/cmd/operator-opamp-bridge/agent/agent.go
@@ -119,11 +119,17 @@ func (agent *Agent) generateCollectorPoolHealth() (map[string]*protobufs.Compone
 		if err != nil {
 			return nil, err
 		}
+
+		isPoolHealthy := true
+		for _, pod := range podMap {
+			isPoolHealthy = isPoolHealthy && pod.Healthy
+		}
 		healthMap[key.String()] = &protobufs.ComponentHealth{
 			StartTimeUnixNano:  uint64(col.ObjectMeta.GetCreationTimestamp().UnixNano()),
 			StatusTimeUnixNano: uint64(agent.clock.Now().UnixNano()),
 			Status:             col.Status.Scale.StatusReplicas,
 			ComponentHealthMap: podMap,
+			Healthy:            isPoolHealthy,
 		}
 	}
 	return healthMap, nil

--- a/cmd/operator-opamp-bridge/agent/agent_test.go
+++ b/cmd/operator-opamp-bridge/agent/agent_test.go
@@ -272,7 +272,7 @@ func TestAgent_getHealth(t *testing.T) {
 					StatusTimeUnixNano: uint64(fakeClock.Now().UnixNano()),
 					ComponentHealthMap: map[string]*protobufs.ComponentHealth{
 						"testnamespace/collector": {
-							Healthy:            false, // we're working with mocks so the status will never be reconciled.
+							Healthy:            true,
 							StartTimeUnixNano:  collectorStartTime,
 							LastError:          "",
 							Status:             "",
@@ -305,7 +305,7 @@ func TestAgent_getHealth(t *testing.T) {
 					StatusTimeUnixNano: uint64(fakeClock.Now().UnixNano()),
 					ComponentHealthMap: map[string]*protobufs.ComponentHealth{
 						"testnamespace/collector": {
-							Healthy:            false, // we're working with mocks so the status will never be reconciled.
+							Healthy:            true,
 							StartTimeUnixNano:  collectorStartTime,
 							LastError:          "",
 							Status:             "",
@@ -313,7 +313,7 @@ func TestAgent_getHealth(t *testing.T) {
 							ComponentHealthMap: map[string]*protobufs.ComponentHealth{},
 						},
 						"testnamespace/other": {
-							Healthy:            false, // we're working with mocks so the status will never be reconciled.
+							Healthy:            true,
 							StartTimeUnixNano:  collectorStartTime,
 							LastError:          "",
 							Status:             "",
@@ -345,7 +345,7 @@ func TestAgent_getHealth(t *testing.T) {
 					StatusTimeUnixNano: uint64(fakeClock.Now().UnixNano()),
 					ComponentHealthMap: map[string]*protobufs.ComponentHealth{
 						"other/third": {
-							Healthy:            false, // we're working with mocks so the status will never be reconciled.
+							Healthy:            true,
 							StartTimeUnixNano:  collectorStartTime,
 							LastError:          "",
 							Status:             "",


### PR DESCRIPTION
**Description:** 
This sets the `healthy` bool field in the component health at the collector pool level in the opamp bridge heartbeat health report. This deduces the collector pool-level health by ANDing the health of all component pods in the pool.

**Link to tracking Issue(s):** #2936

- Resolves: #2936

**Testing:** Unit tests were updated to reflect the new state with this change

**Documentation:** n/a
