### PR TITLE
Fix upgrade testing

### DIFF
--- a/pkg/collector/upgrade/suite_test.go
+++ b/pkg/collector/upgrade/suite_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/rbac"
+	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 )
 
 var (
@@ -159,4 +160,10 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(code)
+}
+
+func makeVersion(v string) version.Version {
+	return version.Version{
+		OpenTelemetryCollector: v,
+	}
 }

--- a/pkg/collector/upgrade/v0_104_0_test.go
+++ b/pkg/collector/upgrade/v0_104_0_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -46,7 +45,7 @@ func Test0_104_0Upgrade(t *testing.T) {
 
 	versionUpgrade := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.104.0"),
 		Client:   k8sClient,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}
@@ -56,7 +55,9 @@ func Test0_104_0Upgrade(t *testing.T) {
 		t.Errorf("expect err: nil but got: %v", err)
 	}
 	assert.EqualValues(t,
-		map[string]string{},
+		map[string]string{
+			"feature-gates": "-component.UseLocalHostAsDefaultHost",
+		},
 		col.Spec.Args, "missing featuregate")
 }
 

--- a/pkg/collector/upgrade/v0_105_0_test.go
+++ b/pkg/collector/upgrade/v0_105_0_test.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -59,7 +58,7 @@ func Test0_105_0Upgrade(t *testing.T) {
 
 	versionUpgrade := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.105.0"),
 		Client:   k8sClient,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_15_0_test.go
+++ b/pkg/collector/upgrade/v0_15_0_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -57,7 +56,7 @@ func TestRemoveMetricsTypeFlags(t *testing.T) {
 	// test
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.15.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_19_0_test.go
+++ b/pkg/collector/upgrade/v0_19_0_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/adapters"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -74,7 +73,7 @@ service:
 	// test
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.19.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}
@@ -124,7 +123,7 @@ service:
 	// test
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.19.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}
@@ -191,7 +190,7 @@ service:
 	// test
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.19.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_24_0_test.go
+++ b/pkg/collector/upgrade/v0_24_0_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -64,7 +63,7 @@ service:
 	// test
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.24.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_31_0_test.go
+++ b/pkg/collector/upgrade/v0_31_0_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -63,7 +62,7 @@ service:
 	// test
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.31.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_36_0_test.go
+++ b/pkg/collector/upgrade/v0_36_0_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -79,7 +78,7 @@ service:
 
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.36.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_38_0_test.go
+++ b/pkg/collector/upgrade/v0_38_0_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -72,7 +71,7 @@ service:
 	// EXPECTED: drop logging args and configure logging parameters into config from args
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.38.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_39_0_test.go
+++ b/pkg/collector/upgrade/v0_39_0_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -74,7 +73,7 @@ service:
 	// drop processors.memory_limiter field 'ballast_size_mib'
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.39.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_41_0_test.go
+++ b/pkg/collector/upgrade/v0_41_0_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -64,7 +63,7 @@ service:
 	// TESTCASE 1: restructure cors for both allowed_origin & allowed_headers
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.41.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_43_0_test.go
+++ b/pkg/collector/upgrade/v0_43_0_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -70,7 +69,7 @@ service:
 	// test
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.43.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_56_0_test.go
+++ b/pkg/collector/upgrade/v0_56_0_test.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -50,7 +49,7 @@ func Test0_56_0Upgrade(t *testing.T) {
 	collectorInstance.Status.Version = "0.55.0"
 	versionUpgrade := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.56.0"),
 		Client:   k8sClient,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_57_2_test.go
+++ b/pkg/collector/upgrade/v0_57_2_test.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -67,7 +66,7 @@ service:
 	//Test to remove port and change endpoint value.
 	versionUpgrade := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.57.2"),
 		Client:   k8sClient,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}

--- a/pkg/collector/upgrade/v0_61_0_test.go
+++ b/pkg/collector/upgrade/v0_61_0_test.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -72,7 +71,7 @@ func Test0_61_0Upgrade(t *testing.T) {
 
 			versionUpgrade := &upgrade.VersionUpgrade{
 				Log:      logger,
-				Version:  version.Get(),
+				Version:  makeVersion("0.61.0"),
 				Client:   k8sClient,
 				Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 			}

--- a/pkg/collector/upgrade/v0_9_0_test.go
+++ b/pkg/collector/upgrade/v0_9_0_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/collector/upgrade"
 )
 
@@ -56,7 +55,7 @@ func TestRemoveConnectionDelay(t *testing.T) {
 	// test
 	up := &upgrade.VersionUpgrade{
 		Log:      logger,
-		Version:  version.Get(),
+		Version:  makeVersion("0.9.0"),
 		Client:   nil,
 		Recorder: record.NewFakeRecorder(upgrade.RecordBufferSize),
 	}


### PR DESCRIPTION
**Description:** Fixes a bug in the upgrade testing that ran all the upgrades despite a version being set. This will now let us run each upgrades in isolation (future upgrades will not effect the current one.) i.e. a test for 0.9.0 would have to take 0.15.0 into account, this is no longer the case.
