### PR TITLE
Fix OpenTelemetryCollector example YAML in Target Allocator README

### DIFF
--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -98,7 +98,7 @@ spec:
   mode: statefulset
   targetAllocator:
     enabled: true
-  config: |
+  config:
     receivers:
       prometheus:
         config:
@@ -109,7 +109,7 @@ spec:
             - targets: [ '0.0.0.0:8888' ]
 
     exporters:
-      logging:
+      logging: {}
 
     service:
       pipelines:


### PR DESCRIPTION
**Description:**
Updated Target Allocator README. The sample code for using the TA with `v1beta1` of the `OpenTelemetryCollector` CR was not using the correct constructs as per the [API docs](https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api.md#opentelemetrycollector-1).

**Link to tracking Issue(s):** n/a

**Testing:** n/a (doc update)

**Documentation:** See description above
