### PR TITLE
Add handling of environment variables from ConfigMaps and Secrets

### DIFF
--- a/.chloggen/enhancement-envs-from-configmap.yaml
+++ b/.chloggen/enhancement-envs-from-configmap.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for detecting and reading environment variables from POD's ConfigMap resources.
+
+# One or more tracking issues related to the change
+issues: [1393, 1814]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Now the auto-instrumentation will see the environment variables defined via POD's `env.valueFrom.configMapKeyRef` and
+  `envFrom.configMapRef` fields, so the auto-instrumentation will be able to prevent overriding them, or it will be able
+  to extend the existing definition.

--- a/.chloggen/enhancement-envs-from-secret.yaml
+++ b/.chloggen/enhancement-envs-from-secret.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for detecting and reading environment variables from POD's Secret resources.
+
+# One or more tracking issues related to the change
+issues: [1393, 1814]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Now the auto-instrumentation will see the environment variables defined via POD's `env.valueFrom.secretKeyRef` and
+  `envFrom.secretRef` fields, so the auto-instrumentation will be able to prevent overriding them, or it will be able to
+  extend the existing definition.

--- a/pkg/instrumentation/container.go
+++ b/pkg/instrumentation/container.go
@@ -1,0 +1,336 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instrumentation
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Container struct {
+	client       client.Reader
+	ctx          context.Context
+	logger       logr.Logger
+	namespace    string
+	index        int
+	inheritedEnv map[string]string
+	configMaps   map[string]*corev1.ConfigMap
+}
+
+func NewContainer(client client.Reader, ctx context.Context, logger logr.Logger, namespace string, pod *corev1.Pod, index int) (Container, error) {
+	if pod.Namespace != "" {
+		namespace = pod.Namespace
+	}
+	container := &pod.Spec.Containers[index]
+
+	configMaps := make(map[string]*corev1.ConfigMap)
+	inheritedEnv := make(map[string]string)
+	for _, envsFrom := range container.EnvFrom {
+		if envsFrom.ConfigMapRef != nil {
+			prefix := envsFrom.Prefix
+			name := envsFrom.ConfigMapRef.Name
+			if cm, err := getOrLoadResource(client, ctx, namespace, configMaps, name); err == nil {
+				for k, v := range cm.Data {
+					// Safely overwrite the value, last one from EnvFrom wins in Kubernetes, with the direct value
+					// from the container itself taking precedence
+					inheritedEnv[prefix+k] = v
+				}
+			} else if envsFrom.ConfigMapRef.Optional == nil || !*envsFrom.ConfigMapRef.Optional {
+				return Container{}, fmt.Errorf("failed to load environment variables: %w", err)
+			}
+		} else if envsFrom.SecretRef != nil {
+			logger.V(2).Info("ignoring SecretRef in EnvFrom", "container", container.Name, "secret", envsFrom.SecretRef.Name)
+		}
+	}
+
+	if len(inheritedEnv) == 0 {
+		inheritedEnv = nil
+	}
+
+	return Container{
+		client:       client,
+		ctx:          ctx,
+		logger:       logger,
+		namespace:    namespace,
+		index:        index,
+		inheritedEnv: inheritedEnv,
+		configMaps:   configMaps,
+	}, nil
+}
+
+func getOrLoadResource[T any, PT interface {
+	client.Object
+	*T
+}](client client.Reader, ctx context.Context, namespace string, cache map[string]*T, name string) (*T, error) {
+	var obj T
+	if cached, ok := cache[name]; ok {
+		if cached != nil {
+			return cached, nil
+		} else {
+			return nil, fmt.Errorf("failed to get %s %s/%s", reflect.TypeOf(obj).Name(), namespace, name)
+		}
+	}
+
+	if client == nil || ctx == nil {
+		// Cache error value
+		cache[name] = nil
+		return nil, fmt.Errorf("client or context is nil, cannot load %s %s/%s", reflect.TypeOf(obj).Name(), namespace, name)
+	}
+
+	err := client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, PT(&obj))
+	if err != nil {
+		// Cache error value
+		cache[name] = nil
+		return nil, fmt.Errorf("failed to get %s %s/%s: %w", reflect.TypeOf(obj).Name(), namespace, name, err)
+	}
+
+	cache[name] = &obj
+	return &obj, nil
+}
+
+func (c *Container) validate(pod *corev1.Pod, envsToBeValidated ...string) error {
+	// Try if the value is resolvable
+	for _, envToBeValidated := range envsToBeValidated {
+		for _, envVar := range pod.Spec.Containers[c.index].Env {
+			if envVar.Name == envToBeValidated {
+				if _, err := c.resolveEnvVar(envVar); err != nil {
+					return err
+				}
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func getContainerIndex(pod *corev1.Pod, containerName string) int {
+	// We search for specific container to inject variables and if no one is found
+	// We fall back to the first container
+	var index = 0
+	for idx, container := range pod.Spec.Containers {
+		if container.Name == containerName {
+			index = idx
+		}
+	}
+
+	return index
+}
+
+func (c *Container) exists(pod *corev1.Pod, name string) bool {
+	if found := existsEnvVarInEnv(pod.Spec.Containers[c.index].Env, name); found {
+		return found
+	}
+	if _, found := c.inheritedEnv[name]; found {
+		return found
+	}
+	return false
+}
+
+func (c *Container) setOrAppendEnvVar(pod *corev1.Pod, envVar corev1.EnvVar) {
+	if idx, found := findEnvVarInEnv(pod.Spec.Containers[c.index].Env, envVar.Name); found {
+		pod.Spec.Containers[c.index].Env[idx] = envVar
+	} else {
+		c.appendEnvVar(pod, envVar)
+	}
+}
+
+func (c *Container) getOrMakeEnvVar(pod *corev1.Pod, name string) (corev1.EnvVar, error) {
+	var envVar corev1.EnvVar
+	var idx int
+	var found bool
+	if idx, found = findEnvVarInEnv(pod.Spec.Containers[c.index].Env, name); found {
+		envVar = pod.Spec.Containers[c.index].Env[idx]
+	} else if envVar, found = getEnvVarFromMap(c.inheritedEnv, name); found {
+		// do nothing
+	} else {
+		envVar = corev1.EnvVar{Name: name}
+	}
+	return c.resolveEnvVar(envVar)
+}
+
+func (c *Container) resolveEnvVar(envVar corev1.EnvVar) (corev1.EnvVar, error) {
+	if envVar.Value == "" && envVar.ValueFrom != nil {
+		if envVar.ValueFrom.ConfigMapKeyRef != nil {
+			configMapName := envVar.ValueFrom.ConfigMapKeyRef.Name
+			configMapKey := envVar.ValueFrom.ConfigMapKeyRef.Key
+			if cm, err := getOrLoadResource(c.client, c.ctx, c.namespace, c.configMaps, configMapName); err == nil {
+				if value, ok := cm.Data[configMapKey]; ok {
+					return corev1.EnvVar{Name: envVar.Name, Value: value}, nil
+				} else if envVar.ValueFrom.ConfigMapKeyRef.Optional == nil || !*envVar.ValueFrom.ConfigMapKeyRef.Optional {
+					return corev1.EnvVar{}, fmt.Errorf("failed to resolve environment variable %s, key %s not found in ConfigMap %s/%s", envVar.Name, configMapKey, c.namespace, configMapName)
+				} else {
+					return corev1.EnvVar{Name: envVar.Name, Value: ""}, nil
+				}
+			} else if envVar.ValueFrom.ConfigMapKeyRef.Optional == nil || !*envVar.ValueFrom.ConfigMapKeyRef.Optional {
+				return corev1.EnvVar{}, fmt.Errorf("failed to resolve environment variable %s: %w", envVar.Name, err)
+			} else {
+				return corev1.EnvVar{Name: envVar.Name, Value: ""}, nil
+			}
+		} else {
+			v := reflect.ValueOf(*envVar.ValueFrom)
+			for i := 0; i < v.NumField(); i++ {
+				if v.Field(i).Kind() == reflect.Ptr && !v.Field(i).IsNil() {
+					return corev1.EnvVar{}, fmt.Errorf("the container defines env var value via ValueFrom.%s, envVar: %s", v.Type().Field(i).Name, envVar.Name)
+				}
+			}
+			return corev1.EnvVar{}, fmt.Errorf("the container defines env var value via ValueFrom, envVar: %s", envVar.Name)
+		}
+	}
+	return envVar, nil
+}
+
+func existsEnvVarInEnv(env []corev1.EnvVar, name string) bool {
+	for i := range env {
+		if env[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func findEnvVarInEnv(env []corev1.EnvVar, name string) (int, bool) {
+	for i := range env {
+		if env[i].Name == name {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func getEnvVarFromMap(env map[string]string, name string) (corev1.EnvVar, bool) {
+	if value, ok := env[name]; ok {
+		return corev1.EnvVar{Name: name, Value: value}, true
+	}
+	return corev1.EnvVar{}, false
+}
+
+func (c *Container) prependEnvVar(pod *corev1.Pod, envVar corev1.EnvVar) {
+	pod.Spec.Containers[c.index].Env = append([]corev1.EnvVar{envVar}, pod.Spec.Containers[c.index].Env...)
+}
+
+func (c *Container) prepend(pod *corev1.Pod, name string, value string) {
+	c.prependEnvVar(pod, corev1.EnvVar{Name: name, Value: value})
+}
+
+func (c *Container) appendEnvVar(pod *corev1.Pod, envVar corev1.EnvVar) {
+	pod.Spec.Containers[c.index].Env = append(pod.Spec.Containers[c.index].Env, envVar)
+}
+
+func (c *Container) append(pod *corev1.Pod, name string, value string) {
+	c.appendEnvVar(pod, corev1.EnvVar{Name: name, Value: value})
+}
+
+func (c *Container) prependIfNotExists(pod *corev1.Pod, name string, value string) {
+	if !c.exists(pod, name) {
+		c.prepend(pod, name, value)
+	}
+}
+
+func (c *Container) prependEnvVarIfNotExists(pod *corev1.Pod, envVar corev1.EnvVar) {
+	if !c.exists(pod, envVar.Name) {
+		c.prependEnvVar(pod, envVar)
+	}
+}
+
+func (c *Container) appendIfNotExists(pod *corev1.Pod, name string, value string) {
+	if !c.exists(pod, name) {
+		c.append(pod, name, value)
+	}
+}
+
+func (c *Container) appendEnvVarIfNotExists(pod *corev1.Pod, envVar corev1.EnvVar) {
+	if !c.exists(pod, envVar.Name) {
+		c.appendEnvVar(pod, envVar)
+	}
+}
+
+//goland:noinspection SpellCheckingInspection
+type Concatter interface {
+	Concat(vals ...string) string
+}
+
+type ConcatFunc func(vals ...string) string
+
+func (f ConcatFunc) Concat(vals ...string) string {
+	return f(vals...)
+}
+
+func (c *Container) appendOrConcat(pod *corev1.Pod, name string, value string, concatter Concatter) error {
+	if concatter == nil {
+		return fmt.Errorf("concatter is nil")
+	}
+
+	if envVar, err := c.getOrMakeEnvVar(pod, name); err == nil {
+		envVar.Value = concatter.Concat(envVar.Value, value)
+		c.setOrAppendEnvVar(pod, envVar)
+		return nil
+	} else {
+		return err
+	}
+}
+
+func (c *Container) moveToListEnd(pod *corev1.Pod, name string) {
+	if idx, ok := findEnvVarInEnv(pod.Spec.Containers[c.index].Env, name); ok {
+		envToMove := pod.Spec.Containers[c.index].Env[idx]
+		envs := append(pod.Spec.Containers[c.index].Env[:idx], pod.Spec.Containers[c.index].Env[idx+1:]...)
+		pod.Spec.Containers[c.index].Env = append(envs, envToMove)
+	}
+}
+
+func concatWithCharacterChecked(val1, val2, char string) string {
+	if val1 != "" {
+		if val2 != "" {
+			if val1[len(val1)-1:] == char {
+				if val2[:1] == char {
+					return val1 + val2[1:]
+				} else {
+					return val1 + val2
+				}
+			} else {
+				return val1 + char + val2
+			}
+		} else {
+			return val1
+		}
+	} else {
+		return val2
+	}
+}
+
+func concatWithCharacter(char string, vals ...string) string {
+	result := ""
+	for _, val := range vals {
+		result = concatWithCharacterChecked(result, val, char)
+	}
+	return result
+}
+
+func concatWithSpace(vals ...string) string {
+	return concatWithCharacter(" ", vals...)
+}
+
+func concatWithComma(vals ...string) string {
+	return concatWithCharacter(",", vals...)
+}
+
+func concatWithColon(vals ...string) string {
+	return concatWithCharacter(":", vals...)
+}

--- a/pkg/instrumentation/container_test.go
+++ b/pkg/instrumentation/container_test.go
@@ -1,0 +1,1397 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instrumentation
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewConfigMapRef(name string, prefix string, optional *bool) corev1.EnvFromSource {
+	return corev1.EnvFromSource{
+		Prefix: prefix,
+		ConfigMapRef: &corev1.ConfigMapEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: name,
+			},
+			Optional: optional,
+		},
+	}
+}
+
+func NewSecretRef(name string, prefix string, optional *bool) corev1.EnvFromSource {
+	return corev1.EnvFromSource{
+		Prefix: prefix,
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: name,
+			},
+			Optional: optional,
+		},
+	}
+}
+
+func NewConfigMapKeyRef(name string, key string, optional *bool) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: name,
+			},
+			Key:      key,
+			Optional: optional,
+		},
+	}
+}
+
+func NewSecretKeyRef(name string, key string, optional *bool) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: name,
+			},
+			Key:      key,
+			Optional: optional,
+		},
+	}
+}
+
+func NewFieldRef(fieldPath string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		FieldRef: &corev1.ObjectFieldSelector{
+			FieldPath: fieldPath,
+		},
+	}
+}
+
+func NewResourceFieldRef(containerName string, resource string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		ResourceFieldRef: &corev1.ResourceFieldSelector{
+			ContainerName: containerName,
+			Resource:      resource,
+		},
+	}
+}
+
+func NewStringLogger() (logr.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	logFunc := func(prefix, args string) { buf.WriteString(prefix + args + "\n") }
+	options := funcr.Options{Verbosity: 4}
+	logger := funcr.New(logFunc, options)
+	return logger, &buf
+}
+
+func TestFindContainerByName(t *testing.T) {
+	tests := []struct {
+		name      string
+		container string
+		pod       corev1.Pod
+		expected  int
+	}{
+		{
+			name:      "Container found by name",
+			container: "my-container",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "my-container"},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name:      "Containter found by name between multiple containers",
+			container: "my-container2",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "my-container1"},
+						{Name: "my-container2"},
+					},
+				},
+			},
+			expected: 1,
+		},
+		{
+			name:      "Default container returned",
+			container: "",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "my-container1"},
+						{Name: "my-container2"},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name:      "No matching container found, default returned",
+			container: "no-match",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "my-container1"},
+						{Name: "my-container2"},
+					},
+				},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := test.pod
+			index := getContainerIndex(&pod, test.container)
+			assert.Equal(t, test.expected, index)
+		})
+	}
+}
+
+func TestInheritedEnv(t *testing.T) {
+	true := true
+	false := false
+
+	tests := []struct {
+		name     string
+		ns       corev1.Namespace
+		cm       []corev1.ConfigMap
+		secret   []corev1.Secret
+		pod      corev1.Pod
+		err      string
+		log      string
+		expected map[string]string
+	}{
+		{
+			name: "No ConfigMap usage",
+			ns: corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "inheritedenv-noconfigmap",
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-pod",
+					Namespace: "inheritedenv-noconfigmapv",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app"}},
+				},
+			},
+		},
+		{
+			name: "Simple ConfigMap usage",
+			ns: corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "inheritedenv-simple",
+				},
+			},
+			cm: []corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-config",
+						Namespace: "inheritedenv-simple",
+					},
+					Data: map[string]string{
+						"OTEL_SERVICE_NAME":       "my-service",
+						"OTEL_TRACES_SAMPLER_ARG": "0.85",
+					},
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-pod",
+					Namespace: "inheritedenv-simple",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "app",
+							EnvFrom: []corev1.EnvFromSource{NewConfigMapRef("my-config", "", nil)},
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				"OTEL_SERVICE_NAME":       "my-service",
+				"OTEL_TRACES_SAMPLER_ARG": "0.85",
+			},
+		},
+		{
+			name: "Multiple ConfigMap usage with overriding",
+			ns: corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "inheritedenv-multiple",
+				},
+			},
+			cm: []corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-config",
+						Namespace: "inheritedenv-multiple",
+					},
+					Data: map[string]string{
+						"OTEL_SERVICE_NAME":       "my-service",
+						"OTEL_TRACES_SAMPLER":     "parentbased_traceidratio",
+						"OTEL_TRACES_SAMPLER_ARG": "0.85",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-another-config",
+						Namespace: "inheritedenv-multiple",
+					},
+					Data: map[string]string{
+						"OTEL_TRACES_SAMPLER_ARG": "0.95",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-prefixed-config",
+						Namespace: "inheritedenv-multiple",
+					},
+					Data: map[string]string{
+						"EXPORTER_OTLP_TIMEOUT": "20",
+					},
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-pod",
+					Namespace: "inheritedenv-multiple",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "app",
+							EnvFrom: []corev1.EnvFromSource{
+								NewConfigMapRef("my-config", "", nil),
+								NewConfigMapRef("my-another-config", "", nil),
+								NewConfigMapRef("my-prefixed-config", "OTEL_", nil),
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				"OTEL_SERVICE_NAME":          "my-service",
+				"OTEL_TRACES_SAMPLER":        "parentbased_traceidratio",
+				"OTEL_TRACES_SAMPLER_ARG":    "0.95",
+				"OTEL_EXPORTER_OTLP_TIMEOUT": "20",
+			},
+		},
+		{
+			name: "Optional ConfigMap not found",
+			ns: corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "inheritedenv-notfoundoptional",
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-pod",
+					Namespace: "inheritedenv-notfoundoptional",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "app",
+							EnvFrom: []corev1.EnvFromSource{
+								NewConfigMapRef("my-config", "", &true),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Implicitly mandatory ConfigMap not found",
+			ns: corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "inheritedenv-notfoundimplicit",
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-pod",
+					Namespace: "inheritedenv-notfoundimplicit",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "app",
+							EnvFrom: []corev1.EnvFromSource{
+								NewConfigMapRef("my-config", "", nil),
+							},
+						},
+					},
+				},
+			},
+			err: "failed to get ConfigMap inheritedenv-notfoundimplicit/my-config",
+		},
+		{
+			name: "Explicitly mandatory ConfigMap not found",
+			ns: corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "inheritedenv-notfoundexplicit",
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-pod",
+					Namespace: "inheritedenv-notfoundexplicit",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "app",
+							EnvFrom: []corev1.EnvFromSource{
+								NewConfigMapRef("my-config", "", &false),
+							},
+						},
+					},
+				},
+			},
+			err: "failed to get ConfigMap inheritedenv-notfoundexplicit/my-config",
+		},
+		{
+			name: "SecretRef not supported",
+			ns: corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "inheritedenv-secretref",
+				},
+			},
+			secret: []corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-secret",
+						Namespace: "inheritedenv-secretref",
+					},
+					Data: map[string][]byte{
+						"OTEL_ENVFROM_SECRET_VALUE1": []byte("my-secret-value1"),
+					},
+				},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-pod",
+					Namespace: "inheritedenv-secretref",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "app",
+							EnvFrom: []corev1.EnvFromSource{
+								NewSecretRef("my-secret", "", nil),
+							},
+						},
+					},
+				},
+			},
+			log: "ignoring SecretRef in EnvFrom",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			err := k8sClient.Create(context.Background(), &test.ns)
+			require.NoError(t, err)
+			defer func() {
+				_ = k8sClient.Delete(context.Background(), &test.ns)
+			}()
+
+			for _, cm := range test.cm {
+				cm := cm
+				err = k8sClient.Create(context.Background(), &cm)
+				require.NoError(t, err)
+				//goland:noinspection GoDeferInLoop
+				defer func() {
+					_ = k8sClient.Delete(context.Background(), &cm)
+				}()
+			}
+			for _, secret := range test.secret {
+				secret := secret
+				err = k8sClient.Create(context.Background(), &secret)
+				require.NoError(t, err)
+				//goland:noinspection GoDeferInLoop
+				defer func() {
+					_ = k8sClient.Delete(context.Background(), &secret)
+				}()
+			}
+
+			pod := test.pod
+			logger, buf := NewStringLogger()
+			container, err := NewContainer(k8sClient, context.Background(), logger, test.ns.Name, &pod, 0)
+			if test.err == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, container.inheritedEnv)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.err)
+			}
+			if test.log != "" {
+				assert.Contains(t, buf.String(), test.log)
+			}
+		})
+	}
+}
+
+type ModificationTester interface {
+	Test(pod *corev1.Pod, c Container)
+}
+
+type ModificationTestFunc func(pod *corev1.Pod, c Container)
+
+func (f ModificationTestFunc) Test(pod *corev1.Pod, c Container) {
+	f(pod, c)
+}
+
+var _ ModificationTester = ModificationTestFunc(nil)
+
+func TestModifications(t *testing.T) {
+	testNs := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "modifications",
+		},
+	}
+	testCm := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-config",
+				Namespace: "modifications",
+			},
+			Data: map[string]string{
+				"OTEL_ENVFROM_VALUE1": "my-envfrom-value1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-refconfig",
+				Namespace: "modifications",
+			},
+			Data: map[string]string{
+				"ref-value1": "my-valuefrom-value1",
+			},
+		},
+	}
+	testSecret := []corev1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-secret",
+				Namespace: "modifications",
+			},
+			Data: map[string][]byte{
+				"OTEL_ENVFROM_SECRET_VALUE1": []byte("my-secret-value1"),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-refsecret",
+				Namespace: "modifications",
+			},
+			Data: map[string][]byte{
+				"secret-ref-value1": []byte("my-valuefrom-value1"),
+			},
+		},
+	}
+	testPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-pod",
+			Namespace: "modifications",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					EnvFrom: []corev1.EnvFromSource{
+						{
+							ConfigMapRef: &corev1.ConfigMapEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "my-config",
+								},
+							},
+						},
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "OTEL_ENV_VALUE1",
+							Value: "my-env-value1",
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_CONFIGMAP1",
+							ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil),
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_SECRET1",
+							ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		tester   ModificationTester
+		expected []corev1.EnvVar
+	}{
+		{
+			name: "Test prepend",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.prepend(pod, "OTEL_ENV_VALUE2", "my-env-value2")
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"},
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+			},
+		},
+		{
+			name: "Test prependEnvVar",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.prependEnvVar(pod, corev1.EnvVar{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"})
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"},
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+			},
+		},
+		{
+			name: "Test append",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.append(pod, "OTEL_ENV_VALUE2", "my-env-value2")
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"},
+			},
+		},
+		{
+			name: "Test appendEnvVar",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.appendEnvVar(pod, corev1.EnvVar{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"})
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"},
+			},
+		},
+		{
+			name: "Test prependIfNotExists when env var does not exist",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.prependIfNotExists(pod, "OTEL_ENV_VALUE2", "my-env-value2")
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"},
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+			},
+		},
+		{
+			name: "Test prependIfNotExists when env var exists",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.prependIfNotExists(pod, "OTEL_ENV_VALUE1", "my-overridden-value1")
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+			},
+		},
+		{
+			name: "Test prependEnvVarIfNotExists when env var does not exist",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.prependEnvVarIfNotExists(pod, corev1.EnvVar{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"})
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"},
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+			},
+		},
+		{
+			name: "Test prependEnvVarIfNotExists when env var exists",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.prependEnvVarIfNotExists(pod, corev1.EnvVar{Name: "OTEL_ENV_VALUE1", Value: "my-overridden-value1"})
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+			},
+		},
+		{
+			name: "Test appendIfNotExists when env var does not exist",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.appendIfNotExists(pod, "OTEL_ENV_VALUE2", "my-env-value2")
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"},
+			},
+		},
+		{
+			name: "Test appendIfNotExists when env var exists",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.appendIfNotExists(pod, "OTEL_ENV_VALUE1", "my-overridden-value1")
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+			},
+		},
+		{
+			name: "Test appendEnvVarIfNotExists when env var does not exist",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.appendEnvVarIfNotExists(pod, corev1.EnvVar{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"})
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"},
+			},
+		},
+		{
+			name: "Test appendEnvVarIfNotExists when env var exists",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.appendEnvVarIfNotExists(pod, corev1.EnvVar{Name: "OTEL_ENV_VALUE1", Value: "my-overridden-value1"})
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+			},
+		},
+		{
+			name: "Test setOrAppendEnvVar when env var does not exist",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.setOrAppendEnvVar(pod, corev1.EnvVar{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"})
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUE2", Value: "my-env-value2"},
+			},
+		},
+		{
+			name: "Test setOrAppendEnvVar when env var exists in Env",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.setOrAppendEnvVar(pod, corev1.EnvVar{Name: "OTEL_ENV_VALUE1", Value: "my-overridden-value1"})
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-overridden-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+			},
+		},
+		{
+			name: "Test setOrAppendEnvVar when env var exists as ConfigMapKeyRef",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.setOrAppendEnvVar(pod, corev1.EnvVar{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", Value: "my-overridden-value1"})
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", Value: "my-overridden-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+			},
+		},
+		{
+			name: "Test setOrAppendEnvVar on existing unsupported env var",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.setOrAppendEnvVar(pod, corev1.EnvVar{Name: "OTEL_ENV_VALUEFROM_SECRET1", Value: "my-overridden-value1"})
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", Value: "my-overridden-value1"},
+			},
+		},
+		{
+			name: "Test moveToListEnd when env var exists",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.moveToListEnd(pod, "OTEL_ENV_VALUE1")
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+			},
+		},
+		{
+			name: "Test moveToListEnd when env var does not exist",
+			pod:  &testPod,
+			tester: ModificationTestFunc(func(pod *corev1.Pod, c Container) {
+				c.moveToListEnd(pod, "OTEL_ENV_VALUE2")
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE1", Value: "my-env-value1"},
+				{Name: "OTEL_ENV_VALUEFROM_CONFIGMAP1", ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil)},
+				{Name: "OTEL_ENV_VALUEFROM_SECRET1", ValueFrom: NewSecretKeyRef("my-secret-refconfig", "secret-ref-value1", nil)},
+			},
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), &testNs)
+	require.NoError(t, err)
+	defer func() {
+		_ = k8sClient.Delete(context.Background(), &testNs)
+	}()
+
+	for _, cm := range testCm {
+		cm := cm
+		err = k8sClient.Create(context.Background(), &cm)
+		require.NoError(t, err)
+		//goland:noinspection GoDeferInLoop
+		defer func() {
+			_ = k8sClient.Delete(context.Background(), &cm)
+		}()
+	}
+	for _, secret := range testSecret {
+		secret := secret
+		err = k8sClient.Create(context.Background(), &secret)
+		require.NoError(t, err)
+		//goland:noinspection GoDeferInLoop
+		defer func() {
+			_ = k8sClient.Delete(context.Background(), &secret)
+		}()
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			pod := test.pod.DeepCopy()
+
+			container, err := NewContainer(k8sClient, context.Background(), logr.Discard(), testNs.Name, pod, 0)
+			require.NoError(t, err)
+			test.tester.Test(pod, container)
+			assert.Equal(t, test.expected, pod.Spec.Containers[0].Env)
+		})
+	}
+}
+
+type LoadConfigMapTester interface {
+	Test(client client.Reader, ctx context.Context, configMaps map[string]*corev1.ConfigMap) (*corev1.ConfigMap, error)
+}
+
+type LoadConfigMapTestFunc func(client client.Reader, ctx context.Context, configMaps map[string]*corev1.ConfigMap) (*corev1.ConfigMap, error)
+
+func (f LoadConfigMapTestFunc) Test(client client.Reader, ctx context.Context, configMaps map[string]*corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return f(client, ctx, configMaps)
+}
+
+var _ LoadConfigMapTester = LoadConfigMapTestFunc(nil)
+
+func TestLoadConfigMap(t *testing.T) {
+	testNs := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "loadconfigmap",
+		},
+	}
+	testCm := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-config",
+				Namespace: "loadconfigmap",
+			},
+			Data: map[string]string{
+				"OTEL_ENVFROM_VALUE1": "my-envfrom-value1",
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		tester   LoadConfigMapTester
+		err      string
+		expected map[string]map[string]string
+	}{
+		{
+			name: "Test loading of ConfigMap",
+			tester: LoadConfigMapTestFunc(func(client client.Reader, ctx context.Context, configMaps map[string]*corev1.ConfigMap) (*corev1.ConfigMap, error) {
+				return getOrLoadResource(client, ctx, "loadconfigmap", configMaps, "my-config")
+			}),
+			expected: map[string]map[string]string{
+				"my-config": {"OTEL_ENVFROM_VALUE1": "my-envfrom-value1"},
+			},
+		},
+		{
+			name: "Test cached loading of ConfigMap",
+			tester: LoadConfigMapTestFunc(func(client client.Reader, ctx context.Context, configMaps map[string]*corev1.ConfigMap) (*corev1.ConfigMap, error) {
+				_, _ = getOrLoadResource(client, ctx, "loadconfigmap", configMaps, "my-config")
+				return getOrLoadResource(nil, nil, "loadconfigmap", configMaps, "my-config")
+			}),
+			expected: map[string]map[string]string{
+				"my-config": {"OTEL_ENVFROM_VALUE1": "my-envfrom-value1"},
+			},
+		},
+		{
+			name: "Test missing ConfigMap",
+			tester: LoadConfigMapTestFunc(func(client client.Reader, ctx context.Context, configMaps map[string]*corev1.ConfigMap) (*corev1.ConfigMap, error) {
+				return getOrLoadResource(client, ctx, "loadconfigmap", configMaps, "nonexisting-config")
+			}),
+			err: "failed to get ConfigMap loadconfigmap/nonexisting-config: ",
+			expected: map[string]map[string]string{
+				"nonexisting-config": nil,
+			},
+		},
+		{
+			name: "Test cached missing ConfigMap",
+			tester: LoadConfigMapTestFunc(func(client client.Reader, ctx context.Context, configMaps map[string]*corev1.ConfigMap) (*corev1.ConfigMap, error) {
+				_, _ = getOrLoadResource(client, ctx, "loadconfigmap", configMaps, "nonexisting-config")
+				return getOrLoadResource(nil, nil, "loadconfigmap", configMaps, "nonexisting-config")
+			}),
+			err: "failed to get ConfigMap loadconfigmap/nonexisting-config",
+			expected: map[string]map[string]string{
+				"nonexisting-config": nil,
+			},
+		},
+		{
+			name: "Test unconfigured",
+			tester: LoadConfigMapTestFunc(func(client client.Reader, ctx context.Context, configMaps map[string]*corev1.ConfigMap) (*corev1.ConfigMap, error) {
+				return getOrLoadResource(nil, nil, "loadconfigmap", configMaps, "my-config")
+			}),
+			err: "cannot load ConfigMap loadconfigmap/my-config",
+			expected: map[string]map[string]string{
+				"my-config": nil,
+			},
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), &testNs)
+	require.NoError(t, err)
+	defer func() {
+		_ = k8sClient.Delete(context.Background(), &testNs)
+	}()
+
+	for _, cm := range testCm {
+		cm := cm
+		err = k8sClient.Create(context.Background(), &cm)
+		require.NoError(t, err)
+		//goland:noinspection GoDeferInLoop
+		defer func() {
+			_ = k8sClient.Delete(context.Background(), &cm)
+		}()
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			maps := map[string]*corev1.ConfigMap{}
+			cm, err := test.tester.Test(k8sClient, context.Background(), maps)
+
+			if test.err == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, testCm[0].Data, cm.Data)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), test.err)
+				}
+			}
+
+			if test.expected == nil {
+				assert.Nil(t, cm)
+			} else {
+				for key, value := range test.expected {
+					cm, ok := maps[key]
+					assert.True(t, ok)
+					if value == nil {
+						assert.Nil(t, cm)
+					} else {
+						if assert.NotNil(t, cm) {
+							assert.Equal(t, value, cm.Data)
+						}
+					}
+				}
+				assert.Len(t, maps, len(test.expected))
+			}
+		})
+	}
+}
+
+func TestResolving(t *testing.T) {
+	true := true
+	false := false
+
+	testNs := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "validations",
+		},
+	}
+	testCm := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-config",
+				Namespace: "validations",
+			},
+			Data: map[string]string{
+				"OTEL_ENVFROM_VALUE1": "my-envfrom-value1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-refconfig",
+				Namespace: "validations",
+			},
+			Data: map[string]string{
+				"ref-value1": "my-valuefrom-value1",
+			},
+		},
+	}
+	testSecret := []corev1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-secret",
+				Namespace: "validations",
+			},
+			Data: map[string][]byte{
+				"OTEL_ENVFROM_SECRET_VALUE1": []byte("my-secret-value1"),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-refsecret",
+				Namespace: "validations",
+			},
+			Data: map[string][]byte{
+				"secret-ref-value1": []byte("my-valuefrom-value1"),
+			},
+		},
+	}
+	testPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-pod",
+			Namespace: "validations",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					EnvFrom: []corev1.EnvFromSource{
+						NewConfigMapRef("my-config", "", nil),
+						NewSecretRef("my-secret", "", nil),
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "OTEL_ENV_VALUE1",
+							Value: "my-env-value1",
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_CONFIGMAP1",
+							ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value1", nil),
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_CONFIGMAP2",
+							ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value-nonexisting", nil),
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_CONFIGMAP3",
+							ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value-nonexisting", &false),
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_CONFIGMAP4",
+							ValueFrom: NewConfigMapKeyRef("my-refconfig", "ref-value-nonexisting", &true),
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_CONFIGMAP5",
+							ValueFrom: NewConfigMapKeyRef("my-refconfig-nonexisting", "ref-value1", nil),
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_CONFIGMAP6",
+							ValueFrom: NewConfigMapKeyRef("my-refconfig-nonexisting", "ref-value1", &false),
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_CONFIGMAP7",
+							ValueFrom: NewConfigMapKeyRef("my-refconfig-nonexisting", "ref-value1", &true),
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_SECRET1",
+							ValueFrom: NewSecretKeyRef("my-refsecret", "secret-ref-value1", nil),
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_FIELD1",
+							ValueFrom: NewFieldRef("spec.nodeName"),
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_RESOURCEFIELD1",
+							ValueFrom: NewResourceFieldRef("app", "limits.cpu"),
+						},
+						{
+							Name:      "OTEL_ENV_VALUEFROM_INVALID",
+							ValueFrom: &corev1.EnvVarSource{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		variable        string
+		err             string
+		expectedExists  bool
+		expectedResolve string
+	}{
+		{
+			name:            "Test existing variable",
+			variable:        "OTEL_ENV_VALUE1",
+			expectedExists:  true,
+			expectedResolve: "my-env-value1",
+		},
+		{
+			name:            "Test non-existing variable",
+			variable:        "OTEL_ENV_VALUE_NONEXISTING",
+			expectedExists:  false,
+			expectedResolve: "",
+		},
+		{
+			name:            "Test existing ConfigMap variable",
+			variable:        "OTEL_ENVFROM_VALUE1",
+			expectedExists:  true,
+			expectedResolve: "my-envfrom-value1",
+		},
+		{
+			name:            "Test existing ConfigMapKeyRef variable",
+			variable:        "OTEL_ENV_VALUEFROM_CONFIGMAP1",
+			expectedExists:  true,
+			expectedResolve: "my-valuefrom-value1",
+		},
+		{
+			name:           "Test implicitly mandatory non-existing ConfigMapKeyRef variable",
+			variable:       "OTEL_ENV_VALUEFROM_CONFIGMAP2",
+			expectedExists: true,
+			err:            "failed to resolve environment variable OTEL_ENV_VALUEFROM_CONFIGMAP2, key ref-value-nonexisting not found in ConfigMap validations/my-refconfig",
+		},
+		{
+			name:           "Test explicitly mandatory non-existing ConfigMapKeyRef variable",
+			variable:       "OTEL_ENV_VALUEFROM_CONFIGMAP3",
+			expectedExists: true,
+			err:            "failed to resolve environment variable OTEL_ENV_VALUEFROM_CONFIGMAP3, key ref-value-nonexisting not found in ConfigMap validations/my-refconfig",
+		},
+		{
+			name:            "Test optional non-existing ConfigMapKeyRef variable",
+			variable:        "OTEL_ENV_VALUEFROM_CONFIGMAP4",
+			expectedExists:  true,
+			expectedResolve: "",
+		},
+		{
+			name:           "Test implicitly mandatory variable of non-existing ConfigMap",
+			variable:       "OTEL_ENV_VALUEFROM_CONFIGMAP5",
+			expectedExists: true,
+			err:            "failed to resolve environment variable OTEL_ENV_VALUEFROM_CONFIGMAP5: ",
+		},
+		{
+			name:           "Test explicitly mandatory variable of non-existing ConfigMap",
+			variable:       "OTEL_ENV_VALUEFROM_CONFIGMAP6",
+			expectedExists: true,
+			err:            "failed to resolve environment variable OTEL_ENV_VALUEFROM_CONFIGMAP6: ",
+		},
+		{
+			name:            "Test optional variable of non-existing ConfigMap",
+			variable:        "OTEL_ENV_VALUEFROM_CONFIGMAP7",
+			expectedExists:  true,
+			expectedResolve: "",
+		},
+		{
+			name:           "Test unsupported existing Secret variable",
+			variable:       "OTEL_ENV_VALUEFROM_SECRET1",
+			expectedExists: true,
+			err:            "the container defines env var value via ValueFrom.SecretKeyRef, envVar: OTEL_ENV_VALUEFROM_SECRET1",
+		},
+		{
+			name:           "Test unsupported existing FieldRef variable",
+			variable:       "OTEL_ENV_VALUEFROM_FIELD1",
+			expectedExists: true,
+			err:            "the container defines env var value via ValueFrom.FieldRef, envVar: OTEL_ENV_VALUEFROM_FIELD1",
+		},
+		{
+			name:           "Test unsupported existing ResourceFieldRef variable",
+			variable:       "OTEL_ENV_VALUEFROM_RESOURCEFIELD1",
+			expectedExists: true,
+			err:            "the container defines env var value via ValueFrom.ResourceFieldRef, envVar: OTEL_ENV_VALUEFROM_RESOURCEFIELD1",
+		},
+		{
+			name:           "Test invalid variable",
+			variable:       "OTEL_ENV_VALUEFROM_INVALID",
+			expectedExists: true,
+			err:            "the container defines env var value via ValueFrom, envVar: OTEL_ENV_VALUEFROM_INVALID",
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), &testNs)
+	require.NoError(t, err)
+	defer func() {
+		_ = k8sClient.Delete(context.Background(), &testNs)
+	}()
+
+	for _, cm := range testCm {
+		cm := cm
+		err = k8sClient.Create(context.Background(), &cm)
+		require.NoError(t, err)
+		//goland:noinspection GoDeferInLoop
+		defer func() {
+			_ = k8sClient.Delete(context.Background(), &cm)
+		}()
+	}
+	for _, secret := range testSecret {
+		secret := secret
+		err = k8sClient.Create(context.Background(), &secret)
+		require.NoError(t, err)
+		//goland:noinspection GoDeferInLoop
+		defer func() {
+			_ = k8sClient.Delete(context.Background(), &secret)
+		}()
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			c, err := NewContainer(k8sClient, context.Background(), logr.Discard(), testNs.Name, &testPod, 0)
+			require.NoError(t, err)
+
+			exists := c.exists(&testPod, test.variable)
+			errValidate := c.validate(&testPod, test.variable)
+			resolved, errGet := c.getOrMakeEnvVar(&testPod, test.variable)
+
+			assert.Equal(t, test.expectedExists, exists)
+
+			if test.err == "" {
+				assert.NoError(t, errValidate)
+				assert.NoError(t, errGet)
+				assert.Equal(t, test.variable, resolved.Name)
+				assert.Equal(t, test.expectedResolve, resolved.Value)
+			} else {
+				if assert.Error(t, errValidate) {
+					assert.Contains(t, errValidate.Error(), test.err)
+				}
+				if assert.Error(t, errGet) {
+					assert.Contains(t, errGet.Error(), test.err)
+				}
+			}
+		})
+	}
+}
+
+func TestConcatenations(t *testing.T) {
+	testNs := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "concatenations",
+		},
+	}
+	testPod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-pod",
+			Namespace: "concatenations",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					Env: []corev1.EnvVar{
+						{
+							Name:  "OTEL_ENV_VALUE",
+							Value: "my-env-value",
+						},
+						{
+							Name:  "OTEL_ENV_COLON",
+							Value: "my-env-value:",
+						},
+						{
+							Name:      "OTEL_ENV_INVALID",
+							ValueFrom: NewConfigMapKeyRef("non-existing", "some-key", nil),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	//goland:noinspection SpellCheckingInspection
+	tests := []struct {
+		name      string
+		variable  string
+		value     string
+		concatter Concatter
+		err       string
+		expected  []corev1.EnvVar
+	}{
+		{
+			name:      "Test concatenation on non-existing variable",
+			variable:  "OTEL_ENV_NEW",
+			value:     "added",
+			concatter: ConcatFunc(concatWithColon),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE", Value: "my-env-value"},
+				{Name: "OTEL_ENV_COLON", Value: "my-env-value:"},
+				{Name: "OTEL_ENV_INVALID", ValueFrom: NewConfigMapKeyRef("non-existing", "some-key", nil)},
+				{Name: "OTEL_ENV_NEW", Value: "added"},
+			},
+		},
+		{
+			name:      "Test concatenation with colon",
+			variable:  "OTEL_ENV_VALUE",
+			value:     "added",
+			concatter: ConcatFunc(concatWithColon),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE", Value: "my-env-value:added"},
+				{Name: "OTEL_ENV_COLON", Value: "my-env-value:"},
+				{Name: "OTEL_ENV_INVALID", ValueFrom: NewConfigMapKeyRef("non-existing", "some-key", nil)},
+			},
+		},
+		{
+			name:      "Test concatenation of empty value",
+			variable:  "OTEL_ENV_VALUE",
+			value:     "",
+			concatter: ConcatFunc(concatWithColon),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE", Value: "my-env-value"},
+				{Name: "OTEL_ENV_COLON", Value: "my-env-value:"},
+				{Name: "OTEL_ENV_INVALID", ValueFrom: NewConfigMapKeyRef("non-existing", "some-key", nil)},
+			},
+		},
+		{
+			name:      "Test concatenation not adding redundant colon",
+			variable:  "OTEL_ENV_COLON",
+			value:     "added",
+			concatter: ConcatFunc(concatWithColon),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE", Value: "my-env-value"},
+				{Name: "OTEL_ENV_COLON", Value: "my-env-value:added"},
+				{Name: "OTEL_ENV_INVALID", ValueFrom: NewConfigMapKeyRef("non-existing", "some-key", nil)},
+			},
+		},
+		{
+			name:      "Test concatenation not adding redundant colon on both sides",
+			variable:  "OTEL_ENV_COLON",
+			value:     ":added",
+			concatter: ConcatFunc(concatWithColon),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE", Value: "my-env-value"},
+				{Name: "OTEL_ENV_COLON", Value: "my-env-value:added"},
+				{Name: "OTEL_ENV_INVALID", ValueFrom: NewConfigMapKeyRef("non-existing", "some-key", nil)},
+			},
+		},
+		{
+			name:      "Test concatenation with comma",
+			variable:  "OTEL_ENV_VALUE",
+			value:     "added",
+			concatter: ConcatFunc(concatWithComma),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE", Value: "my-env-value,added"},
+				{Name: "OTEL_ENV_COLON", Value: "my-env-value:"},
+				{Name: "OTEL_ENV_INVALID", ValueFrom: NewConfigMapKeyRef("non-existing", "some-key", nil)},
+			},
+		},
+		{
+			name:      "Test concatenation with space",
+			variable:  "OTEL_ENV_VALUE",
+			value:     "added",
+			concatter: ConcatFunc(concatWithSpace),
+			expected: []corev1.EnvVar{
+				{Name: "OTEL_ENV_VALUE", Value: "my-env-value added"},
+				{Name: "OTEL_ENV_COLON", Value: "my-env-value:"},
+				{Name: "OTEL_ENV_INVALID", ValueFrom: NewConfigMapKeyRef("non-existing", "some-key", nil)},
+			},
+		},
+		{
+			name:      "Test concatenation with non-resolvable variable",
+			variable:  "OTEL_ENV_INVALID",
+			value:     "added",
+			concatter: ConcatFunc(concatWithColon),
+			err:       "failed to resolve environment variable OTEL_ENV_INVALID: ",
+		},
+		{
+			name:      "Test concatenation with nil concatter",
+			variable:  "OTEL_ENV_VALUE",
+			value:     "added",
+			concatter: nil,
+			err:       "concatter is nil",
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), &testNs)
+	require.NoError(t, err)
+	defer func() {
+		_ = k8sClient.Delete(context.Background(), &testNs)
+	}()
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			pod := testPod.DeepCopy()
+			c, err := NewContainer(k8sClient, context.Background(), logr.Discard(), testNs.Name, pod, 0)
+			require.NoError(t, err)
+
+			err = c.appendOrConcat(pod, test.variable, test.value, test.concatter)
+
+			if test.err == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, pod.Spec.Containers[0].Env)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), test.err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/instrumentation/container_test.go
+++ b/pkg/instrumentation/container_test.go
@@ -377,7 +377,7 @@ func TestInheritedEnv(t *testing.T) {
 			err: "failed to get ConfigMap inheritedenv-notfoundexplicit/my-config",
 		},
 		{
-			name: "SecretRef not supported",
+			name: "Simple SecretRef usage",
 			ns: corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "inheritedenv-secretref",
@@ -410,7 +410,9 @@ func TestInheritedEnv(t *testing.T) {
 					},
 				},
 			},
