### PR TITLE
Use 0.0.0.0 as otlp receiver default address

### DIFF
--- a/.chloggen/enable_localhost_fg_otlp_#3126.yaml
+++ b/.chloggen/enable_localhost_fg_otlp_#3126.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds a feature gate `operator.collector.UseLocalHostAsDefaultHost` that, when enabled, binds unspecified receiver listener addresses to all interfaces.
+
+# One or more tracking issues related to the change
+issues: [3126]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/components/receivers/helpers.go
+++ b/internal/components/receivers/helpers.go
@@ -21,10 +21,10 @@ import (
 )
 
 // registry holds a record of all known receiver parsers.
-var registry = make(map[string]components.ComponentPortParser)
+var registry = make(map[string]components.ComponentParser)
 
 // Register adds a new parser builder to the list of known builders.
-func Register(name string, p components.ComponentPortParser) {
+func Register(name string, p components.ComponentParser) {
 	registry[name] = p
 }
 
@@ -35,112 +35,190 @@ func IsRegistered(name string) bool {
 }
 
 // ReceiverFor returns a parser builder for the given exporter name.
-func ReceiverFor(name string) components.ComponentPortParser {
+func ReceiverFor(name string) components.ComponentParser {
 	if parser, ok := registry[components.ComponentType(name)]; ok {
 		return parser
 	}
-	return components.NewSilentSinglePortParser(components.ComponentType(name), components.UnsetPort)
+	return components.NewComponentParser(
+		components.WithComponentPortParser(
+			components.NewSilentSinglePortParser(components.ComponentType(name), components.UnsetPort),
+		),
+	)
 }
 
 var (
-	componentParsers = []components.ComponentPortParser{
-		components.NewMultiPortReceiver("otlp",
-			components.WithPortMapping(
-				"grpc",
-				4317,
-				components.WithAppProtocol(&components.GrpcProtocol),
-				components.WithTargetPort(4317),
-			), components.WithPortMapping(
-				"http",
-				4318,
-				components.WithAppProtocol(&components.HttpProtocol),
-				components.WithTargetPort(4318),
+	componentParsers = []components.ComponentParser{
+		components.NewComponentParser(
+			// TODO: components.WithDefaultConfigOTLP(),
+			components.WithComponentPortParser(
+				components.NewMultiPortReceiver("otlp",
+					components.WithPortMapping(
+						"grpc",
+						4317,
+						components.WithAppProtocol(&components.GrpcProtocol),
+						components.WithTargetPort(4317),
+					), components.WithPortMapping(
+						"http",
+						4318,
+						components.WithAppProtocol(&components.HttpProtocol),
+						components.WithTargetPort(4318),
+					),
+				),
 			),
 		),
-		components.NewMultiPortReceiver("skywalking",
-			components.WithPortMapping(components.GrpcProtocol, 11800,
-				components.WithTargetPort(11800),
-				components.WithAppProtocol(&components.GrpcProtocol),
-			),
-			components.WithPortMapping(components.HttpProtocol, 12800,
-				components.WithTargetPort(12800),
-				components.WithAppProtocol(&components.HttpProtocol),
-			)),
-		components.NewMultiPortReceiver("jaeger",
-			components.WithPortMapping(components.GrpcProtocol, 14250,
-				components.WithTargetPort(14250),
-				components.WithProtocol(corev1.ProtocolTCP),
-				components.WithAppProtocol(&components.GrpcProtocol),
-			),
-			components.WithPortMapping("thrift_http", 14268,
-				components.WithTargetPort(14268),
-				components.WithProtocol(corev1.ProtocolTCP),
-				components.WithAppProtocol(&components.HttpProtocol),
-			),
-			components.WithPortMapping("thrift_compact", 6831,
-				components.WithTargetPort(6831),
-				components.WithProtocol(corev1.ProtocolUDP),
-			),
-			components.WithPortMapping("thrift_binary", 6832,
-				components.WithTargetPort(6832),
-				components.WithProtocol(corev1.ProtocolUDP),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewMultiPortReceiver("skywalking",
+					components.WithPortMapping(components.GrpcProtocol, 11800,
+						components.WithTargetPort(11800),
+						components.WithAppProtocol(&components.GrpcProtocol),
+					),
+					components.WithPortMapping(components.HttpProtocol, 12800,
+						components.WithTargetPort(12800),
+						components.WithAppProtocol(&components.HttpProtocol),
+					),
+				),
 			),
 		),
-		components.NewMultiPortReceiver("loki",
-			components.WithPortMapping(components.GrpcProtocol, 9095,
-				components.WithTargetPort(9095),
-				components.WithAppProtocol(&components.GrpcProtocol),
-			),
-			components.WithPortMapping(components.HttpProtocol, 3100,
-				components.WithTargetPort(3100),
-				components.WithAppProtocol(&components.HttpProtocol),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewMultiPortReceiver("jaeger",
+					components.WithPortMapping(components.GrpcProtocol, 14250,
+						components.WithTargetPort(14250),
+						components.WithProtocol(corev1.ProtocolTCP),
+						components.WithAppProtocol(&components.GrpcProtocol),
+					),
+					components.WithPortMapping("thrift_http", 14268,
+						components.WithTargetPort(14268),
+						components.WithProtocol(corev1.ProtocolTCP),
+						components.WithAppProtocol(&components.HttpProtocol),
+					),
+					components.WithPortMapping("thrift_compact", 6831,
+						components.WithTargetPort(6831),
+						components.WithProtocol(corev1.ProtocolUDP),
+					),
+					components.WithPortMapping("thrift_binary", 6832,
+						components.WithTargetPort(6832),
+						components.WithProtocol(corev1.ProtocolUDP),
+					),
+				),
 			),
 		),
-		components.NewSinglePortParser("awsxray", 2000, components.WithTargetPort(2000)),
-		components.NewSinglePortParser("carbon", 2003, components.WithTargetPort(2003)),
-		components.NewSinglePortParser("collectd", 8081, components.WithTargetPort(8081)),
-		components.NewSinglePortParser("fluentforward", 8006, components.WithTargetPort(8006)),
-		components.NewSinglePortParser("influxdb", 8086, components.WithTargetPort(8086)),
-		components.NewSinglePortParser("opencensus", 55678, components.WithAppProtocol(nil), components.WithTargetPort(55678)),
-		components.NewSinglePortParser("sapm", 7276, components.WithTargetPort(7276)),
-		components.NewSinglePortParser("signalfx", 9943, components.WithTargetPort(9943)),
-		components.NewSinglePortParser("splunk_hec", 8088, components.WithTargetPort(8088)),
-		components.NewSinglePortParser("statsd", 8125, components.WithProtocol(corev1.ProtocolUDP), components.WithTargetPort(8125)),
-		components.NewSinglePortParser("tcplog", components.UnsetPort, components.WithProtocol(corev1.ProtocolTCP)),
-		components.NewSinglePortParser("udplog", components.UnsetPort, components.WithProtocol(corev1.ProtocolUDP)),
-		components.NewSinglePortParser("wavefront", 2003, components.WithTargetPort(2003)),
-		components.NewSinglePortParser("zipkin", 9411, components.WithAppProtocol(&components.HttpProtocol), components.WithProtocol(corev1.ProtocolTCP), components.WithTargetPort(3100)),
-		NewScraperParser("prometheus"),
-		NewScraperParser("kubeletstats"),
-		NewScraperParser("sshcheck"),
-		NewScraperParser("cloudfoundry"),
-		NewScraperParser("vcenter"),
-		NewScraperParser("oracledb"),
-		NewScraperParser("snmp"),
-		NewScraperParser("googlecloudpubsub"),
-		NewScraperParser("chrony"),
-		NewScraperParser("jmx"),
-		NewScraperParser("podman_stats"),
-		NewScraperParser("pulsar"),
-		NewScraperParser("docker_stats"),
-		NewScraperParser("aerospike"),
-		NewScraperParser("zookeeper"),
-		NewScraperParser("prometheus_simple"),
-		NewScraperParser("saphana"),
-		NewScraperParser("riak"),
-		NewScraperParser("redis"),
-		NewScraperParser("rabbitmq"),
-		NewScraperParser("purefb"),
-		NewScraperParser("postgresql"),
-		NewScraperParser("nsxt"),
-		NewScraperParser("nginx"),
-		NewScraperParser("mysql"),
-		NewScraperParser("memcached"),
-		NewScraperParser("httpcheck"),
-		NewScraperParser("haproxy"),
-		NewScraperParser("flinkmetrics"),
-		NewScraperParser("couchdb"),
-		NewScraperParser("filelog"),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewMultiPortReceiver("loki",
+					components.WithPortMapping(components.GrpcProtocol, 9095,
+						components.WithTargetPort(9095),
+						components.WithAppProtocol(&components.GrpcProtocol),
+					),
+					components.WithPortMapping(components.HttpProtocol, 3100,
+						components.WithTargetPort(3100),
+						components.WithAppProtocol(&components.HttpProtocol),
+					),
+				),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("awsxray", 2000, components.WithTargetPort(2000)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("carbon", 2003, components.WithTargetPort(2003)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("collectd", 8081, components.WithTargetPort(8081)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("fluentforward", 8006, components.WithTargetPort(8006)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("influxdb", 8086, components.WithTargetPort(8086)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("opencensus", 55678, components.WithAppProtocol(nil), components.WithTargetPort(55678)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("sapm", 7276, components.WithTargetPort(7276)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("signalfx", 9943, components.WithTargetPort(9943)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("splunk_hec", 8088, components.WithTargetPort(8088)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("statsd", 8125, components.WithProtocol(corev1.ProtocolUDP), components.WithTargetPort(8125)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("tcplog", components.UnsetPort, components.WithProtocol(corev1.ProtocolTCP)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("udplog", components.UnsetPort, components.WithProtocol(corev1.ProtocolUDP)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("wavefront", 2003, components.WithTargetPort(2003)),
+			),
+		),
+		components.NewComponentParser(
+			components.WithComponentPortParser(
+				components.NewSinglePortParser("zipkin", 9411, components.WithAppProtocol(&components.HttpProtocol), components.WithProtocol(corev1.ProtocolTCP), components.WithTargetPort(3100)),
+			),
+		),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("prometheus"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("kubeletstats"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("sshcheck"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("cloudfoundry"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("vcenter"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("oracledb"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("snmp"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("googlecloudpubsub"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("chrony"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("jmx"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("podman_stats"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("pulsar"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("docker_stats"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("aerospike"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("zookeeper"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("prometheus_simple"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("saphana"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("riak"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("redis"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("rabbitmq"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("purefb"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("postgresql"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("nsxt"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("nginx"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("mysql"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("memcached"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("httpcheck"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("haproxy"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("flinkmetrics"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("couchdb"))),
+		components.NewComponentParser(components.WithComponentPortParser(NewScraperParser("filelog"))),
 	}
 )
 

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -40,6 +40,13 @@ var (
 		featuregate.WithRegisterDescription("enables feature to set GOMEMLIMIT and GOMAXPROCS automatically"),
 		featuregate.WithRegisterFromVersion("v0.100.0"),
 	)
+	// DoNotUseLocalHostAsDefaultHost is the feature gate that, when enabled, binds unspecified receiver listener addresses to all interfaces.
+	DoNotUseLocalHostAsDefaultHost = featuregate.GlobalRegistry().MustRegister(
+		"operator.collector.UseLocalHostAsDefaultHost",
+		featuregate.StageAlpha,
+		featuregate.WithRegisterDescription("reverts the effect of the enabled collector feature gate \"component.UseLocalHostAsDefaultHost\" which is disabled by default since Operator v0.104.0."),
+		featuregate.WithRegisterFromVersion("v0.105.0"),
+	)
 )
 
 // Flags creates a new FlagSet that represents the available featuregate flags using the supplied featuregate registry.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
* Adds a feature gate `operator.collector.UseLocalHostAsDefaultHost` that, when enabled, binds unspecified receiver listener addresses to all interfaces
* Contains impl. for OTLP Receiver

**Link to tracking Issue(s):** <Issue number if applicable>

- Belongs to: https://github.com/open-telemetry/opentelemetry-operator/issues/3126

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
