### PR TITLE
Allow autoscaler targetCPUUtilization and TargetMemoryUtilization to be greater than 99

### DIFF
--- a/.chloggen/3258-autoscaler-utilization-greater-than-99.yaml
+++ b/.chloggen/3258-autoscaler-utilization-greater-than-99.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow autoscaler targetCPUUtilization and TargetMemoryUtilization to be greater than 99"
+
+# One or more tracking issues related to the change
+issues: [3258]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1beta1/collector_webhook.go
+++ b/apis/v1beta1/collector_webhook.go
@@ -378,11 +378,11 @@ func checkAutoscalerSpec(autoscaler *AutoscalerSpec) error {
 			return fmt.Errorf("the OpenTelemetry Spec autoscale configuration is incorrect, scaleUp should be one or more")
 		}
 	}
-	if autoscaler.TargetCPUUtilization != nil && (*autoscaler.TargetCPUUtilization < int32(1) || *autoscaler.TargetCPUUtilization > int32(99)) {
-		return fmt.Errorf("the OpenTelemetry Spec autoscale configuration is incorrect, targetCPUUtilization should be greater than 0 and less than 100")
+	if autoscaler.TargetCPUUtilization != nil && *autoscaler.TargetCPUUtilization < int32(1) {
+		return fmt.Errorf("the OpenTelemetry Spec autoscale configuration is incorrect, targetCPUUtilization should be greater than 0")
 	}
-	if autoscaler.TargetMemoryUtilization != nil && (*autoscaler.TargetMemoryUtilization < int32(1) || *autoscaler.TargetMemoryUtilization > int32(99)) {
-		return fmt.Errorf("the OpenTelemetry Spec autoscale configuration is incorrect, targetMemoryUtilization should be greater than 0 and less than 100")
+	if autoscaler.TargetMemoryUtilization != nil && *autoscaler.TargetMemoryUtilization < int32(1) {
+		return fmt.Errorf("the OpenTelemetry Spec autoscale configuration is incorrect, targetMemoryUtilization should be greater than 0")
 	}
 
 	for _, metric := range autoscaler.Metrics {

--- a/apis/v1beta1/collector_webhook_test.go
+++ b/apis/v1beta1/collector_webhook_test.go
@@ -859,7 +859,19 @@ func TestOTELColValidatingWebhook(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: "targetCPUUtilization should be greater than 0 and less than 100",
+			expectedErr: "targetCPUUtilization should be greater than 0",
+		},
+		{
+			name: "invalid autoscaler target memory utilization",
+			otelcol: OpenTelemetryCollector{
+				Spec: OpenTelemetryCollectorSpec{
+					Autoscaler: &AutoscalerSpec{
+						MaxReplicas:             &three,
+						TargetMemoryUtilization: &zero,
+					},
+				},
+			},
+			expectedErr: "targetMemoryUtilization should be greater than 0",
 		},
 		{
 			name: "autoscaler minReplicas is less than maxReplicas",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Allowing the autoscaler targetCPUUtilization and TargetMemoryUtilization to be greater than 99.
Added an extra test for checking the TargetMemoryUtilization value.

**Link to tracking Issue(s):** <Issue number if applicable>
[3258](https://github.com/open-telemetry/opentelemetry-operator/issues/3258)
- Resolves: #3258 

**Testing:** <Describe what testing was performed and which tests were added.>
TestOTELColValidatingWebhook tests the modified conditions

**Documentation:** <Describe the documentation added.>
N/A