### PR TITLE
Fix dropdown menu to select individual OpenTelemetry Collector instances

### DIFF
--- a/.chloggen/3189-openshift-dashboard-differentiate-otelcols.yaml
+++ b/.chloggen/3189-openshift-dashboard-differentiate-otelcols.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: When there were multiple OpenTelemetry Collector, the dashboard doesn't allow to select them individually.
+
+# One or more tracking issues related to the change
+issues: [3189]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/openshift/dashboards/metrics-dashboard.json
+++ b/internal/openshift/dashboards/metrics-dashboard.json
@@ -55,17 +55,17 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(otelcol_receiver_accepted_metric_points{receiver=~\"$metric receiver\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_receiver_accepted_metric_points{receiver=~\"$metric receiver\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{receiver}}/{{service_name}}/{{namespace}} accepted/sec",
+              "legendFormat": "{{receiver}}/{{service}}/{{namespace}} accepted/sec",
               "refId": "A"
             },
             {
-              "expr": "rate(otelcol_receiver_refused_metric_points{receiver=~\"$metric receiver\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_receiver_refused_metric_points{receiver=~\"$metric receiver\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "interval": "",
-              "legendFormat": "{{ receiver }}/{{service_name}}/{{namespace}} refused/ sec",
+              "legendFormat": "{{ receiver }}/{{service}}/{{namespace}} refused/ sec",
               "refId": "B"
             }
           ],
@@ -140,17 +140,17 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(otelcol_exporter_sent_metric_points{exporter=~\"$metric exporter\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_exporter_sent_metric_points{exporter=~\"$metric exporter\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{exporter}}/{{service_name}}/{{namespace}} sent/sec",
+              "legendFormat": "{{exporter}}/{{service}}/{{namespace}} sent/sec",
               "refId": "A"
             },
             {
-              "expr": "rate(otelcol_exporter_send_failed_metric_points{exporter=~\"$metric exporter\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_exporter_send_failed_metric_points{exporter=~\"$metric exporter\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "interval": "",
-              "legendFormat": "{{ exporter }}/{{service_name}}/{{namespace}} failed/sec",
+              "legendFormat": "{{ exporter }}/{{service}}/{{namespace}} failed/sec",
               "refId": "B"
             }
           ],
@@ -225,7 +225,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(otelcol_processor_accepted_metric_points{processor=~\"$metric processor\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_processor_accepted_metric_points{processor=~\"$metric processor\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -233,15 +233,15 @@
               "refId": "A"
             },
             {
-              "expr": "rate(otelcol_processor_dropped_metric_points{processor=~\"$metric processor\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_processor_dropped_metric_points{processor=~\"$metric processor\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "interval": "",
-              "legendFormat": "{{processor}}/{{service_name}}/{{namespace}} | dropped",
+              "legendFormat": "{{processor}}/{{service}}/{{namespace}} | dropped",
               "refId": "B"
             },
             {
-              "expr": "rate(otelcol_processor_refused_metric_points{processor=~\"$metric processor\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_processor_refused_metric_points{processor=~\"$metric processor\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "interval": "",
-              "legendFormat": "{{processor}}/{{service_name}}/{{namespace}} | refused",
+              "legendFormat": "{{processor}}/{{service}}/{{namespace}} | refused",
               "refId": "C"
             }
           ],
@@ -328,17 +328,17 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(otelcol_receiver_accepted_spans{receiver=~\"$span receiver\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_receiver_accepted_spans{receiver=~\"$span receiver\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{receiver}}/{{service_name}}/{{namespace}} accepted/sec",
+              "legendFormat": "{{receiver}}/{{service}}/{{namespace}} accepted/sec",
               "refId": "A"
             },
             {
-              "expr": "rate(otelcol_receiver_refused_spans{receiver=~\"$span receiver\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_receiver_refused_spans{receiver=~\"$span receiver\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "interval": "",
-              "legendFormat": "{{ receiver }}/{{service_name}}/{{namespace}} refused/sec",
+              "legendFormat": "{{ receiver }}/{{service}}/{{namespace}} refused/sec",
               "refId": "B"
             }
           ],
