### PR TITLE
autoinstrumentation: install musl based autoinstrumentation in Python Docker image

### DIFF
--- a/.chloggen/3384-build-musl-python-autoinstrumentation.yaml
+++ b/.chloggen/3384-build-musl-python-autoinstrumentation.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: build musl based auto-instrumentation in Python docker image
+
+# One or more tracking issues related to the change
+issues: [2264]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/autoinstrumentation/python/Dockerfile
+++ b/autoinstrumentation/python/Dockerfile
@@ -1,12 +1,12 @@
 # To build one auto-instrumentation image for Python, please:
-# - Ensure the packages are installed in the `/autoinstrumentation` directory. This is required as when instrumenting the pod,
-#   one init container will be created to copy all the content in `/autoinstrumentation` directory to your app's container. Then
+# - Ensure the packages are installed in the `/autoinstrumentation,{-musl}` directory. This is required as when instrumenting the pod,
+#   one init container will be created to copy all the content in `/autoinstrumentation{,-musl}` directory to your app's container. Then
 #   update the `PYTHONPATH` environment variable accordingly. To achieve this, you can mimic the one in `autoinstrumentation/python/Dockerfile`
 #   by using multi-stage builds. In the first stage, install all the required packages in one custom directory with `pip install --target`.
-#   Then in the second stage, copy the directory to `/autoinstrumentation`.
+#   Then in the second stage, copy the directory to `/autoinstrumentation{,-musl}`.
 # - Ensure you have `opentelemetry-distro` and `opentelemetry-instrumentation` or your customized alternatives installed.
 #   Those two packages are essential to Python auto-instrumentation.
-# - Grant the necessary access to `/autoinstrumentation` directory. `chmod -R go+r /autoinstrumentation`
+# - Grant the necessary access to `/autoinstrumentation{,-musl}` directory. `chmod -R go+r /autoinstrumentation`
 # - For auto-instrumentation by container injection, the Linux command cp is
 #   used and must be availabe in the image.
 FROM python:3.11 AS build
@@ -17,8 +17,19 @@ ADD requirements.txt .
 
 RUN mkdir workspace && pip install --target workspace -r requirements.txt
 
+FROM python:3.11-alpine AS build-musl
+
+WORKDIR /operator-build
+
+ADD requirements.txt .
+
+RUN apk add gcc python3-dev musl-dev linux-headers
+RUN mkdir workspace && pip install --target workspace -r requirements.txt
+
 FROM busybox
 
 COPY --from=build /operator-build/workspace /autoinstrumentation
+COPY --from=build-musl /operator-build/workspace /autoinstrumentation-musl
 
 RUN chmod -R go+r /autoinstrumentation
+RUN chmod -R go+r /autoinstrumentation-musl


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

As discussed [here](https://github.com/open-telemetry/opentelemetry-operator/pull/3332#discussion_r1812285084) this introduce in the python image autoinstrumentation built from a musl container.

This is a prerequisite to actually add support for an annotation to use the musl based instrumentation instead of the default glibc one: https://github.com/open-telemetry/opentelemetry-operator/pull/3332

**Link to tracking Issue(s):** <Issue number if applicable>

- Refs: #2264 

**Testing:** image builds fine

**Documentation:** <Describe the documentation added.>
