### PR TITLE
Add a benchmark for the whole targets pipeline

### DIFF
--- a/cmd/otel-allocator/benchmark_test.go
+++ b/cmd/otel-allocator/benchmark_test.go
@@ -1,0 +1,175 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	gokitlog "github.com/go-kit/log"
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/model/relabel"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/prehook"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/server"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
+)
+
+// BenchmarkProcessTargets benchmarks the whole target allocation pipeline. It starts with data the prometheus
+// discovery manager would normally output, and pushes it all the way into the allocator. It notably doe *not* check
+// the HTTP server afterward. Test data is chosen to be reasonably representative of what the Prometheus service discovery
+// outputs in the real world.
+func BenchmarkProcessTargets(b *testing.B) {
+	numTargets := 10000
+	targetsPerGroup := 5
+	groupsPerJob := 20
+	tsets := prepareBenchmarkData(numTargets, targetsPerGroup, groupsPerJob)
+
+	b.ResetTimer()
+	for _, strategy := range allocation.GetRegisteredAllocatorNames() {
+		b.Run(strategy, func(b *testing.B) {
+			targetDiscoverer, allocator := createTestDiscoverer(strategy, map[string][]*relabel.Config{})
+			for i := 0; i < b.N; i++ {
+				targetDiscoverer.ProcessTargets(tsets, allocator.SetTargets)
+			}
+		})
+	}
+}
+
+// BenchmarkProcessTargetsWithRelabelConfig is BenchmarkProcessTargets with a relabel config set. The relabel config
+// does not actually modify any records, but does force the prehook to perform any necessary conversions along the way.
+func BenchmarkProcessTargetsWithRelabelConfig(b *testing.B) {
+	numTargets := 10000
+	targetsPerGroup := 5
+	groupsPerJob := 20
+	tsets := prepareBenchmarkData(numTargets, targetsPerGroup, groupsPerJob)
+	prehookConfig := make(map[string][]*relabel.Config, len(tsets))
+	for jobName := range tsets {
+		prehookConfig[jobName] = []*relabel.Config{
+			{
+				Action: "keep",
+				Regex:  relabel.MustNewRegexp(".*"),
+			},
+		}
+	}
+
+	b.ResetTimer()
+	for _, strategy := range allocation.GetRegisteredAllocatorNames() {
+		b.Run(strategy, func(b *testing.B) {
+			targetDiscoverer, allocator := createTestDiscoverer(strategy, prehookConfig)
+			for i := 0; i < b.N; i++ {
+				targetDiscoverer.ProcessTargets(tsets, allocator.SetTargets)
+			}
+		})
+	}
+}
+
+func prepareBenchmarkData(numTargets, targetsPerGroup, groupsPerJob int) map[string][]*targetgroup.Group {
+	numGroups := numTargets / targetsPerGroup
+	numJobs := numGroups / groupsPerJob
+	jobNamePrefix := "test-"
+	groupLabels := model.LabelSet{
+		"__meta_kubernetes_pod_controller_name":                                                 "example",
+		"__meta_kubernetes_pod_ip":                                                              "10.244.0.251",
+		"__meta_kubernetes_pod_uid":                                                             "676ebee7-14f8-481e-a937-d2affaec4105",
+		"__meta_kubernetes_endpointslice_port_protocol":                                         "TCP",
+		"__meta_kubernetes_endpointslice_endpoint_conditions_ready":                             "true",
+		"__meta_kubernetes_service_annotation_kubectl_kubernetes_io_last_applied_configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"annotations\":{},\"labels\":{\"app\":\"example\"},\"name\":\"example-svc\",\"namespace\":\"example\"},\"spec\":{\"clusterIP\":\"None\",\"ports\":[{\"name\":\"http-example\",\"port\":9006,\"targetPort\":9006}],\"selector\":{\"app\":\"example\"},\"type\":\"ClusterIP\"}}\n",
+		"__meta_kubernetes_endpointslice_labelpresent_app":                                      "true",
+		"__meta_kubernetes_endpointslice_name":                                                  "example-svc-qgwxf",
+		"__address__":                                                                           "10.244.0.251:9006",
+		"__meta_kubernetes_endpointslice_endpoint_conditions_terminating":                       "false",
+		"__meta_kubernetes_pod_labelpresent_pod_template_hash":                                  "true",
+		"__meta_kubernetes_endpointslice_label_kubernetes_io_service_name":                      "example-svc",
+		"__meta_kubernetes_endpointslice_labelpresent_service_kubernetes_io_headless":           "true",
+		"__meta_kubernetes_pod_label_pod_template_hash":                                         "6b549885f8",
+		"__meta_kubernetes_endpointslice_address_target_name":                                   "example-6b549885f8-7tbcw",
+		"__meta_kubernetes_pod_labelpresent_app":                                                "true",
+		"somelabel":                                                                             "somevalue",
+	}
+	exampleTarget := model.LabelSet{
+		"__meta_kubernetes_endpointslice_port":                                                               "9006",
+		"__meta_kubernetes_service_label_app":                                                                "example",
+		"__meta_kubernetes_endpointslice_port_name":                                                          "http-example",
+		"__meta_kubernetes_pod_ready":                                                                        "true",
+		"__meta_kubernetes_endpointslice_address_type":                                                       "IPv4",
+		"__meta_kubernetes_endpointslice_label_endpointslice_kubernetes_io_managed_by":                       "endpointslice-controller.k8s.io",
+		"__meta_kubernetes_endpointslice_labelpresent_endpointslice_kubernetes_io_managed_by":                "true",
+		"__meta_kubernetes_endpointslice_label_app":                                                          "example",
+		"__meta_kubernetes_endpointslice_endpoint_conditions_serving":                                        "true",
+		"__meta_kubernetes_pod_phase":                                                                        "Running",
+		"__meta_kubernetes_pod_controller_kind":                                                              "ReplicaSet",
+		"__meta_kubernetes_service_annotationpresent_kubectl_kubernetes_io_last_applied_configuration":       "true",
+		"__meta_kubernetes_service_labelpresent_app":                                                         "true",
+		"__meta_kubernetes_endpointslice_labelpresent_kubernetes_io_service_name":                            "true",
+		"__meta_kubernetes_endpointslice_annotation_endpoints_kubernetes_io_last_change_trigger_time":        "2023-09-27T16:01:29Z",
+		"__meta_kubernetes_pod_name":                                                                         "example-6b549885f8-7tbcw",
+		"__meta_kubernetes_service_name":                                                                     "example-svc",
+		"__meta_kubernetes_namespace":                                                                        "example",
+		"__meta_kubernetes_endpointslice_annotationpresent_endpoints_kubernetes_io_last_change_trigger_time": "true",
+		"__meta_kubernetes_pod_node_name":                                                                    "kind-control-plane",
+		"__meta_kubernetes_endpointslice_address_target_kind":                                                "Pod",
+		"__meta_kubernetes_pod_host_ip":                                                                      "172.18.0.2",
+		"__meta_kubernetes_endpointslice_label_service_kubernetes_io_headless":                               "",
+		"__meta_kubernetes_pod_label_app":                                                                    "example",
+	}
+	targets := []model.LabelSet{}
+	for i := 0; i < numTargets; i++ {
+		targets = append(targets, exampleTarget.Clone())
+	}
+	groups := make([]*targetgroup.Group, numGroups)
+	for i := 0; i < numGroups; i++ {
+		groupTargets := targets[(i * targetsPerGroup):(i*targetsPerGroup + targetsPerGroup)]
+		groups[i] = &targetgroup.Group{
+			Labels:  groupLabels,
+			Targets: groupTargets,
+		}
+	}
+	tsets := make(map[string][]*targetgroup.Group, numJobs)
+	for i := 0; i < numJobs; i++ {
+		jobGroups := groups[(i * groupsPerJob):(i*groupsPerJob + groupsPerJob)]
+		jobName := fmt.Sprintf("%s%d", jobNamePrefix, i)
+		tsets[jobName] = jobGroups
+	}
+	return tsets
+}
+
+func createTestDiscoverer(allocationStrategy string, prehookConfig map[string][]*relabel.Config) (*target.Discoverer, allocation.Allocator) {
+	ctx := context.Background()
+	logger := ctrl.Log.WithName(fmt.Sprintf("bench-%s", allocationStrategy))
+	ctrl.SetLogger(logr.New(log.NullLogSink{}))
+	allocatorPrehook := prehook.New("relabel-config", logger)
+	allocatorPrehook.SetConfig(prehookConfig)
+	allocator, err := allocation.New(allocationStrategy, logger, allocation.WithFilter(allocatorPrehook))
+	srv := server.NewServer(logger, allocator, "localhost:0")
+	if err != nil {
+		setupLog.Error(err, "Unable to initialize allocation strategy")
+		os.Exit(1)
+	}
+	registry := prometheus.NewRegistry()
+	sdMetrics, _ := discovery.CreateAndRegisterSDMetrics(registry)
+	discoveryManager := discovery.NewManager(ctx, gokitlog.NewNopLogger(), registry, sdMetrics)
+	targetDiscoverer := target.NewDiscoverer(logger, discoveryManager, allocatorPrehook, srv)
+	return targetDiscoverer, allocator
+}

