### PR TITLE
Add arm64 artefacts to dotnet autoinstrumentation container.

### DIFF
--- a/.chloggen/dotnet-instrumenation-arm64.yml
+++ b/.chloggen/dotnet-instrumenation-arm64.yml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. operator, target allocator, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add arm64 artefacts to dotnet autoinstrumentation container. 
+
+# One or more tracking issues related to the change
+issues: [5868]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/autoinstrumentation/dotnet/Dockerfile
+++ b/autoinstrumentation/dotnet/Dockerfile
@@ -20,12 +20,17 @@ ARG version
 
 WORKDIR /autoinstrumentation
 
-ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip .
-ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl-x64.zip .
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
 
 RUN unzip opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip &&\
+    unzip opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip "linux-arm64/*" -d .&&\
     unzip opentelemetry-dotnet-instrumentation-linux-musl-x64.zip "linux-musl-x64/*" -d . &&\
-    rm opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip opentelemetry-dotnet-instrumentation-linux-musl-x64.zip &&\
+    unzip opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip "linux-musl-arm64/*" -d . &&\
+    unzip opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip "store/arm64/*" -d .&&\
+    rm opentelemetry-dotnet-instrumentation-*.zip &&\
     chmod -R go+r .
 
 FROM busybox

--- a/autoinstrumentation/dotnet/Dockerfile
+++ b/autoinstrumentation/dotnet/Dockerfile
@@ -20,10 +20,10 @@ ARG version
 
 WORKDIR /autoinstrumentation
 
-ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip
-ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip
-ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip
-ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl-x64.zip
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip .
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip .
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl-arm64.zip .
+ADD https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/download/v$version/opentelemetry-dotnet-instrumentation-linux-musl-x64.zip .
 
 RUN unzip opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip &&\
     unzip opentelemetry-dotnet-instrumentation-linux-glibc-arm64.zip "linux-arm64/*" -d .&&\


### PR DESCRIPTION
This will allow the operator to auto instrument dotnet applications on `arm64` containers. (Including k8s on OSX M1/M2/M3 etc)

Validated manually as part of Elastic's distribution of OpenTelemetry .NET

https://github.com/elastic/elastic-otel-dotnet/pull/155

CC @Kielek & @RassK who did the bulk of the work actually creating the artefacts 🙏 