### PR TITLE
Allow setting target allocator via label

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,6 +31,7 @@ jobs:
          - e2e-pdb
          - e2e-prometheuscr
          - e2e-targetallocator
+         - e2e-targetallocator-cr
          - e2e-upgrade
          - e2e-multi-instrumentation
          - e2e-metadata-filters
@@ -50,6 +51,8 @@ jobs:
            setup: "add-operator-arg OPERATOR_ARG='--feature-gates=operator.sidecarcontainers.native' prepare-e2e"
            kube-version: "1.29"
          - group: e2e-targetallocator
+           setup: "enable-targetallocator-cr prepare-e2e"
+         - group: e2e-targetallocator-cr
            setup: "enable-targetallocator-cr prepare-e2e"
     steps:
     - name: Check out code into the Go module directory

--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,11 @@ e2e-prometheuscr: chainsaw
 e2e-targetallocator: chainsaw
 	$(CHAINSAW) test --test-dir ./tests/e2e-targetallocator
 
+# Target allocator CR end-to-tests
+.PHONY: e2e-targetallocator-cr
+e2e-targetallocator-cr: chainsaw
+	$(CHAINSAW) test --test-dir ./tests/e2e-targetallocator-cr
+
 .PHONY: add-certmanager-permissions
 add-certmanager-permissions: 
 	# Kustomize only allows patches in the folder where the kustomization is located

--- a/apis/v1beta1/collector_webhook.go
+++ b/apis/v1beta1/collector_webhook.go
@@ -122,7 +122,7 @@ func (c CollectorWebhook) ValidateCreate(ctx context.Context, obj runtime.Object
 		c.metrics.create(ctx, otelcol)
 	}
 	if c.bv != nil {
-		newWarnings := c.bv(*otelcol)
+		newWarnings := c.bv(ctx, *otelcol)
 		warnings = append(warnings, newWarnings...)
 	}
 	return warnings, nil
@@ -152,7 +152,7 @@ func (c CollectorWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj run
 	}
 
 	if c.bv != nil {
-		newWarnings := c.bv(*otelcol)
+		newWarnings := c.bv(ctx, *otelcol)
 		warnings = append(warnings, newWarnings...)
 	}
 	return warnings, nil