--- a/cmd/otel-allocator/target/discovery.go
+++ b/cmd/otel-allocator/target/discovery.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/relabel"
 	"gopkg.in/yaml.v3"
 
@@ -110,22 +111,26 @@ func (m *Discoverer) Watch(fn func(targets map[string]*Item)) error {
 			m.log.Info("Service Discovery watch event stopped: discovery manager closed")
 			return nil
 		case tsets := <-m.manager.SyncCh():
-			targets := map[string]*Item{}
-
-			for jobName, tgs := range tsets {
-				var count float64 = 0
-				for _, tg := range tgs {
-					for _, t := range tg.Targets {
-						count++
-						item := NewItem(jobName, string(t[model.AddressLabel]), t.Merge(tg.Labels), "")
-						targets[item.Hash()] = item
-					}
-				}
-				targetsDiscovered.WithLabelValues(jobName).Set(count)
-			}
-			fn(targets)
+			m.ProcessTargets(tsets, fn)
 		}
 	}
+}
+
+func (m *Discoverer) ProcessTargets(tsets map[string][]*targetgroup.Group, fn func(targets map[string]*Item)) {
+	targets := map[string]*Item{}
+
+	for jobName, tgs := range tsets {
+		var count float64 = 0
+		for _, tg := range tgs {
+			for _, t := range tg.Targets {
+				count++
+				item := NewItem(jobName, string(t[model.AddressLabel]), t.Merge(tg.Labels), "")
+				targets[item.Hash()] = item
+			}
+		}
+		targetsDiscovered.WithLabelValues(jobName).Set(count)
+	}
+	fn(targets)
 }
 
 func (m *Discoverer) Close() {


### PR DESCRIPTION
Add a benchmark for the whole scrape target processing pipeline in the target allocator. I'd like to make some changes to this pipeline in subsequent PRs that will improve its performance, and wrote this benchmark to measure the improvement. I did my best to use realistic data, and the labels in the benchmark are taken directly from a real production cluster.

Current output is as follows on my machine:

```
goos: linux
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator
cpu: AMD Ryzen 9 7950X3D 16-Core Processor          
BenchmarkProcessTargets/per-node-32            	      14	  79449090 ns/op	47902082 B/op	  132380 allocs/op
BenchmarkProcessTargets/per-node-32            	      14	  80049443 ns/op	47898982 B/op	  132376 allocs/op
BenchmarkProcessTargets/per-node-32            	      14	  79190720 ns/op	47895784 B/op	  132368 allocs/op
BenchmarkProcessTargets/per-node-32            	      14	  79240592 ns/op	47914164 B/op	  132425 allocs/op
BenchmarkProcessTargets/per-node-32            	      14	  79701044 ns/op	47904677 B/op	  132402 allocs/op
BenchmarkProcessTargets/per-node-32            	      14	  79306193 ns/op	47896969 B/op	  132374 allocs/op
BenchmarkProcessTargets/per-node-32            	      14	  78996677 ns/op	47907460 B/op	  132408 allocs/op
BenchmarkProcessTargets/per-node-32            	      14	  79620516 ns/op	47893134 B/op	  132359 allocs/op
BenchmarkProcessTargets/per-node-32            	      14	  78569563 ns/op	47890921 B/op	  132352 allocs/op
BenchmarkProcessTargets/per-node-32            	      13	  79823405 ns/op	47904442 B/op	  132389 allocs/op
BenchmarkProcessTargets/least-weighted-32      	      13	  80194468 ns/op	47904215 B/op	  132394 allocs/op
BenchmarkProcessTargets/least-weighted-32      	      14	  79167548 ns/op	47910850 B/op	  132423 allocs/op
BenchmarkProcessTargets/least-weighted-32      	      13	  79440631 ns/op	47909941 B/op	  132413 allocs/op
BenchmarkProcessTargets/least-weighted-32      	      13	  79345335 ns/op	47909766 B/op	  132415 allocs/op
BenchmarkProcessTargets/least-weighted-32      	      13	  80256056 ns/op	47885332 B/op	  132332 allocs/op
BenchmarkProcessTargets/least-weighted-32      	      14	  80227125 ns/op	47905310 B/op	  132401 allocs/op
BenchmarkProcessTargets/least-weighted-32      	      13	  79355045 ns/op	47916236 B/op	  132438 allocs/op
BenchmarkProcessTargets/least-weighted-32      	      14	  78973434 ns/op	47903948 B/op	  132398 allocs/op
BenchmarkProcessTargets/least-weighted-32      	      13	  78269978 ns/op	47896699 B/op	  132368 allocs/op
BenchmarkProcessTargets/least-weighted-32      	      14	  79113204 ns/op	47905487 B/op	  132401 allocs/op
BenchmarkProcessTargets/consistent-hashing-32  	    a  14	  79156249 ns/op	47898197 B/op	  132375 allocs/op
BenchmarkProcessTargets/consistent-hashing-32  	      14	  80757290 ns/op	47908586 B/op	  132414 allocs/op
BenchmarkProcessTargets/consistent-hashing-32  	      13	  79251686 ns/op	47916901 B/op	  132441 allocs/op
BenchmarkProcessTargets/consistent-hashing-32  	      13	  79404973 ns/op	47915320 B/op	  132416 allocs/op
BenchmarkProcessTargets/consistent-hashing-32  	      14	  78935858 ns/op	47900689 B/op	  132387 allocs/op
BenchmarkProcessTargets/consistent-hashing-32  	      14	  80309503 ns/op	47885685 B/op	  132334 allocs/op
BenchmarkProcessTargets/consistent-hashing-32  	      13	  79082189 ns/op	47895481 B/op	  132366 allocs/op
BenchmarkProcessTargets/consistent-hashing-32  	      13	  79127577 ns/op	47904273 B/op	  132398 allocs/op
BenchmarkProcessTargets/consistent-hashing-32  	      14	  79708004 ns/op	47896783 B/op	  132369 allocs/op
BenchmarkProcessTargets/consistent-hashing-32  	      13	  78994510 ns/op	47903958 B/op	  132398 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/least-weighted-32         	      14	  79203552 ns/op	48205795 B/op	  132765 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/least-weighted-32         	      13	  79884622 ns/op	48222678 B/op	  132821 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/least-weighted-32         	      14	  78830938 ns/op	48208493 B/op	  132775 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/least-weighted-32         	      13	  79417045 ns/op	48208318 B/op	  132771 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/least-weighted-32         	      14	  79665405 ns/op	48213104 B/op	  132795 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/least-weighted-32         	      13	  79803822 ns/op	48215220 B/op	  132799 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/least-weighted-32         	      13	  80373446 ns/op	48214001 B/op	  132797 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/least-weighted-32         	      14	  79659748 ns/op	48224180 B/op	  132831 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/least-weighted-32         	      14	  79605281 ns/op	48203514 B/op	  132762 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/least-weighted-32         	      14	  79926999 ns/op	48211490 B/op	  132785 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/consistent-hashing-32     	      13	  77815588 ns/op	48211020 B/op	  132787 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/consistent-hashing-32     	      13	  79461895 ns/op	48214384 B/op	  132795 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/consistent-hashing-32     	      14	  79784373 ns/op	48209019 B/op	  132780 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/consistent-hashing-32     	      13	  80092055 ns/op	48209649 B/op	  132778 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/consistent-hashing-32     	      13	  79281861 ns/op	48199032 B/op	  132746 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/consistent-hashing-32     	      13	  79839818 ns/op	48216235 B/op	  132806 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/consistent-hashing-32     	      13	  79663551 ns/op	48209070 B/op	  132778 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/consistent-hashing-32     	      15	  79139760 ns/op	48192452 B/op	  132724 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/consistent-hashing-32     	      13	  79057136 ns/op	48215898 B/op	  132804 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/consistent-hashing-32     	      14	  79476125 ns/op	48210661 B/op	  132785 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/per-node-32               	      14	  79956889 ns/op	48200762 B/op	  132753 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/per-node-32               	      14	  79073909 ns/op	48231310 B/op	  132813 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/per-node-32               	      13	  79043000 ns/op	48208338 B/op	  132776 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/per-node-32               	      14	  79360126 ns/op	48207381 B/op	  132775 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/per-node-32               	      14	  79905481 ns/op	48202028 B/op	  132754 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/per-node-32               	      14	  79699799 ns/op	48199753 B/op	  132748 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/per-node-32               	      14	  79732757 ns/op	48210348 B/op	  132786 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/per-node-32               	      14	  79110739 ns/op	48201767 B/op	  132752 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/per-node-32               	      14	  78742812 ns/op	48209524 B/op	  132782 allocs/op
BenchmarkProcessTargetsWithRelabelConfig/per-node-32               	      14	  79589282 ns/op	48201804 B/op	  132757 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator	70.322s

```
