### PR TITLE
[Chore] Update test export-to-cluster-logging-lokistack to detect storageclass

### DIFF
--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/chainsaw-test.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/chainsaw-test.yaml
@@ -20,6 +20,16 @@ spec:
         file: install-minio-assert.yaml
   - name: Create the LokiStack instance
     try:
+    - command:
+        entrypoint: oc
+        args:
+        - get
+        - storageclass
+        - -o
+        - jsonpath={.items[0].metadata.name}
+        outputs:
+        - name: STORAGE_CLASS_NAME
+          value: ($stdout)
     - apply:
         file: install-loki.yaml
     - assert:

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-loki.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-loki.yaml
@@ -12,6 +12,6 @@ spec:
     secret:
       name: logging-loki-s3 
       type: s3
-  storageClassName: gp2-csi
+  storageClassName: ($STORAGE_CLASS_NAME)
   tenants:
     mode: openshift-logging


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Update the test to detect storageclass available on the cluster. 
```
% oc get storageclasses.storage.k8s.io 
NAME                     PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
ssd-csi                  pd.csi.storage.gke.io   Delete          WaitForFirstConsumer   true                   3h56m
standard-csi (default)   pd.csi.storage.gke.io   Delete          WaitForFirstConsumer   true                   3h56m

--- PASS: chainsaw (0.00s)
    --- PASS: chainsaw/export-to-cluster-logging-lokistack (192.23s)
PASS
Tests Summary...
- Passed  tests 1
- Failed  tests 0
- Skipped tests 0
Done.
```