-			log: "ignoring SecretRef in EnvFrom",
+			expected: map[string]string{
+				"OTEL_ENVFROM_SECRET_VALUE1": "my-secret-value1",
+			},
 		},
 	}
 
@@ -1011,7 +1013,7 @@ func TestResolving(t *testing.T) {
 				Namespace: "validations",
 			},
 			Data: map[string][]byte{
-				"secret-ref-value1": []byte("my-valuefrom-value1"),
+				"secret-ref-value1": []byte("my-secret-valuefrom-value1"),
 			},
 		},
 	}
@@ -1151,10 +1153,10 @@ func TestResolving(t *testing.T) {
 			expectedResolve: "",
 		},
 		{
-			name:           "Test unsupported existing Secret variable",
-			variable:       "OTEL_ENV_VALUEFROM_SECRET1",
-			expectedExists: true,
-			err:            "the container defines env var value via ValueFrom.SecretKeyRef, envVar: OTEL_ENV_VALUEFROM_SECRET1",
+			name:            "Test unsupported existing Secret variable",
+			variable:        "OTEL_ENV_VALUEFROM_SECRET1",
+			expectedExists:  true,
+			expectedResolve: "my-secret-valuefrom-value1",
 		},
 		{
 			name:           "Test unsupported existing FieldRef variable",

--- a/pkg/instrumentation/dotnet_test.go
+++ b/pkg/instrumentation/dotnet_test.go
@@ -15,10 +15,13 @@
 package instrumentation
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -550,7 +553,10 @@ func TestInjectDotNetSDK(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			pod, err := injectDotNetSDK(test.DotNet, test.pod, 0, test.runtime)
+			pod := test.pod
+			container, err := NewContainer(k8sClient, context.Background(), logr.Discard(), "", &pod, 0)
+			require.NoError(t, err)
+			pod, err = injectDotNetSDK(test.DotNet, pod, container, test.runtime)
 			assert.Equal(t, test.expected, pod)
 			assert.Equal(t, test.err, err)
 		})

