### PR TITLE
Update selector documentation for Target Allocator

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,8 @@ spec:
     serviceAccount: everything-prometheus-operator-needs
     prometheusCR:
       enabled: true
+      serviceMonitorSelector: {}
+      podMonitorSelector: {}
   config:
     receivers:
       prometheus:

--- a/apis/v1beta1/targetallocator_types.go
+++ b/apis/v1beta1/targetallocator_types.go
@@ -31,13 +31,15 @@ type TargetAllocatorPrometheusCR struct {
 	// +kubebuilder:validation:Format:=duration
 	ScrapeInterval *metav1.Duration `json:"scrapeInterval,omitempty"`
 	// PodMonitors to be selected for target discovery.
-	// This is a map of {key,value} pairs. Each {key,value} in the map is going to exactly match a label in a
-	// PodMonitor's meta labels. The requirements are ANDed.
+	// A label selector is a label query over a set of resources. The result of matchLabels and
+	// matchExpressions are ANDed. An empty label selector matches all objects. A null
+	// label selector matches no objects.
 	// +optional
 	PodMonitorSelector *metav1.LabelSelector `json:"podMonitorSelector,omitempty"`
 	// ServiceMonitors to be selected for target discovery.
-	// This is a map of {key,value} pairs. Each {key,value} in the map is going to exactly match a label in a
-	// ServiceMonitor's meta labels. The requirements are ANDed.
+	// A label selector is a label query over a set of resources. The result of matchLabels and
+	// matchExpressions are ANDed. An empty label selector matches all objects. A null
+	// label selector matches no objects.
 	// +optional
 	ServiceMonitorSelector *metav1.LabelSelector `json:"serviceMonitorSelector,omitempty"`
 }

--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -131,28 +131,7 @@ and jobs on the `/scrape_configs` and `/jobs` endpoints respectively.
 
 The CRs can be filtered by labels as documented here: [api.md#opentelemetrycollectorspectargetallocatorprometheuscr](../../docs/api.md#opentelemetrycollectorspectargetallocatorprometheuscr)
 
-The Prometheus Receiver in the deployed Collector also has to know where the Allocator service exists. This is done by a
-OpenTelemetry Collector Operator-specific config.
-
-```yaml
-  config: |
-    receivers:
-      prometheus:
-        config:
-          scrape_configs:
-          - job_name: 'otel-collector'
-        target_allocator:
-          endpoint: http://my-targetallocator-service
-          interval: 30s
-          collector_id: "${POD_NAME}"
-```
-
 Upstream documentation here: [PrometheusReceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver#opentelemetry-operator)
-
-The TargetAllocator service is named based on the `OpenTelemetryCollector` CR name. For example, if your Collector CR name is `my-collector`, then the TargetAllocator `service` and `deployment` will each be named `my-collector-targetallocator`, and the `pod` will be named `my-collector-targetallocator-<pod_id>`. `collector_id` should be unique per
-collector instance, such as the pod name. The `POD_NAME` environment variable is convenient since this is supplied
-to collector instance pods by default.
-
 
 ### RBAC
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -43103,8 +43103,9 @@ All CR instances which the ServiceAccount has access to will be retrieved. This 
         <td>object</td>
         <td>
           PodMonitors to be selected for target discovery.
-This is a map of {key,value} pairs. Each {key,value} in the map is going to exactly match a label in a
-PodMonitor's meta labels. The requirements are ANDed.<br/>
+A label selector is a label query over a set of resources. The result of matchLabels and
+matchExpressions are ANDed. An empty label selector matches all objects. A null
+label selector matches no objects.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -43126,8 +43127,9 @@ Default: "30s"<br/>
         <td>object</td>
         <td>
           ServiceMonitors to be selected for target discovery.
-This is a map of {key,value} pairs. Each {key,value} in the map is going to exactly match a label in a
-ServiceMonitor's meta labels. The requirements are ANDed.<br/>
+A label selector is a label query over a set of resources. The result of matchLabels and
+matchExpressions are ANDed. An empty label selector matches all objects. A null
+label selector matches no objects.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -43140,8 +43142,9 @@ ServiceMonitor's meta labels. The requirements are ANDed.<br/>
 
 
 PodMonitors to be selected for target discovery.
-This is a map of {key,value} pairs. Each {key,value} in the map is going to exactly match a label in a
-PodMonitor's meta labels. The requirements are ANDed.
+A label selector is a label query over a set of resources. The result of matchLabels and
+matchExpressions are ANDed. An empty label selector matches all objects. A null
+label selector matches no objects.
 
 <table>
     <thead>
@@ -43224,8 +43227,9 @@ merge patch.<br/>
 
 
 ServiceMonitors to be selected for target discovery.
-This is a map of {key,value} pairs. Each {key,value} in the map is going to exactly match a label in a
-ServiceMonitor's meta labels. The requirements are ANDed.
+A label selector is a label query over a set of resources. The result of matchLabels and
+matchExpressions are ANDed. An empty label selector matches all objects. A null
+label selector matches no objects.
 
 <table>
     <thead>

--- a/docs/crd-changelog.md
+++ b/docs/crd-changelog.md
@@ -145,6 +145,9 @@ spec:
           key: value
 ```
 
+> [!NOTE]  
+> A `nil` selector now selects no resources, while an empty selector selects all of them. To get the old default behaviour, it's necessary to set `serviceMonitorSelector: {}`.
+
 ### Default Collector image
 
 The OpenTelemetry Collector maintainers recently introduced a [Collector distribution][k8s_distro] specifically aimed at 


### PR DESCRIPTION
It's not clear that you need to use an empty selector in `v1beta1` CRs to select all the resources. See #2993 for an example of the kind of confusion this can create. Update the documentation to make this clearer.

I've also deleted some outdated content from the target allocator README.