@@ -435,7 +435,7 @@ func checkAutoscalerSpec(autoscaler *AutoscalerSpec) error {
 
 // BuildValidator enables running the manifest generators for the collector reconciler
 // +kubebuilder:object:generate=false
-type BuildValidator func(c OpenTelemetryCollector) admission.Warnings
+type BuildValidator func(ctx context.Context, c OpenTelemetryCollector) admission.Warnings
 
 func NewCollectorWebhook(
 	logger logr.Logger,

--- a/apis/v1beta1/collector_webhook_test.go
+++ b/apis/v1beta1/collector_webhook_test.go
@@ -83,7 +83,7 @@ func TestValidate(t *testing.T) {
 		},
 	}
 
-	bv := func(collector v1beta1.OpenTelemetryCollector) admission.Warnings {
+	bv := func(_ context.Context, collector v1beta1.OpenTelemetryCollector) admission.Warnings {
 		var warnings admission.Warnings
 		cfg := config.New(
 			config.WithCollectorImage("default-collector"),
@@ -518,7 +518,7 @@ func TestCollectorDefaultingWebhook(t *testing.T) {
 		},
 	}
 
-	bv := func(collector v1beta1.OpenTelemetryCollector) admission.Warnings {
+	bv := func(_ context.Context, collector v1beta1.OpenTelemetryCollector) admission.Warnings {
 		var warnings admission.Warnings
 		cfg := config.New(
 			config.WithCollectorImage("default-collector"),
@@ -1365,7 +1365,7 @@ func TestOTELColValidatingWebhook(t *testing.T) {
 		},
 	}
 
-	bv := func(collector v1beta1.OpenTelemetryCollector) admission.Warnings {
+	bv := func(_ context.Context, collector v1beta1.OpenTelemetryCollector) admission.Warnings {
 		var warnings admission.Warnings
 		cfg := config.New(
 			config.WithCollectorImage("default-collector"),
@@ -1433,7 +1433,7 @@ func TestOTELColValidateUpdateWebhook(t *testing.T) {
 		},
 	}
 
-	bv := func(collector v1beta1.OpenTelemetryCollector) admission.Warnings {
+	bv := func(_ context.Context, collector v1beta1.OpenTelemetryCollector) admission.Warnings {
 		var warnings admission.Warnings
 		cfg := config.New(
 			config.WithCollectorImage("default-collector"),

--- a/controllers/opentelemetrycollector_controller.go
+++ b/controllers/opentelemetrycollector_controller.go
@@ -48,10 +48,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	collectorStatus "github.com/open-telemetry/opentelemetry-operator/internal/status/collector"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
-
-const collectorTargetAllocatorLabelName = "opentelemetry.io/target-allocator"
 
 var (
 	ownedClusterObjectTypes = []client.Object{
@@ -191,10 +190,9 @@ func (r *OpenTelemetryCollectorReconciler) GetParams(ctx context.Context, instan
 }
 
 func (r *OpenTelemetryCollectorReconciler) getTargetAllocator(ctx context.Context, params manifests.Params) (*v1alpha1.TargetAllocator, error) {
-	otelcol := params.OtelCol
-	if taName, ok := otelcol.GetLabels()[collectorTargetAllocatorLabelName]; ok {
+	if taName, ok := params.OtelCol.GetLabels()[constants.LabelTargetAllocator]; ok {
 		targetAllocator := &v1alpha1.TargetAllocator{}
-		taKey := client.ObjectKey{Name: taName, Namespace: otelcol.GetNamespace()}
+		taKey := client.ObjectKey{Name: taName, Namespace: params.OtelCol.GetNamespace()}
 		err := r.Client.Get(ctx, taKey, targetAllocator)
 		if err != nil {
 			return nil, err

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -64,7 +64,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/testdata"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/rbac"
-	// +kubebuilder:scaffold:imports
 )
 
 var (

--- a/controllers/targetallocator_controller.go
+++ b/controllers/targetallocator_controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/targetallocator"
 	taStatus "github.com/open-telemetry/opentelemetry-operator/internal/status/targetallocator"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
 
@@ -102,7 +103,7 @@ func (r *TargetAllocatorReconciler) getCollector(ctx context.Context, instance v
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.GetNamespace()),
 		client.MatchingLabels{
-			collectorTargetAllocatorLabelName: instance.GetName(),
+			constants.LabelTargetAllocator: instance.GetName(),
 		},
 	}
 	err := r.List(ctx, &collectors, listOpts...)
@@ -216,7 +217,7 @@ func (r *TargetAllocatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	collectorSelector := metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
-				Key:      collectorTargetAllocatorLabelName,
+				Key:      constants.LabelTargetAllocator,
 				Operator: metav1.LabelSelectorOpExists,
 			},
 		},
@@ -246,7 +247,7 @@ func getTargetAllocatorForCollector(_ context.Context, collector client.Object) 
 }
 
 func getTargetAllocatorRequestsFromLabel(_ context.Context, collector client.Object) []reconcile.Request {
-	if taName, ok := collector.GetLabels()[collectorTargetAllocatorLabelName]; ok {
+	if taName, ok := collector.GetLabels()[constants.LabelTargetAllocator]; ok {
 		return []reconcile.Request{
 			{
 				NamespacedName: types.NamespacedName{

--- a/controllers/targetallocator_reconciler_test.go
+++ b/controllers/targetallocator_reconciler_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 )
 
 var testLogger = logf.Log.WithName("opamp-bridge-controller-unit-tests")
@@ -57,7 +58,7 @@ func TestTargetAllocatorReconciler_GetCollector(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
 			Labels: map[string]string{
-				collectorTargetAllocatorLabelName: "label-ta",
+				constants.LabelTargetAllocator: "label-ta",
 			},
 		},
 	}
@@ -163,7 +164,7 @@ func TestGetTargetAllocatorRequestsFromLabel(t *testing.T) {
 			Name:      "test",
 			Namespace: "default",
 			Labels: map[string]string{
-				collectorTargetAllocatorLabelName: "label-ta",
+				constants.LabelTargetAllocator: "label-ta",
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -440,7 +440,7 @@ func main() {
 
 		bv := func(collector otelv1beta1.OpenTelemetryCollector) admission.Warnings {
 			var warnings admission.Warnings
-			params, newErr := collectorReconciler.GetParams(collector)
+			params, newErr := collectorReconciler.GetParams(context.Background(), collector)
 			if err != nil {
 				warnings = append(warnings, newErr.Error())
 				return warnings

--- a/main.go
+++ b/main.go
@@ -438,9 +438,9 @@ func main() {
 
 		}
 
-		bv := func(collector otelv1beta1.OpenTelemetryCollector) admission.Warnings {
+		bv := func(ctx context.Context, collector otelv1beta1.OpenTelemetryCollector) admission.Warnings {
 			var warnings admission.Warnings
-			params, newErr := collectorReconciler.GetParams(context.Background(), collector)
+			params, newErr := collectorReconciler.GetParams(ctx, collector)
 			if err != nil {
 				warnings = append(warnings, newErr.Error())
 				return warnings

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -40,6 +40,7 @@ const (
 	LabelAppVersion  = "app.kubernetes.io/version"
 	LabelAppPartOf   = "app.kubernetes.io/part-of"
 
+	LabelTargetAllocator              = "opentelemetry.io/target-allocator"
 	ResourceAttributeAnnotationPrefix = "resource.opentelemetry.io/"
 
 	EnvPodName  = "OTEL_RESOURCE_ATTRIBUTES_POD_NAME"

--- a/tests/e2e-targetallocator-cr/targetallocator-label/00-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/00-assert.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ta-collector
+data:
+  collector.yaml: |
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: otel-collector
+              scrape_interval: 10s
+              static_configs:
+                - targets:
+                    - 0.0.0.0:8888
+    exporters:
+      debug: {}
+    service:
+      telemetry:
+        metrics:
+          address: 0.0.0.0:8888
+      pipelines:
+        metrics:
+          exporters:
+            - debug
+          receivers:
+            - prometheus
+
+---
+apiVersion: v1
+data:
+  targetallocator.yaml: |
+    allocation_strategy: consistent-hashing
+    collector_selector: null
+    filter_strategy: ""
+kind: ConfigMap
+metadata:
+  name: ta-targetallocator

--- a/tests/e2e-targetallocator-cr/targetallocator-label/00-install.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/00-install.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: TargetAllocator
+metadata:
+  name: ta
+spec:
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: ta
+spec:
+  mode: statefulset
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: 'otel-collector'
+              scrape_interval: 10s
+              static_configs:
+                - targets: [ '0.0.0.0:8888' ]
+    exporters:
+      debug: {}
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [debug]
+

--- a/tests/e2e-targetallocator-cr/targetallocator-label/01-add-ta-label.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/01-add-ta-label.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: ta
+  labels:
+    opentelemetry.io/target-allocator: ta
+spec:
+  mode: statefulset
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: 'otel-collector'
+              scrape_interval: 10s
+              static_configs:
+                - targets: [ '0.0.0.0:8888' ]
+    exporters:
+      debug: {}
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [debug]
+

--- a/tests/e2e-targetallocator-cr/targetallocator-label/01-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/01-assert.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ta-collector
+data:
+  collector.yaml: |
+    exporters:
+        debug: {}
+    receivers:
+        prometheus:
+            config: {}
+            target_allocator:
+                collector_id: ${POD_NAME}
+                endpoint: http://ta-targetallocator:80
+                interval: 30s
+    service:
+        pipelines:
+            metrics:
+                exporters:
+                    - debug
+                receivers:
+                    - prometheus
+        telemetry:
+            metrics:
+                address: 0.0.0.0:8888
+---
+apiVersion: v1
+data:
+  targetallocator.yaml:
+    ( contains(@, join(':', ['app.kubernetes.io/component', ' opentelemetry-collector'])) ): true
+    ( contains(@, join('', ['app.kubernetes.io/instance:', ' ', $namespace, '.ta'])) ): true
+    ( contains(@, join(':', ['app.kubernetes.io/managed-by', ' opentelemetry-operator'])) ): true
+    ( contains(@, join(':', ['app.kubernetes.io/part-of', ' opentelemetry'])) ): true
+    ( contains(@, join(':', ['job_name', ' otel-collector'])) ): true
+kind: ConfigMap
+metadata:
+  name: ta-targetallocator

--- a/tests/e2e-targetallocator-cr/targetallocator-label/02-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/02-assert.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ta-collector
+data:
+  collector.yaml: |
+    exporters:
+        debug: {}
+    receivers:
+        prometheus:
+            config: {}
+            target_allocator:
+                collector_id: ${POD_NAME}
+                endpoint: http://ta-targetallocator:80
+                interval: 30s
+    service:
+        pipelines:
+            metrics:
+                exporters:
+                    - debug
+                receivers:
+                    - prometheus
+        telemetry:
+            metrics:
+                address: 0.0.0.0:8888
+---
+apiVersion: v1
+data:
+  targetallocator.yaml:
+    ( contains(@, join(':', ['app.kubernetes.io/component', ' opentelemetry-collector'])) ): true
+    ( contains(@, join('', ['app.kubernetes.io/instance:', ' ', $namespace, '.ta'])) ): true
+    ( contains(@, join(':', ['app.kubernetes.io/managed-by', ' opentelemetry-operator'])) ): true
+    ( contains(@, join(':', ['app.kubernetes.io/part-of', ' opentelemetry'])) ): true
+    ( contains(@, join(':', ['job_name', ' otel-collector'])) ): false
+kind: ConfigMap
+metadata:
+  name: ta-targetallocator

--- a/tests/e2e-targetallocator-cr/targetallocator-label/02-change-collector-config.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/02-change-collector-config.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: ta
+  labels:
+    opentelemetry.io/target-allocator: ta
+spec:
+  mode: statefulset
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs: []
+    exporters:
+      debug: {}
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [debug]
+

--- a/tests/e2e-targetallocator-cr/targetallocator-label/03-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/03-assert.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+data:
+  targetallocator.yaml: |
+    allocation_strategy: consistent-hashing
+    collector_selector: null
+    filter_strategy: ""
+kind: ConfigMap
+metadata:
+  name: ta-targetallocator

--- a/tests/e2e-targetallocator-cr/targetallocator-label/chainsaw-test.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/chainsaw-test.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: targetallocator-label
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        template: true
+        file: 00-install.yaml
+    - assert:
+        file: 00-assert.yaml
+    catch:
+    - podLogs:
+        selector: app.kubernetes.io/name=opentelemetry-operator
+  - name: step-01
+    try:
+      - apply:
+          template: true
+          file: 01-add-ta-label.yaml
+      - assert:
+          file: 01-assert.yaml
+    catch:
+      - podLogs:
+          selector: app.kubernetes.io/name=opentelemetry-operator
+  - name: step-02
+    try:
+      - apply:
+          template: true
+          file: 02-change-collector-config.yaml
+      - assert:
+          file: 02-assert.yaml
+    catch:
+      - podLogs:
+          selector: app.kubernetes.io/name=opentelemetry-operator
+  - name: step-03
+    try:
+      - delete:
+          ref:
+            apiVersion: opentelemetry.io/v1beta1
+            kind: OpenTelemetryCollector
+            name: ta
+      - assert:
+          file: 03-assert.yaml
+    catch:
+      - podLogs:
+          selector: app.kubernetes.io/name=opentelemetry-operator
+    


### PR DESCRIPTION
**Description:**
Allow connecting the OpenTelemetryCollector and TargetAllocator CRs by setting a label on the Collector CR.

**Link to tracking Issue(s):** <Issue number if applicable>

- Related to: #2422 

**Testing:**
Added some basic unit tests and an e2e test showing how label changes affect the Collector manifests.


