### PR TITLE
 using opentelemetry.io* namespace for extracing resource based on annotations  from k8s Api #2330 

### DIFF
--- a/.chloggen/extract-resources-ns.yaml
+++ b/.chloggen/extract-resources-ns.yaml
@@ -1,0 +1,13 @@
+change_type: enhancement
+
+component: instrumentation
+
+note: "introduced ability to set Otel resource attributes based on annotations for instrumentation"
+
+issues:
+  - 2181
+
+
+subtext: |
+
+  resource.opentelemetry.io/your-key: "your-value"

--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ spec:
 EOF
 ```
 
-### using opentelemetry.io* namespace for extracing resource
+### Setting instrumentation resource attributes via namespace annotations
 
 This example shows a pod configuration with OpenTelemetry annotations using the `resource.opentelemetry.io/` prefix. These annotations can be used to add resource attributes to data produced by OpenTelemetry instrumentation.
 

--- a/README.md
+++ b/README.md
@@ -714,7 +714,7 @@ EOF
 
 ### using opentelemetry.io* namespace for extracing resource
 
-This example shows a pod configuration with OpenTelemetry annotations using the `resource.opentelemetry.io/` prefix. These annotations can be used to extract resource information for OpenTelemetry instrumentation.
+This example shows a pod configuration with OpenTelemetry annotations using the `resource.opentelemetry.io/` prefix. These annotations can be used to add resource attributes to data produced by OpenTelemetry instrumentation.
 
 ```yaml
 apiVersion: v1

