### PR TITLE
Remove collectorSelector field from TA CRD

### DIFF
--- a/apis/v1alpha1/targetallocator_types.go
+++ b/apis/v1alpha1/targetallocator_types.go
@@ -60,8 +60,6 @@ type TargetAllocatorStatus struct {
 type TargetAllocatorSpec struct {
 	// Common defines fields that are common to all OpenTelemetry CRD workloads.
 	v1beta1.OpenTelemetryCommonFields `json:",inline"`
-	// CollectorSelector is the selector for Collector Pods the target allocator will allocate targets to.
-	CollectorSelector metav1.LabelSelector `json:"collectorSelector,omitempty"`
 	// AllocationStrategy determines which strategy the target allocator should use for allocation.
 	// The current options are least-weighted, consistent-hashing and per-node. The default is
 	// consistent-hashing.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1308,7 +1308,6 @@ func (in *TargetAllocatorList) DeepCopyObject() runtime.Object {
 func (in *TargetAllocatorSpec) DeepCopyInto(out *TargetAllocatorSpec) {
 	*out = *in
 	in.OpenTelemetryCommonFields.DeepCopyInto(&out.OpenTelemetryCommonFields)
-	in.CollectorSelector.DeepCopyInto(&out.CollectorSelector)
 	if in.ScrapeConfigs != nil {
 		in, out := &in.ScrapeConfigs, &out.ScrapeConfigs
 		*out = make([]v1beta1.AnyConfig, len(*in))

--- a/config/crd/bases/opentelemetry.io_targetallocators.yaml
+++ b/config/crd/bases/opentelemetry.io_targetallocators.yaml
@@ -1078,30 +1078,6 @@ spec:
                 additionalProperties:
                   type: string
                 type: object
-              collectorSelector:
-                properties:
-                  matchExpressions:
-                    items:
-                      properties:
-                        key:
-                          type: string
-                        operator:
-                          type: string
-                        values:
-                          items:
-                            type: string
-                          type: array
-                      required:
-                      - key
-                      - operator
-                      type: object
-                    type: array
-                  matchLabels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                type: object
-                x-kubernetes-map-type: atomic
               env:
                 items:
                   properties:

--- a/internal/manifests/collector/targetallocator.go
+++ b/internal/manifests/collector/targetallocator.go
@@ -20,7 +20,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/targetallocator/adapters"
 )
 
@@ -30,10 +29,6 @@ func TargetAllocator(params manifests.Params) (*v1alpha1.TargetAllocator, error)
 	taSpec := params.OtelCol.Spec.TargetAllocator
 	if !taSpec.Enabled {
 		return nil, nil
-	}
-
-	collectorSelector := metav1.LabelSelector{
-		MatchLabels: manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, ComponentOpenTelemetryCollector),
 	}
 
 	configStr, err := params.OtelCol.Spec.Config.Yaml()
@@ -68,7 +63,6 @@ func TargetAllocator(params manifests.Params) (*v1alpha1.TargetAllocator, error)
 				PodAnnotations:            params.OtelCol.Spec.PodAnnotations,
 				PodDisruptionBudget:       taSpec.PodDisruptionBudget,
 			},
-			CollectorSelector:  collectorSelector,
 			AllocationStrategy: taSpec.AllocationStrategy,
 			FilterStrategy:     taSpec.FilterStrategy,
 			ScrapeConfigs:      scrapeConfigs,

--- a/internal/manifests/collector/targetallocator_test.go
+++ b/internal/manifests/collector/targetallocator_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 )
 
 func TestTargetAllocator(t *testing.T) {
@@ -91,9 +90,6 @@ func TestTargetAllocator(t *testing.T) {
 			want: &v1alpha1.TargetAllocator{
 				ObjectMeta: objectMetadata,
 				Spec: v1alpha1.TargetAllocatorSpec{
-					CollectorSelector: metav1.LabelSelector{
-						MatchLabels: manifestutils.SelectorLabels(objectMetadata, ComponentOpenTelemetryCollector),
-					},
 					ScrapeConfigs: []v1beta1.AnyConfig{},
 				},
 			},
@@ -281,9 +277,6 @@ func TestTargetAllocator(t *testing.T) {
 								IntVal: 1,
 							},
 						},
-					},
-					CollectorSelector: metav1.LabelSelector{
-						MatchLabels: manifestutils.SelectorLabels(objectMetadata, ComponentOpenTelemetryCollector),
 					},
 					AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
 					FilterStrategy:     v1beta1.TargetAllocatorFilterStrategyRelabelConfig,

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
@@ -36,7 +37,10 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	taSpec := instance.Spec
 
 	taConfig := make(map[interface{}]interface{})
