### PR TITLE
Enable Prometheus CR via the TA config file

### DIFF
--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -109,9 +109,10 @@ func LoadFromCLI(target *Config, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	target.PrometheusCR.Enabled, err = getPrometheusCREnabled(flagSet)
-	if err != nil {
-		return err
+	if prometheusCREnabled, changed, flagErr := getPrometheusCREnabled(flagSet); flagErr != nil {
+		return flagErr
+	} else if changed {
+		target.PrometheusCR.Enabled = prometheusCREnabled
 	}
 
 	target.HTTPS.Enabled, err = getHttpsEnabled(flagSet)

--- a/cmd/otel-allocator/config/config_test.go
+++ b/cmd/otel-allocator/config/config_test.go
@@ -59,6 +59,7 @@ func TestLoad(t *testing.T) {
 				},
 				FilterStrategy: DefaultFilterStrategy,
 				PrometheusCR: PrometheusCRConfig{
+					Enabled:        true,
 					ScrapeInterval: model.Duration(time.Second * 60),
 				},
 				HTTPS: HTTPSServerConfig{

--- a/cmd/otel-allocator/config/flags.go
+++ b/cmd/otel-allocator/config/flags.go
@@ -69,8 +69,13 @@ func getListenAddr(flagSet *pflag.FlagSet) (string, error) {
 	return flagSet.GetString(listenAddrFlagName)
 }
 
-func getPrometheusCREnabled(flagSet *pflag.FlagSet) (bool, error) {
-	return flagSet.GetBool(prometheusCREnabledFlagName)
+func getPrometheusCREnabled(flagSet *pflag.FlagSet) (value bool, changed bool, err error) {
+	if changed = flagSet.Changed(prometheusCREnabledFlagName); !changed {
+		value, err = false, nil
+		return
+	}
+	value, err = flagSet.GetBool(prometheusCREnabledFlagName)
+	return
 }
 
 func getHttpsListenAddr(flagSet *pflag.FlagSet) (string, error) {

--- a/cmd/otel-allocator/config/flags_test.go
+++ b/cmd/otel-allocator/config/flags_test.go
@@ -62,7 +62,10 @@ func TestFlagGetters(t *testing.T) {
 			name:          "GetPrometheusCREnabled",
 			flagArgs:      []string{"--" + prometheusCREnabledFlagName, "true"},
 			expectedValue: true,
-			getterFunc:    func(fs *pflag.FlagSet) (interface{}, error) { return getPrometheusCREnabled(fs) },
+			getterFunc: func(fs *pflag.FlagSet) (interface{}, error) {
+				_, value, err := getPrometheusCREnabled(fs)
+				return value, err
+			},
 		},
 		{
 			name:        "InvalidFlag",

--- a/cmd/otel-allocator/config/testdata/config_test.yaml
+++ b/cmd/otel-allocator/config/testdata/config_test.yaml
@@ -3,6 +3,7 @@ collector_selector:
     app.kubernetes.io/instance: default.test
     app.kubernetes.io/managed-by: opentelemetry-operator
 prometheus_cr:
+  enabled: true
   scrape_interval: 60s
 https:
   enabled: true

--- a/controllers/builder_test.go
+++ b/controllers/builder_test.go
@@ -1392,6 +1392,7 @@ config:
       target_label: instance
 filter_strategy: relabel-config
 prometheus_cr:
+  enabled: true
   pod_monitor_selector: null
   service_monitor_selector: null
 `,
@@ -1426,7 +1427,7 @@ prometheus_cr:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "dd0ff440929239a362ebc85256b89e109d37bd2c77b400bd2039582cbda56be5",
+									"opentelemetry-targetallocator-config/hash": "9d78d2ecfad18bad24dec7e9a825b4ce45657ecbb2e6b32845b585b7c15ea407",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -1461,9 +1462,6 @@ prometheus_cr:
 													},
 												},
 											},
-										},
-										Args: []string{
-											"--enable-prometheus-cr-watcher",
 										},
 										Ports: []corev1.ContainerPort{
 											{
@@ -1787,6 +1785,7 @@ config:
       target_label: instance
 filter_strategy: relabel-config
 prometheus_cr:
+  enabled: true
   pod_monitor_selector: null
   service_monitor_selector: null
 `,
@@ -1821,7 +1820,7 @@ prometheus_cr:
 									"app.kubernetes.io/version":    "latest",
 								},
 								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "dd0ff440929239a362ebc85256b89e109d37bd2c77b400bd2039582cbda56be5",
+									"opentelemetry-targetallocator-config/hash": "9d78d2ecfad18bad24dec7e9a825b4ce45657ecbb2e6b32845b585b7c15ea407",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -1856,9 +1855,6 @@ prometheus_cr:
 													},
 												},
 											},
-										},
-										Args: []string{
-											"--enable-prometheus-cr-watcher",
 										},
 										Ports: []corev1.ContainerPort{
 											{

--- a/controllers/reconcile_test.go
+++ b/controllers/reconcile_test.go
@@ -484,11 +484,6 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 							taConfig["config"] = promConfig["config"]
 							taConfig["allocation_strategy"] = "consistent-hashing"
 							taConfig["filter_strategy"] = "relabel-config"
-							taConfig["prometheus_cr"] = map[string]any{
-								"scrape_interval":          "30s",
-								"pod_monitor_selector":     &metav1.LabelSelector{},
-								"service_monitor_selector": &metav1.LabelSelector{},
-							}
 							taConfigYAML, _ := yaml.Marshal(taConfig)
 							assert.Equal(t, string(taConfigYAML), actual.Data["targetallocator.yaml"])
 							assert.NotContains(t, actual.Data["targetallocator.yaml"], "0.0.0.0:10100")

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -36,7 +36,6 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	taSpec := instance.Spec
 
 	taConfig := make(map[interface{}]interface{})
-	prometheusCRConfig := make(map[interface{}]interface{})
 	taConfig["collector_selector"] = taSpec.CollectorSelector
 
 	// Add scrape configs if present
@@ -53,15 +52,18 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	}
 	taConfig["filter_strategy"] = taSpec.FilterStrategy
 
-	if taSpec.PrometheusCR.ScrapeInterval.Size() > 0 {
-		prometheusCRConfig["scrape_interval"] = taSpec.PrometheusCR.ScrapeInterval.Duration
-	}
+	if taSpec.PrometheusCR.Enabled {
+		prometheusCRConfig := map[interface{}]interface{}{
+			"enabled": true,
+		}
+		if taSpec.PrometheusCR.ScrapeInterval.Size() > 0 {
+			prometheusCRConfig["scrape_interval"] = taSpec.PrometheusCR.ScrapeInterval.Duration
+		}
 
-	prometheusCRConfig["service_monitor_selector"] = taSpec.PrometheusCR.ServiceMonitorSelector
+		prometheusCRConfig["service_monitor_selector"] = taSpec.PrometheusCR.ServiceMonitorSelector
 
-	prometheusCRConfig["pod_monitor_selector"] = taSpec.PrometheusCR.PodMonitorSelector
+		prometheusCRConfig["pod_monitor_selector"] = taSpec.PrometheusCR.PodMonitorSelector
 
-	if len(prometheusCRConfig) > 0 {
 		taConfig["prometheus_cr"] = prometheusCRConfig
 	}
 

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -58,9 +58,6 @@ config:
       - 0.0.0.0:8888
       - 0.0.0.0:9999
 filter_strategy: relabel-config
-prometheus_cr:
-  pod_monitor_selector: null
-  service_monitor_selector: null
 `,
 		}
 		collector := collectorInstance()
@@ -94,9 +91,6 @@ collector_selector:
     app.kubernetes.io/part-of: opentelemetry
   matchexpressions: []
 filter_strategy: relabel-config
-prometheus_cr:
-  pod_monitor_selector: null
-  service_monitor_selector: null
 `,
 		}
 		collector := collectorInstance()
@@ -140,6 +134,7 @@ config:
       - 0.0.0.0:9999
 filter_strategy: relabel-config
 prometheus_cr:
+  enabled: true
   pod_monitor_selector:
     matchlabels:
       release: my-instance
@@ -151,6 +146,7 @@ prometheus_cr:
 `,
 		}
 		targetAllocator := targetAllocatorInstance()
+		targetAllocator.Spec.PrometheusCR.Enabled = true
 		targetAllocator.Spec.PrometheusCR.PodMonitorSelector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				"release": "my-instance",
@@ -197,6 +193,7 @@ config:
       - 0.0.0.0:9999
 filter_strategy: relabel-config
 prometheus_cr:
+  enabled: true
   pod_monitor_selector: null
   scrape_interval: 30s
   service_monitor_selector: null
@@ -204,6 +201,7 @@ prometheus_cr:
 		}
 
 		targetAllocator := targetAllocatorInstance()
+		targetAllocator.Spec.PrometheusCR.Enabled = true
 		targetAllocator.Spec.PrometheusCR.ScrapeInterval = &metav1.Duration{Duration: time.Second * 30}
 		cfg := config.New()
 		params := manifests.Params{

--- a/internal/manifests/targetallocator/container_test.go
+++ b/internal/manifests/targetallocator/container_test.go
@@ -361,3 +361,25 @@ func TestSecurityContext(t *testing.T) {
 	// verify
 	assert.Equal(t, securityContext, c.SecurityContext)
 }
+
+func TestArgs(t *testing.T) {
+	// prepare
+	targetAllocator := v1alpha1.TargetAllocator{
+		Spec: v1alpha1.TargetAllocatorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+				Args: map[string]string{
+					"key":  "value",
+					"akey": "avalue",
+				},
+			},
+		},
+	}
+	cfg := config.New()
+
+	// test
+	c := Container(cfg, logger, targetAllocator)
+
+	// verify
+	expected := []string{"--akey=avalue", "--key=value"}
+	assert.Equal(t, expected, c.Args)
+}

--- a/tests/e2e-targetallocator/targetallocator-features/00-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-features/00-assert.yaml
@@ -57,9 +57,7 @@ spec:
                 values:
                 - "true"
       containers:
-      - args:
-        - --enable-prometheus-cr-watcher
-        env:
+      - env:
         - name: TEST_ENV
           value: test
         - name: OTELCOL_NAMESPACE


### PR DESCRIPTION
Prometheus CR was arbitrarily enabled by a command-line flag instead of the configuration file setting. Use the config file instead for consistency. This also lets us avoid adding the PrometheusCR section altogether if it's not enabled.

I've also added proper support for `Args` in the TargetAllocator CRD. This is currently a no-op, as this field cannot be set via the embedded TA struct.

