### PR TITLE
Upgrade Go version in Ci to 1.22.3

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "~1.22.3"
 
       - name: Ensure no changes to the CHANGELOG
         run: |

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-go@v5
       id: setup-go
       with:
-        go-version: "~1.21.1"
+        go-version: "~1.22.3"
 
     - name: Cache tools
       uses: actions/cache@v4
@@ -46,7 +46,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "~1.21.1"
+        go-version: "~1.22.3"
 
     - name: Cache tools
       uses: actions/cache@v4
@@ -81,7 +81,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "~1.21.1"
+        go-version: "~1.22.3"
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/setup-go@v5
       id: setup-go
       with:
-        go-version: "~1.21.3"
+        go-version: "~1.22.3"
     - name: Cache tools
       uses: actions/cache@v4
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "~1.21.1"
+        go-version: "~1.22.3"
 
     - name: "generate release resources"
       run: make release-artifacts IMG_PREFIX="ghcr.io/open-telemetry/opentelemetry-operator" VERSION=${DESIRED_VERSION}

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v5
         id: setup-go
         with:
-          go-version: "~1.21.1"
+          go-version: "~1.22.3"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4


### PR DESCRIPTION
Should we just remove these version pins and let the action always use the latest Go? Looks like we forget to bump this, and dependabot doesn't help with it.

Should unblock #3028.