### PR TITLE
Set OTEL_LOGS_EXPORTER for python

### DIFF
--- a/.chloggen/3330-python-otel-logs-exporter.yaml
+++ b/.chloggen/3330-python-otel-logs-exporter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: set OTEL_LOGS_EXPORTER env var to oltp in python instrumentation
+
+# One or more tracking issues related to the change
+issues: [3330]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/3330-python-otel-logs-exporter.yaml
+++ b/.chloggen/3330-python-otel-logs-exporter.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: auto-instrumentation
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: set OTEL_LOGS_EXPORTER env var to oltp in python instrumentation
+note: set OTEL_LOGS_EXPORTER env var to otlp in python instrumentation
 
 # One or more tracking issues related to the change
 issues: [3330]

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -1259,6 +1259,10 @@ func TestMutatePod(t *testing.T) {
 								Value: "otlp",
 							},
 							{
+								Name:  "OTEL_LOGS_EXPORTER",
+								Value: "otlp",
+							},
+							{
 								Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
 								Value: "http://localhost:4318",
 							},
@@ -1359,6 +1363,10 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_LOGS_EXPORTER",
 									Value: "otlp",
 								},
 								{
@@ -1455,6 +1463,10 @@ func TestMutatePod(t *testing.T) {
 								Value: "otlp",
 							},
 							{
+								Name:  "OTEL_LOGS_EXPORTER",
+								Value: "otlp",
+							},
+							{
 								Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
 								Value: "http://localhost:4318",
 							},
@@ -1563,6 +1575,10 @@ func TestMutatePod(t *testing.T) {
 									Value: "otlp",
 								},
 								{
+									Name:  "OTEL_LOGS_EXPORTER",
+									Value: "otlp",
+								},
+								{
 									Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
 									Value: "http://localhost:4318",
 								},
@@ -1651,6 +1667,10 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_LOGS_EXPORTER",
 									Value: "otlp",
 								},
 								{
@@ -1744,6 +1764,10 @@ func TestMutatePod(t *testing.T) {
 							},
 							{
 								Name:  "OTEL_METRICS_EXPORTER",
+								Value: "otlp",
+							},
+							{
+								Name:  "OTEL_LOGS_EXPORTER",
 								Value: "otlp",
 							},
 							{
@@ -4126,6 +4150,10 @@ func TestMutatePod(t *testing.T) {
 									Value: "otlp",
 								},
 								{
+									Name:  "OTEL_LOGS_EXPORTER",
+									Value: "otlp",
+								},
+								{
 									Name:  "OTEL_SERVICE_NAME",
 									Value: "python1",
 								},
@@ -4198,6 +4226,10 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_LOGS_EXPORTER",
 									Value: "otlp",
 								},
 								{

--- a/pkg/instrumentation/python.go
+++ b/pkg/instrumentation/python.go
@@ -71,7 +71,7 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 		})
 	}
 
-	// Set OTEL_TRACES_EXPORTER to oltp exporter if not set by user because it is what our autoinstrumentation supports.
+	// Set OTEL_TRACES_EXPORTER to otlp exporter if not set by user because it is what our autoinstrumentation supports.
 	idx = getIndexOfEnv(container.Env, envOtelTracesExporter)
 	if idx == -1 {
 		container.Env = append(container.Env, corev1.EnvVar{
@@ -80,7 +80,7 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 		})
 	}
 
-	// Set OTEL_METRICS_EXPORTER to oltp exporter if not set by user because it is what our autoinstrumentation supports.
+	// Set OTEL_METRICS_EXPORTER to otlp exporter if not set by user because it is what our autoinstrumentation supports.
 	idx = getIndexOfEnv(container.Env, envOtelMetricsExporter)
 	if idx == -1 {
 		container.Env = append(container.Env, corev1.EnvVar{
@@ -89,7 +89,7 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 		})
 	}
 