--- a/pkg/instrumentation/exporter.go
+++ b/pkg/instrumentation/exporter.go
@@ -25,14 +25,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 )
 
-func configureExporter(exporter v1alpha1.Exporter, pod *corev1.Pod, container *corev1.Container) {
+func configureExporter(exporter v1alpha1.Exporter, pod *corev1.Pod, container Container) {
 	if exporter.Endpoint != "" {
-		if getIndexOfEnv(container.Env, constants.EnvOTELExporterOTLPEndpoint) == -1 {
-			container.Env = append(container.Env, corev1.EnvVar{
-				Name:  constants.EnvOTELExporterOTLPEndpoint,
-				Value: exporter.Endpoint,
-			})
-		}
+		container.appendIfNotExists(pod, constants.EnvOTELExporterOTLPEndpoint, exporter.Endpoint)
 	}
 	if exporter.TLS == nil {
 		return
@@ -52,36 +47,21 @@ func configureExporter(exporter v1alpha1.Exporter, pod *corev1.Pod, container *c
 		if filepath.IsAbs(exporter.TLS.CA) {
 			envVarVal = exporter.TLS.CA
 		}
-		if getIndexOfEnv(container.Env, constants.EnvOTELExporterCertificate) == -1 {
-			container.Env = append(container.Env, corev1.EnvVar{
-				Name:  constants.EnvOTELExporterCertificate,
-				Value: envVarVal,
-			})
-		}
+		container.appendIfNotExists(pod, constants.EnvOTELExporterCertificate, envVarVal)
 	}
 	if exporter.TLS.Cert != "" {
 		envVarVal := fmt.Sprintf("%s/%s", secretMountPath, exporter.TLS.Cert)
 		if filepath.IsAbs(exporter.TLS.Cert) {
 			envVarVal = exporter.TLS.Cert
 		}
-		if getIndexOfEnv(container.Env, constants.EnvOTELExporterClientCertificate) == -1 {
-			container.Env = append(container.Env, corev1.EnvVar{
-				Name:  constants.EnvOTELExporterClientCertificate,
-				Value: envVarVal,
-			})
-		}
+		container.appendIfNotExists(pod, constants.EnvOTELExporterClientCertificate, envVarVal)
 	}
 	if exporter.TLS.Key != "" {
 		envVarVar := fmt.Sprintf("%s/%s", secretMountPath, exporter.TLS.Key)
 		if filepath.IsAbs(exporter.TLS.Key) {
 			envVarVar = exporter.TLS.Key
 		}
-		if getIndexOfEnv(container.Env, constants.EnvOTELExporterClientKey) == -1 {
-			container.Env = append(container.Env, corev1.EnvVar{
-				Name:  constants.EnvOTELExporterClientKey,
-				Value: envVarVar,
-			})
-		}
+		container.appendIfNotExists(pod, constants.EnvOTELExporterClientKey, envVarVar)
 	}
 
 	if exporter.TLS.SecretName != "" {
@@ -101,13 +81,13 @@ func configureExporter(exporter v1alpha1.Exporter, pod *corev1.Pod, container *c
 				}})
 		}
 		addVolumeMount := true
-		for _, vol := range container.VolumeMounts {
+		for _, vol := range pod.Spec.Containers[container.index].VolumeMounts {
 			if vol.Name == secretVolumeName {
 				addVolumeMount = false
 			}
 		}
 		if addVolumeMount {
-			container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			pod.Spec.Containers[container.index].VolumeMounts = append(pod.Spec.Containers[container.index].VolumeMounts, corev1.VolumeMount{
 				Name:      secretVolumeName,
 				MountPath: secretMountPath,
 				ReadOnly:  true,
@@ -134,13 +114,13 @@ func configureExporter(exporter v1alpha1.Exporter, pod *corev1.Pod, container *c
 				}})
 		}
 		addVolumeMount := true
-		for _, vol := range container.VolumeMounts {
+		for _, vol := range pod.Spec.Containers[container.index].VolumeMounts {
 			if vol.Name == configMapVolumeName {
 				addVolumeMount = false
 			}
 		}
 		if addVolumeMount {
-			container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			pod.Spec.Containers[container.index].VolumeMounts = append(pod.Spec.Containers[container.index].VolumeMounts, corev1.VolumeMount{
 				Name:      configMapVolumeName,
 				MountPath: configMapMountPath,
 				ReadOnly:  true,

--- a/pkg/instrumentation/exporter_test.go
+++ b/pkg/instrumentation/exporter_test.go
@@ -15,8 +15,10 @@
 package instrumentation
 
 import (
+	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 
@@ -202,7 +204,9 @@ func TestExporter(t *testing.T) {
 					},
 				},
 			}
-			configureExporter(test.exporter, &pod, &pod.Spec.Containers[0])
+			container, err := NewContainer(k8sClient, context.Background(), logr.Discard(), "", &pod, 0)
+			assert.NoError(t, err)
+			configureExporter(test.exporter, &pod, container)
 			assert.Equal(t, test.expected, pod)
 		})
 	}

--- a/pkg/instrumentation/golang.go
+++ b/pkg/instrumentation/golang.go
@@ -82,8 +82,7 @@ func injectGoSDK(goSpec v1alpha1.Go, pod corev1.Pod, cfg config.Config) (corev1.
 	// Inject Go instrumentation spec env vars.
 	// For Go, env vars must be added to the agent contain
 	for _, env := range goSpec.Env {
-		idx := getIndexOfEnv(goAgent.Env, env.Name)
-		if idx == -1 {
+		if !existsEnvVarInEnv(goAgent.Env, env.Name) {
 			goAgent.Env = append(goAgent.Env, env)
 		}
 	}

--- a/pkg/instrumentation/javaagent.go
+++ b/pkg/instrumentation/javaagent.go
@@ -24,29 +24,22 @@ import (
 
 const (
 	envJavaToolsOptions   = "JAVA_TOOL_OPTIONS"
-	javaAgent             = " -javaagent:/otel-auto-instrumentation-java/javaagent.jar"
+	javaAgent             = "-javaagent:/otel-auto-instrumentation-java/javaagent.jar"
 	javaInitContainerName = initContainerName + "-java"
 	javaVolumeName        = volumeName + "-java"
 	javaInstrMountPath    = "/otel-auto-instrumentation-java"
 )
 
-func injectJavaagent(javaSpec v1alpha1.Java, pod corev1.Pod, index int) (corev1.Pod, error) {
+func injectJavaagent(javaSpec v1alpha1.Java, pod corev1.Pod, container Container) (corev1.Pod, error) {
 	volume := instrVolume(javaSpec.VolumeClaimTemplate, javaVolumeName, javaSpec.VolumeSizeLimit)
 
-	// caller checks if there is at least one container.
-	container := &pod.Spec.Containers[index]
-
-	err := validateContainerEnv(container.Env, envJavaToolsOptions)
-	if err != nil {
+	if err := container.validate(&pod, envJavaToolsOptions); err != nil {
 		return pod, err
 	}
 
 	// inject Java instrumentation spec env vars.
 	for _, env := range javaSpec.Env {
-		idx := getIndexOfEnv(container.Env, env.Name)
-		if idx == -1 {
-			container.Env = append(container.Env, env)
-		}
+		container.appendEnvVarIfNotExists(&pod, env)
 	}
 
 	javaJVMArgument := javaAgent
@@ -54,17 +47,11 @@ func injectJavaagent(javaSpec v1alpha1.Java, pod corev1.Pod, index int) (corev1.
 		javaJVMArgument = javaAgent + fmt.Sprintf(" -Dotel.javaagent.extensions=%s/extensions", javaInstrMountPath)
 	}
 
-	idx := getIndexOfEnv(container.Env, envJavaToolsOptions)
-	if idx == -1 {
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  envJavaToolsOptions,
-			Value: javaJVMArgument,
-		})
-	} else {
-		container.Env[idx].Value = container.Env[idx].Value + javaJVMArgument
+	if err := container.appendOrConcat(&pod, envJavaToolsOptions, javaJVMArgument, ConcatFunc(concatWithSpace)); err != nil {
+		return pod, err
 	}
 
-	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+	pod.Spec.Containers[container.index].VolumeMounts = append(pod.Spec.Containers[container.index].VolumeMounts, corev1.VolumeMount{
 		Name:      volume.Name,
 		MountPath: javaInstrMountPath,
 	})
@@ -97,5 +84,5 @@ func injectJavaagent(javaSpec v1alpha1.Java, pod corev1.Pod, index int) (corev1.
 		}
 
 	}
-	return pod, err
+	return pod, nil
 }

--- a/pkg/instrumentation/python_test.go
+++ b/pkg/instrumentation/python_test.go
@@ -15,10 +15,13 @@
 package instrumentation
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
@@ -519,7 +522,10 @@ func TestInjectPythonSDK(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			pod, err := injectPythonSDK(test.Python, test.pod, 0)
+			pod := test.pod
+			container, err := NewContainer(k8sClient, context.Background(), logr.Discard(), "", &pod, 0)
+			require.NoError(t, err)
+			pod, err = injectPythonSDK(test.Python, pod, container)
 			assert.Equal(t, test.expected, pod)
 			assert.Equal(t, test.err, err)
 		})

--- a/tests/e2e-instrumentation/instrumentation-java-envfrom-configmap/00-install-collector.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-envfrom-configmap/00-install-collector.yaml
@@ -1,0 +1,22 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: sidecar
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+
+    exporters:
+      debug:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]
+  mode: sidecar

--- a/tests/e2e-instrumentation/instrumentation-java-envfrom-configmap/00-install-instrumentation.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-envfrom-configmap/00-install-instrumentation.yaml
@@ -1,0 +1,34 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: java
+spec:
+  env:
+    - name: OTEL_TRACES_EXPORTER
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4317
+    - name: OTEL_EXPORTER_OTLP_TIMEOUT
+      value: "20"
+    - name: OTEL_TRACES_SAMPLER
+      value: parentbased_traceidratio
+    - name: OTEL_TRACES_SAMPLER_ARG
+      value: "0.85"
+    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
+      value: "true"
+  exporter:
+    endpoint: http://localhost:4317
+  propagators:
+    - jaeger
+    - b3
+  sampler:
+    type: parentbased_traceidratio
+    argument: "0.25"
+  java:
+    env:
+    - name: OTEL_JAVAAGENT_DEBUG
+      value: "true"
+    - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
+      value: "false"
+    - name: SPLUNK_PROFILER_ENABLED
+      value: "false"

--- a/tests/e2e-instrumentation/instrumentation-java-envfrom-configmap/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-envfrom-configmap/01-assert.yaml
@@ -2,11 +2,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    instrumentation.opentelemetry.io/container-names: myapp,myrabbit
     instrumentation.opentelemetry.io/inject-java: "true"
     sidecar.opentelemetry.io/inject: "true"
   labels:
-    app: my-java-multi
+    app: my-java
 spec:
   containers:
   - env:
@@ -25,7 +24,7 @@ spec:
     - name: SPLUNK_PROFILER_ENABLED
       value: "false"
     - name: JAVA_TOOL_OPTIONS
-      value: '-javaagent:/otel-auto-instrumentation-java/javaagent.jar'
+      value: '-XX:+UseContainerSupport -javaagent:/otel-auto-instrumentation-java/javaagent.jar'
     - name: OTEL_TRACES_EXPORTER
       value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -38,8 +37,6 @@ spec:
       value: "0.85"
     - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
       value: "true"
-    - name: OTEL_SERVICE_NAME
-      value: my-java-multi
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
       valueFrom:
         fieldRef:
@@ -53,57 +50,10 @@ spec:
     - name: OTEL_PROPAGATORS
       value: jaeger,b3
     - name: OTEL_RESOURCE_ATTRIBUTES
+    envFrom:
+    - configMapRef:
+        name: my-conf
     name: myapp
-    volumeMounts:
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      readOnly: true
-    - mountPath: /otel-auto-instrumentation-java
-      name: opentelemetry-auto-instrumentation-java
-  - env:
-    - name: OTEL_NODE_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.hostIP
-    - name: OTEL_POD_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.podIP
-    - name: OTEL_JAVAAGENT_DEBUG
-      value: "true"
-    - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
-      value: "false"
-    - name: SPLUNK_PROFILER_ENABLED
-      value: "false"
-    - name: JAVA_TOOL_OPTIONS
-      value: '-javaagent:/otel-auto-instrumentation-java/javaagent.jar'
-    - name: OTEL_TRACES_EXPORTER
-      value: otlp
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4317
-    - name: OTEL_EXPORTER_OTLP_TIMEOUT
-      value: "20"
-    - name: OTEL_TRACES_SAMPLER
-      value: parentbased_traceidratio
-    - name: OTEL_TRACES_SAMPLER_ARG
-      value: "0.85"
-    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
-      value: "true"
-    - name: OTEL_SERVICE_NAME
-      value: my-java-multi
-    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: spec.nodeName
-    - name: OTEL_PROPAGATORS
-      value: jaeger,b3
-    - name: OTEL_RESOURCE_ATTRIBUTES
-    name: myrabbit
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
       readOnly: true
@@ -117,9 +67,6 @@ spec:
 status:
   containerStatuses:
   - name: myapp
-    ready: true
-    started: true
-  - name: myrabbit
     ready: true
     started: true
   - name: otc-container

--- a/tests/e2e-instrumentation/instrumentation-java-envfrom-configmap/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-envfrom-configmap/01-install-app.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-conf
+data:
+  OTEL_SERVICE_NAME: my-app
+  JAVA_TOOL_OPTIONS: -XX:+UseContainerSupport
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-java
+spec:
+  selector:
+    matchLabels:
+      app: my-java
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: my-java
+      annotations:
+        sidecar.opentelemetry.io/inject: "true"
+        instrumentation.opentelemetry.io/inject-java: "true"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 3000
+      containers:
+      - name: myapp
+        image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-java:main
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        envFrom:
+          - configMapRef:
+              name: my-conf

--- a/tests/e2e-instrumentation/instrumentation-java-envfrom-configmap/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-envfrom-configmap/chainsaw-test.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: instrumentation-java-envfrom-configmap
+spec:
+  steps:
+  - name: step-00
+    try:
+    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
+    - command:
+        entrypoint: kubectl
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.uid-range=1000/1000
+        - --overwrite
+    - command:
+        entrypoint: kubectl
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.supplemental-groups=3000/3000
+        - --overwrite
+    - apply:
+        file: 00-install-collector.yaml
+    - apply:
+        file: 00-install-instrumentation.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-app.yaml
+    - assert:
+        file: 01-assert.yaml
+    catch:
+      - podLogs:
+          selector: app=my-java

--- a/tests/e2e-instrumentation/instrumentation-java-envfrom-secret/00-install-collector.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-envfrom-secret/00-install-collector.yaml
@@ -1,0 +1,22 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: sidecar
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+
+    exporters:
+      debug:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]
+  mode: sidecar

--- a/tests/e2e-instrumentation/instrumentation-java-envfrom-secret/00-install-instrumentation.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-envfrom-secret/00-install-instrumentation.yaml
@@ -1,0 +1,34 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: java
+spec:
+  env:
+    - name: OTEL_TRACES_EXPORTER
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4317
+    - name: OTEL_EXPORTER_OTLP_TIMEOUT
+      value: "20"
+    - name: OTEL_TRACES_SAMPLER
+      value: parentbased_traceidratio
+    - name: OTEL_TRACES_SAMPLER_ARG
+      value: "0.85"
+    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
+      value: "true"
+  exporter:
+    endpoint: http://localhost:4317
+  propagators:
+    - jaeger
+    - b3
+  sampler:
+    type: parentbased_traceidratio
+    argument: "0.25"
+  java:
+    env:
+    - name: OTEL_JAVAAGENT_DEBUG
+      value: "true"
+    - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
+      value: "false"
+    - name: SPLUNK_PROFILER_ENABLED
+      value: "false"

--- a/tests/e2e-instrumentation/instrumentation-java-envfrom-secret/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-envfrom-secret/01-assert.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    instrumentation.opentelemetry.io/inject-java: "true"
+    sidecar.opentelemetry.io/inject: "true"
+  labels:
+    app: my-java
+spec:
+  containers:
+  - env:
+    - name: OTEL_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: OTEL_JAVAAGENT_DEBUG
+      value: "true"
+    - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
+      value: "false"
+    - name: SPLUNK_PROFILER_ENABLED
+      value: "false"
+    - name: JAVA_TOOL_OPTIONS
+      value: '-XX:+UseContainerSupport -javaagent:/otel-auto-instrumentation-java/javaagent.jar'
+    - name: OTEL_TRACES_EXPORTER
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4317
+    - name: OTEL_EXPORTER_OTLP_TIMEOUT
+      value: "20"
+    - name: OTEL_TRACES_SAMPLER
+      value: parentbased_traceidratio
+    - name: OTEL_TRACES_SAMPLER_ARG
+      value: "0.85"
+    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
+      value: "true"
+    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: spec.nodeName
+    - name: OTEL_PROPAGATORS
+      value: jaeger,b3
+    - name: OTEL_RESOURCE_ATTRIBUTES
+    envFrom:
+    - secretRef:
+        name: my-conf
+    name: myapp
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      readOnly: true
+    - mountPath: /otel-auto-instrumentation-java
+      name: opentelemetry-auto-instrumentation-java
+  - args:
+    - --config=env:OTEL_CONFIG
+    name: otc-container
+  initContainers:
+  - name: opentelemetry-auto-instrumentation-java
+status:
+  containerStatuses:
+  - name: myapp
+    ready: true
+    started: true
+  - name: otc-container
+    ready: true
+    started: true
+  initContainerStatuses:
+  - name: opentelemetry-auto-instrumentation-java
+    ready: true
+  phase: Running

--- a/tests/e2e-instrumentation/instrumentation-java-envfrom-secret/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-envfrom-secret/01-install-app.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-conf
+data:
+  OTEL_SERVICE_NAME: bXktYXBw
+  JAVA_TOOL_OPTIONS: LVhYOitVc2VDb250YWluZXJTdXBwb3J0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-java
+spec:
+  selector:
+    matchLabels:
+      app: my-java
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: my-java
+      annotations:
+        sidecar.opentelemetry.io/inject: "true"
+        instrumentation.opentelemetry.io/inject-java: "true"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 3000
+      containers:
+      - name: myapp
+        image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-java:main
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        envFrom:
+          - secretRef:
+              name: my-conf

--- a/tests/e2e-instrumentation/instrumentation-java-envfrom-secret/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-envfrom-secret/chainsaw-test.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: instrumentation-java-envfrom-secret
+spec:
+  steps:
+  - name: step-00
+    try:
+    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
+    - command:
+        entrypoint: kubectl
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.uid-range=1000/1000
+        - --overwrite
+    - command:
+        entrypoint: kubectl
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.supplemental-groups=3000/3000
+        - --overwrite
+    - apply:
+        file: 00-install-collector.yaml
+    - apply:
+        file: 00-install-instrumentation.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-app.yaml
+    - assert:
+        file: 01-assert.yaml
+    catch:
+      - podLogs:
+          selector: app=my-java

--- a/tests/e2e-instrumentation/instrumentation-java-multicontainer/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-multicontainer/02-assert.yaml
@@ -36,7 +36,7 @@ spec:
     - name: SPLUNK_PROFILER_ENABLED
       value: "false"
     - name: JAVA_TOOL_OPTIONS
-      value: ' -javaagent:/otel-auto-instrumentation-java/javaagent.jar'
+      value: '-javaagent:/otel-auto-instrumentation-java/javaagent.jar'
     - name: OTEL_TRACES_EXPORTER
       value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/tests/e2e-instrumentation/instrumentation-java-other-ns/03-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-other-ns/03-assert.yaml
@@ -24,7 +24,7 @@ spec:
     - name: SPLUNK_PROFILER_ENABLED
       value: "false"
     - name: JAVA_TOOL_OPTIONS
-      value: ' -javaagent:/otel-auto-instrumentation-java/javaagent.jar'
+      value: '-javaagent:/otel-auto-instrumentation-java/javaagent.jar'
     - name: OTEL_TRACES_EXPORTER
       value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/tests/e2e-instrumentation/instrumentation-java-tls/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-tls/01-assert.yaml
@@ -17,7 +17,7 @@ spec:
         fieldRef:
           fieldPath: status.podIP
     - name: JAVA_TOOL_OPTIONS
-      value: ' -javaagent:/otel-auto-instrumentation-java/javaagent.jar'
+      value: '-javaagent:/otel-auto-instrumentation-java/javaagent.jar'
     - name: OTEL_SERVICE_NAME
       value: my-java
     - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/tests/e2e-instrumentation/instrumentation-java-valuefrom-configmap/00-install-collector.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-valuefrom-configmap/00-install-collector.yaml
@@ -1,0 +1,22 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: sidecar
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+
+    exporters:
+      debug:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]
+  mode: sidecar

--- a/tests/e2e-instrumentation/instrumentation-java-valuefrom-configmap/00-install-instrumentation.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-valuefrom-configmap/00-install-instrumentation.yaml
@@ -1,0 +1,34 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: java
+spec:
+  env:
+    - name: OTEL_TRACES_EXPORTER
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4317
+    - name: OTEL_EXPORTER_OTLP_TIMEOUT
+      value: "20"
+    - name: OTEL_TRACES_SAMPLER
+      value: parentbased_traceidratio
+    - name: OTEL_TRACES_SAMPLER_ARG
+      value: "0.85"
+    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
+      value: "true"
+  exporter:
+    endpoint: http://localhost:4317
+  propagators:
+    - jaeger
+    - b3
+  sampler:
+    type: parentbased_traceidratio
+    argument: "0.25"
+  java:
+    env:
+    - name: OTEL_JAVAAGENT_DEBUG
+      value: "true"
+    - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
+      value: "false"
+    - name: SPLUNK_PROFILER_ENABLED
+      value: "false"

--- a/tests/e2e-instrumentation/instrumentation-java-valuefrom-configmap/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-valuefrom-configmap/01-assert.yaml
@@ -2,11 +2,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    instrumentation.opentelemetry.io/container-names: myapp,myrabbit
     instrumentation.opentelemetry.io/inject-java: "true"
     sidecar.opentelemetry.io/inject: "true"
   labels:
-    app: my-java-multi
+    app: my-java
 spec:
   containers:
   - env:
@@ -18,14 +17,19 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: status.podIP
+    - name: OTEL_SERVICE_NAME
+      valueFrom:
+        configMapKeyRef:
+          name: my-conf
+          key: otel-service-name
+    - name: JAVA_TOOL_OPTIONS
+      value: '-XX:+UseContainerSupport -javaagent:/otel-auto-instrumentation-java/javaagent.jar'
     - name: OTEL_JAVAAGENT_DEBUG
       value: "true"
     - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
       value: "false"
     - name: SPLUNK_PROFILER_ENABLED
       value: "false"
-    - name: JAVA_TOOL_OPTIONS
-      value: '-javaagent:/otel-auto-instrumentation-java/javaagent.jar'
     - name: OTEL_TRACES_EXPORTER
       value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -38,8 +42,6 @@ spec:
       value: "0.85"
     - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
       value: "true"
-    - name: OTEL_SERVICE_NAME
-      value: my-java-multi
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
       valueFrom:
         fieldRef:
@@ -59,56 +61,6 @@ spec:
       readOnly: true
     - mountPath: /otel-auto-instrumentation-java
       name: opentelemetry-auto-instrumentation-java
-  - env:
-    - name: OTEL_NODE_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.hostIP
-    - name: OTEL_POD_IP
-      valueFrom:
-        fieldRef:
-          fieldPath: status.podIP
-    - name: OTEL_JAVAAGENT_DEBUG
-      value: "true"
-    - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
-      value: "false"
-    - name: SPLUNK_PROFILER_ENABLED
-      value: "false"
-    - name: JAVA_TOOL_OPTIONS
-      value: '-javaagent:/otel-auto-instrumentation-java/javaagent.jar'
-    - name: OTEL_TRACES_EXPORTER
-      value: otlp
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4317
-    - name: OTEL_EXPORTER_OTLP_TIMEOUT
-      value: "20"
-    - name: OTEL_TRACES_SAMPLER
-      value: parentbased_traceidratio
-    - name: OTEL_TRACES_SAMPLER_ARG
-      value: "0.85"
-    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
-      value: "true"
-    - name: OTEL_SERVICE_NAME
-      value: my-java-multi
-    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
-    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: spec.nodeName
-    - name: OTEL_PROPAGATORS
-      value: jaeger,b3
-    - name: OTEL_RESOURCE_ATTRIBUTES
-    name: myrabbit
-    volumeMounts:
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      readOnly: true
-    - mountPath: /otel-auto-instrumentation-java
-      name: opentelemetry-auto-instrumentation-java
   - args:
     - --config=env:OTEL_CONFIG
     name: otc-container
@@ -117,9 +69,6 @@ spec:
 status:
   containerStatuses:
   - name: myapp
-    ready: true
-    started: true
-  - name: myrabbit
     ready: true
     started: true
   - name: otc-container

--- a/tests/e2e-instrumentation/instrumentation-java-valuefrom-configmap/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-valuefrom-configmap/01-install-app.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-conf
+data:
+  otel-service-name: my-app
+  java-tool-options: -XX:+UseContainerSupport
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-java
+spec:
+  selector:
+    matchLabels:
+      app: my-java
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: my-java
+      annotations:
+        sidecar.opentelemetry.io/inject: "true"
+        instrumentation.opentelemetry.io/inject-java: "true"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 3000
+      containers:
+      - name: myapp
+        image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-java:main
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: my-conf
+              key: otel-service-name
+        - name: JAVA_TOOL_OPTIONS
+          valueFrom:
+            configMapKeyRef:
+              name: my-conf
+              key: java-tool-options

--- a/tests/e2e-instrumentation/instrumentation-java-valuefrom-configmap/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-valuefrom-configmap/chainsaw-test.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: instrumentation-java-valuefrom-configmap
+spec:
+  steps:
+  - name: step-00
+    try:
+    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
+    - command:
+        entrypoint: kubectl
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.uid-range=1000/1000
+        - --overwrite
+    - command:
+        entrypoint: kubectl
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.supplemental-groups=3000/3000
+        - --overwrite
+    - apply:
+        file: 00-install-collector.yaml
+    - apply:
+        file: 00-install-instrumentation.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-app.yaml
+    - assert:
+        file: 01-assert.yaml
+    catch:
+      - podLogs:
+          selector: app=my-java

--- a/tests/e2e-instrumentation/instrumentation-java-valuefrom-secret/00-install-collector.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-valuefrom-secret/00-install-collector.yaml
@@ -1,0 +1,22 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: sidecar
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+
+    exporters:
+      debug:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]
+  mode: sidecar

