### PR TITLE
[all] add support for Windows nodes

### DIFF
--- a/.chloggen/support_windows.yaml
+++ b/.chloggen/support_windows.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: all
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add windows support for the operator
+
+# One or more tracking issues related to the change
+issues: [642]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  PLATFORMS: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+  PLATFORMS: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
 
 jobs:
   publish:
@@ -46,8 +46,9 @@ jobs:
         run: |
           for platform in $(echo $PLATFORMS | tr "," "\n"); do
             arch=${platform#*/}
-            echo "Building manager for $arch"
-            make manager ARCH=$arch
+            os=${platform%/*}
+            echo "Building manager for os $os and arch $arch"
+            make manager ARCH=$arch GOOS=$os
           done
 
       - name: Docker meta

--- a/.github/workflows/publish-operator-opamp-bridge.yaml
+++ b/.github/workflows/publish-operator-opamp-bridge.yaml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  PLATFORMS: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+  PLATFORMS: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
 
 jobs:
   publish:
@@ -35,8 +35,9 @@ jobs:
         run: |
           for platform in $(echo $PLATFORMS | tr "," "\n"); do
             arch=${platform#*/}
-            echo "Building operator-opamp-bridge for $arch"
-            make operator-opamp-bridge ARCH=$arch
+            os=${platform%/*}
+            echo "Building operator-opamp-bridge for os $os and arch $arch"
+            make operator-opamp-bridge ARCH=$arch GOOS=$os
           done
 
       - name: Docker meta

--- a/.github/workflows/publish-target-allocator.yaml
+++ b/.github/workflows/publish-target-allocator.yaml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 env:
-  PLATFORMS: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+  PLATFORMS: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
 
 jobs:
   publish:
@@ -35,8 +35,9 @@ jobs:
         run: |
           for platform in $(echo $PLATFORMS | tr "," "\n"); do
             arch=${platform#*/}
-            echo "Building target allocator for $arch"
-            make targetallocator ARCH=$arch
+            os=${platform%/*}
+            echo "Building target allocator for os $os and arch $arch"
+            make targetallocator ARCH=$arch GOOS=$os
           done
 
       - name: Docker meta

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /
 COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy binary built on the host
-COPY bin/manager_${TARGETARCH} manager
+COPY bin/manager_${TARGETOS}_${TARGETARCH} manager
 
 USER 65532:65532
 

--- a/Makefile
+++ b/Makefile
@@ -141,17 +141,17 @@ ci: generate fmt vet test ensure-generate-is-noop
 # Build manager binary
 .PHONY: manager
 manager: generate
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -o bin/manager_${ARCH} -ldflags "${COMMON_LDFLAGS} ${OPERATOR_LDFLAGS}" main.go
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -o bin/manager_${GOOS}_${ARCH} -ldflags "${COMMON_LDFLAGS} ${OPERATOR_LDFLAGS}" main.go
 
 # Build target allocator binary
 .PHONY: targetallocator
 targetallocator:
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -o cmd/otel-allocator/bin/targetallocator_${ARCH} -ldflags "${COMMON_LDFLAGS}" ./cmd/otel-allocator
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -o cmd/otel-allocator/bin/targetallocator_${GOOS}_${ARCH} -ldflags "${COMMON_LDFLAGS}" ./cmd/otel-allocator
 
 # Build opamp bridge binary
 .PHONY: operator-opamp-bridge
 operator-opamp-bridge: generate
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -o cmd/operator-opamp-bridge/bin/opampbridge_${ARCH} -ldflags "${COMMON_LDFLAGS}" ./cmd/operator-opamp-bridge
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -o cmd/operator-opamp-bridge/bin/opampbridge_${GOOS}_${ARCH} -ldflags "${COMMON_LDFLAGS}" ./cmd/operator-opamp-bridge
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 .PHONY: run

--- a/cmd/operator-opamp-bridge/Dockerfile
+++ b/cmd/operator-opamp-bridge/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /root/
 COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy binary built on the host
-COPY bin/opampbridge_${TARGETARCH} ./main
+COPY bin/opampbridge_${TARGETOS}_${TARGETARCH} ./main
 
 # "nonroot"
 USER 65532:65532

--- a/cmd/otel-allocator/Dockerfile
+++ b/cmd/otel-allocator/Dockerfile
@@ -14,6 +14,6 @@ WORKDIR /root/
 COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy binary built on the host
-COPY bin/targetallocator_${TARGETARCH} ./main
+COPY bin/targetallocator_${TARGETOS}_${TARGETARCH} ./main
 
 ENTRYPOINT ["./main"]


### PR DESCRIPTION
**Description:** 
Add support to build Windows images of the Docker images used by the operator and add them as an additional manifest platform on pushed images.

**Link to tracking Issue(s):**
Fixes #642

**Testing:**
Not much. I however have a k8s environment with Windows nodes to try things in.