### PR TITLE
[Chore] Fix image push for Mac and Windows using Docker/Podman Desktop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ scorecard-tests: operator-sdk
 .PHONY: container
 container: GOOS = linux
 container: manager
-	docker build -t ${IMG} .
+	docker build --load -t ${IMG} .
 
 # Push the container image, used only for local dev purposes
 .PHONY: container-push
@@ -350,17 +350,17 @@ container-operator-opamp-bridge-push:
 .PHONY: container-target-allocator
 container-target-allocator: GOOS = linux
 container-target-allocator: targetallocator
-	docker build -t ${TARGETALLOCATOR_IMG} cmd/otel-allocator
+	docker build --load -t ${TARGETALLOCATOR_IMG} cmd/otel-allocator
 
 .PHONY: container-operator-opamp-bridge
 container-operator-opamp-bridge: GOOS = linux
 container-operator-opamp-bridge: operator-opamp-bridge
-	docker build -t ${OPERATOROPAMPBRIDGE_IMG} cmd/operator-opamp-bridge
+	docker build --load -t ${OPERATOROPAMPBRIDGE_IMG} cmd/operator-opamp-bridge
 
 .PHONY: container-bridge-test-server
 container-bridge-test-server: GOOS = linux
 container-bridge-test-server:
-	docker build -t ${BRIDGETESTSERVER_IMG} tests/test-e2e-apps/bridge-server
+	docker build --load -t ${BRIDGETESTSERVER_IMG} tests/test-e2e-apps/bridge-server
 
 .PHONY: start-kind
 start-kind: kind
@@ -551,7 +551,7 @@ reset: kustomize operator-sdk manifests
 # Build the bundle image, used only for local dev purposes
 .PHONY: bundle-build
 bundle-build:
-	docker build -f ./bundle/$(BUNDLE_VARIANT)/bundle.Dockerfile -t $(BUNDLE_IMG) ./bundle/$(BUNDLE_VARIANT)
+	docker build --load -f ./bundle/$(BUNDLE_VARIANT)/bundle.Dockerfile -t $(BUNDLE_IMG) ./bundle/$(BUNDLE_VARIANT)
 
 .PHONY: bundle-push
 bundle-push:


### PR DESCRIPTION
**Description:** 
The PR fixes the following issue when building the images on Mac, Windows which uses Docker/Podman Desktop. 
```
=> [certificates 1/2] FROM docker.io/library/alpine:3.20@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9a  0.0s
 => => resolve docker.io/library/alpine:3.20@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5       0.0s
 => [stage-1 1/3] WORKDIR /root/                                                                                           0.0s
 => [internal] load build context                                                                                          1.4s
 => => transferring context: 97.21MB                                                                                       1.4s
 => CACHED [certificates 2/2] RUN apk --no-cache add ca-certificates                                                       0.0s
 => CACHED [stage-1 2/3] COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt    0.0s
 => [stage-1 3/3] COPY bin/targetallocator_amd64 ./main                                                                    0.1s
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load

 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
docker push quay.io/rhn_support_ikanse/target-allocator:latest
Error response from daemon: failed to find image quay.io/rhn_support_ikanse/target-allocator:latest: quay.io/rhn_support_ikanse/target-allocator:latest: image not known
make: *** [container-target-allocator-push] Error 1
```