--- a/tests/e2e-instrumentation/instrumentation-java-valuefrom-secret/00-install-instrumentation.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-valuefrom-secret/00-install-instrumentation.yaml
@@ -1,0 +1,34 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: java
+spec:
+  env:
+    - name: OTEL_TRACES_EXPORTER
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4317
+    - name: OTEL_EXPORTER_OTLP_TIMEOUT
+      value: "20"
+    - name: OTEL_TRACES_SAMPLER
+      value: parentbased_traceidratio
+    - name: OTEL_TRACES_SAMPLER_ARG
+      value: "0.85"
+    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
+      value: "true"
+  exporter:
+    endpoint: http://localhost:4317
+  propagators:
+    - jaeger
+    - b3
+  sampler:
+    type: parentbased_traceidratio
+    argument: "0.25"
+  java:
+    env:
+    - name: OTEL_JAVAAGENT_DEBUG
+      value: "true"
+    - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
+      value: "false"
+    - name: SPLUNK_PROFILER_ENABLED
+      value: "false"

--- a/tests/e2e-instrumentation/instrumentation-java-valuefrom-secret/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-valuefrom-secret/01-assert.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    instrumentation.opentelemetry.io/inject-java: "true"
+    sidecar.opentelemetry.io/inject: "true"
+  labels:
+    app: my-java
+spec:
+  containers:
+  - env:
+    - name: OTEL_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: OTEL_SERVICE_NAME
+      valueFrom:
+        secretKeyRef:
+          name: my-conf
+          key: otel-service-name
+    - name: JAVA_TOOL_OPTIONS
+      value: '-XX:+UseContainerSupport -javaagent:/otel-auto-instrumentation-java/javaagent.jar'
+    - name: OTEL_JAVAAGENT_DEBUG
+      value: "true"
+    - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
+      value: "false"
+    - name: SPLUNK_PROFILER_ENABLED
+      value: "false"
+    - name: OTEL_TRACES_EXPORTER
+      value: otlp
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4317
+    - name: OTEL_EXPORTER_OTLP_TIMEOUT
+      value: "20"
+    - name: OTEL_TRACES_SAMPLER
+      value: parentbased_traceidratio
+    - name: OTEL_TRACES_SAMPLER_ARG
+      value: "0.85"
+    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
+      value: "true"
+    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: spec.nodeName
+    - name: OTEL_PROPAGATORS
+      value: jaeger,b3
+    - name: OTEL_RESOURCE_ATTRIBUTES
+    name: myapp
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      readOnly: true
+    - mountPath: /otel-auto-instrumentation-java
+      name: opentelemetry-auto-instrumentation-java
+  - args:
+    - --config=env:OTEL_CONFIG
+    name: otc-container
+  initContainers:
+  - name: opentelemetry-auto-instrumentation-java
+status:
+  containerStatuses:
+  - name: myapp
+    ready: true
+    started: true
+  - name: otc-container
+    ready: true
+    started: true
+  initContainerStatuses:
+  - name: opentelemetry-auto-instrumentation-java
+    ready: true
+  phase: Running

