### PR TITLE
[Chore] Fix test cases querying OpenShift user workload monitoring stack.

### DIFF
--- a/tests/e2e-openshift/monitoring/check_metrics.sh
+++ b/tests/e2e-openshift/monitoring/check_metrics.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-SECRET=$(oc get secret -n openshift-user-workload-monitoring | grep prometheus-user-workload-token | head -n 1 | awk '{print $1}')
-TOKEN=$(echo $(oc get secret $SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d)
+TOKEN=$(oc create token prometheus-user-workload -n openshift-user-workload-monitoring)
 THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
 
 #Check metrics for OpenTelemetry collector instance.

--- a/tests/e2e-openshift/otlp-metrics-traces/check_metrics.sh
+++ b/tests/e2e-openshift/otlp-metrics-traces/check_metrics.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-SECRET=$(oc get secret -n openshift-user-workload-monitoring | grep prometheus-user-workload-token | head -n 1 | awk '{print $1}')
-TOKEN=$(echo $(oc get secret $SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d)
+TOKEN=$(oc create token prometheus-user-workload -n openshift-user-workload-monitoring)
 THANOS_QUERIER_HOST=$(oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host')
 
 while true; do


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

In OpenShift 4.16 tokens for service account are not generated by default and we have to now use the TokenRequest API to create token. The PR fixes the check_metrics.sh script to create a token from prometheus-user-workload SA. 

**Testing:** <Describe what testing was performed and which tests were added.>
Tested on OpenShift 4.15 and 4.16:

```
--- PASS: chainsaw (173.73s)
    --- PASS: chainsaw/monitoring (96.42s)
    --- PASS: chainsaw/otlp-metrics-traces (77.32s)
PASS
Tests Summary...
- Passed  tests 2
- Failed  tests 0
- Skipped tests 0
Done.
```
