### PR TITLE
Fix TA in clusters with global proxy

### DIFF
--- a/.chloggen/fix-ta-with-proxy.yaml
+++ b/.chloggen/fix-ta-with-proxy.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix collector to target allocator connection in clusters with proxy.
+
+# One or more tracking issues related to the change
+issues: [3187]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  On clusters with global proxy the collector might fail to talk to target allocator
+  because the endpoint is set to `<ta-service-name>:port` and therefore it will go to proxy
+  and request might be forwarded to internet. Clusters with proxy configure `NO_PROXY` to `.svc.cluster.local` so 
+  the calls to this endpoint will not go through the proxy.

--- a/controllers/builder_test.go
+++ b/controllers/builder_test.go
@@ -1291,7 +1291,7 @@ service:
 						Annotations: map[string]string{},
 					},
 					Data: map[string]string{
-						"collector.yaml": "exporters:\n    logging: null\nreceivers:\n    prometheus:\n        config: {}\n        target_allocator:\n            collector_id: ${POD_NAME}\n            endpoint: http://test-targetallocator:80\n            interval: 30s\nservice:\n    pipelines:\n        metrics:\n            exporters:\n                - logging\n            receivers:\n                - prometheus\n",
+						"collector.yaml": "exporters:\n    logging: null\nreceivers:\n    prometheus:\n        config: {}\n        target_allocator:\n            collector_id: ${POD_NAME}\n            endpoint: http://test-targetallocator.test.svc.cluster.local:80\n            interval: 30s\nservice:\n    pipelines:\n        metrics:\n            exporters:\n                - logging\n            receivers:\n                - prometheus\n",
 					},
 				},
 				&corev1.ServiceAccount{
@@ -1682,7 +1682,7 @@ prometheus_cr:
 						Annotations: map[string]string{},
 					},
 					Data: map[string]string{
-						"collector.yaml": "exporters:\n    logging: null\nreceivers:\n    prometheus:\n        config: {}\n        target_allocator:\n            collector_id: ${POD_NAME}\n            endpoint: http://test-targetallocator:80\n            interval: 30s\nservice:\n    pipelines:\n        metrics:\n            exporters:\n                - logging\n            receivers:\n                - prometheus\n",
+						"collector.yaml": "exporters:\n    logging: null\nreceivers:\n    prometheus:\n        config: {}\n        target_allocator:\n            collector_id: ${POD_NAME}\n            endpoint: http://test-targetallocator.test.svc.cluster.local:80\n            interval: 30s\nservice:\n    pipelines:\n        metrics:\n            exporters:\n                - logging\n            receivers:\n                - prometheus\n",
 					},
 				},
 				&corev1.ServiceAccount{

--- a/internal/manifests/collector/config_replace.go
+++ b/internal/manifests/collector/config_replace.go
@@ -71,7 +71,7 @@ func ReplaceConfig(otelcol v1beta1.OpenTelemetryCollector, targetAllocator *v1al
 
 	// To avoid issues caused by Prometheus validation logic, which fails regex validation when it encounters
 	// $$ in the prom config, we update the YAML file directly without marshaling and unmarshalling.
-	updPromCfgMap, getCfgPromErr := ta.AddTAConfigToPromConfig(promCfgMap, naming.TAService(targetAllocator.Name))
+	updPromCfgMap, getCfgPromErr := ta.AddTAConfigToPromConfig(promCfgMap, naming.TAService(targetAllocator.Name), targetAllocator.Namespace)
 	if getCfgPromErr != nil {
 		return "", getCfgPromErr
 	}

--- a/internal/manifests/collector/config_replace_test.go
+++ b/internal/manifests/collector/config_replace_test.go
@@ -43,7 +43,7 @@ func TestPrometheusParser(t *testing.T) {
 		assert.NotContains(t, prometheusConfig, "scrape_configs")
 
 		expectedTAConfig := map[interface{}]interface{}{
-			"endpoint":     "http://test-targetallocator:80",
+			"endpoint":     "http://test-targetallocator.default.svc.cluster.local:80",
 			"interval":     "30s",
 			"collector_id": "${POD_NAME}",
 		}
@@ -68,7 +68,7 @@ func TestPrometheusParser(t *testing.T) {
 		assert.NotContains(t, prometheusConfig, "scrape_configs")
 
 		expectedTAConfig := map[interface{}]interface{}{
-			"endpoint":     "http://test-targetallocator:80",
+			"endpoint":     "http://test-targetallocator.default.svc.cluster.local:80",
 			"interval":     "30s",
 			"collector_id": "${POD_NAME}",
 		}

--- a/internal/manifests/collector/configmap_test.go
+++ b/internal/manifests/collector/configmap_test.go
@@ -84,7 +84,7 @@ receivers:
     config: {}
     target_allocator:
       collector_id: ${POD_NAME}
-      endpoint: http://test-targetallocator:80
+      endpoint: http://test-targetallocator.default.svc.cluster.local:80
       interval: 30s
 service:
   pipelines:

--- a/internal/manifests/collector/testdata/config_expected_targetallocator.yaml
+++ b/internal/manifests/collector/testdata/config_expected_targetallocator.yaml
@@ -9,7 +9,7 @@ receivers:
         scrape_timeout: 10s
     target_allocator:
       collector_id: ${POD_NAME}
-      endpoint: http://test-targetallocator:80
+      endpoint: http://test-targetallocator.default.svc.cluster.local:80
       interval: 30s
 service:
   pipelines:

--- a/internal/manifests/collector/testdata/relabel_config_expected_with_sd_config.yaml
+++ b/internal/manifests/collector/testdata/relabel_config_expected_with_sd_config.yaml
@@ -10,7 +10,7 @@ receivers:
       scrape_configs:
       - honor_labels: true
         http_sd_configs:
-        - url: http://test-targetallocator:80/jobs/service-x/targets?collector_id=$POD_NAME
+        - url: http://test-targetallocator.default.svc.cluster.local:80/jobs/service-x/targets?collector_id=$POD_NAME
         job_name: service-x
         metric_relabel_configs:
         - action: keep

--- a/internal/manifests/targetallocator/adapters/config_to_prom_config.go
+++ b/internal/manifests/targetallocator/adapters/config_to_prom_config.go
@@ -196,7 +196,7 @@ func UnescapeDollarSignsInPromConfig(cfg string) (map[interface{}]interface{}, e
 // This function removes any existing service discovery configurations (e.g., `sd_configs`, `dns_sd_configs`, `file_sd_configs`, etc.)
 // from the `scrape_configs` section and adds a single `http_sd_configs` configuration.
 // The `http_sd_configs` points to the TA (Target Allocator) endpoint that provides the list of targets for the given job.
-func AddHTTPSDConfigToPromConfig(prometheus map[interface{}]interface{}, taServiceName string) (map[interface{}]interface{}, error) {
+func AddHTTPSDConfigToPromConfig(prometheus map[interface{}]interface{}, taServiceName string, taNamespace string) (map[interface{}]interface{}, error) {
 	prometheusConfigProperty, ok := prometheus["config"]
 	if !ok {
 		return nil, errorNoComponent("prometheusConfig")
@@ -249,7 +249,7 @@ func AddHTTPSDConfigToPromConfig(prometheus map[interface{}]interface{}, taServi
 		escapedJob := url.QueryEscape(jobName)
 		scrapeConfig["http_sd_configs"] = []interface{}{
 			map[string]interface{}{
-				"url": fmt.Sprintf("http://%s:80/jobs/%s/targets?collector_id=$POD_NAME", taServiceName, escapedJob),
+				"url": fmt.Sprintf("http://%s.%s.svc.cluster.local:80/jobs/%s/targets?collector_id=$POD_NAME", taServiceName, taNamespace, escapedJob),
 			},
 		}
 	}
@@ -260,7 +260,7 @@ func AddHTTPSDConfigToPromConfig(prometheus map[interface{}]interface{}, taServi
 // AddTAConfigToPromConfig adds or updates the target_allocator configuration in the Prometheus configuration.
 // If the `EnableTargetAllocatorRewrite` feature flag for the target allocator is enabled, this function
 // removes the existing scrape_configs from the collector's Prometheus configuration as it's not required.
-func AddTAConfigToPromConfig(prometheus map[interface{}]interface{}, taServiceName string) (map[interface{}]interface{}, error) {
+func AddTAConfigToPromConfig(prometheus map[interface{}]interface{}, taServiceName string, taNamespace string) (map[interface{}]interface{}, error) {
 	prometheusConfigProperty, ok := prometheus["config"]
 	if !ok {
 		return nil, errorNoComponent("prometheusConfig")
@@ -281,7 +281,7 @@ func AddTAConfigToPromConfig(prometheus map[interface{}]interface{}, taServiceNa
 		return nil, errorNotAMap("target_allocator")
 	}
 
-	targetAllocatorCfg["endpoint"] = fmt.Sprintf("http://%s:80", taServiceName)
+	targetAllocatorCfg["endpoint"] = fmt.Sprintf("http://%s.%s.svc.cluster.local:80", taServiceName, taNamespace)
 	targetAllocatorCfg["interval"] = "30s"
 	targetAllocatorCfg["collector_id"] = "${POD_NAME}"
 

--- a/internal/manifests/targetallocator/adapters/config_to_prom_config_test.go
+++ b/internal/manifests/targetallocator/adapters/config_to_prom_config_test.go
@@ -279,7 +279,7 @@ func TestAddHTTPSDConfigToPromConfig(t *testing.T) {
 						"job_name": "test_job",
 						"http_sd_configs": []interface{}{
 							map[string]interface{}{
-								"url": fmt.Sprintf("http://%s:80/jobs/%s/targets?collector_id=$POD_NAME", taServiceName, url.QueryEscape("test_job")),
+								"url": fmt.Sprintf("http://%s.default.svc.cluster.local:80/jobs/%s/targets?collector_id=$POD_NAME", taServiceName, url.QueryEscape("test_job")),
 							},
 						},
 					},
@@ -287,7 +287,7 @@ func TestAddHTTPSDConfigToPromConfig(t *testing.T) {
 			},
 		}
 
-		actualCfg, err := ta.AddHTTPSDConfigToPromConfig(cfg, taServiceName)
+		actualCfg, err := ta.AddHTTPSDConfigToPromConfig(cfg, taServiceName, "default")
 		assert.NoError(t, err)
 		assert.Equal(t, expectedCfg, actualCfg)
 	})
@@ -308,7 +308,7 @@ func TestAddHTTPSDConfigToPromConfig(t *testing.T) {
 
 		taServiceName := "test-service"
 
-		_, err := ta.AddHTTPSDConfigToPromConfig(cfg, taServiceName)
+		_, err := ta.AddHTTPSDConfigToPromConfig(cfg, taServiceName, "default")
 		assert.Error(t, err)
 		assert.EqualError(t, err, "no scrape_configs available as part of the configuration")
 	})
@@ -338,13 +338,13 @@ func TestAddTAConfigToPromConfig(t *testing.T) {
 		expectedResult := map[interface{}]interface{}{
 			"config": map[interface{}]interface{}{},
 			"target_allocator": map[interface{}]interface{}{
-				"endpoint":     "http://test-targetallocator:80",
+				"endpoint":     "http://test-targetallocator.default.svc.cluster.local:80",
 				"interval":     "30s",
 				"collector_id": "${POD_NAME}",
 			},
 		}
 
-		result, err := ta.AddTAConfigToPromConfig(cfg, taServiceName)
+		result, err := ta.AddTAConfigToPromConfig(cfg, taServiceName, "default")
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedResult, result)
@@ -374,7 +374,7 @@ func TestAddTAConfigToPromConfig(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				_, err := ta.AddTAConfigToPromConfig(tc.cfg, taServiceName)
+				_, err := ta.AddTAConfigToPromConfig(tc.cfg, taServiceName, "default")
 
 				assert.Error(t, err)
 				assert.EqualError(t, err, tc.errText)

--- a/tests/e2e-targetallocator/targetallocator-kubernetessd/00-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-kubernetessd/00-assert.yaml
@@ -26,7 +26,7 @@ data:
             config: {}
             target_allocator:
                 collector_id: ${POD_NAME}
-                endpoint: http://prometheus-kubernetessd-targetallocator:80
+                endpoint: http://prometheus-kubernetessd-targetallocator.chainsaw-targetallocator-kubernetessd.svc.cluster.local:80
                 interval: 30s
     service:
         pipelines:

--- a/tests/e2e-targetallocator/targetallocator-kubernetessd/chainsaw-test.yaml
+++ b/tests/e2e-targetallocator/targetallocator-kubernetessd/chainsaw-test.yaml
@@ -5,6 +5,7 @@ metadata:
   creationTimestamp: null
   name: targetallocator-kubernetessd
 spec:
+  namespace: chainsaw-targetallocator-kubernetessd
   steps:
   - name: step-00
     try:

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/00-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/00-assert.yaml
@@ -31,7 +31,7 @@ data:
             config: {}
             target_allocator:
                 collector_id: ${POD_NAME}
-                endpoint: http://prometheus-cr-targetallocator:80
+                endpoint: http://prometheus-cr-targetallocator.chainsaw-targetallocator-prometheuscr.svc.cluster.local:80
                 interval: 30s
     service:
         pipelines:

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/chainsaw-test.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/chainsaw-test.yaml
@@ -5,6 +5,7 @@ metadata:
   creationTimestamp: null
   name: targetallocator-prometheuscr
 spec:
+  namespace: chainsaw-targetallocator-prometheuscr
   steps:
   - name: step-00
     try:

--- a/tests/e2e/smoke-targetallocator/00-assert.yaml
+++ b/tests/e2e/smoke-targetallocator/00-assert.yaml
@@ -33,7 +33,7 @@ data:
             config: {}
             target_allocator:
                 collector_id: ${POD_NAME}
-                endpoint: http://stateful-targetallocator:80
+                endpoint: http://stateful-targetallocator.chainsaw-smoke-targetallocator.svc.cluster.local:80
                 interval: 30s
     service:
         pipelines:

--- a/tests/e2e/smoke-targetallocator/chainsaw-test.yaml
+++ b/tests/e2e/smoke-targetallocator/chainsaw-test.yaml
@@ -5,6 +5,7 @@ metadata:
   creationTimestamp: null
   name: smoke-targetallocator
 spec:
+  namespace: chainsaw-smoke-targetallocator
   steps:
   - name: step-00
     try:


### PR DESCRIPTION
Operator image: docker.io/pavolloffay/opentelemetry-operator:dev-b67d063e-1722432504 

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->


See the changelog for more info.

On clusters with global proxy following error was happening on the collector
```
2024-07-22T21:11:58.189Z       info    [service@v0.102.1/service.go:113](mailto:service@v0.102.1/service.go:113)       Setting up own telemetry...

2024-07-22T21:11:58.189Z       info    [service@v0.102.1/telemetry.go:96](mailto:service@v0.102.1/telemetry.go:96)      Serving metrics {"address": ":8888", "level": "Normal"}

2024-07-22T21:11:58.189Z       info    [exporter@v0.102.1/exporter.go:275](mailto:exporter@v0.102.1/exporter.go:275)     Development component. May change in the future.  {"kind": "exporter", "data_type": "metrics", "name": "debug"}

2024-07-22T21:11:58.191Z       info    [service@v0.102.1/service.go:180](mailto:service@v0.102.1/service.go:180)       Starting otelcol...     {"Version": "0.102.1", "NumCPU": 12}

2024-07-22T21:11:58.191Z       info    extensions/extensions.go:34    Starting extensions...

2024-07-22T21:11:58.191Z       info        [prometheusreceiver@v0.102.0/metrics_receiver.go:279](mailto:prometheusreceiver@v0.102.0/metrics_receiver.go:279)   Starting discovery manager        {"kind": "receiver", "name": "prometheus", "data_type": "metrics"}

2024-07-22T21:11:58.192Z       info        [prometheusreceiver@v0.102.0/metrics_receiver.go:121](mailto:prometheusreceiver@v0.102.0/metrics_receiver.go:121)   Starting target allocator discovery      {"kind": "receiver", "name": "prometheus", "data_type": "metrics"}

2024-07-22T21:11:58.265Z       error        [prometheusreceiver@v0.102.0/metrics_receiver.go:154](mailto:prometheusreceiver@v0.102.0/metrics_receiver.go:154)   Failed to retrieve job list        {"kind": "receiver", "name": "prometheus", "data_type": "metrics", "error": "yaml: line 6: mapping values are not allowed in this context"}

[github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver.(*pReceiver).syncTargetAllocator](http://github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver.(*pReceiver).syncTargetAllocator)

        [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver@v0.102.0/metrics_receiver.go:154](mailto:github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver@v0.102.0/metrics_receiver.go:154)

[github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver.(*pReceiver).startTargetAllocator](http://github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver.(*pReceiver).startTargetAllocator)

        [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver@v0.102.0/metrics_receiver.go:123](mailto:github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver@v0.102.0/metrics_receiver.go:123)

[github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver.(*pReceiver).Start](http://github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver.(*pReceiver).Start)

        [github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver@v0.102.0/metrics_receiver.go:107](mailto:github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver@v0.102.0/metrics_receiver.go:107)

[go.opentelemetry.io/collector/service/internal/graph.(*Graph).StartAll](http://go.opentelemetry.io/collector/service/internal/graph.(*Graph).StartAll)

        [go.opentelemetry.io/collector/service@v0.102.1/internal/graph/graph.go:421](mailto:go.opentelemetry.io/collector/service@v0.102.1/internal/graph/graph.go:421)

[go.opentelemetry.io/collector/service.(*Service).Start](http://go.opentelemetry.io/collector/service.(*Service).Start)

        [go.opentelemetry.io/collector/service@v0.102.1/service.go:198](mailto:go.opentelemetry.io/collector/service@v0.102.1/service.go:198)

[go.opentelemetry.io/collector/otelcol.(*Collector).setupConfigurationComponents](http://go.opentelemetry.io/collector/otelcol.(*Collector).setupConfigurationComponents)

        [go.opentelemetry.io/collector/otelcol@v0.102.1/collector.go:223](mailto:go.opentelemetry.io/collector/otelcol@v0.102.1/collector.go:223)

[go.opentelemetry.io/collector/otelcol.(*Collector).Run](http://go.opentelemetry.io/collector/otelcol.(*Collector).Run)

        [go.opentelemetry.io/collector/otelcol@v0.102.1/collector.go:277](mailto:go.opentelemetry.io/collector/otelcol@v0.102.1/collector.go:277)

[go.opentelemetry.io/collector/otelcol.NewCommand.func1](http://go.opentelemetry.io/collector/otelcol.NewCommand.func1)

        [go.opentelemetry.io/collector/otelcol@v0.102.1/command.go:35](mailto:go.opentelemetry.io/collector/otelcol@v0.102.1/command.go:35)

[github.com/spf13/cobra.(*Command).execute](http://github.com/spf13/cobra.(*Command).execute)

        [github.com/spf13/cobra@v1.8.0/command.go:983](mailto:github.com/spf13/cobra@v1.8.0/command.go:983)

[github.com/spf13/cobra.(*Command).ExecuteC](http://github.com/spf13/cobra.(*Command).ExecuteC)

        [github.com/spf13/cobra@v1.8.0/command.go:1115](mailto:github.com/spf13/cobra@v1.8.0/command.go:1115)

[github.com/spf13/cobra.(*Command).Execute](http://github.com/spf13/cobra.(*Command).Execute)

        [github.com/spf13/cobra@v1.8.0/command.go:1039](mailto:github.com/spf13/cobra@v1.8.0/command.go:1039)

main.runInteractive

        [github.com/os-observability/redhat-opentelemetry-collector/main.go:53](http://github.com/os-observability/redhat-opentelemetry-collector/main.go:53)

main.run

        [github.com/os-observability/redhat-opentelemetry-collector/main_others.go:10](http://github.com/os-observability/redhat-opentelemetry-collector/main_others.go:10)

main.main

        [github.com/os-observability/redhat-opentelemetry-collector/main.go:46](http://github.com/os-observability/redhat-opentelemetry-collector/main.go:46)

runtime.main

        runtime/proc.go:271

2024-07-22T21:11:58.265Z       info    [service@v0.102.1/service.go:243](mailto:service@v0.102.1/service.go:243)       Starting shutdown...

2024-07-22T21:11:58.265Z       info    extensions/extensions.go:59    Stopping extensions...

2024-07-22T21:11:58.265Z       info    [service@v0.102.1/service.go:257](mailto:service@v0.102.1/service.go:257)       Shutdown complete.

Error: cannot start pipelines: yaml: line 6: mapping values are not allowed in this context

2024/07/22 21:11:58 collector server run finished with error: cannot start pipelines: yaml: line 6: mapping values are not allowed in this context
```

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #issue-number

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