@@ -413,17 +413,17 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(otelcol_exporter_sent_spans{exporter=~\"$span exporter\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_exporter_sent_spans{exporter=~\"$span exporter\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{exporter}}/{{service_name}}/{{namespace}} sent/sec",
+              "legendFormat": "{{exporter}}/{{service}}/{{namespace}} sent/sec",
               "refId": "A"
             },
             {
-              "expr": "rate(otelcol_exporter_send_failed_spans{exporter=~\"$span exporter\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_exporter_send_failed_spans{exporter=~\"$span exporter\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "interval": "",
-              "legendFormat": "{{ exporter }}/{{service_name}}/{{namespace}} failed/sec",
+              "legendFormat": "{{ exporter }}/{{service}}/{{namespace}} failed/sec",
               "refId": "B"
             }
           ],
@@ -498,23 +498,23 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(otelcol_processor_accepted_spans{processor=~\"$span processor\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_processor_accepted_spans{processor=~\"$span processor\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{processor}}/{{service_name}}/{{namespace}} | accepted",
+              "legendFormat": "{{processor}}/{{service}}/{{namespace}} | accepted",
               "refId": "A"
             },
             {
-              "expr": "rate(otelcol_processor_dropped_spans{processor=~\"$span processor\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_processor_dropped_spans{processor=~\"$span processor\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "interval": "",
-              "legendFormat": "{{processor}}/{{service_name}}/{{namespace}} | dropped",
+              "legendFormat": "{{processor}}/{{service}}/{{namespace}} | dropped",
               "refId": "B"
             },
             {
-              "expr": "rate(otelcol_processor_refused_spans{processor=~\"$span processor\",namespace=~\"$namespace\",service_name=~\"$collector instance\"}[1m])",
+              "expr": "rate(otelcol_processor_refused_spans{processor=~\"$span processor\",namespace=~\"$namespace\",service=~\"$collector instance\"}[1m])",
               "interval": "",
-              "legendFormat": "{{processor}}/{{service_name}}/{{namespace}} | refused",
+              "legendFormat": "{{processor}}/{{service}}/{{namespace}} | refused",
               "refId": "C"
             }
           ],
@@ -603,12 +603,12 @@
             {
               "editorMode": "code",
               "exemplar": true,
-              "expr": "otelcol_process_memory_rss{service_name=~\"$collector instance\",namespace=~\"$namespace\"}",
+              "expr": "otelcol_process_memory_rss{service=~\"$collector instance\",namespace=~\"$namespace\"}",
               "format": "time_series",
               "hide": false,
               "interval": "$minstep",
               "intervalFactor": 1,
-              "legendFormat": "{{service_name}}/{{namespace}}",
+              "legendFormat": "{{service}}/{{namespace}}",
               "range": true,
               "refId": "C"
             }
@@ -684,11 +684,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "otelcol_process_runtime_heap_alloc_bytes{service_name=~\"$collector instance\",namespace=~\"$namespace\"}",
+              "expr": "otelcol_process_runtime_heap_alloc_bytes{service=~\"$collector instance\",namespace=~\"$namespace\"}",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{service_name}}/{{namespace}}",
+              "legendFormat": "{{service}}/{{namespace}}",
               "refId": "A"
             }
           ],
@@ -765,12 +765,12 @@
             {
               "editorMode": "code",
               "exemplar": true,
-              "expr": "rate(otelcol_process_cpu_seconds{service_name=~\"$collector instance\",namespace=~\"$namespace\"}[1m])*100",
+              "expr": "rate(otelcol_process_cpu_seconds{service=~\"$collector instance\",namespace=~\"$namespace\"}[1m])*100",
               "format": "time_series",
               "hide": false,
               "interval": "$minstep",
               "intervalFactor": 1,
-              "legendFormat": "CPU usage {{service_name}}/{{namespace}}",
+              "legendFormat": "CPU usage {{service}}/{{namespace}}",
               "range": true
             }
           ],
@@ -1020,7 +1020,7 @@
         "multi": true,
         "name": "collector instance",
         "options": [],
-        "query": "label_values(target_info, service_name)",
+        "query": "label_values(target_info, service)",
         "refresh": 2,
         "regex": "",
         "sort": 2,


### PR DESCRIPTION
**Description:** 
Allow the dropdown menu to show the different collector instances in a namespace.

**Link to tracking Issue(s):**

- Resolves:  #3189
