### PR TITLE
Upgrade Go version in Ci to 1.22.4

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "~1.22.3"
+          go-version: "~1.22.4"
 
       - name: Ensure no changes to the CHANGELOG
         run: |

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-go@v5
       id: setup-go
       with:
-        go-version: "~1.22.3"
+        go-version: "~1.22.4"
 
     - name: Cache tools
       uses: actions/cache@v4
@@ -46,7 +46,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "~1.22.3"
+        go-version: "~1.22.4"
 
     - name: Cache tools
       uses: actions/cache@v4
@@ -81,7 +81,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "~1.22.3"
+        go-version: "~1.22.4"
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/setup-go@v5
       id: setup-go
       with:
-        go-version: "~1.22.3"
+        go-version: "~1.22.4"
     - name: Cache tools
       uses: actions/cache@v4
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "~1.22.3"
+        go-version: "~1.22.4"
 
     - name: "generate release resources"
       run: make release-artifacts IMG_PREFIX="ghcr.io/open-telemetry/opentelemetry-operator" VERSION=${DESIRED_VERSION}

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-go@v5
         id: setup-go
         with:
-          go-version: "~1.22.3"
+          go-version: "~1.22.4"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4


### PR DESCRIPTION
1.22.4 fixes an annoying toolchain version parsing issue, allowing us to keep a Go directive in our go.mod without a patch number. See https://github.com/golang/go/issues/62278.

This should properly fix dependabot issues like #3028