--- a/tests/e2e-instrumentation/instrumentation-java-valuefrom-secret/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-valuefrom-secret/01-install-app.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-conf
+data:
+  otel-service-name: bXktYXBw
+  java-tool-options: LVhYOitVc2VDb250YWluZXJTdXBwb3J0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-java
+spec:
+  selector:
+    matchLabels:
+      app: my-java
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: my-java
+      annotations:
+        sidecar.opentelemetry.io/inject: "true"
+        instrumentation.opentelemetry.io/inject-java: "true"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 3000
+      containers:
+      - name: myapp
+        image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-java:main
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        env:
+        - name: OTEL_SERVICE_NAME
+          valueFrom:
+            secretKeyRef:
+              name: my-conf
+              key: otel-service-name
+        - name: JAVA_TOOL_OPTIONS
+          valueFrom:
+            secretKeyRef:
+              name: my-conf
+              key: java-tool-options

--- a/tests/e2e-instrumentation/instrumentation-java-valuefrom-secret/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-valuefrom-secret/chainsaw-test.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: instrumentation-java-valuefrom-secret
+spec:
+  steps:
+  - name: step-00
+    try:
+    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
+    - command:
+        entrypoint: kubectl
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.uid-range=1000/1000
+        - --overwrite
+    - command:
+        entrypoint: kubectl
+        args:
+        - annotate
+        - namespace
+        - ${NAMESPACE}
+        - openshift.io/sa.scc.supplemental-groups=3000/3000
+        - --overwrite
+    - apply:
+        file: 00-install-collector.yaml
+    - apply:
+        file: 00-install-instrumentation.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-app.yaml
+    - assert:
+        file: 01-assert.yaml
+    catch:
+      - podLogs:
+          selector: app=my-java

