### PR TITLE
Add a separate Params struct for Target Allocator

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -51,8 +51,37 @@ func BuildCollector(params manifests.Params) ([]client.Object, error) {
 	builders := []manifests.Builder[manifests.Params]{
 		collector.Build,
 	}
+	var resources []client.Object
+	for _, builder := range builders {
+		objs, err := builder(params)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, objs...)
+	}
 	if params.OtelCol.Spec.TargetAllocator.Enabled {
-		builders = append(builders, targetallocator.Build)
+		taParams := targetallocator.Params{
+			Client:          params.Client,
+			Scheme:          params.Scheme,
+			Recorder:        params.Recorder,
+			Log:             params.Log,
+			Config:          params.Config,
+			Collector:       params.OtelCol,
+			TargetAllocator: params.TargetAllocator,
+		}
+		taResources, err := BuildTargetAllocator(taParams)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, taResources...)
+	}
+	return resources, nil
+}
+
+// BuildOpAMPBridge returns the generation and collected errors of all manifests for a given instance.
+func BuildOpAMPBridge(params manifests.Params) ([]client.Object, error) {
+	builders := []manifests.Builder[manifests.Params]{
+		opampbridge.Build,
 	}
 	var resources []client.Object
 	for _, builder := range builders {
@@ -65,10 +94,10 @@ func BuildCollector(params manifests.Params) ([]client.Object, error) {
 	return resources, nil
 }
 
-// BuildOpAMPBridge returns the generation and collected errors of all manifests for a given instance.
-func BuildOpAMPBridge(params manifests.Params) ([]client.Object, error) {
-	builders := []manifests.Builder[manifests.Params]{
-		opampbridge.Build,
+// BuildTargetAllocator returns the generation and collected errors of all manifests for a given instance.
+func BuildTargetAllocator(params targetallocator.Params) ([]client.Object, error) {
+	builders := []manifests.Builder[targetallocator.Params]{
+		targetallocator.Build,
 	}
 	var resources []client.Object
 	for _, builder := range builders {

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -48,9 +48,11 @@ func isNamespaceScoped(obj client.Object) bool {
 
 // BuildCollector returns the generation and collected errors of all manifests for a given instance.
 func BuildCollector(params manifests.Params) ([]client.Object, error) {
-	builders := []manifests.Builder{
+	builders := []manifests.Builder[manifests.Params]{
 		collector.Build,
-		targetallocator.Build,
+	}
+	if params.OtelCol.Spec.TargetAllocator.Enabled {
+		builders = append(builders, targetallocator.Build)
 	}
 	var resources []client.Object
 	for _, builder := range builders {
@@ -65,7 +67,7 @@ func BuildCollector(params manifests.Params) ([]client.Object, error) {
 
 // BuildOpAMPBridge returns the generation and collected errors of all manifests for a given instance.
 func BuildOpAMPBridge(params manifests.Params) ([]client.Object, error) {
-	builders := []manifests.Builder{
+	builders := []manifests.Builder[manifests.Params]{
 		opampbridge.Build,
 	}
 	var resources []client.Object

--- a/internal/manifests/builder.go
+++ b/internal/manifests/builder.go
@@ -20,19 +20,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type Builder func(params Params) ([]client.Object, error)
+type Builder[Params any] func(params Params) ([]client.Object, error)
 
-type ManifestFactory[T client.Object] func(params Params) (T, error)
-type SimpleManifestFactory[T client.Object] func(params Params) T
-type K8sManifestFactory ManifestFactory[client.Object]
+type ManifestFactory[T client.Object, Params any] func(params Params) (T, error)
+type SimpleManifestFactory[T client.Object, Params any] func(params Params) T
+type K8sManifestFactory[Params any] ManifestFactory[client.Object, Params]
 
-func FactoryWithoutError[T client.Object](f SimpleManifestFactory[T]) K8sManifestFactory {
+func FactoryWithoutError[T client.Object, Params any](f SimpleManifestFactory[T, Params]) K8sManifestFactory[Params] {
 	return func(params Params) (client.Object, error) {
 		return f(params), nil
 	}
 }
 
-func Factory[T client.Object](f ManifestFactory[T]) K8sManifestFactory {
+func Factory[T client.Object, Params any](f ManifestFactory[T, Params]) K8sManifestFactory[Params] {
 	return func(params Params) (client.Object, error) {
 		return f(params)
 	}

--- a/internal/manifests/collector/collector.go
+++ b/internal/manifests/collector/collector.go
@@ -30,7 +30,7 @@ const (
 // Build creates the manifest for the collector resource.
 func Build(params manifests.Params) ([]client.Object, error) {
 	var resourceManifests []client.Object
-	var manifestFactories []manifests.K8sManifestFactory
+	var manifestFactories []manifests.K8sManifestFactory[manifests.Params]
 	switch params.OtelCol.Spec.Mode {
 	case v1beta1.ModeDeployment:
 		manifestFactories = append(manifestFactories, manifests.Factory(Deployment))
@@ -43,7 +43,7 @@ func Build(params manifests.Params) ([]client.Object, error) {
 	case v1beta1.ModeSidecar:
 		params.Log.V(5).Info("not building sidecar...")
 	}
-	manifestFactories = append(manifestFactories, []manifests.K8sManifestFactory{
+	manifestFactories = append(manifestFactories, []manifests.K8sManifestFactory[manifests.Params]{
 		manifests.Factory(ConfigMap),
 		manifests.Factory(HorizontalPodAutoscaler),
 		manifests.Factory(ServiceAccount),

--- a/internal/manifests/opampbridge/opampbridge.go
+++ b/internal/manifests/opampbridge/opampbridge.go
@@ -27,7 +27,7 @@ const (
 // Build creates the manifest for the OpAMPBridge resource.
 func Build(params manifests.Params) ([]client.Object, error) {
 	var resourceManifests []client.Object
-	resourceFactories := []manifests.K8sManifestFactory{
+	resourceFactories := []manifests.K8sManifestFactory[manifests.Params]{
 		manifests.FactoryWithoutError(Deployment),
 		manifests.Factory(ConfigMap),
 		manifests.FactoryWithoutError(ServiceAccount),

--- a/internal/manifests/targetallocator/annotations_test.go
+++ b/internal/manifests/targetallocator/annotations_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
 func TestPodAnnotations(t *testing.T) {
@@ -40,8 +39,8 @@ func TestConfigMapHash(t *testing.T) {
 	cfg := config.New()
 	collector := collectorInstance()
 	targetAllocator := targetAllocatorInstance()
-	params := manifests.Params{
-		OtelCol:         collector,
+	params := Params{
+		Collector:       collector,
 		TargetAllocator: targetAllocator,
 		Config:          cfg,
 		Log:             logr.Discard(),

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
@@ -30,7 +29,7 @@ const (
 	targetAllocatorFilename = "targetallocator.yaml"
 )
 
-func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
+func ConfigMap(params Params) (*corev1.ConfigMap, error) {
 	instance := params.TargetAllocator
 	name := naming.TAConfigMap(instance.Name)
 	labels := manifestutils.Labels(instance.ObjectMeta, name, params.TargetAllocator.Spec.Image, ComponentOpenTelemetryTargetAllocator, nil)
@@ -39,7 +38,7 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	taConfig := make(map[interface{}]interface{})
 
 	taConfig["collector_selector"] = metav1.LabelSelector{
-		MatchLabels: manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, collector.ComponentOpenTelemetryCollector),
+		MatchLabels: manifestutils.SelectorLabels(params.Collector.ObjectMeta, collector.ComponentOpenTelemetryCollector),
 	}
 
 	// Add scrape configs if present

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
 func TestDesiredConfigMap(t *testing.T) {
@@ -38,8 +37,8 @@ func TestDesiredConfigMap(t *testing.T) {
 	collector := collectorInstance()
 	targetAllocator := targetAllocatorInstance()
 	cfg := config.New()
-	params := manifests.Params{
-		OtelCol:         collector,
+	params := Params{
+		Collector:       collector,
 		TargetAllocator: targetAllocator,
 		Config:          cfg,
 		Log:             logr.Discard(),

--- a/internal/manifests/targetallocator/deployment.go
+++ b/internal/manifests/targetallocator/deployment.go
@@ -19,13 +19,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 // Deployment builds the deployment for the given instance.
-func Deployment(params manifests.Params) (*appsv1.Deployment, error) {
+func Deployment(params Params) (*appsv1.Deployment, error) {
 	name := naming.TargetAllocator(params.TargetAllocator.Name)
 	labels := manifestutils.Labels(params.TargetAllocator.ObjectMeta, name, params.TargetAllocator.Spec.Image, ComponentOpenTelemetryTargetAllocator, nil)
 

--- a/internal/manifests/targetallocator/deployment_test.go
+++ b/internal/manifests/targetallocator/deployment_test.go
@@ -89,7 +89,7 @@ func TestDeploymentSecurityContext(t *testing.T) {
 
 	cfg := config.New()
 
-	params1 := manifests.Params{
+	params1 := Params{
 		TargetAllocator: targetallocator11,
 		Config:          cfg,
 		Log:             logger,
@@ -114,7 +114,7 @@ func TestDeploymentSecurityContext(t *testing.T) {
 
 	cfg = config.New()
 
-	params2 := manifests.Params{
+	params2 := Params{
 		TargetAllocator: targetAllocator2,
 		Config:          cfg,
 		Log:             logger,
@@ -133,8 +133,8 @@ func TestDeploymentNewDefault(t *testing.T) {
 	targetAllocator := targetAllocatorInstance()
 	cfg := config.New()
 
-	params := manifests.Params{
-		OtelCol:         otelcol,
+	params := Params{
+		Collector:       otelcol,
 		TargetAllocator: targetAllocator,
 		Config:          cfg,
 		Log:             logger,
@@ -167,8 +167,8 @@ func TestDeploymentPodAnnotations(t *testing.T) {
 	targetAllocator.Spec.PodAnnotations = testPodAnnotationValues
 	cfg := config.New()
 
-	params := manifests.Params{
-		OtelCol:         otelcol,
+	params := Params{
+		Collector:       otelcol,
 		TargetAllocator: targetAllocator,
 		Config:          cfg,
 		Log:             logger,
@@ -225,7 +225,7 @@ func TestDeploymentNodeSelector(t *testing.T) {
 
 	cfg := config.New()
 
-	params1 := manifests.Params{
+	params1 := Params{
 		TargetAllocator: targetAllocator1,
 		Config:          cfg,
 		Log:             logger,
@@ -250,7 +250,7 @@ func TestDeploymentNodeSelector(t *testing.T) {
 
 	cfg = config.New()
 
-	params2 := manifests.Params{
+	params2 := Params{
 		TargetAllocator: targetAllocator2,
 		Config:          cfg,
 		Log:             logger,
@@ -267,7 +267,7 @@ func TestDeploymentAffinity(t *testing.T) {
 
 	cfg := config.New()
 
-	params1 := manifests.Params{
+	params1 := Params{
 		TargetAllocator: targetAllocator1,
 		Config:          cfg,
 		Log:             logger,
@@ -290,7 +290,7 @@ func TestDeploymentAffinity(t *testing.T) {
 
 	cfg = config.New()
 
-	params2 := manifests.Params{
+	params2 := Params{
 		TargetAllocator: targetAllocator2,
 		Config:          cfg,
 		Log:             logger,
@@ -310,7 +310,7 @@ func TestDeploymentTolerations(t *testing.T) {
 	}
 
 	cfg := config.New()
-	params1 := manifests.Params{
+	params1 := Params{
 		TargetAllocator: targetAllocator1,
 		Config:          cfg,
 		Log:             logger,
@@ -332,7 +332,7 @@ func TestDeploymentTolerations(t *testing.T) {
 		},
 	}
 
-	params2 := manifests.Params{
+	params2 := Params{
 		TargetAllocator: targetAllocator2,
 		Config:          cfg,
 		Log:             logger,
@@ -355,7 +355,7 @@ func TestDeploymentTopologySpreadConstraints(t *testing.T) {
 
 	cfg := config.New()
 
-	params1 := manifests.Params{
+	params1 := Params{
 		TargetAllocator: targetAllocator1,
 		Config:          cfg,
 		Log:             logger,
@@ -378,7 +378,7 @@ func TestDeploymentTopologySpreadConstraints(t *testing.T) {
 	}
 
 	cfg = config.New()
-	params2 := manifests.Params{
+	params2 := Params{
 		TargetAllocator: targetAllocator2,
 		Config:          cfg,
 		Log:             logger,
@@ -401,8 +401,8 @@ func TestDeploymentSetInitContainer(t *testing.T) {
 		},
 	}
 	otelcol := collectorInstance()
-	params := manifests.Params{
-		OtelCol:         otelcol,
+	params := Params{
+		Collector:       otelcol,
 		TargetAllocator: targetAllocator,
 		Config:          config.New(),
 		Log:             logger,
@@ -423,8 +423,8 @@ func TestDeploymentAdditionalContainers(t *testing.T) {
 		},
 	}
 	otelcol := collectorInstance()
-	params := manifests.Params{
-		OtelCol:         otelcol,
+	params := Params{
+		Collector:       otelcol,
 		TargetAllocator: targetAllocator,
 		Config:          config.New(),
 		Log:             logger,
@@ -441,8 +441,8 @@ func TestDeploymentHostNetwork(t *testing.T) {
 	// Test default
 	targetAllocator := targetAllocatorInstance()
 	otelcol := collectorInstance()
-	params := manifests.Params{
-		OtelCol:         otelcol,
+	params := Params{
+		Collector:       otelcol,
 		TargetAllocator: targetAllocator,
 		Config:          config.New(),
 		Log:             logger,
@@ -467,8 +467,8 @@ func TestDeploymentShareProcessNamespace(t *testing.T) {
 	// Test default
 	targetAllocator := targetAllocatorInstance()
 	otelcol := collectorInstance()
-	params := manifests.Params{
-		OtelCol:         otelcol,
+	params := Params{
+		Collector:       otelcol,
 		TargetAllocator: targetAllocator,
 		Config:          config.New(),
 		Log:             logger,
@@ -490,8 +490,8 @@ func TestDeploymentPriorityClassName(t *testing.T) {
 	// Test default
 	targetAllocator := targetAllocatorInstance()
 	otelcol := collectorInstance()
-	params := manifests.Params{
-		OtelCol:         otelcol,
+	params := Params{
+		Collector:       otelcol,
 		TargetAllocator: targetAllocator,
 		Config:          config.New(),
 		Log:             logger,
@@ -513,8 +513,8 @@ func TestDeploymentTerminationGracePeriodSeconds(t *testing.T) {
 	// Test default
 	targetAllocator := targetAllocatorInstance()
 	otelcol := collectorInstance()
-	params := manifests.Params{
-		OtelCol:         otelcol,
+	params := Params{
+		Collector:       otelcol,
 		TargetAllocator: targetAllocator,
 		Config:          config.New(),
 		Log:             logger,

--- a/internal/manifests/targetallocator/poddisruptionbudget.go
+++ b/internal/manifests/targetallocator/poddisruptionbudget.go
@@ -21,12 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
-func PodDisruptionBudget(params manifests.Params) (*policyV1.PodDisruptionBudget, error) {
+func PodDisruptionBudget(params Params) (*policyV1.PodDisruptionBudget, error) {
 	// defaulting webhook should set this if the strategy is compatible, but if unset then return nil.
 	if params.TargetAllocator.Spec.PodDisruptionBudget == nil {
 		params.Log.Info("pdb field is unset in Spec, skipping podDisruptionBudget creation")

--- a/internal/manifests/targetallocator/poddisruptionbudget_test.go
+++ b/internal/manifests/targetallocator/poddisruptionbudget_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
 type test struct {
@@ -84,7 +83,7 @@ func TestPDBWithValidStrategy(t *testing.T) {
 					},
 				}
 				configuration := config.New()
-				pdb, err := PodDisruptionBudget(manifests.Params{
+				pdb, err := PodDisruptionBudget(Params{
 					Log:             logger,
 					Config:          configuration,
 					TargetAllocator: targetAllocator,
@@ -119,7 +118,7 @@ func TestPDBWithNotValidStrategy(t *testing.T) {
 				},
 			}
 			configuration := config.New()
-			pdb, err := PodDisruptionBudget(manifests.Params{
+			pdb, err := PodDisruptionBudget(Params{
 				Log:             logger,
 				Config:          configuration,
 				TargetAllocator: targetAllocator,
@@ -139,7 +138,7 @@ func TestNoPDB(t *testing.T) {
 		},
 	}
 	configuration := config.New()
-	pdb, err := PodDisruptionBudget(manifests.Params{
+	pdb, err := PodDisruptionBudget(Params{
 		Log:             logger,
 		Config:          configuration,
 		TargetAllocator: targetAllocator,

--- a/internal/manifests/targetallocator/service.go
+++ b/internal/manifests/targetallocator/service.go
@@ -19,12 +19,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
-func Service(params manifests.Params) *corev1.Service {
+func Service(params Params) *corev1.Service {
 	name := naming.TAService(params.TargetAllocator.Name)
 	labels := manifestutils.Labels(params.TargetAllocator.ObjectMeta, name, params.TargetAllocator.Spec.Image, ComponentOpenTelemetryTargetAllocator, nil)
 	selector := manifestutils.TASelectorLabels(params.TargetAllocator, ComponentOpenTelemetryTargetAllocator)

--- a/internal/manifests/targetallocator/service_test.go
+++ b/internal/manifests/targetallocator/service_test.go
@@ -22,14 +22,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
 func TestServicePorts(t *testing.T) {
 	targetAllocator := targetAllocatorInstance()
 	cfg := config.New()
 
-	params := manifests.Params{
+	params := Params{
 		TargetAllocator: targetAllocator,
 		Config:          cfg,
 		Log:             logger,

--- a/internal/manifests/targetallocator/serviceaccount.go
+++ b/internal/manifests/targetallocator/serviceaccount.go
@@ -19,7 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
@@ -34,7 +33,7 @@ func ServiceAccountName(instance v1alpha1.TargetAllocator) string {
 }
 
 // ServiceAccount returns the service account for the given instance.
-func ServiceAccount(params manifests.Params) *corev1.ServiceAccount {
+func ServiceAccount(params Params) *corev1.ServiceAccount {
 	if len(params.TargetAllocator.Spec.ServiceAccount) > 0 {
 		return nil
 	}

--- a/internal/manifests/targetallocator/serviceaccount_test.go
+++ b/internal/manifests/targetallocator/serviceaccount_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 )
 
@@ -63,7 +62,7 @@ func TestServiceAccountOverrideName(t *testing.T) {
 }
 
 func TestServiceAccountDefault(t *testing.T) {
-	params := manifests.Params{
+	params := Params{
 		TargetAllocator: v1alpha1.TargetAllocator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-instance",
@@ -73,9 +72,9 @@ func TestServiceAccountDefault(t *testing.T) {
 	expected := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "my-instance-targetallocator",
-			Namespace:   params.OtelCol.Namespace,
+			Namespace:   params.Collector.Namespace,
 			Labels:      manifestutils.Labels(params.TargetAllocator.ObjectMeta, "my-instance-targetallocator", params.TargetAllocator.Spec.Image, ComponentOpenTelemetryTargetAllocator, nil),
-			Annotations: params.OtelCol.Annotations,
+			Annotations: params.Collector.Annotations,
 		},
 	}
 
@@ -87,7 +86,7 @@ func TestServiceAccountDefault(t *testing.T) {
 }
 
 func TestServiceAccountOverride(t *testing.T) {
-	params := manifests.Params{
+	params := Params{
 		TargetAllocator: v1alpha1.TargetAllocator{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-instance",

--- a/internal/manifests/targetallocator/servicemonitor.go
+++ b/internal/manifests/targetallocator/servicemonitor.go
@@ -18,13 +18,12 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
 )
 
 // ServiceMonitor returns the service monitor for the given instance.
-func ServiceMonitor(params manifests.Params) *monitoringv1.ServiceMonitor {
+func ServiceMonitor(params Params) *monitoringv1.ServiceMonitor {
 	name := naming.TargetAllocator(params.TargetAllocator.Name)
 	labels := manifestutils.Labels(params.TargetAllocator.ObjectMeta, name, params.TargetAllocator.Spec.Image, ComponentOpenTelemetryTargetAllocator, nil)
 

--- a/internal/manifests/targetallocator/servicemonitor_test.go
+++ b/internal/manifests/targetallocator/servicemonitor_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
 func TestDesiredServiceMonitors(t *testing.T) {
@@ -41,7 +40,7 @@ func TestDesiredServiceMonitors(t *testing.T) {
 	}
 	cfg := config.New()
 
-	params := manifests.Params{
+	params := Params{
 		TargetAllocator: ta,
 		Config:          cfg,
 		Log:             logger,

--- a/internal/manifests/targetallocator/targetallocator.go
+++ b/internal/manifests/targetallocator/targetallocator.go
@@ -15,8 +15,14 @@
 package targetallocator
 
 import (
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
@@ -26,9 +32,9 @@ const (
 )
 
 // Build creates the manifest for the TargetAllocator resource.
-func Build(params manifests.Params) ([]client.Object, error) {
+func Build(params Params) ([]client.Object, error) {
 	var resourceManifests []client.Object
-	resourceFactories := []manifests.K8sManifestFactory[manifests.Params]{
+	resourceFactories := []manifests.K8sManifestFactory[Params]{
 		manifests.Factory(ConfigMap),
 		manifests.Factory(Deployment),
 		manifests.FactoryWithoutError(ServiceAccount),
@@ -51,12 +57,12 @@ func Build(params manifests.Params) ([]client.Object, error) {
 	return resourceManifests, nil
 }
 
-//type Params struct {
-//	Client          client.Client
-//	Recorder        record.EventRecorder
-//	Scheme          *runtime.Scheme
-//	Log             logr.Logger
-//	Collectors      []v1beta1.OpenTelemetryCollector
-//	TargetAllocator v1alpha1.TargetAllocator
-//	Config          config.Config
-//}
+type Params struct {
+	Client          client.Client
+	Recorder        record.EventRecorder
+	Scheme          *runtime.Scheme
+	Log             logr.Logger
+	Collector       v1beta1.OpenTelemetryCollector
+	TargetAllocator v1alpha1.TargetAllocator
+	Config          config.Config
+}

--- a/internal/manifests/targetallocator/targetallocator.go
+++ b/internal/manifests/targetallocator/targetallocator.go
@@ -28,10 +28,7 @@ const (
 // Build creates the manifest for the TargetAllocator resource.
 func Build(params manifests.Params) ([]client.Object, error) {
 	var resourceManifests []client.Object
-	if !params.OtelCol.Spec.TargetAllocator.Enabled {
-		return resourceManifests, nil
-	}
-	resourceFactories := []manifests.K8sManifestFactory{
+	resourceFactories := []manifests.K8sManifestFactory[manifests.Params]{
 		manifests.Factory(ConfigMap),
 		manifests.Factory(Deployment),
 		manifests.FactoryWithoutError(ServiceAccount),
@@ -53,3 +50,13 @@ func Build(params manifests.Params) ([]client.Object, error) {
 	}
 	return resourceManifests, nil
 }
+
+//type Params struct {
+//	Client          client.Client
+//	Recorder        record.EventRecorder
+//	Scheme          *runtime.Scheme
+//	Log             logr.Logger
+//	Collectors      []v1beta1.OpenTelemetryCollector
+//	TargetAllocator v1alpha1.TargetAllocator
+//	Config          config.Config
+//}


### PR DESCRIPTION
Make the builder definitions more generic to allow different Params structures for different builders. Use this to define a separate Params structure for the TargetAllocator.