-	// Set OTEL_LOGS_EXPORTER to oltp exporter if not set by user because it is what our autoinstrumentation supports.
+	// Set OTEL_LOGS_EXPORTER to otlp exporter if not set by user because it is what our autoinstrumentation supports.
 	idx = getIndexOfEnv(container.Env, envOtelLogsExporter)
 	if idx == -1 {
 		container.Env = append(container.Env, corev1.EnvVar{

--- a/pkg/instrumentation/python.go
+++ b/pkg/instrumentation/python.go
@@ -26,6 +26,7 @@ const (
 	envPythonPath               = "PYTHONPATH"
 	envOtelTracesExporter       = "OTEL_TRACES_EXPORTER"
 	envOtelMetricsExporter      = "OTEL_METRICS_EXPORTER"
+	envOtelLogsExporter         = "OTEL_LOGS_EXPORTER"
 	envOtelExporterOTLPProtocol = "OTEL_EXPORTER_OTLP_PROTOCOL"
 	pythonPathPrefix            = "/otel-auto-instrumentation-python/opentelemetry/instrumentation/auto_instrumentation"
 	pythonPathSuffix            = "/otel-auto-instrumentation-python"
@@ -70,7 +71,7 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 		})
 	}
 
-	// Set OTEL_TRACES_EXPORTER to HTTP exporter if not set by user because it is what our autoinstrumentation supports.
+	// Set OTEL_TRACES_EXPORTER to oltp exporter if not set by user because it is what our autoinstrumentation supports.
 	idx = getIndexOfEnv(container.Env, envOtelTracesExporter)
 	if idx == -1 {
 		container.Env = append(container.Env, corev1.EnvVar{
@@ -79,11 +80,20 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 		})
 	}
 
-	// Set OTEL_METRICS_EXPORTER to HTTP exporter if not set by user because it is what our autoinstrumentation supports.
+	// Set OTEL_METRICS_EXPORTER to oltp exporter if not set by user because it is what our autoinstrumentation supports.
 	idx = getIndexOfEnv(container.Env, envOtelMetricsExporter)
 	if idx == -1 {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  envOtelMetricsExporter,
+			Value: "otlp",
+		})
+	}
+
+	// Set OTEL_LOGS_EXPORTER to oltp exporter if not set by user because it is what our autoinstrumentation supports.
+	idx = getIndexOfEnv(container.Env, envOtelLogsExporter)
+	if idx == -1 {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  envOtelLogsExporter,
 			Value: "otlp",
 		})
 	}

--- a/pkg/instrumentation/python_test.go
+++ b/pkg/instrumentation/python_test.go
@@ -90,6 +90,10 @@ func TestInjectPythonSDK(t *testing.T) {
 									Name:  "OTEL_METRICS_EXPORTER",
 									Value: "otlp",
 								},
+								{
+									Name:  "OTEL_LOGS_EXPORTER",
+									Value: "otlp",
+								},
 							},
 						},
 					},
@@ -161,6 +165,10 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_LOGS_EXPORTER",
 									Value: "otlp",
 								},
 							},
@@ -235,6 +243,10 @@ func TestInjectPythonSDK(t *testing.T) {
 									Name:  "OTEL_METRICS_EXPORTER",
 									Value: "otlp",
 								},
+								{
+									Name:  "OTEL_LOGS_EXPORTER",
+									Value: "otlp",
+								},
 							},
 						},
 					},
@@ -307,6 +319,86 @@ func TestInjectPythonSDK(t *testing.T) {
 									Name:  "OTEL_TRACES_EXPORTER",
 									Value: "otlp",
 								},
+								{
+									Name:  "OTEL_LOGS_EXPORTER",
+									Value: "otlp",
+								},
+							},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name:   "OTEL_LOGS_EXPORTER defined",
+			Python: v1alpha1.Python{Image: "foo/bar:1"},
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Env: []corev1.EnvVar{
+								{
+									Name:  "OTEL_LOGS_EXPORTER",
+									Value: "somebackend",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "opentelemetry-auto-instrumentation-python",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:    "opentelemetry-auto-instrumentation-python",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "-r", "/autoinstrumentation/.", "/otel-auto-instrumentation-python"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-python",
+								MountPath: "/otel-auto-instrumentation-python",
+							}},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "opentelemetry-auto-instrumentation-python",
+									MountPath: "/otel-auto-instrumentation-python",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "OTEL_LOGS_EXPORTER",
+									Value: "somebackend",
+								},
+								{
+									Name:  "PYTHONPATH",
+									Value: fmt.Sprintf("%s:%s", "/otel-auto-instrumentation-python/opentelemetry/instrumentation/auto_instrumentation", "/otel-auto-instrumentation-python"),
+								},
+								{
+									Name:  "OTEL_EXPORTER_OTLP_PROTOCOL",
+									Value: "http/protobuf",
+								},
+								{
+									Name:  "OTEL_TRACES_EXPORTER",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
+								},
 							},
 						},
 					},
