### PR TITLE
Require Go 1.22 for building the operator

### DIFF
--- a/.chloggen/chore_upgrade-go-122.yaml
+++ b/.chloggen/chore_upgrade-go-122.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector, target allocator, opamp
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Require Go 1.22 for building the operator
+
+# One or more tracking issues related to the change
+issues: [2757]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -19,12 +19,12 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.3'
+          go-version: '~1.22.4'
 
-      - name: Unshallow 
+      - name: Unshallow
         run: git fetch --prune --unshallow
 
-      - name: Describe the current state 
+      - name: Describe the current state
         run: git describe --tags
 
       - name: Set env vars for the job
@@ -41,7 +41,7 @@ jobs:
           grep -v '\#' versions.txt | grep autoinstrumentation-nginx | awk -F= '{print "AUTO_INSTRUMENTATION_NGINX_VERSION="$2}' >> $GITHUB_ENV
           echo "VERSION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
           echo "VERSION=$(git describe --tags | sed 's/^v//')" >> $GITHUB_ENV
-      
+
       - name: Build the binary for each supported architecture
         run: |
           for platform in $(echo $PLATFORMS | tr "," "\n"); do
@@ -49,7 +49,7 @@ jobs:
             echo "Building manager for $arch"
             make manager ARCH=$arch
           done
-        
+
       - name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/publish-operator-opamp-bridge.yaml
+++ b/.github/workflows/publish-operator-opamp-bridge.yaml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.3'
+          go-version: '~1.22.4'
 
       # TODO: We're currently not using this. Should we?
       - name: Read version

--- a/.github/workflows/publish-target-allocator.yaml
+++ b/.github/workflows/publish-target-allocator.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.3'
+          go-version: '~1.22.4'
 
       # TODO: We're currently not using this. Should we?
       - name: Read version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-operator
 
-go 1.21.0
+go 1.22.0
 
 retract v1.51.0
 

--- a/tests/e2e-openshift/Dockerfile
+++ b/tests/e2e-openshift/Dockerfile
@@ -1,6 +1,6 @@
-# The Dockerfile's resulting image is purpose-built for executing OpenTelemetry Operator e2e tests within the OpenShift release (https://github.com/openshift/release) using Prow CI. 
+# The Dockerfile's resulting image is purpose-built for executing OpenTelemetry Operator e2e tests within the OpenShift release (https://github.com/openshift/release) using Prow CI.
 
-FROM golang:1.21
+FROM golang:1.22
 
 # Copy the repository files
 COPY . /tmp/opentelemetry-operator

--- a/tests/instrumentation-e2e-apps/golang/Dockerfile
+++ b/tests/instrumentation-e2e-apps/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 
 COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -o app main.go


### PR DESCRIPTION
As we haven't merged our Go support policy yet, let's upgrade to 1.22 ahead of time to unblock some dependency updates.

**Link to tracking Issue(s):** #2757

