### PR TITLE
Retry failed namespace informer creation in promOperator CRD watcher

### DIFF
--- a/.chloggen/3216-ta-retry-namespace-informer-creation.yaml
+++ b/.chloggen/3216-ta-retry-namespace-informer-creation.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Retrying failed namespace informer creation in promOperator CRD watcher, then exit if creation issue cannot be resolved"
+
+# One or more tracking issues related to the change
+issues: [3216]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
Added retry mechanism for namespace informer creation in promOperator CRD watcher.
In case of the namespace informer creation still fails, then exit the target allocator with error.

**Link to tracking Issue(s):** [3216](https://github.com/open-telemetry/opentelemetry-operator/issues/3216)

- Resolves: #3216 

**Testing:**
Done some manual testing
If I changed the context to have timeout, and configured the timeout to 1 nanosecond:
```
$ go run cmd/otel-allocator/main.go
{"level":"info","ts":"2024-08-29T23:17:08+02:00","msg":"Starting the Target Allocator"}
{"level":"error","ts":"2024-08-29T23:17:08+02:00","logger":"setup.prometheus-cr-watcher","msg":"Retrying namespace informer creation in promOperator CRD watcher","error":"client rate limiter Wait returned an error: context deadline exceeded","stacktrace":"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher.NewPrometheusCRWatcher.func1\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/watcher/promOperator.go:111\nk8s.io/client-go/util/retry.OnError.func1\n\t/Users/dhaja/go/pkg/mod/k8s.io/client-go@v0.31.0/util/retry/util.go:55\nk8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection\n\t/Users/dhaja/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/wait.go:145\nk8s.io/apimachinery/pkg/util/wait.ExponentialBackoff\n\t/Users/dhaja/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:461\nk8s.io/client-go/util/retry.OnError\n\t/Users/dhaja/go/pkg/mod/k8s.io/client-go@v0.31.0/util/retry/util.go:50\ngithub.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher.NewPrometheusCRWatcher\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/watcher/promOperator.go:109\nmain.main\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/main.go:119\nruntime.main\n\t/opt/homebrew/Cellar/go/1.23.0/libexec/src/runtime/proc.go:272"}
{"level":"error","ts":"2024-08-29T23:17:08+02:00","logger":"setup.prometheus-cr-watcher","msg":"Retrying namespace informer creation in promOperator CRD watcher","error":"client rate limiter Wait returned an error: context deadline exceeded","stacktrace":"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher.NewPrometheusCRWatcher.func1\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/watcher/promOperator.go:111\nk8s.io/client-go/util/retry.OnError.func1\n\t/Users/dhaja/go/pkg/mod/k8s.io/client-go@v0.31.0/util/retry/util.go:55\nk8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection\n\t/Users/dhaja/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/wait.go:145\nk8s.io/apimachinery/pkg/util/wait.ExponentialBackoff\n\t/Users/dhaja/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:461\nk8s.io/client-go/util/retry.OnError\n\t/Users/dhaja/go/pkg/mod/k8s.io/client-go@v0.31.0/util/retry/util.go:50\ngithub.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher.NewPrometheusCRWatcher\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/watcher/promOperator.go:109\nmain.main\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/main.go:119\nruntime.main\n\t/opt/homebrew/Cellar/go/1.23.0/libexec/src/runtime/proc.go:272"}
{"level":"error","ts":"2024-08-29T23:17:08+02:00","logger":"setup.prometheus-cr-watcher","msg":"Retrying namespace informer creation in promOperator CRD watcher","error":"client rate limiter Wait returned an error: context deadline exceeded","stacktrace":"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher.NewPrometheusCRWatcher.func1\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/watcher/promOperator.go:111\nk8s.io/client-go/util/retry.OnError.func1\n\t/Users/dhaja/go/pkg/mod/k8s.io/client-go@v0.31.0/util/retry/util.go:55\nk8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection\n\t/Users/dhaja/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/wait.go:145\nk8s.io/apimachinery/pkg/util/wait.ExponentialBackoff\n\t/Users/dhaja/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:461\nk8s.io/client-go/util/retry.OnError\n\t/Users/dhaja/go/pkg/mod/k8s.io/client-go@v0.31.0/util/retry/util.go:50\ngithub.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher.NewPrometheusCRWatcher\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/watcher/promOperator.go:109\nmain.main\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/main.go:119\nruntime.main\n\t/opt/homebrew/Cellar/go/1.23.0/libexec/src/runtime/proc.go:272"}
{"level":"error","ts":"2024-08-29T23:17:08+02:00","logger":"setup.prometheus-cr-watcher","msg":"Retrying namespace informer creation in promOperator CRD watcher","error":"client rate limiter Wait returned an error: context deadline exceeded","stacktrace":"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher.NewPrometheusCRWatcher.func1\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/watcher/promOperator.go:111\nk8s.io/client-go/util/retry.OnError.func1\n\t/Users/dhaja/go/pkg/mod/k8s.io/client-go@v0.31.0/util/retry/util.go:55\nk8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection\n\t/Users/dhaja/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/wait.go:145\nk8s.io/apimachinery/pkg/util/wait.ExponentialBackoff\n\t/Users/dhaja/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:461\nk8s.io/client-go/util/retry.OnError\n\t/Users/dhaja/go/pkg/mod/k8s.io/client-go@v0.31.0/util/retry/util.go:50\ngithub.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher.NewPrometheusCRWatcher\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/watcher/promOperator.go:109\nmain.main\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/main.go:119\nruntime.main\n\t/opt/homebrew/Cellar/go/1.23.0/libexec/src/runtime/proc.go:272"}
{"level":"error","ts":"2024-08-29T23:17:08+02:00","logger":"setup.prometheus-cr-watcher","msg":"Retrying namespace informer creation in promOperator CRD watcher","error":"client rate limiter Wait returned an error: context deadline exceeded","stacktrace":"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher.NewPrometheusCRWatcher.func1\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/watcher/promOperator.go:111\nk8s.io/client-go/util/retry.OnError.func1\n\t/Users/dhaja/go/pkg/mod/k8s.io/client-go@v0.31.0/util/retry/util.go:55\nk8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection\n\t/Users/dhaja/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/wait.go:145\nk8s.io/apimachinery/pkg/util/wait.ExponentialBackoff\n\t/Users/dhaja/go/pkg/mod/k8s.io/apimachinery@v0.31.0/pkg/util/wait/backoff.go:461\nk8s.io/client-go/util/retry.OnError\n\t/Users/dhaja/go/pkg/mod/k8s.io/client-go@v0.31.0/util/retry/util.go:50\ngithub.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher.NewPrometheusCRWatcher\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/watcher/promOperator.go:109\nmain.main\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/main.go:119\nruntime.main\n\t/opt/homebrew/Cellar/go/1.23.0/libexec/src/runtime/proc.go:272"}
{"level":"error","ts":"2024-08-29T23:17:08+02:00","logger":"setup.prometheus-cr-watcher","msg":"Failed to create namespace informer in promOperator CRD watcher","error":"client rate limiter Wait returned an error: context deadline exceeded","stacktrace":"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/watcher.NewPrometheusCRWatcher\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/watcher/promOperator.go:118\nmain.main\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/main.go:119\nruntime.main\n\t/opt/homebrew/Cellar/go/1.23.0/libexec/src/runtime/proc.go:272"}
{"level":"error","ts":"2024-08-29T23:17:08+02:00","logger":"setup","msg":"Can't start the prometheus watcher","error":"client rate limiter Wait returned an error: context deadline exceeded","stacktrace":"main.main\n\t/Users/dhaja/Projects/external/forked/opentelemetry-operator/cmd/otel-allocator/main.go:121\nruntime.main\n\t/opt/homebrew/Cellar/go/1.23.0/libexec/src/runtime/proc.go:272"}
exit status 1
```
Without any "network issue"/failure:
```
$ go run cmd/otel-allocator/main.go
{"level":"info","ts":"2024-08-29T23:12:54+02:00","msg":"Starting the Target Allocator"}
{"level":"info","ts":"2024-08-29T23:12:54+02:00","logger":"allocator","msg":"Starting server..."}
{"level":"info","ts":"2024-08-29T23:12:54+02:00","msg":"Waiting for caches to sync for namespace"}
{"level":"info","ts":"2024-08-29T23:12:54+02:00","msg":"Caches are synced for namespace"}
{"level":"info","ts":"2024-08-29T23:12:54+02:00","msg":"Waiting for caches to sync for servicemonitors"}
{"level":"info","ts":"2024-08-29T23:12:54+02:00","msg":"Caches are synced for servicemonitors"}
{"level":"info","ts":"2024-08-29T23:12:54+02:00","msg":"Waiting for caches to sync for podmonitors"}
{"level":"info","ts":"2024-08-29T23:12:54+02:00","msg":"Caches are synced for podmonitors"}
```

**Documentation:** <Describe the documentation added.>
N/A