@@ -377,6 +469,10 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
+								},
+								{
+									Name:  "OTEL_LOGS_EXPORTER",
 									Value: "otlp",
 								},
 							},

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -1262,6 +1262,10 @@ func TestInjectPython(t *testing.T) {
 							Value: "otlp",
 						},
 						{
+							Name:  "OTEL_LOGS_EXPORTER",
+							Value: "otlp",
+						},
+						{
 							Name:  "OTEL_SERVICE_NAME",
 							Value: "app",
 						},

--- a/tests/e2e-instrumentation/instrumentation-python-multicontainer/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-multicontainer/01-assert.yaml
@@ -26,6 +26,8 @@ spec:
       value: otlp
     - name: OTEL_METRICS_EXPORTER
       value: otlp
+    - name: OTEL_LOGS_EXPORTER
+      value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://localhost:4317
     - name: OTEL_EXPORTER_OTLP_TIMEOUT
@@ -73,6 +75,8 @@ spec:
     - name: OTEL_TRACES_EXPORTER
       value: otlp
     - name: OTEL_METRICS_EXPORTER
+      value: otlp
+    - name: OTEL_LOGS_EXPORTER
       value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://localhost:4317

--- a/tests/e2e-instrumentation/instrumentation-python-multicontainer/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-multicontainer/02-assert.yaml
@@ -37,6 +37,8 @@ spec:
       value: otlp
     - name: OTEL_METRICS_EXPORTER
       value: otlp
+    - name: OTEL_LOGS_EXPORTER
+      value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://localhost:4317
     - name: OTEL_EXPORTER_OTLP_TIMEOUT

--- a/tests/e2e-instrumentation/instrumentation-python/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/01-assert.yaml
@@ -29,6 +29,8 @@ spec:
       value: http/protobuf
     - name: OTEL_METRICS_EXPORTER
       value: otlp
+    - name: OTEL_LOGS_EXPORTER
+      value: otlp
     - name: OTEL_EXPORTER_OTLP_TIMEOUT
       value: "20"
     - name: OTEL_TRACES_SAMPLER

--- a/tests/e2e-instrumentation/instrumentation-python/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/01-assert.yaml
@@ -21,6 +21,8 @@ spec:
       value: debug
     - name: OTEL_TRACES_EXPORTER
       value: otlp
+    - name: OTEL_LOGS_EXPORTER
+      value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://localhost:4318
     - name: PYTHONPATH

--- a/tests/e2e-instrumentation/instrumentation-python/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/01-assert.yaml
@@ -21,8 +21,6 @@ spec:
       value: debug
     - name: OTEL_TRACES_EXPORTER
       value: otlp
-    - name: OTEL_LOGS_EXPORTER
-      value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://localhost:4318
     - name: PYTHONPATH

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer-go/02-assert.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer-go/02-assert.yaml
@@ -43,6 +43,8 @@ spec:
       value: otlp
     - name: OTEL_METRICS_EXPORTER
       value: otlp
+    - name: OTEL_LOGS_EXPORTER
+      value: otlp
     - name: OTEL_EXPORTER_OTLP_TIMEOUT
       value: "20"
     - name: OTEL_TRACES_SAMPLER

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/01-assert.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/01-assert.yaml
@@ -185,6 +185,8 @@ spec:
       value: otlp
     - name: OTEL_METRICS_EXPORTER
       value: otlp
+    - name: OTEL_LOGS_EXPORTER
+      value: otlp
     - name: OTEL_TRACES_SAMPLER
       value: parentbased_traceidratio
     - name: OTEL_TRACES_SAMPLER_ARG


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Set `OTEL_LOGS_EXPORTER` to `otlp` to match the other signals. Logging is still disabled because it requires `OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED` set to true but that's a bigger change and may require a discussion.

**Link to tracking Issue(s):** 

- Resolves: none

**Testing:**

make test

**Documentation:** 
