### PR TITLE
Prepare Collector reconciliation for TargetAllocator CRD

### DIFF
--- a/controllers/builder_test.go
+++ b/controllers/builder_test.go
@@ -1988,7 +1988,7 @@ prometheus_cr:
 			}
 			targetAllocator, err := collector.TargetAllocator(params)
 			require.NoError(t, err)
-			params.TargetAllocator = *targetAllocator
+			params.TargetAllocator = targetAllocator
 			if len(tt.featuregates) > 0 {
 				fg := strings.Join(tt.featuregates, ",")
 				flagset := featuregate.Flags(colfeaturegate.GlobalRegistry())

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -59,7 +59,8 @@ func BuildCollector(params manifests.Params) ([]client.Object, error) {
 		}
 		resources = append(resources, objs...)
 	}
-	if params.OtelCol.Spec.TargetAllocator.Enabled {
+	// TODO: Remove this after TargetAllocator CRD is reconciled
+	if params.TargetAllocator != nil {
 		taParams := targetallocator.Params{
 			Client:          params.Client,
 			Scheme:          params.Scheme,
@@ -67,7 +68,7 @@ func BuildCollector(params manifests.Params) ([]client.Object, error) {
 			Log:             params.Log,
 			Config:          params.Config,
 			Collector:       params.OtelCol,
-			TargetAllocator: params.TargetAllocator,
+			TargetAllocator: *params.TargetAllocator,
 		}
 		taResources, err := BuildTargetAllocator(taParams)
 		if err != nil {

--- a/controllers/opentelemetrycollector_controller.go
+++ b/controllers/opentelemetrycollector_controller.go
@@ -183,9 +183,7 @@ func (r *OpenTelemetryCollectorReconciler) getParams(instance v1beta1.OpenTeleme
 	if err != nil {
 		return p, err
 	}
-	if targetAllocator != nil {
-		p.TargetAllocator = *targetAllocator
-	}
+	p.TargetAllocator = targetAllocator
 	return p, nil
 }
 

--- a/internal/manifests/collector/config_replace_test.go
+++ b/internal/manifests/collector/config_replace_test.go
@@ -31,8 +31,7 @@ func TestPrometheusParser(t *testing.T) {
 
 	t.Run("should update config with targetAllocator block if block not present", func(t *testing.T) {
 		// Set up the test scenario
-		param.OtelCol.Spec.TargetAllocator.Enabled = true
-		actualConfig, err := ReplaceConfig(param.OtelCol)
+		actualConfig, err := ReplaceConfig(param.OtelCol, param.TargetAllocator)
 		assert.NoError(t, err)
 
 		// Verify the expected changes in the config
@@ -57,9 +56,7 @@ func TestPrometheusParser(t *testing.T) {
 		paramTa, err := newParams("test/test-img", "testdata/http_sd_config_ta_test.yaml")
 		require.NoError(t, err)
 
-		paramTa.OtelCol.Spec.TargetAllocator.Enabled = true
-
-		actualConfig, err := ReplaceConfig(paramTa.OtelCol)
+		actualConfig, err := ReplaceConfig(paramTa.OtelCol, param.TargetAllocator)
 		assert.NoError(t, err)
 
 		// Verify the expected changes in the config
@@ -80,9 +77,7 @@ func TestPrometheusParser(t *testing.T) {
 	})
 
 	t.Run("should not update config with http_sd_config", func(t *testing.T) {
-		param.OtelCol.Spec.TargetAllocator.Enabled = false
-
-		actualConfig, err := ReplaceConfig(param.OtelCol)
+		actualConfig, err := ReplaceConfig(param.OtelCol, nil)
 		assert.NoError(t, err)
 
 		// prepare
@@ -120,25 +115,23 @@ func TestReplaceConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("should not modify config when TargetAllocator is disabled", func(t *testing.T) {
-		param.OtelCol.Spec.TargetAllocator.Enabled = false
 		expectedConfigBytes, err := os.ReadFile("testdata/relabel_config_original.yaml")
 		assert.NoError(t, err)
 		expectedConfig := string(expectedConfigBytes)
 
-		actualConfig, err := ReplaceConfig(param.OtelCol)
+		actualConfig, err := ReplaceConfig(param.OtelCol, nil)
 		assert.NoError(t, err)
 
 		assert.YAMLEq(t, expectedConfig, actualConfig)
 	})
 
 	t.Run("should remove scrape configs if TargetAllocator is enabled", func(t *testing.T) {
-		param.OtelCol.Spec.TargetAllocator.Enabled = true
 
 		expectedConfigBytes, err := os.ReadFile("testdata/config_expected_targetallocator.yaml")
 		assert.NoError(t, err)
 		expectedConfig := string(expectedConfigBytes)
 
-		actualConfig, err := ReplaceConfig(param.OtelCol)
+		actualConfig, err := ReplaceConfig(param.OtelCol, param.TargetAllocator)
 		assert.NoError(t, err)
 
 		assert.YAMLEq(t, expectedConfig, actualConfig)

--- a/internal/manifests/collector/configmap.go
+++ b/internal/manifests/collector/configmap.go
@@ -32,7 +32,7 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	collectorName := naming.Collector(params.OtelCol.Name)
 	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, collectorName, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, []string{})
 
-	replacedConf, err := ReplaceConfig(params.OtelCol)
+	replacedConf, err := ReplaceConfig(params.OtelCol, params.TargetAllocator)
 	if err != nil {
 		params.Log.V(2).Info("failed to update prometheus config to use sharded targets: ", "err", err)
 		return nil, err

--- a/internal/manifests/collector/suite_test.go
+++ b/internal/manifests/collector/suite_test.go
@@ -129,7 +129,7 @@ func newParams(taContainerImage string, file string, options ...config.Option) (
 	}
 	cfg := config.New(append(defaultOptions, options...)...)
 
-	return manifests.Params{
+	params := manifests.Params{
 		Config: cfg,
 		OtelCol: v1beta1.OpenTelemetryCollector{
 			TypeMeta: metav1.TypeMeta{
@@ -168,5 +168,10 @@ func newParams(taContainerImage string, file string, options ...config.Option) (
 			},
 		},
 		Log: logger,
-	}, nil
+	}
+	targetAllocator, err := TargetAllocator(params)
+	if err == nil {
+		params.TargetAllocator = targetAllocator
+	}
+	return params, nil
 }

--- a/internal/manifests/params.go
+++ b/internal/manifests/params.go
@@ -32,7 +32,7 @@ type Params struct {
 	Scheme          *runtime.Scheme
 	Log             logr.Logger
 	OtelCol         v1beta1.OpenTelemetryCollector
-	TargetAllocator v1alpha1.TargetAllocator
+	TargetAllocator *v1alpha1.TargetAllocator
 	OpAMPBridge     v1alpha1.OpAMPBridge
 	Config          config.Config
 }

--- a/internal/naming/main.go
+++ b/internal/naming/main.go
@@ -142,8 +142,8 @@ func ClusterRoleBinding(otelcol, namespace string) string {
 }
 
 // TAService returns the name to use for the TargetAllocator service.
-func TAService(otelcol string) string {
-	return DNSName(Truncate("%s-targetallocator", 63, otelcol))
+func TAService(taName string) string {
+	return DNSName(Truncate("%s-targetallocator", 63, taName))
 }
 
 // OpAMPBridgeService returns the name to use for the OpAMPBridge service.

--- a/pkg/sidecar/pod.go
+++ b/pkg/sidecar/pod.go
@@ -34,7 +34,7 @@ const (
 
 // add a new sidecar container to the given pod, based on the given OpenTelemetryCollector.
 func add(cfg config.Config, logger logr.Logger, otelcol v1beta1.OpenTelemetryCollector, pod corev1.Pod, attributes []corev1.EnvVar) (corev1.Pod, error) {
-	otelColCfg, err := collector.ReplaceConfig(otelcol)
+	otelColCfg, err := collector.ReplaceConfig(otelcol, nil)
 	if err != nil {
 		return pod, err
 	}


### PR DESCRIPTION
**Description:** 

Refactor how the target allocator is treated by collector reconciliation.

I've converted `params.TargetAllocator` to a pointer, and now whenever any of the collector manifest builders want to know if a Target Allocator is enabled, they check that pointer instead of `params.OtelCol.Spec.TargetAllocator.Enabled`. The reason for this is that there will be more ways to assign a target allocator to a collector after the TargetAllocator CRD is introduced.

Logically, this PR doesn't change anything.

**Link to tracking Issue(s):** #2422 
