### PR TITLE
[chore] Add runbooks file

### DIFF
--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1,0 +1,23 @@
+# OpenTelemetry Operator Runbooks
+
+See [`README.md`](../README.md) for more details about the OpenTelemetry Operator.
+
+## Manager Rules
+
+### [ReconcileErrors](#reconcileerrors)
+
+|||
+|-:|-|
+| Meaning | The OpenTelemetry Operator is unable to succeed in the reconciliaton step, probably because of a missconifgured OpenTelemetryCollector. |
+| Impact | No impact on already running deployments or new correct ones. |
+| Diagnosis | Check manager logs for reasons why this might happen. <br> <br> Example: `failed to create objects for <podName>: Deployment.apps "<deploymentName>" is invalid: spec.template.spec.containers[0].env[1].valueFrom: Invalid value: "": may not be specified when "value" is not empty`|
+| Mitigation | Find out which OpenTelemetryCollector is causing the errors and fix the config. |
+
+### [WorkqueueDepth](#workqueuedepth)
+
+|||
+|-:|-|
+| Meaning | The working queue for the operator is larger than 0. |
+| Impact | No impact if the queue depth reverts to 0 quickly. More investigation is needed if the problem persists. |
+| Diagnosis | Check manager logs for reasons why this might happen. |
+| Mitigation | This could be caused by many errors. Act based on what the logs are showing. |

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -8,7 +8,7 @@ See [`README.md`](../README.md) for more details about the OpenTelemetry Operato
 
 |||
 |-:|-|
-| Meaning | The OpenTelemetry Operator is unable to succeed in the reconciliaton step, probably because of a missconifgured OpenTelemetryCollector. |
+| Meaning | The OpenTelemetry Operator cannot succeed in the reconciliation step, probably because of a misconfigured OpenTelemetryCollector. |
 | Impact | No impact on already running deployments or new correct ones. |
 | Diagnosis | Check manager logs for reasons why this might happen. <br> <br> Example: `failed to create objects for <podName>: Deployment.apps "<deploymentName>" is invalid: spec.template.spec.containers[0].env[1].valueFrom: Invalid value: "": may not be specified when "value" is not empty`|
 | Mitigation | Find out which OpenTelemetryCollector is causing the errors and fix the config. |

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -10,7 +10,7 @@ See [`README.md`](../README.md) for more details about the OpenTelemetry Operato
 |-:|-|
 | Meaning | The OpenTelemetry Operator cannot succeed in the reconciliation step, probably because of a misconfigured OpenTelemetryCollector. |
 | Impact | No impact on already running deployments or new correct ones. |
-| Diagnosis | Check manager logs for reasons why this might happen. <br> <br> Example: `failed to create objects for <podName>: Deployment.apps "<deploymentName>" is invalid: spec.template.spec.containers[0].env[1].valueFrom: Invalid value: "": may not be specified when "value" is not empty`|
+| Diagnosis | Check manager logs for reasons why this might happen. |
 | Mitigation | Find out which OpenTelemetryCollector is causing the errors and fix the config. |
 
 ### [WorkqueueDepth](#workqueuedepth)


### PR DESCRIPTION
**Documentation:** <Describe the documentation added.>
Added a runbooks.md file primarily to have an endpoint to point to from [here](https://github.com/bogdan-at-adobe/opentelemetry-helm-charts/blob/7f64f3fad27888839cdf0059b597b5d5f688e318/charts/opentelemetry-operator/templates/prometheusrule.yaml#L49) since it expects a url.  
