### PR TITLE
Use a different struct for scrape target serialization

### DIFF
--- a/cmd/otel-allocator/server/bench_test.go
+++ b/cmd/otel-allocator/server/bench_test.go
@@ -198,7 +198,7 @@ func BenchmarkTargetItemsJSONHandler(b *testing.B) {
 		},
 	}
 	for _, tc := range tests {
-		data := makeNTargetItems(*random, tc.numTargets, tc.numLabels)
+		data := makeNTargetJSON(*random, tc.numTargets, tc.numLabels)
 		b.Run(fmt.Sprintf("%d_targets_%d_labels", tc.numTargets, tc.numLabels), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
@@ -242,7 +242,7 @@ func makeNCollectorJSON(random rand.Rand, numCollectors, numItems int) map[strin
 	for i := 0; i < numCollectors; i++ {
 		items[randSeq(random, 20)] = collectorJSON{
 			Link: randSeq(random, 120),
-			Jobs: makeNTargetItems(random, numItems, 50),
+			Jobs: makeNTargetJSON(random, numItems, 50),
 		}
 	}
 	return items
@@ -259,6 +259,15 @@ func makeNTargetItems(random rand.Rand, numItems, numLabels int) []*target.Item 
 		))
 	}
 	return items
+}
+
+func makeNTargetJSON(random rand.Rand, numItems, numLabels int) []*targetJSON {
+	items := makeNTargetItems(random, numItems, numLabels)
+	targets := make([]*targetJSON, numItems)
+	for i := 0; i < numItems; i++ {
+		targets[i] = targetJsonFromTargetItem(items[i])
+	}
+	return targets
 }
 
 func makeNNewLabels(random rand.Rand, n int) model.LabelSet {

--- a/cmd/otel-allocator/server/server.go
+++ b/cmd/otel-allocator/server/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	promcommconfig "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
 	"gopkg.in/yaml.v2"
 
@@ -57,8 +58,17 @@ var (
 )
 
 type collectorJSON struct {
-	Link string         `json:"_link"`
-	Jobs []*target.Item `json:"targets"`
+	Link string        `json:"_link"`
+	Jobs []*targetJSON `json:"targets"`
+}
+
+type linkJSON struct {
+	Link string `json:"_link"`
+}
+
+type targetJSON struct {
+	TargetURL []string       `json:"targets"`
+	Labels    model.LabelSet `json:"labels"`
 }
 
 type Server struct {
@@ -263,9 +273,9 @@ func (s *Server) ReadinessProbeHandler(c *gin.Context) {
 }
 
 func (s *Server) JobHandler(c *gin.Context) {
-	displayData := make(map[string]target.LinkJSON)
+	displayData := make(map[string]linkJSON)
 	for _, v := range s.allocator.TargetItems() {
-		displayData[v.JobName] = target.LinkJSON{Link: v.Link.Link}
+		displayData[v.JobName] = linkJSON{Link: fmt.Sprintf("/jobs/%s/targets", url.QueryEscape(v.JobName))}
 	}
 	s.jsonHandler(c.Writer, displayData)
 }
@@ -294,16 +304,16 @@ func (s *Server) TargetsHandler(c *gin.Context) {
 	if len(q) == 0 {
 		displayData := GetAllTargetsByJob(s.allocator, jobId)
 		s.jsonHandler(c.Writer, displayData)
-
 	} else {
-		tgs := s.allocator.GetTargetsForCollectorAndJob(q[0], jobId)
+		targets := GetAllTargetsByCollectorAndJob(s.allocator, q[0], jobId)
 		// Displays empty list if nothing matches
-		if len(tgs) == 0 {
+		if len(targets) == 0 {
 			s.jsonHandler(c.Writer, []interface{}{})
 			return
 		}
-		s.jsonHandler(c.Writer, tgs)
+		s.jsonHandler(c.Writer, targets)
 	}
+
 }
 
 func (s *Server) errorHandler(w http.ResponseWriter, err error) {
@@ -323,10 +333,23 @@ func (s *Server) jsonHandler(w http.ResponseWriter, data interface{}) {
 func GetAllTargetsByJob(allocator allocation.Allocator, job string) map[string]collectorJSON {
 	displayData := make(map[string]collectorJSON)
 	for _, col := range allocator.Collectors() {
-		items := allocator.GetTargetsForCollectorAndJob(col.Name, job)
-		displayData[col.Name] = collectorJSON{Link: fmt.Sprintf("/jobs/%s/targets?collector_id=%s", url.QueryEscape(job), col.Name), Jobs: items}
+		targets := GetAllTargetsByCollectorAndJob(allocator, col.Name, job)
+		displayData[col.Name] = collectorJSON{
+			Link: fmt.Sprintf("/jobs/%s/targets?collector_id=%s", url.QueryEscape(job), col.Name),
+			Jobs: targets,
+		}
 	}
 	return displayData
+}
+
+// GetAllTargetsByCollector returns all the targets for a given collector and job.
+func GetAllTargetsByCollectorAndJob(allocator allocation.Allocator, collectorName string, jobName string) []*targetJSON {
+	items := allocator.GetTargetsForCollectorAndJob(collectorName, jobName)
+	targets := make([]*targetJSON, len(items))
+	for i, item := range items {
+		targets[i] = targetJsonFromTargetItem(item)
+	}
+	return targets
 }
 
 // registerPprof registers the pprof handlers and either serves the requested
@@ -347,4 +370,11 @@ func registerPprof(g *gin.RouterGroup) {
 			gin.WrapF(pprof.Index)(c)
 		}
 	})
+}
+
+func targetJsonFromTargetItem(item *target.Item) *targetJSON {
+	return &targetJSON{
+		TargetURL: item.TargetURL,
+		Labels:    item.Labels,
+	}
 }

--- a/cmd/otel-allocator/server/server_test.go
+++ b/cmd/otel-allocator/server/server_test.go
@@ -74,7 +74,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 		allocator allocation.Allocator
 	}
 	type want struct {
-		items     []*target.Item
+		items     []*targetJSON
 		errString string
 	}
 	tests := []struct {
@@ -91,7 +91,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 				allocator: leastWeighted,
 			},
 			want: want{
-				items: []*target.Item{},
+				items: []*targetJSON{},
 			},
 		},
 		{
@@ -105,7 +105,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 				allocator: leastWeighted,
 			},
 			want: want{
-				items: []*target.Item{
+				items: []*targetJSON{
 					{
 						TargetURL: []string{"test-url"},
 						Labels: map[model.LabelName]model.LabelValue{
@@ -127,7 +127,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 				allocator: leastWeighted,
 			},
 			want: want{
-				items: []*target.Item{
+				items: []*targetJSON{
 					{
 						TargetURL: []string{"test-url"},
 						Labels: map[model.LabelName]model.LabelValue{
@@ -149,7 +149,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 				allocator: leastWeighted,
 			},
 			want: want{
-				items: []*target.Item{
+				items: []*targetJSON{
 					{
 						TargetURL: []string{"test-url"},
 						Labels: map[model.LabelName]model.LabelValue{
@@ -186,7 +186,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 				assert.EqualError(t, err, tt.want.errString)
 				return
 			}
-			var itemResponse []*target.Item
+			var itemResponse []*targetJSON
 			err = json.Unmarshal(bodyBytes, &itemResponse)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tt.want.items, itemResponse)
@@ -555,19 +555,19 @@ func TestServer_JobHandler(t *testing.T) {
 		description  string
 		targetItems  map[string]*target.Item
 		expectedCode int
-		expectedJobs map[string]target.LinkJSON
+		expectedJobs map[string]linkJSON
 	}{
 		{
 			description:  "nil jobs",
 			targetItems:  nil,
 			expectedCode: http.StatusOK,
-			expectedJobs: make(map[string]target.LinkJSON),
+			expectedJobs: make(map[string]linkJSON),
 		},
 		{
 			description:  "empty jobs",
 			targetItems:  map[string]*target.Item{},
 			expectedCode: http.StatusOK,
-			expectedJobs: make(map[string]target.LinkJSON),
+			expectedJobs: make(map[string]linkJSON),
 		},
 		{
 			description: "one job",
@@ -575,7 +575,7 @@ func TestServer_JobHandler(t *testing.T) {
 				"targetitem": target.NewItem("job1", "", model.LabelSet{}, ""),
 			},
 			expectedCode: http.StatusOK,
-			expectedJobs: map[string]target.LinkJSON{
+			expectedJobs: map[string]linkJSON{
 				"job1": newLink("job1"),
 			},
 		},
@@ -588,7 +588,7 @@ func TestServer_JobHandler(t *testing.T) {
 				"d": target.NewItem("job3", "", model.LabelSet{}, ""),
 				"e": target.NewItem("job3", "", model.LabelSet{}, "")},
 			expectedCode: http.StatusOK,
-			expectedJobs: map[string]target.LinkJSON{
+			expectedJobs: map[string]linkJSON{
 				"job1": newLink("job1"),
 				"job2": newLink("job2"),
 				"job3": newLink("job3"),
@@ -609,7 +609,7 @@ func TestServer_JobHandler(t *testing.T) {
 			assert.Equal(t, tc.expectedCode, result.StatusCode)
 			bodyBytes, err := io.ReadAll(result.Body)
 			require.NoError(t, err)
-			jobs := map[string]target.LinkJSON{}
+			jobs := map[string]linkJSON{}
 			err = json.Unmarshal(bodyBytes, &jobs)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedJobs, jobs)
@@ -737,6 +737,6 @@ func TestServer_ScrapeConfigRespose(t *testing.T) {
 	}
 }
 
-func newLink(jobName string) target.LinkJSON {
-	return target.LinkJSON{Link: fmt.Sprintf("/jobs/%s/targets", url.QueryEscape(jobName))}
+func newLink(jobName string) linkJSON {
+	return linkJSON{Link: fmt.Sprintf("/jobs/%s/targets", url.QueryEscape(jobName))}
 }

--- a/cmd/otel-allocator/target/target.go
+++ b/cmd/otel-allocator/target/target.go
@@ -15,9 +15,6 @@
 package target
 
 import (
-	"fmt"
-	"net/url"
-
 	"github.com/prometheus/common/model"
 )
 
@@ -34,17 +31,11 @@ var (
 	endpointSliceTargetNameLabel model.LabelName = "__meta_kubernetes_endpointslice_address_target_name"
 )
 
-// LinkJSON This package contains common structs and methods that relate to scrape targets.
-type LinkJSON struct {
-	Link string `json:"_link"`
-}
-
 type Item struct {
-	JobName       string         `json:"-"`
-	Link          LinkJSON       `json:"-"`
-	TargetURL     []string       `json:"targets"`
-	Labels        model.LabelSet `json:"labels"`
-	CollectorName string         `json:"-"`
+	JobName       string
+	TargetURL     []string
+	Labels        model.LabelSet
+	CollectorName string
 	hash          string
 }
 
@@ -73,7 +64,6 @@ func (t *Item) GetNodeName() string {
 func NewItem(jobName string, targetURL string, label model.LabelSet, collectorName string) *Item {
 	return &Item{
 		JobName:       jobName,
-		Link:          LinkJSON{Link: fmt.Sprintf("/jobs/%s/targets", url.QueryEscape(jobName))},
 		hash:          jobName + targetURL + label.Fingerprint().String(),
 		TargetURL:     []string{targetURL},
 		Labels:        label,


### PR DESCRIPTION
Use a different struct for serializing HTTP server output than we use for internally representing targets. Out internal target struct should only hold the information necessary for target allocation, it doesn't need to concern itself with what the HTTP endpoints ultimately output. I removed the JSON tags from the struct, and introduced a separate struct used exclusively by the server.

As a result, we save some memory on target generation and allocation, but introduce additional allocations for the HTTP endpoint. Given that in larger clusters, the latter accounts for the vast majority of target allocator runtime, I think this is a worthwhile trade.

Benchstat doesn't show much of a difference:

```
goos: linux
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/server
cpu: AMD Ryzen 9 7950X3D 16-Core Processor          
                                                                         │ bench_server_main.txt │      bench_server_branch.txt       │
                                                                         │        sec/op         │   sec/op     vs base               │
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_100-32                     3.255µ ± 1%   3.276µ ± 1%       ~ (p=0.128 n=10)
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_1000-32                    3.318µ ± 1%   3.306µ ± 2%       ~ (p=0.781 n=10)
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_10000-32                   3.240µ ± 2%   3.201µ ± 1%  -1.20% (p=0.037 n=10)
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_100000-32                  2.841µ ± 2%   2.751µ ± 2%  -3.17% (p=0.001 n=10)
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_100-32                    3.304µ ± 1%   3.289µ ± 1%       ~ (p=0.225 n=10)
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_1000-32                   3.354µ ± 1%   3.305µ ± 1%  -1.46% (p=0.000 n=10)
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_10000-32                  3.263µ ± 2%   3.187µ ± 2%  -2.34% (p=0.012 n=10)
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_100000-32                 2.950µ ± 1%   2.853µ ± 1%  -3.29% (p=0.000 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_100-32                 3.309µ ± 1%   3.357µ ± 1%  +1.45% (p=0.006 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_1000-32                3.349µ ± 1%   3.368µ ± 2%       ~ (p=0.210 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_10000-32               3.270µ ± 1%   3.236µ ± 1%  -1.04% (p=0.045 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_100000-32              2.906µ ± 2%   2.856µ ± 1%  -1.74% (p=0.001 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_100-32                3.321µ ± 1%   3.320µ ± 2%       ~ (p=0.912 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_1000-32               3.328µ ± 2%   3.310µ ± 1%       ~ (p=0.218 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_10000-32              3.186µ ± 1%   3.217µ ± 1%       ~ (p=0.078 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_100000-32             2.920µ ± 1%   2.893µ ± 1%  -0.91% (p=0.000 n=10)
ServerTargetsHandler/per-node_num_cols_100_num_jobs_100-32                           3.228µ ± 1%   3.220µ ± 1%       ~ (p=0.617 n=10)
ServerTargetsHandler/per-node_num_cols_100_num_jobs_1000-32                          3.285µ ± 2%   3.229µ ± 1%  -1.70% (p=0.014 n=10)
ServerTargetsHandler/per-node_num_cols_100_num_jobs_10000-32                         3.173µ ± 2%   3.084µ ± 2%  -2.82% (p=0.004 n=10)
ServerTargetsHandler/per-node_num_cols_100_num_jobs_100000-32                        2.793µ ± 1%   2.713µ ± 2%  -2.86% (p=0.000 n=10)
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_100-32                          3.260µ ± 1%   3.218µ ± 2%       ~ (p=0.101 n=10)
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_1000-32                         3.251µ ± 1%   3.248µ ± 1%       ~ (p=0.305 n=10)
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_10000-32                        3.181µ ± 1%   3.107µ ± 2%  -2.34% (p=0.003 n=10)
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_100000-32                       2.831µ ± 1%   2.756µ ± 1%  -2.65% (p=0.000 n=10)
ScrapeConfigsHandler/0_targets-32                                                    2.706µ ± 2%   2.663µ ± 1%  -1.57% (p=0.001 n=10)
ScrapeConfigsHandler/5_targets-32                                                    3.158µ ± 1%   3.088µ ± 2%  -2.23% (p=0.002 n=10)
ScrapeConfigsHandler/10_targets-32                                                   3.608µ ± 1%   3.574µ ± 1%  -0.94% (p=0.018 n=10)
ScrapeConfigsHandler/50_targets-32                                                   5.829µ ± 2%   5.686µ ± 1%  -2.45% (p=0.001 n=10)
ScrapeConfigsHandler/100_targets-32                                                  9.577µ ± 1%   9.649µ ± 1%       ~ (p=0.190 n=10)
ScrapeConfigsHandler/500_targets-32                                                  28.60µ ± 1%   29.16µ ± 1%       ~ (p=0.075 n=10)
CollectorMapJSONHandler/0_collectors_0_targets-32                                    890.9n ± 2%   871.4n ± 2%  -2.19% (p=0.025 n=10)
CollectorMapJSONHandler/5_collectors_5_targets-32                                    118.0µ ± 1%   116.5µ ± 1%  -1.27% (p=0.000 n=10)
CollectorMapJSONHandler/5_collectors_50_targets-32                                   1.137m ± 1%   1.138m ± 1%       ~ (p=0.315 n=10)
CollectorMapJSONHandler/5_collectors_500_targets-32                                  9.203m ± 2%   9.554m ± 7%       ~ (p=0.063 n=10)
CollectorMapJSONHandler/50_collectors_5_targets-32                                   1.171m ± 1%   1.141m ± 1%  -2.60% (p=0.000 n=10)
CollectorMapJSONHandler/50_collectors_50_targets-32                                  9.166m ± 2%   9.696m ± 2%  +5.78% (p=0.000 n=10)
CollectorMapJSONHandler/50_collectors_500_targets-32                                 97.31m ± 2%   96.40m ± 1%       ~ (p=0.436 n=10)
CollectorMapJSONHandler/50_collectors_5000_targets-32                               1001.7m ± 1%   989.0m ± 3%       ~ (p=0.247 n=10)
TargetItemsJSONHandler/0_targets_0_labels-32                                         806.9n ± 4%   807.9n ± 1%       ~ (p=0.684 n=10)
TargetItemsJSONHandler/5_targets_5_labels-32                                         4.478µ ± 1%   4.479µ ± 1%       ~ (p=0.541 n=10)
TargetItemsJSONHandler/5_targets_50_labels-32                                        27.35µ ± 1%   27.56µ ± 1%  +0.78% (p=0.035 n=10)
TargetItemsJSONHandler/50_targets_5_labels-32                                        42.84µ ± 1%   42.86µ ± 1%       ~ (p=1.000 n=10)
TargetItemsJSONHandler/50_targets_50_labels-32                                       225.7µ ± 1%   232.1µ ± 1%  +2.88% (p=0.000 n=10)
TargetItemsJSONHandler/500_targets_50_labels-32                                      2.314m ± 1%   2.415m ± 2%  +4.38% (p=0.000 n=10)
TargetItemsJSONHandler/500_targets_500_labels-32                                     24.90m ± 2%   24.59m ± 5%       ~ (p=0.579 n=10)
TargetItemsJSONHandler/5000_targets_50_labels-32                                     23.83m ± 2%   23.14m ± 2%  -2.89% (p=0.003 n=10)
TargetItemsJSONHandler/5000_targets_500_labels-32                                    253.5m ± 2%   252.6m ± 1%       ~ (p=0.353 n=10)
geomean                                                                              27.02µ        26.86µ       -0.58%

                                                                         │ bench_server_main.txt │        bench_server_branch.txt        │
                                                                         │         B/op          │     B/op      vs base                 │
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_100-32                    6.828Ki ± 0%   6.828Ki ± 0%  +0.01% (p=0.033 n=10)
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_1000-32                   6.845Ki ± 0%   6.846Ki ± 0%  +0.01% (p=0.003 n=10)
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_10000-32                  6.844Ki ± 0%   6.845Ki ± 0%  +0.01% (p=0.001 n=10)
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_100000-32                 6.838Ki ± 0%   6.839Ki ± 0%  +0.01% (p=0.000 n=10)
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_100-32                   6.845Ki ± 0%   6.845Ki ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_1000-32                  6.852Ki ± 0%   6.852Ki ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_10000-32                 6.849Ki ± 0%   6.849Ki ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_100000-32                6.843Ki ± 0%   6.843Ki ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_100-32                6.827Ki ± 0%   6.827Ki ± 0%       ~ (p=1.000 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_1000-32               6.845Ki ± 0%   6.845Ki ± 0%  +0.01% (p=0.033 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_10000-32              6.844Ki ± 0%   6.845Ki ± 0%  +0.01% (p=0.000 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_100000-32             6.838Ki ± 0%   6.839Ki ± 0%  +0.01% (p=0.000 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_100-32               6.844Ki ± 0%   6.844Ki ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_1000-32              6.851Ki ± 0%   6.851Ki ± 0%       ~ (p=0.211 n=10)
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_10000-32             6.849Ki ± 0%   6.849Ki ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_100000-32            6.843Ki ± 0%   6.843Ki ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_100_num_jobs_100-32                          6.825Ki ± 0%   6.825Ki ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_100_num_jobs_1000-32                         6.843Ki ± 0%   6.844Ki ± 0%  +0.01% (p=0.005 n=10)
ServerTargetsHandler/per-node_num_cols_100_num_jobs_10000-32                        6.843Ki ± 0%   6.844Ki ± 0%  +0.01% (p=0.000 n=10)
ServerTargetsHandler/per-node_num_cols_100_num_jobs_100000-32                       6.837Ki ± 0%   6.838Ki ± 0%  +0.01% (p=0.000 n=10)
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_100-32                         6.844Ki ± 0%   6.844Ki ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_1000-32                        6.852Ki ± 0%   6.852Ki ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_10000-32                       6.850Ki ± 0%   6.850Ki ± 0%       ~ (p=0.474 n=10)
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_100000-32                      6.843Ki ± 0%   6.844Ki ± 0%  +0.01% (p=0.001 n=10)
ScrapeConfigsHandler/0_targets-32                                                   6.691Ki ± 0%   6.691Ki ± 0%       ~ (p=1.000 n=10) ¹
ScrapeConfigsHandler/5_targets-32                                                   8.880Ki ± 0%   8.880Ki ± 0%       ~ (p=1.000 n=10) ¹
ScrapeConfigsHandler/10_targets-32                                                  11.38Ki ± 0%   11.38Ki ± 0%       ~ (p=1.000 n=10) ¹
ScrapeConfigsHandler/50_targets-32                                                  27.89Ki ± 0%   27.89Ki ± 0%       ~ (p=1.000 n=10) ¹
ScrapeConfigsHandler/100_targets-32                                                 54.65Ki ± 0%   54.65Ki ± 0%  +0.00% (p=0.011 n=10)
ScrapeConfigsHandler/500_targets-32                                                 214.7Ki ± 0%   214.7Ki ± 0%       ~ (p=0.997 n=10)
CollectorMapJSONHandler/0_collectors_0_targets-32                                   1.711Ki ± 0%   1.711Ki ± 0%       ~ (p=1.000 n=10) ¹
CollectorMapJSONHandler/5_collectors_5_targets-32                                   346.3Ki ± 0%   346.3Ki ± 0%       ~ (p=0.170 n=10)
CollectorMapJSONHandler/5_collectors_50_targets-32                                  3.716Mi ± 0%   3.716Mi ± 0%  +0.00% (p=0.014 n=10)
CollectorMapJSONHandler/5_collectors_500_targets-32                                 37.92Mi ± 0%   37.92Mi ± 0%       ~ (p=0.247 n=10)
CollectorMapJSONHandler/50_collectors_5_targets-32                                  3.723Mi ± 0%   3.723Mi ± 0%       ~ (p=0.931 n=10)
CollectorMapJSONHandler/50_collectors_50_targets-32                                 37.93Mi ± 0%   37.93Mi ± 0%       ~ (p=0.322 n=10)
CollectorMapJSONHandler/50_collectors_500_targets-32                                362.0Mi ± 0%   362.0Mi ± 0%  +0.00% (p=0.000 n=10)
CollectorMapJSONHandler/50_collectors_5000_targets-32                               4.024Gi ± 0%   4.024Gi ± 0%       ~ (p=1.000 n=10)
TargetItemsJSONHandler/0_targets_0_labels-32                                        1.609Ki ± 0%   1.609Ki ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/5_targets_5_labels-32                                        8.383Ki ± 0%   8.383Ki ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/5_targets_50_labels-32                                       75.88Ki ± 0%   75.88Ki ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/50_targets_5_labels-32                                       109.2Ki ± 0%   109.2Ki ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/50_targets_50_labels-32                                      637.2Ki ± 0%   637.2Ki ± 0%       ~ (p=0.635 n=10)
TargetItemsJSONHandler/500_targets_50_labels-32                                     7.580Mi ± 0%   7.580Mi ± 0%       ~ (p=0.615 n=10)
TargetItemsJSONHandler/500_targets_500_labels-32                                    73.55Mi ± 0%   73.55Mi ± 0%       ~ (p=0.127 n=10)
TargetItemsJSONHandler/5000_targets_50_labels-32                                    74.83Mi ± 0%   74.83Mi ± 0%       ~ (p=0.306 n=10)
TargetItemsJSONHandler/5000_targets_500_labels-32                                   697.8Mi ± 0%   697.8Mi ± 0%       ~ (p=0.143 n=10)
geomean                                                                             71.16Ki        71.16Ki       +0.00%
¹ all samples are equal

                                                                         │ bench_server_main.txt │       bench_server_branch.txt        │
                                                                         │       allocs/op       │  allocs/op   vs base                 │
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_100-32                      25.00 ± 0%    25.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_1000-32                     25.00 ± 0%    25.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_10000-32                    26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/least-weighted_num_cols_100_num_jobs_100000-32                   26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_100-32                     25.00 ± 0%    25.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_1000-32                    26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_10000-32                   26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/least-weighted_num_cols_1000_num_jobs_100000-32                  26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_100-32                  25.00 ± 0%    25.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_1000-32                 25.00 ± 0%    25.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_10000-32                26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/consistent-hashing_num_cols_100_num_jobs_100000-32               26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_100-32                 25.00 ± 0%    25.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_1000-32                26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_10000-32               26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/consistent-hashing_num_cols_1000_num_jobs_100000-32              26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_100_num_jobs_100-32                            25.00 ± 0%    25.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_100_num_jobs_1000-32                           25.00 ± 0%    25.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_100_num_jobs_10000-32                          25.00 ± 0%    25.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_100_num_jobs_100000-32                         26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_100-32                           25.00 ± 0%    25.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_1000-32                          26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_10000-32                         26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ServerTargetsHandler/per-node_num_cols_1000_num_jobs_100000-32                        26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ScrapeConfigsHandler/0_targets-32                                                     26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ScrapeConfigsHandler/5_targets-32                                                     26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ScrapeConfigsHandler/10_targets-32                                                    26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ScrapeConfigsHandler/50_targets-32                                                    26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ScrapeConfigsHandler/100_targets-32                                                   26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
ScrapeConfigsHandler/500_targets-32                                                   26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
CollectorMapJSONHandler/0_collectors_0_targets-32                                     15.00 ± 0%    15.00 ± 0%       ~ (p=1.000 n=10) ¹
CollectorMapJSONHandler/5_collectors_5_targets-32                                     80.00 ± 0%    80.00 ± 0%       ~ (p=1.000 n=10) ¹
CollectorMapJSONHandler/5_collectors_50_targets-32                                    539.0 ± 0%    539.0 ± 0%       ~ (p=1.000 n=10) ¹
CollectorMapJSONHandler/5_collectors_500_targets-32                                  5.049k ± 0%   5.049k ± 0%       ~ (p=1.000 n=10) ¹
CollectorMapJSONHandler/50_collectors_5_targets-32                                    539.0 ± 0%    539.0 ± 0%       ~ (p=1.000 n=10) ¹
CollectorMapJSONHandler/50_collectors_50_targets-32                                  5.049k ± 0%   5.049k ± 0%       ~ (p=1.000 n=10) ¹
CollectorMapJSONHandler/50_collectors_500_targets-32                                 50.06k ± 0%   50.06k ± 0%       ~ (p=1.000 n=10) ¹
CollectorMapJSONHandler/50_collectors_5000_targets-32                                500.1k ± 0%   500.1k ± 0%       ~ (p=0.474 n=10)
TargetItemsJSONHandler/0_targets_0_labels-32                                          13.00 ± 0%    13.00 ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/5_targets_5_labels-32                                          26.00 ± 0%    26.00 ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/5_targets_50_labels-32                                         33.00 ± 0%    33.00 ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/50_targets_5_labels-32                                         124.0 ± 0%    124.0 ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/50_targets_50_labels-32                                        130.0 ± 0%    130.0 ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/500_targets_50_labels-32                                      1.040k ± 0%   1.040k ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/500_targets_500_labels-32                                     1.050k ± 0%   1.050k ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/5000_targets_50_labels-32                                     10.05k ± 0%   10.05k ± 0%       ~ (p=1.000 n=10) ¹
TargetItemsJSONHandler/5000_targets_500_labels-32                                    10.06k ± 0%   10.06k ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                               86.01         86.01       +0.00%
¹ all samples are equal
```

```
goos: linux
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator
cpu: AMD Ryzen 9 7950X3D 16-Core Processor          
                                                      │ bench_targets_main.txt │      bench_targets_branch.txt      │
                                                      │         sec/op         │   sec/op     vs base               │
ProcessTargets/per-node-32                                         79.38m ± 1%   78.40m ± 1%  -1.23% (p=0.000 n=10)
ProcessTargets/least-weighted-32                                   79.35m ± 1%   78.22m ± 1%  -1.42% (p=0.002 n=10)
ProcessTargets/consistent-hashing-32                               79.20m ± 1%   78.15m ± 1%  -1.33% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted-32                  79.66m ± 1%   78.72m ± 1%  -1.18% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing-32              79.47m ± 1%   78.72m ± 1%  -0.95% (p=0.011 n=10)
ProcessTargetsWithRelabelConfig/per-node-32                        79.47m ± 1%   78.65m ± 1%  -1.04% (p=0.003 n=10)
geomean                                                            79.42m        78.48m       -1.19%

                                                      │ bench_targets_main.txt │      bench_targets_branch.txt       │
                                                      │          B/op          │     B/op      vs base               │
ProcessTargets/per-node-32                                        45.68Mi ± 0%   45.15Mi ± 0%  -1.16% (p=0.000 n=10)
ProcessTargets/least-weighted-32                                  45.69Mi ± 0%   45.15Mi ± 0%  -1.18% (p=0.000 n=10)
ProcessTargets/consistent-hashing-32                              45.68Mi ± 0%   45.14Mi ± 0%  -1.18% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted-32                 45.98Mi ± 0%   45.44Mi ± 0%  -1.17% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing-32             45.98Mi ± 0%   45.44Mi ± 0%  -1.17% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node-32                       45.97Mi ± 0%   45.44Mi ± 0%  -1.15% (p=0.000 n=10)
geomean                                                           45.83Mi        45.29Mi       -1.17%

                                                      │ bench_targets_main.txt │      bench_targets_branch.txt       │
                                                      │       allocs/op        │  allocs/op   vs base                │
ProcessTargets/per-node-32                                         132.4k ± 0%   112.4k ± 0%  -15.10% (p=0.000 n=10)
ProcessTargets/least-weighted-32                                   132.4k ± 0%   112.4k ± 0%  -15.12% (p=0.000 n=10)
ProcessTargets/consistent-hashing-32                               132.4k ± 0%   112.4k ± 0%  -15.13% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted-32                  132.8k ± 0%   112.8k ± 0%  -15.08% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing-32              132.8k ± 0%   112.8k ± 0%  -15.08% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node-32                        132.8k ± 0%   112.8k ± 0%  -15.06% (p=0.000 n=10)
geomean                                                            132.6k        112.6k       -15.10%

```