--- a/tests/e2e-instrumentation/instrumentation-java/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java/01-assert.yaml
@@ -24,7 +24,7 @@ spec:
     - name: SPLUNK_PROFILER_ENABLED
       value: "false"
     - name: JAVA_TOOL_OPTIONS
-      value: ' -javaagent:/otel-auto-instrumentation-java/javaagent.jar'
+      value: '-javaagent:/otel-auto-instrumentation-java/javaagent.jar'
     - name: OTEL_TRACES_EXPORTER
       value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/01-assert.yaml
@@ -21,7 +21,7 @@ spec:
     - name: NODE_PATH
       value: /usr/local/lib/node_modules
     - name: NODE_OPTIONS
-      value: ' --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
+      value: '--require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
     - name: OTEL_TRACES_EXPORTER
       value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -65,7 +65,7 @@ spec:
         fieldRef:
           fieldPath: status.podIP
     - name: NODE_OPTIONS
-      value: ' --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
+      value: '--require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
     - name: OTEL_TRACES_EXPORTER
       value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/02-assert.yaml
@@ -32,7 +32,7 @@ spec:
     - name: NODE_PATH
       value: /usr/local/lib/node_modules
     - name: NODE_OPTIONS
-      value: ' --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
+      value: '--require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
     - name: OTEL_TRACES_EXPORTER
       value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/tests/e2e-instrumentation/instrumentation-nodejs-volume/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-volume/01-assert.yaml
