### PR TITLE
Verify ServiceMonitor and PodMonitor are installed in prom cr availability check

### DIFF
--- a/.chloggen/verify-prom-crd-resources.yaml
+++ b/.chloggen/verify-prom-crd-resources.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure all Prometheus CRDs are installed
+
+# One or more tracking issues related to the change
+issues: [2964]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION


**Description:**
Currently the Prometheus CRs availability checks today that the API group `monitoring.coreos.com` is installed, and then adds the ServiceMonitor and PodMonitor to the scheme. However, I only have the ServiceMonitor CRD installed which results in the operator is unable to start. 

This change adds verification that both the expected resources are installed and not only that the API group is installed.