### PR TITLE
Release leader election lease on exit

### DIFF
--- a/.chloggen/feat_drop-lease-on-exit.yaml
+++ b/.chloggen/feat_drop-lease-on-exit.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Release leader election lease on exit
+
+# One or more tracking issues related to the change
+issues: [3058]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/main.go
+++ b/main.go
@@ -249,13 +249,14 @@ func main() {
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
 		},
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "9f7554c3.opentelemetry.io",
-		LeaseDuration:          &leaseDuration,
-		RenewDeadline:          &renewDeadline,
-		RetryPeriod:            &retryPeriod,
-		PprofBindAddress:       pprofAddr,
+		HealthProbeBindAddress:        probeAddr,
+		LeaderElection:                enableLeaderElection,
+		LeaderElectionID:              "9f7554c3.opentelemetry.io",
+		LeaderElectionReleaseOnCancel: true,
+		LeaseDuration:                 &leaseDuration,
+		RenewDeadline:                 &renewDeadline,
+		RetryPeriod:                   &retryPeriod,
+		PprofBindAddress:              pprofAddr,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    webhookPort,
 			TLSOpts: optionsTlSOptsFuncs,
@@ -427,6 +428,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
+	// NOTE: We enable LeaderElectionReleaseOnCancel, and to be safe we need to exit right after the manager does
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)


### PR DESCRIPTION
**Description:**
This will make rollouts and restarts much faster. See #3058 for more detail.

**Link to tracking Issue(s):**

- Resolves: #3058

**Testing:**

Tested the default manifests in a kind cluster.
