### PR TITLE
Add appArmorProfile to securityContext

### DIFF
--- a/bundle/manifests/opentelemetry.io_opampbridges.yaml
+++ b/bundle/manifests/opentelemetry.io_opampbridges.yaml
@@ -597,6 +597,15 @@ spec:
                     required:
                     - type
                     type: object
+                  appArmorProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
                   supplementalGroups:
                     items:
                       format: int64
@@ -730,6 +739,15 @@ spec:
                         type: string
                     type: object
                   seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  appArmorProfile:
                     properties:
                       localhostProfile:
                         type: string

--- a/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -566,6 +566,15 @@ spec:
                           required:
                           - type
                           type: object
+                        appArmorProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
                         windowsOptions:
                           properties:
                             gmsaCredentialSpec:
@@ -1917,6 +1926,15 @@ spec:
                           required:
                           - type
                           type: object
+                        appArmorProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
                         windowsOptions:
                           properties:
                             gmsaCredentialSpec:
@@ -2280,6 +2298,15 @@ spec:
                     required:
                     - type
                     type: object
+                  appArmorProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
                   supplementalGroups:
                     items:
                       format: int64
@@ -2415,6 +2442,15 @@ spec:
                         type: string
                     type: object
                   seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  appArmorProfile:
                     properties:
                       localhostProfile:
                         type: string
@@ -2986,6 +3022,15 @@ spec:
                         required:
                         - type
                         type: object
+                      appArmorProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
                       supplementalGroups:
                         items:
                           format: int64
@@ -3107,6 +3152,15 @@ spec:
                             type: string
                         type: object
                       seccompProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      appArmorProfile:
                         properties:
                           localhostProfile:
                             type: string
@@ -4813,6 +4867,15 @@ spec:
                           required:
                           - type
                           type: object
+                        appArmorProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
                         windowsOptions:
                           properties:
                             gmsaCredentialSpec:
@@ -6241,6 +6304,15 @@ spec:
                           required:
                           - type
                           type: object
+                        appArmorProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
                         windowsOptions:
                           properties:
                             gmsaCredentialSpec:
@@ -6598,6 +6670,15 @@ spec:
                     required:
                     - type
                     type: object
+                  appArmorProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
                   supplementalGroups:
                     items:
                       format: int64
@@ -6754,6 +6835,15 @@ spec:
                         type: string
                     type: object
                   seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  appArmorProfile:
                     properties:
                       localhostProfile:
                         type: string
@@ -7328,6 +7418,15 @@ spec:
                         required:
                         - type
                         type: object
+                      appArmorProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
                       supplementalGroups:
                         items:
                           format: int64
@@ -7489,6 +7588,15 @@ spec:
                             type: string
                         type: object
                       seccompProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      appArmorProfile:
                         properties:
                           localhostProfile:
                             type: string

--- a/config/crd/bases/opentelemetry.io_opampbridges.yaml
+++ b/config/crd/bases/opentelemetry.io_opampbridges.yaml
@@ -594,6 +594,15 @@ spec:
                     required:
                     - type
                     type: object
+                  appArmorProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
                   supplementalGroups:
                     items:
                       format: int64
@@ -727,6 +736,15 @@ spec:
                         type: string
                     type: object
                   seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  appArmorProfile:
                     properties:
                       localhostProfile:
                         type: string

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -552,6 +552,15 @@ spec:
                           required:
                           - type
                           type: object
+                        appArmorProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
                         windowsOptions:
                           properties:
                             gmsaCredentialSpec:
@@ -1903,6 +1912,15 @@ spec:
                           required:
                           - type
                           type: object
+                        appArmorProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
                         windowsOptions:
                           properties:
                             gmsaCredentialSpec:
@@ -2266,6 +2284,15 @@ spec:
                     required:
                     - type
                     type: object
+                  appArmorProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
                   supplementalGroups:
                     items:
                       format: int64
@@ -2401,6 +2428,15 @@ spec:
                         type: string
                     type: object
                   seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  appArmorProfile:
                     properties:
                       localhostProfile:
                         type: string
@@ -2972,6 +3008,15 @@ spec:
                         required:
                         - type
                         type: object
+                      appArmorProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
                       supplementalGroups:
                         items:
                           format: int64
@@ -3093,6 +3138,15 @@ spec:
                             type: string
                         type: object
                       seccompProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      appArmorProfile:
                         properties:
                           localhostProfile:
                             type: string
@@ -4799,6 +4853,15 @@ spec:
                           required:
                           - type
                           type: object
+                        appArmorProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
                         windowsOptions:
                           properties:
                             gmsaCredentialSpec:
@@ -6227,6 +6290,15 @@ spec:
                           required:
                           - type
                           type: object
+                        appArmorProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
                         windowsOptions:
                           properties:
                             gmsaCredentialSpec:
@@ -6584,6 +6656,15 @@ spec:
                     required:
                     - type
                     type: object
+                  appArmorProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
                   supplementalGroups:
                     items:
                       format: int64
@@ -6740,6 +6821,15 @@ spec:
                         type: string
                     type: object
                   seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  appArmorProfile:
                     properties:
                       localhostProfile:
                         type: string
@@ -7314,6 +7404,15 @@ spec:
                         required:
                         - type
                         type: object
+                      appArmorProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
                       supplementalGroups:
                         items:
                           format: int64
@@ -7475,6 +7574,15 @@ spec:
                             type: string
                         type: object
                       seccompProfile:
+                        properties:
+                          localhostProfile:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      appArmorProfile:
                         properties:
                           localhostProfile:
                             type: string

--- a/config/crd/bases/opentelemetry.io_targetallocators.yaml
+++ b/config/crd/bases/opentelemetry.io_targetallocators.yaml
@@ -524,6 +524,15 @@ spec:
                           required:
                           - type
                           type: object
+                        appArmorProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
                         windowsOptions:
                           properties:
                             gmsaCredentialSpec:
@@ -1699,6 +1708,15 @@ spec:
                           required:
                           - type
                           type: object
+                        appArmorProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
                         windowsOptions:
                           properties:
                             gmsaCredentialSpec:
@@ -2028,6 +2046,15 @@ spec:
                     required:
                     - type
                     type: object
+                  appArmorProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
                   supplementalGroups:
                     items:
                       format: int64
@@ -2226,6 +2253,15 @@ spec:
                         type: string
                     type: object
                   seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  appArmorProfile:
                     properties:
                       localhostProfile:
                         type: string


### PR DESCRIPTION
**Description:** Add appArmorProfile in securityContext definitions so it is not removed by openteletry-operator

**Link to tracking Issue(s):**  #3036

- Resolves:  #3036

**Testing:** None

**Documentation:** None
