### PR TITLE
[Chore] Enable the OTEL dashboard feature in OpenShift operator bundle

### DIFF
--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -501,6 +501,7 @@ spec:
                 - --enable-nginx-instrumentation=true
                 - --enable-go-instrumentation=true
                 - --enable-multi-instrumentation=true
+                - --openshift-create-dashboard=true
                 - --feature-gates=+operator.observability.prometheus
                 env:
                 - name: SERVICE_ACCOUNT_NAME

--- a/config/overlays/openshift/manager-patch.yaml
+++ b/config/overlays/openshift/manager-patch.yaml
@@ -8,4 +8,5 @@
     - --enable-nginx-instrumentation=true
     - '--enable-go-instrumentation=true'
     - '--enable-multi-instrumentation=true'
+    - '--openshift-create-dashboard=true'
     - '--feature-gates=+operator.observability.prometheus'


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The PR enables the OTEL OpenShift dashboard feature in the OpenShift bundle by default. Refer feature [changelog](https://github.com/open-telemetry/opentelemetry-operator/blob/main/.chloggen/2995-openshift-dashboard.yaml#L16).