-	taConfig["collector_selector"] = taSpec.CollectorSelector
+
+	taConfig["collector_selector"] = metav1.LabelSelector{
+		MatchLabels: manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, collector.ComponentOpenTelemetryCollector),
+	}
 
 	// Add scrape configs if present
 	if instance.Spec.ScrapeConfigs != nil && len(instance.Spec.ScrapeConfigs) > 0 {

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -35,6 +35,15 @@ func TestDesiredConfigMap(t *testing.T) {
 		"app.kubernetes.io/part-of":    "opentelemetry",
 		"app.kubernetes.io/version":    "0.47.0",
 	}
+	collector := collectorInstance()
+	targetAllocator := targetAllocatorInstance()
+	cfg := config.New()
+	params := manifests.Params{
+		OtelCol:         collector,
+		TargetAllocator: targetAllocator,
+		Config:          cfg,
+		Log:             logr.Discard(),
+	}
 
 	t.Run("should return expected target allocator config map", func(t *testing.T) {
 		expectedLabels["app.kubernetes.io/component"] = "opentelemetry-targetallocator"
@@ -60,15 +69,7 @@ config:
 filter_strategy: relabel-config
 `,
 		}
-		collector := collectorInstance()
-		targetAllocator := targetAllocatorInstance()
-		cfg := config.New()
-		params := manifests.Params{
-			OtelCol:         collector,
-			TargetAllocator: targetAllocator,
-			Config:          cfg,
-			Log:             logr.Discard(),
-		}
+
 		actual, err := ConfigMap(params)
 		require.NoError(t, err)
 
@@ -93,16 +94,9 @@ collector_selector:
 filter_strategy: relabel-config
 `,
 		}
-		collector := collectorInstance()
-		targetAllocator := targetAllocatorInstance()
+		targetAllocator = targetAllocatorInstance()
 		targetAllocator.Spec.ScrapeConfigs = []v1beta1.AnyConfig{}
-		cfg := config.New()
-		params := manifests.Params{
-			OtelCol:         collector,
-			TargetAllocator: targetAllocator,
-			Config:          cfg,
-			Log:             logr.Discard(),
-		}
+		params.TargetAllocator = targetAllocator
 		actual, err := ConfigMap(params)
 		require.NoError(t, err)
 
@@ -145,7 +139,7 @@ prometheus_cr:
     matchexpressions: []
 `,
 		}
-		targetAllocator := targetAllocatorInstance()
+		targetAllocator = targetAllocatorInstance()
 		targetAllocator.Spec.PrometheusCR.Enabled = true
 		targetAllocator.Spec.PrometheusCR.PodMonitorSelector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -156,12 +150,7 @@ prometheus_cr:
 			MatchLabels: map[string]string{
 				"release": "my-instance",
 			}}
-		cfg := config.New()
-		params := manifests.Params{
-			TargetAllocator: targetAllocator,
-			Config:          cfg,
-			Log:             logr.Discard(),
-		}
+		params.TargetAllocator = targetAllocator
 		actual, err := ConfigMap(params)
 		assert.NoError(t, err)
 
@@ -200,15 +189,10 @@ prometheus_cr:
 `,
 		}
 
-		targetAllocator := targetAllocatorInstance()
+		targetAllocator = targetAllocatorInstance()
 		targetAllocator.Spec.PrometheusCR.Enabled = true
 		targetAllocator.Spec.PrometheusCR.ScrapeInterval = &metav1.Duration{Duration: time.Second * 30}
-		cfg := config.New()
-		params := manifests.Params{
-			TargetAllocator: targetAllocator,
-			Config:          cfg,
-			Log:             logr.Discard(),
-		}
+		params.TargetAllocator = targetAllocator
 		actual, err := ConfigMap(params)
 		assert.NoError(t, err)
 


### PR DESCRIPTION
Doing this as per the decision made in https://github.com/open-telemetry/opentelemetry-operator/issues/2422#issuecomment-2154655906. We're going to use a label to manage this relationship instead.

On a separate note, I'd like to give the TargetAllocator builder a different Params struct, so we can more clearly indicate this relationship. That's a more involved change, though, and I'll make it separately.
