### PR TITLE
[Chore] Export logs to OpenShift in-cluster logging LokiStack

### DIFF
--- a/tests/e2e-openshift/Dockerfile
+++ b/tests/e2e-openshift/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /tmp/go/bin $GOCACHE \
     && chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
 
 # Install dependencies required by test cases and debugging
-RUN apt-get update && apt-get install -y jq vim libreadline-dev
+RUN apt-get update && apt-get install -y jq vim libreadline-dev unzip
 
 # Install kuttl e2e
 RUN curl -LO https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64 \
@@ -33,6 +33,12 @@ RUN curl -LO https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/la
     && tar -xzf openshift-client-linux.tar.gz \
     && chmod +x oc kubectl \
     && mv oc kubectl /usr/local/bin/
+
+# Install the latest version of logcli
+RUN curl -LO https://github.com/grafana/loki/releases/latest/download/logcli-linux-amd64.zip \
+    && unzip logcli-linux-amd64.zip \
+    && chmod +x logcli-linux-amd64 \
+    && mv logcli-linux-amd64 /usr/local/bin/logcli
 
 # Set the working directory
 WORKDIR /tmp/opentelemetry-operator

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/chainsaw-test.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/chainsaw-test.yaml
@@ -1,0 +1,62 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: export-to-cluster-logging-lokistack
+spec:
+  namespace: chainsaw-incllogs
+  description: Tests shipping of logs to OpenShift in-cluster Logging LokiStack instance using OpenTelemetry collector. The tests requires the Loki, OpenTelemetry and Cluster Observability Operator to be installed along with logcli
+  steps:
+  - name: Create the OTEL collector instance
+    try:
+    - apply:
+        file: otel-collector.yaml
+    - assert:
+        file: otel-collector-assert.yaml
+  - name: Install Minio instance
+    try:
+    - apply:
+        file: install-minio.yaml
+    - assert:
+        file: install-minio-assert.yaml
+  - name: Create the LokiStack instance
+    try:
+    - apply:
+        file: install-loki.yaml
+    - assert:
+        file: install-loki-assert.yaml
+  - name: Check the status of LokiStack instance
+    try:
+    - script:
+        timeout: 5m
+        content: kubectl get --namespace openshift-logging lokistacks logging-loki -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+  - name: Enable Logging UI. Not needed by test but can be used for debugging
+    try:
+    - apply:
+        file: logging-uiplugin.yaml
+    - assert:
+        file: logging-uiplugin-assert.yaml
+  - name: Generate logs
+    try:
+    - apply:
+        file: generate-logs.yaml
+    - assert:
+        file: generate-logs-assert.yaml
+  - name: Check logs in LokiStack instance
+    try:
+    - script:
+        timeout: 5m
+        content: ./check_logs.sh
+    cleanup:
+    - delete:
+        ref:
+          apiVersion: loki.grafana.com/v1
+          kind: LokiStack
+          name: logging-loki
+          namespace: openshift-logging
+    - delete:
+        ref:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          labels: 
+            app.kubernetes.io/instance: "logging-loki"
+          namespace: openshift-logging

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/check_logs.sh
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/check_logs.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+TOKEN=$(oc -n openshift-logging create token otel-collector-deployment)
+LOKI_URL=$(oc -n openshift-logging get route logging-loki -o json | jq '.spec.host' -r)
+
+while true; do
+  LOG_OUTPUT=$(logcli -o raw --tls-skip-verify \
+  --bearer-token="${TOKEN}" \
+  --addr "https://${LOKI_URL}/api/logs/v1/application" query '{log_type="application"}')
+
+  if echo "$LOG_OUTPUT" | jq -e '
+    . as $root |
+    select(
+      .body == "the message" and
+      .severity == "Info" and
+      .attributes.app == "server" and
+      .resources."k8s.container.name" == "telemetrygen" and
+      .resources."k8s.namespace.name" == "chainsaw-incllogs"
+    )
+  ' > /dev/null; then
+    echo "Logs found:"
+    break
+  else
+    echo "Logs not found. Continuing to check..."
+    sleep 5
+  fi
+done

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/generate-logs-assert.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/generate-logs-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: telemetrygen
+  namespace: chainsaw-incllogs
+status:
+  active: 1

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/generate-logs.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/generate-logs.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: telemetrygen
+  namespace: chainsaw-incllogs
+spec:
+  template:
+    spec:
+      containers:
+        - name: telemetrygen
+          image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.106.1
+          args:
+            - logs
+            - --otlp-endpoint=otel-collector.openshift-logging.svc.cluster.local:4317
+            - --otlp-insecure
+            - --workers=1
+            - --duration=120s
+            - --otlp-attributes=k8s.container.name="telemetrygen"
+      restartPolicy: Never
+  backoffLimit: 4

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-loki-assert.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-loki-assert.yaml
@@ -1,0 +1,362 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: logging-loki-compactor
+  namespace: openshift-logging
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: logging-loki-index-gateway
+  namespace: openshift-logging
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: logging-loki-ingester
+  namespace: openshift-logging
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logging-loki-distributor
+  namespace: openshift-logging
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logging-loki-gateway
+  namespace: openshift-logging
+status:
+  availableReplicas: 2
+  readyReplicas: 2
+  replicas: 2
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logging-loki-querier
+  namespace: openshift-logging
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logging-loki-query-frontend
+  namespace: openshift-logging
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-compactor-grpc
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: grpclb
+    port: 9095
+    protocol: TCP
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-compactor-http
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    protocol: TCP
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: compactor
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-distributor-grpc
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: grpclb
+    port: 9095
+    protocol: TCP
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-distributor-http
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    protocol: TCP
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: distributor
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-gateway-http
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: public
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: metrics
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
+  - name: opa-metrics
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  selector:
+    app.kubernetes.io/component: lokistack-gateway
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-gossip-ring
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: gossip-ring
+    port: 7946
+    protocol: TCP
+    targetPort: 7946
+  selector:
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-index-gateway-grpc
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: grpclb
+    port: 9095
+    protocol: TCP
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-index-gateway-http
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    protocol: TCP
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: index-gateway
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-ingester-grpc
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: grpclb
+    port: 9095
+    protocol: TCP
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-ingester-http
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    protocol: TCP
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: ingester
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-querier-grpc
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: grpclb
+    port: 9095
+    protocol: TCP
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-querier-http
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    protocol: TCP
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: querier
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-query-frontend-grpc
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: grpclb
+    port: 9095
+    protocol: TCP
+    targetPort: 9095
+  selector:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: logging-loki-query-frontend-http
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: metrics
+    port: 3100
+    protocol: TCP
+    targetPort: 3100
+  selector:
+    app.kubernetes.io/component: query-frontend
+    app.kubernetes.io/created-by: lokistack-controller
+    app.kubernetes.io/instance: logging-loki
+    app.kubernetes.io/managed-by: lokistack-controller
+    app.kubernetes.io/name: lokistack
+  type: ClusterIP

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-loki.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-loki.yaml
@@ -1,0 +1,17 @@
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki 
+  namespace: openshift-logging 
+spec:
+  size: 1x.demo
+  storage:
+    schemas:
+    - version: v13
+      effectiveDate: "2023-10-15"
+    secret:
+      name: logging-loki-s3 
+      type: s3
+  storageClassName: gp2-csi
+  tenants:
+    mode: openshift-logging

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-minio-assert.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-minio-assert.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+  name: minio
+  namespace: openshift-logging
+status:
+  accessModes:
+  - ReadWriteOnce
+  capacity:
+    storage: 2Gi
+  phase: Bound
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: openshift-logging
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: openshift-logging
+spec:
+  ports:
+  - port: 9000
+    protocol: TCP
+    targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-minio.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-minio.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: minio
+  name: minio
+  namespace: openshift-logging
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: openshift-logging
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /storage/tempo && \
+              minio server /storage
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: tempo
+            - name: MINIO_SECRET_KEY
+              value: supersecret
+          image: minio/minio
+          name: minio
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - mountPath: /storage
+              name: storage
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: minio
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: openshift-logging
+spec:
+  ports:
+    - port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app.kubernetes.io/name: minio
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: logging-loki-s3
+  namespace: openshift-logging
+stringData:
+  endpoint: http://minio:9000
+  bucketnames: tempo
+  access_key_id: tempo
+  access_key_secret: supersecret
+type: Opaque

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/logging-uiplugin-assert.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/logging-uiplugin-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logging
+  namespace: openshift-operators
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/logging-uiplugin.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/logging-uiplugin.yaml
@@ -1,0 +1,11 @@
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: logging
+spec:
+  logging:
+    logsLimit: 20
+    lokiStack:
+      name: logging-loki
+    timeout: 300s
+  type: Logging

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/otel-collector-assert.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/otel-collector-assert.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: openshift-logging
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: openshift-logging
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: openshift-logging.otel
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector-headless
+  namespace: openshift-logging
+spec:
+  ports:
+  - appProtocol: grpc
+    name: otlp-grpc
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - appProtocol: http
+    name: otlp-http
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: openshift-logging.otel
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector-monitoring
+  namespace: openshift-logging
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: openshift-logging.otel
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  type: ClusterIP

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/otel-collector.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/otel-collector.yaml
@@ -1,0 +1,116 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector-deployment
+  namespace: openshift-logging
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector-logs-writer
+rules:
+ - apiGroups: ["loki.grafana.com"]
+   resourceNames: ["logs"]
+   resources: ["application"]
+   verbs: ["create", "get"]
+ - apiGroups: [""]
+   resources: ["pods", "namespaces", "nodes"]
+   verbs: ["get", "watch", "list"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector-logs-writer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-collector-logs-writer
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector-deployment
+    namespace: openshift-logging
+
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+  namespace: openshift-logging
+spec:
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.107.0
+  serviceAccount: otel-collector-deployment
+  config:
+    extensions:
+      bearertokenauth:
+        filename: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+          http: {}
+    processors:
+      k8sattributes:
+        auth_type: "serviceAccount"
+        passthrough: false
+        extract:
+          metadata:
+            - k8s.pod.name
+            - k8s.container.name
+            - k8s.namespace.name
+          labels:
+          - tag_name: app.label.component
+            key: app.kubernetes.io/component
+            from: pod
+        pod_association:
+          - sources:
+              - from: resource_attribute
+                name: k8s.pod.name
+              - from: resource_attribute
+                name: k8s.container.name
+              - from: resource_attribute
+                name: k8s.namespace.name
+          - sources:
+              - from: connection
+      resource:
+        attributes:
+          - key: loki.format
+            action: insert
+            value: json
+          - key:  kubernetes_namespace_name
+            from_attribute: k8s.namespace.name
+            action: upsert
+          - key:  kubernetes_pod_name
+            from_attribute: k8s.pod.name
+            action: upsert
+          - key: kubernetes_container_name
+            from_attribute: k8s.container.name
+            action: upsert
+          - key: log_type
+            value: application
+            action: upsert
+          - key: loki.resource.labels
+            value: log_type, kubernetes_namespace_name, kubernetes_pod_name, kubernetes_container_name
+            action: insert
+      transform:
+        log_statements:
+          - context: log
+            statements:
+              - set(attributes["level"], ConvertCase(severity_text, "lower"))
+
+    exporters:
+      loki:
+        endpoint: https://logging-loki-gateway-http.openshift-logging.svc.cluster.local:8080/api/logs/v1/application/loki/api/v1/push
+        tls:
+          ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+        auth:
+          authenticator: bearertokenauth
+
+    service:
+      extensions: [bearertokenauth]
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [k8sattributes, transform, resource]
+          exporters: [loki]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The PR adds a test case for exporting logs through an OTEL collector to OpenShift in-cluster Logging LokiStack instance. 

**Testing:** <Describe what testing was performed and which tests were added.>

```
--- PASS: chainsaw (0.00s)
    --- PASS: chainsaw/export-to-cluster-logging-lokistack (173.06s)
PASS
Tests Summary...
- Passed  tests 1
- Failed  tests 0
- Skipped tests 0
Done.
```