@@ -22,7 +22,7 @@ spec:
         - name: OTEL_NODEJS_DEBUG
           value: "true"
         - name: NODE_OPTIONS
-          value: " --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js"
+          value: "--require /otel-auto-instrumentation-nodejs/autoinstrumentation.js"
         - name: OTEL_TRACES_EXPORTER
           value: otlp
         - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/tests/e2e-instrumentation/instrumentation-nodejs/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs/01-assert.yaml
@@ -22,7 +22,7 @@ spec:
     - name: OTEL_NODEJS_DEBUG
       value: "true"
     - name: NODE_OPTIONS
-      value: ' --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
+      value: '--require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
     - name: OTEL_TRACES_EXPORTER
       value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/01-assert.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/01-assert.yaml
@@ -89,7 +89,7 @@ spec:
     - name: OTEL_SERVICE_NAME
       value: javaapp
     - name: JAVA_TOOL_OPTIONS
-      value: ' -javaagent:/otel-auto-instrumentation-java/javaagent.jar'
+      value: '-javaagent:/otel-auto-instrumentation-java/javaagent.jar'
     - name: OTEL_TRACES_SAMPLER
       value: parentbased_traceidratio
     - name: OTEL_TRACES_SAMPLER_ARG
@@ -131,7 +131,7 @@ spec:
     - name: OTEL_SERVICE_NAME
       value: nodejsapp
     - name: NODE_OPTIONS
