### PR TITLE
Add nop parser for exporters

### DIFF
--- a/.chloggen/fix-parsing-bug.yaml
+++ b/.chloggen/fix-parsing-bug.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes a bug where an exporter would cause a port collision
+
+# One or more tracking issues related to the change
+issues: [3124]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1beta1/config.go
+++ b/apis/v1beta1/config.go
@@ -141,6 +141,7 @@ type Config struct {
 
 // getPortsForComponentKinds gets the ports for the given ComponentKind(s).
 func (c *Config) getPortsForComponentKinds(logger logr.Logger, componentKinds ...ComponentKind) ([]corev1.ServicePort, error) {
+
 	var ports []corev1.ServicePort
 	enabledComponents := c.GetEnabledComponents()
 	for _, componentKind := range componentKinds {

--- a/apis/v1beta1/config_test.go
+++ b/apis/v1beta1/config_test.go
@@ -497,25 +497,12 @@ func TestConfig_GetExporterPorts(t *testing.T) {
 					Name: "prometheus",
 					Port: 8889,
 				},
-				{
-					Name: "otlp",
-					Port: 4317,
-				},
-				{
-					Name: "zipkin",
-					Port: 9411,
-				},
 			},
 		},
 		{
 			name: "extensions",
 			file: "testdata/otelcol-extensions.yaml",
-			want: []v1.ServicePort{
-				{
-					Name: "otlp-auth",
-					Port: 4317,
-				},
-			},
+			want: nil,
 		},
 		{
 			name: "filelog",

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -91,6 +91,7 @@ const (
 	promFile                 = "testdata/test.yaml"
 	updatedPromFile          = "testdata/test_ta_update.yaml"
 	testFileIngress          = "testdata/ingress_testdata.yaml"
+	otlpTestFile             = "testdata/otlp_test.yaml"
 )
 
 var _ autodetect.AutoDetect = (*mockAutoDetect)(nil)

--- a/controllers/testdata/otlp_test.yaml
+++ b/controllers/testdata/otlp_test.yaml
@@ -1,0 +1,23 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+processors:
+exporters:
+  otlp:
+    endpoint: jaeger-allinone-collector-headless.chainsaw-otlp-metrics.svc:4317
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    resource_to_telemetry_conversion:
+      enabled: true # by default resource attributes are dropped
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]

--- a/internal/components/exporters/helpers.go
+++ b/internal/components/exporters/helpers.go
@@ -38,7 +38,7 @@ func ParserFor(name string) components.ComponentPortParser {
 		return parser
 	}
 	// We want the default for exporters to fail silently.
-	return components.NewSilentSinglePortParser(components.ComponentType(name), components.UnsetPort)
+	return components.NewNopParser(components.ComponentType(name), components.UnsetPort)
 }
 
 var (

--- a/internal/components/exporters/helpers_test.go
+++ b/internal/components/exporters/helpers_test.go
@@ -34,8 +34,7 @@ func TestParserForReturns(t *testing.T) {
 		"endpoint": "localhost:9000",
 	})
 	assert.NoError(t, err)
-	assert.Len(t, ports, 1)
-	assert.Equal(t, ports[0].Port, int32(9000))
+	assert.Len(t, ports, 0) // Should use the nop parser
 }
 
 func TestCanRegister(t *testing.T) {

--- a/internal/components/multi_endpoint.go
+++ b/internal/components/multi_endpoint.go
@@ -53,8 +53,8 @@ func (m *MultiPortReceiver) Ports(logger logr.Logger, name string, config interf
 			port := defaultSvc.Port
 			if ec != nil {
 				port = ec.GetPortNumOrDefault(logger, port)
-				defaultSvc.Name = naming.PortName(fmt.Sprintf("%s-%s", name, protocol), port)
 			}
+			defaultSvc.Name = naming.PortName(fmt.Sprintf("%s-%s", name, protocol), port)
 			ports = append(ports, ConstructServicePort(defaultSvc, port))
 		} else {
 			return nil, fmt.Errorf("unknown protocol set: %s", protocol)

--- a/internal/components/nop_parser.go
+++ b/internal/components/nop_parser.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package components
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	_ ComponentPortParser = &NopParser{}
+)
+
+// SingleEndpointParser is a special parser for a generic receiver that has an endpoint or listen_address in its
+// configuration. It doesn't self-register and should be created/used directly.
+type NopParser struct {
+	name string
+}
+
+func (n *NopParser) Ports(logger logr.Logger, name string, config interface{}) ([]corev1.ServicePort, error) {
+	return nil, nil
+}
+
+func (n *NopParser) ParserType() string {
+	return ComponentType(n.name)
+}
+
+func (n *NopParser) ParserName() string {
+	return fmt.Sprintf("__%s", n.name)
+}
+
+func NewNopParser(name string, port int32, opts ...PortBuilderOption) *NopParser {
+	return &NopParser{name: name}
+}


### PR DESCRIPTION
**Description:** 
Fixes a bug where we trying to parse endpoint for exporters which is unnecessary.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves #3124 

**Testing:** unit tests and envtest

**Documentation:** <Describe the documentation added.>
