### PR TITLE
fix(autoinstrumentation-python): autoinstrumentation python export by prometheus

### DIFF
--- a/autoinstrumentation/python/requirements.txt
+++ b/autoinstrumentation/python/requirements.txt
@@ -2,6 +2,7 @@ opentelemetry-distro==0.46b0
 # We don't use the distro[otlp] option which automatically includes exporters since gRPC is not appropriate for
 # injected auto-instrumentation, where it has a strict dependency on the OS / Python version the artifact is built for.
 opentelemetry-exporter-otlp-proto-http==1.25.0
+opentelemetry-exporter-prometheus==0.46b0
 
 opentelemetry-propagator-b3==1.25.0
 opentelemetry-propagator-jaeger==1.25.0


### PR DESCRIPTION
… prometheus

**Description:** <Describe what has changed.>
autoinstrumentation-python can't use prometheus exporter

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #3122

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