-      value: ' --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
+      value: '--require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
     - name: OTEL_TRACES_SAMPLER
       value: parentbased_traceidratio
     - name: OTEL_TRACES_SAMPLER_ARG

--- a/tests/e2e-multi-instrumentation/instrumentation-single-instr-first-container/01-assert.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-single-instr-first-container/01-assert.yaml
@@ -22,7 +22,7 @@ spec:
     - name: OTEL_SERVICE_NAME
       value: nodejsapp
     - name: NODE_OPTIONS
-      value: ' --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
+      value: '--require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
     - name: OTEL_TRACES_SAMPLER
       value: parentbased_traceidratio
     - name: OTEL_TRACES_SAMPLER_ARG


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Added detection and reading of environment variables defined in PODs resources like ConfigMaps and Secrets. Supports both `envFrom` and `valueFrom` forms.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves:
  - #1393
  - #1814

**Testing:**

Added `kubebuilder` tests for new code, tested by deploying the generated image to OpenShift cluster.

**Documentation:** <Describe the documentation added.>

This is an enhancement, which can be read also as a bug fix (missing feature), so I have not added any documentation.

**Implementation notes/questions:**

1. The `ConfigMap` support is in first commit, the `Secret` support is in the second commit. They work the same, they both support “if exists” checks and are able to extend the existing value (append) into a newly created (or updated) environment variable.
2. I was not sure about the `Container` class naming (or have some common methods prefix?), so please suggest how the main class/file should be named - I can change it easily. The class handles everything regarding environment variables on the container currently.
3. I was not sure about the usage of namespace name. The `sdkInjector.inject` method gets one in arguments, but Apache and Nginx auto-instrumentations are ignoring it and taking namespace name from POD definition or from PODs resource map, which looks wrong (at minimum this is suspicious). I took the namespace name from the POD and if not found, I fall back to the one supplied as a parameter to `inject` method.
4. I was not sure about the reading of Secrets (second commit) - whether it is secure to handle them fully. The implementation is as full as for ConfigMaps, so the values can be detected (“if exists” checks) and extended (“append when exists”) into a new or updated environment variable (so Secret is converted to env var!). If necessary, I can change the implementation to just recognise them (record the existence) but fail when the value should be extended.