--- a/README.md
+++ b/README.md
@@ -712,6 +712,25 @@ spec:
 EOF
 ```
 
+### using opentelemetry.io* namespace for extracing resource
+
+This example shows a pod configuration with OpenTelemetry annotations using the `resource.opentelemetry.io/` prefix. These annotations can be used to extract resource information for OpenTelemetry instrumentation.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example-pod
+  annotations:
+    resource.opentelemetry.io/service.name: "my-service"
+    resource.opentelemetry.io/service.version: "1.0.0"
+    resource.opentelemetry.io/environment: "production"
+spec:
+  containers:
+  - name: main-container
+    image: your-image:tag
+ ```
+
 ## Compatibility matrix
 
 ### OpenTelemetry Operator vs. OpenTelemetry Collector

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -31,12 +31,12 @@ const (
 	AnnotationDefaultAutoInstrumentationApacheHttpd = InstrumentationPrefix + "default-auto-instrumentation-apache-httpd-image"
 	AnnotationDefaultAutoInstrumentationNginx       = InstrumentationPrefix + "default-auto-instrumentation-nginx-image"
 
-	EnvPodName        = "OTEL_RESOURCE_ATTRIBUTES_POD_NAME"
-	EnvPodUID         = "OTEL_RESOURCE_ATTRIBUTES_POD_UID"
-	EnvPodIP          = "OTEL_POD_IP"
-	EnvNodeName       = "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME"
-	EnvNodeIP         = "OTEL_NODE_IP"
-	ReservedNamespace = "resource.opentelemetry.io/"
+	EnvPodName              = "OTEL_RESOURCE_ATTRIBUTES_POD_NAME"
+	EnvPodUID               = "OTEL_RESOURCE_ATTRIBUTES_POD_UID"
+	EnvPodIP                = "OTEL_POD_IP"
+	EnvNodeName             = "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME"
+	EnvNodeIP               = "OTEL_NODE_IP"
+	OtelAnnotationNamespace = "resource.opentelemetry.io/"
 
 	FlagCRMetrics   = "enable-cr-metrics"
 	FlagApacheHttpd = "enable-apache-httpd-instrumentation"

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -31,11 +31,12 @@ const (
 	AnnotationDefaultAutoInstrumentationApacheHttpd = InstrumentationPrefix + "default-auto-instrumentation-apache-httpd-image"
 	AnnotationDefaultAutoInstrumentationNginx       = InstrumentationPrefix + "default-auto-instrumentation-nginx-image"
 
-	EnvPodName  = "OTEL_RESOURCE_ATTRIBUTES_POD_NAME"
-	EnvPodUID   = "OTEL_RESOURCE_ATTRIBUTES_POD_UID"
-	EnvPodIP    = "OTEL_POD_IP"
-	EnvNodeName = "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME"
-	EnvNodeIP   = "OTEL_NODE_IP"
+	EnvPodName        = "OTEL_RESOURCE_ATTRIBUTES_POD_NAME"
+	EnvPodUID         = "OTEL_RESOURCE_ATTRIBUTES_POD_UID"
+	EnvPodIP          = "OTEL_POD_IP"
+	EnvNodeName       = "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME"
+	EnvNodeIP         = "OTEL_NODE_IP"
+	ReservedNamespace = "resource.opentelemetry.io/"
 
 	FlagCRMetrics   = "enable-cr-metrics"
 	FlagApacheHttpd = "enable-apache-httpd-instrumentation"

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -479,6 +479,15 @@ func (i *sdkInjector) createResourceMap(ctx context.Context, otelinst v1alpha1.I
 			res[string(k)] = v
 		}
 	}
+
+	for k, v := range pod.GetAnnotations() {
+		if strings.HasPrefix(k, constants.ReservedNamespace) {
+			key := strings.TrimSpace(strings.TrimPrefix(k, constants.ReservedNamespace))
+			if _, ok := res[key]; !ok {
+				res[key] = v
+			}
+		}
+	}
 	return res
 }
 

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -481,8 +481,8 @@ func (i *sdkInjector) createResourceMap(ctx context.Context, otelinst v1alpha1.I
 	}
 
 	for k, v := range pod.GetAnnotations() {
-		if strings.HasPrefix(k, constants.ReservedNamespace) {
-			key := strings.TrimSpace(strings.TrimPrefix(k, constants.ReservedNamespace))
+		if strings.HasPrefix(k, constants.OtelAnnotationNamespace) {
+			key := strings.TrimSpace(strings.TrimPrefix(k, constants.OtelAnnotationNamespace))
 			if _, ok := res[key]; !ok {
 				res[key] = v
 			}

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -484,6 +484,112 @@ func TestSDKInjection(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Resource attribute propagate",
+			inst: v1alpha1.Instrumentation{
+				Spec: v1alpha1.InstrumentationSpec{
+					Exporter: v1alpha1.Exporter{
+						Endpoint: "https://collector:4317",
+					},
+					Resource: v1alpha1.Resource{
+						Attributes: map[string]string{
+							"fromcr": "val",
+						},
+					},
+					Propagators: []v1alpha1.Propagator{"jaeger"},
+					Sampler: v1alpha1.Sampler{
+						Type:     "parentbased_traceidratio",
+						Argument: "0.25",
+					},
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"resource.opentelemetry.io/fromtest": "val",
+						"resource.opentelemetry.io/foo":      "test",
+					},
+					Namespace: "project1",
+					Name:      "app",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Image: "app:latest",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "OTEL_SERVICE_NAME",
+									Value: "explicitly_set",
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+									Value: "explicitly_set",
+								},
+								{
+									Name:  "OTEL_PROPAGATORS",
+									Value: "b3",
+								},
+								{
+									Name:  "OTEL_TRACES_SAMPLER",
+									Value: "always_on",
+								},
+								{
+									Name:  "OTEL_RESOURCE_ATTRIBUTES",
+									Value: "foo=bar,k8s.container.name=other,service.version=explicitly_set,",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "project1",
+					Name:      "app",
+					Annotations: map[string]string{
+						"resource.opentelemetry.io/fromtest": "val",
+						"resource.opentelemetry.io/foo":      "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Image: "app:latest",
+							Env: []corev1.EnvVar{
+								{
+									Name:  "OTEL_SERVICE_NAME",
+									Value: "explicitly_set",
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+									Value: "explicitly_set",
+								},
+								{
+									Name:  "OTEL_PROPAGATORS",
+									Value: "b3",
+								},
+								{
+									Name:  "OTEL_TRACES_SAMPLER",
+									Value: "always_on",
+								},
+								{
+									Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+								{
+									Name:  "OTEL_RESOURCE_ATTRIBUTES",
+									Value: "foo=bar,k8s.container.name=other,service.version=explicitly_set,foo=test,fromcr=val,fromtest=val,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
change_type: sdk.go

- Modified the logic for iterating over pod annotations, utilizing pod.GetAnnotations() to identify and extract resources using the specified namespace prefix (constants.ReservedNamespace).
 - Implemented the use of the OpenTelemetry.io namespace for extracting resource annotations from Kubernetes pods.

- Enhanced handling to streamline the extraction process and avoid overwriting existing resource mappings.


issues: [https://github.com/open-telemetry/opentelemetry-operator/issues/2181]


https://github.com/open-telemetry/opentelemetry-operator/pull/2330


TestCase :white_check_mark: 
```
?       github.com/open-telemetry/opentelemetry-operator/pkg/constants  [no test files]
ok      github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade  
ok      github.com/open-telemetry/opentelemetry-operator/pkg/featuregate        
ok      github.com/open-telemetry/opentelemetry-operator/pkg/instrumentation    
ok      github.com/open-telemetry/opentelemetry-operator/pkg/instrumentation/upgrade    
ok      github.com/open-telemetry/opentelemetry-operator/pkg/sidecar    ```