### PR TITLE
fix: fix container names annotations for sdk, apache, nginx

### DIFF
--- a/.chloggen/container-names.yaml
+++ b/.chloggen/container-names.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix ApacheHttpd, Nginx and SDK injectors to honour their container-names annotations.
+
+# One or more tracking issues related to the change
+issues: [3313]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is a breaking change if anyone is accidentally using the enablement flag with container names for these 3 injectors.

--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -232,15 +232,15 @@ func (langInsts *languageInstrumentations) setLanguageSpecificContainers(ns meta
 		},
 		{
 			iwc:        &langInsts.ApacheHttpd,
-			annotation: annotationInjectApacheHttpd,
+			annotation: annotationInjectApacheHttpdContainersName,
 		},
 		{
 			iwc:        &langInsts.Nginx,
-			annotation: annotationInjectNginx,
+			annotation: annotationInjectNginxContainersName,
 		},
 		{
 			iwc:        &langInsts.Sdk,
-			annotation: annotationInjectSdk,
+			annotation: annotationInjectSdkContainersName,
 		},
 	}
 


### PR DESCRIPTION
Found through code inspection, the ApacheHttpd, Nginx and SDK injectors do not honour their container-names annotations.

I have changed the annotation used for the container list to match the expected annotation constant which already existed in each case but was unused in the code base.

This is a breaking change if anyone is using the enablement flag with container names for these 3 injectors, which I believe would work as truthy would treat a list of container names as true.
