### PR TITLE
Update @swiatekm's affiliation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,7 +815,7 @@ Emeritus Target Allocator Maintainers
 Maintainers ([@open-telemetry/operator-maintainers](https://github.com/orgs/open-telemetry/teams/operator-maintainers)):
 
 - [Jacob Aronoff](https://github.com/jaronoff97), Lightstep
-- [Mikołaj Świątek](https://github.com/swiatekm), Sumo Logic
+- [Mikołaj Świątek](https://github.com/swiatekm), Elastic
 - [Pavol Loffay](https://github.com/pavolloffay), Red Hat
 
 Emeritus Maintainers


### PR DESCRIPTION
I now work for Elastic, and wanted to reflect that in the README.
