### PR TITLE
[chore] move VineethReddy02 to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,6 @@ Maintainers ([@open-telemetry/operator-maintainers](https://github.com/orgs/open
 - [Jacob Aronoff](https://github.com/jaronoff97), Lightstep
 - [Mikołaj Świątek](https://github.com/swiatekm-sumo), Sumo Logic
 - [Pavol Loffay](https://github.com/pavolloffay), Red Hat
-- [Vineeth Pothulapati](https://github.com/VineethReddy02), Timescale
 
 Emeritus Maintainers
 
@@ -797,6 +796,7 @@ Emeritus Maintainers
 - [Bogdan Drutu](https://github.com/BogdanDrutu), Splunk
 - [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs
 - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
+- [Vineeth Pothulapati](https://github.com/VineethReddy02), Timescale
 
 Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,10 +44,9 @@ The operator should be released within a week after the [OpenTelemetry collector
 
 | Version  | Release manager |
 |----------|-----------------|
-| v0.100.0 | @VineethReddy02 |
-| v0.101.0 | @TylerHelmuth   |
-| v0.102.0 | @swiatekm-sumo  |
-| v0.103.0 | @frzifus        |
-| v0.104.0 | @jaronoff97     |
-| v0.105.0 | @pavolloffay    |
-| v0.106.0 | @yuriolisa    |
+| v0.100.0 | @TylerHelmuth   |
+| v0.101.0 | @swiatekm-sumo  |
+| v0.102.0 | @frzifus        |
+| v0.103.0 | @jaronoff97     |
+| v0.104.0 | @pavolloffay    |
+| v0.105.0 | @yuriolisa      |


### PR DESCRIPTION
I'd like to recognize @VineethReddy02's contributions to the project, especially during its early period. Recognizing that Vineeth might not have time to dedicate to the project anymore, I'd like to propose moving Vineeth to emeritus maintainer. 

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
