### PR TITLE
Store Prometheus labels as a slice instead of a map

### DIFF
--- a/cmd/otel-allocator/allocation/allocator_test.go
+++ b/cmd/otel-allocator/allocation/allocator_test.go
@@ -17,7 +17,7 @@ package allocation
 import (
 	"testing"
 
-	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
@@ -176,11 +176,11 @@ func TestAllocationCollision(t *testing.T) {
 
 		cols := MakeNCollectors(3, 0)
 		allocator.SetCollectors(cols)
-		firstLabels := model.LabelSet{
-			"test": "test1",
+		firstLabels := labels.Labels{
+			{Name: "test", Value: "test1"},
 		}
-		secondLabels := model.LabelSet{
-			"test": "test2",
+		secondLabels := labels.Labels{
+			{Name: "test", Value: "test2"},
 		}
 		firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstLabels, "")
 		secondTarget := target.NewItem("sample-name", "0.0.0.0:8000", secondLabels, "")

--- a/cmd/otel-allocator/allocation/consistent_hashing.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing.go
@@ -16,7 +16,6 @@ package allocation
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/buraksezer/consistent"
 	"github.com/cespare/xxhash/v2"
@@ -59,7 +58,7 @@ func (s *consistentHashingStrategy) GetName() string {
 }
 
 func (s *consistentHashingStrategy) GetCollectorForTarget(collectors map[string]*Collector, item *target.Item) (*Collector, error) {
-	hashKey := strings.Join(item.TargetURL, "")
+	hashKey := item.TargetURL
 	member := s.consistentHasher.LocateKey([]byte(hashKey))
 	collectorName := member.String()
 	collector, ok := collectors[collectorName]

--- a/cmd/otel-allocator/allocation/per_node_test.go
+++ b/cmd/otel-allocator/allocation/per_node_test.go
@@ -17,7 +17,7 @@ package allocation
 import (
 	"testing"
 
-	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -33,23 +33,23 @@ func TestAllocationPerNode(t *testing.T) {
 
 	cols := MakeNCollectors(4, 0)
 	s.SetCollectors(cols)
-	firstLabels := model.LabelSet{
-		"test":                            "test1",
-		"__meta_kubernetes_pod_node_name": "node-0",
+	firstLabels := labels.Labels{
+		{Name: "test", Value: "test1"},
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
 	}
-	secondLabels := model.LabelSet{
-		"test":                        "test2",
-		"__meta_kubernetes_node_name": "node-1",
+	secondLabels := labels.Labels{
+		{Name: "test", Value: "test2"},
+		{Name: "__meta_kubernetes_node_name", Value: "node-1"},
 	}
 	// no label, should be skipped
-	thirdLabels := model.LabelSet{
-		"test": "test3",
+	thirdLabels := labels.Labels{
+		{Name: "test", Value: "test3"},
 	}
 	// endpointslice target kind and name
-	fourthLabels := model.LabelSet{
-		"test": "test4",
-		"__meta_kubernetes_endpointslice_address_target_kind": "Node",
-		"__meta_kubernetes_endpointslice_address_target_name": "node-3",
+	fourthLabels := labels.Labels{
+		{Name: "test", Value: "test4"},
+		{Name: "__meta_kubernetes_endpointslice_address_target_kind", Value: "Node"},
+		{Name: "__meta_kubernetes_endpointslice_address_target_name", Value: "node-3"},
 	}
 
 	firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstLabels, "")

--- a/cmd/otel-allocator/allocation/testutils.go
+++ b/cmd/otel-allocator/allocation/testutils.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -39,9 +39,9 @@ func MakeNNewTargets(n int, numCollectors int, startingIndex int) map[string]*ta
 	toReturn := map[string]*target.Item{}
 	for i := startingIndex; i < n+startingIndex; i++ {
 		collector := fmt.Sprintf("collector-%d", colIndex(i, numCollectors))
-		label := model.LabelSet{
-			"i":     model.LabelValue(strconv.Itoa(i)),
-			"total": model.LabelValue(strconv.Itoa(n + startingIndex)),
+		label := labels.Labels{
+			{Name: "i", Value: strconv.Itoa(i)},
+			{Name: "total", Value: strconv.Itoa(n + startingIndex)},
 		}
 		newTarget := target.NewItem(fmt.Sprintf("test-job-%d", i), fmt.Sprintf("test-url-%d", i), label, collector)
 		toReturn[newTarget.Hash()] = newTarget
@@ -65,10 +65,10 @@ func MakeNCollectors(n int, startingIndex int) map[string]*Collector {
 func MakeNNewTargetsWithEmptyCollectors(n int, startingIndex int) map[string]*target.Item {
 	toReturn := map[string]*target.Item{}
 	for i := startingIndex; i < n+startingIndex; i++ {
-		label := model.LabelSet{
-			"i":                               model.LabelValue(strconv.Itoa(i)),
-			"total":                           model.LabelValue(strconv.Itoa(n + startingIndex)),
-			"__meta_kubernetes_pod_node_name": model.LabelValue("node-0"),
+		label := labels.Labels{
+			{Name: "i", Value: strconv.Itoa(i)},
+			{Name: "total", Value: strconv.Itoa(n + startingIndex)},
+			{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
 		}
 		newTarget := target.NewItem(fmt.Sprintf("test-job-%d", i), fmt.Sprintf("test-url-%d", i), label, "")
 		toReturn[newTarget.Hash()] = newTarget

--- a/cmd/otel-allocator/prehook/relabel.go
+++ b/cmd/otel-allocator/prehook/relabel.go
@@ -16,8 +16,6 @@ package prehook
 
 import (
 	"github.com/go-logr/logr"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
@@ -35,18 +33,6 @@ func NewRelabelConfigTargetFilter(log logr.Logger) Hook {
 	}
 }
 
-// helper function converts from model.LabelSet to []labels.Label.
-func convertLabelToPromLabelSet(lbls model.LabelSet) []labels.Label {
-	newLabels := make([]labels.Label, len(lbls))
-	index := 0
-	for k, v := range lbls {
-		newLabels[index].Name = string(k)
-		newLabels[index].Value = string(v)
-		index++
-	}
-	return newLabels
-}
-
 func (tf *RelabelConfigTargetFilter) Apply(targets map[string]*target.Item) map[string]*target.Item {
 	numTargets := len(targets)
 
@@ -58,13 +44,11 @@ func (tf *RelabelConfigTargetFilter) Apply(targets map[string]*target.Item) map[
 	// Note: jobNameKey != tItem.JobName (jobNameKey is hashed)
 	for jobNameKey, tItem := range targets {
 		keepTarget := true
-		lset := convertLabelToPromLabelSet(tItem.Labels)
+		lset := tItem.Labels
 		for _, cfg := range tf.relabelCfg[tItem.JobName] {
-			if newLset, keep := relabel.Process(lset, cfg); !keep {
-				keepTarget = false
+			lset, keepTarget = relabel.Process(lset, cfg)
+			if !keepTarget {
 				break // inner loop
-			} else {
-				lset = newLset
 			}
 		}
 

--- a/cmd/otel-allocator/prehook/relabel.go
+++ b/cmd/otel-allocator/prehook/relabel.go
@@ -43,17 +43,14 @@ func (tf *RelabelConfigTargetFilter) Apply(targets map[string]*target.Item) map[
 
 	// Note: jobNameKey != tItem.JobName (jobNameKey is hashed)
 	for jobNameKey, tItem := range targets {
-		keepTarget := true
+		var keepTarget bool
 		lset := tItem.Labels
 		for _, cfg := range tf.relabelCfg[tItem.JobName] {
 			lset, keepTarget = relabel.Process(lset, cfg)
 			if !keepTarget {
+				delete(targets, jobNameKey)
 				break // inner loop
 			}
-		}
-
-		if !keepTarget {
-			delete(targets, jobNameKey)
 		}
 	}
 

--- a/cmd/otel-allocator/prehook/relabel_test.go
+++ b/cmd/otel-allocator/prehook/relabel_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/assert"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -184,10 +185,10 @@ func makeNNewTargets(rCfgs []relabelConfigObj, n int, numCollectors int, startin
 	relabelConfig := make(map[string][]*relabel.Config)
 	for i := startingIndex; i < n+startingIndex; i++ {
 		collector := fmt.Sprintf("collector-%d", colIndex(i, numCollectors))
-		label := model.LabelSet{
-			"collector": model.LabelValue(collector),
-			"i":         model.LabelValue(strconv.Itoa(i)),
-			"total":     model.LabelValue(strconv.Itoa(n + startingIndex)),
+		label := labels.Labels{
+			{Name: "collector", Value: collector},
+			{Name: "i", Value: strconv.Itoa(i)},
+			{Name: "total", Value: strconv.Itoa(n + startingIndex)},
 		}
 		jobName := fmt.Sprintf("test-job-%d", i)
 		newTarget := target.NewItem(jobName, "test-url", label, collector)

--- a/cmd/otel-allocator/server/bench_test.go
+++ b/cmd/otel-allocator/server/bench_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
@@ -249,12 +250,13 @@ func makeNCollectorJSON(random rand.Rand, numCollectors, numItems int) map[strin
 }
 
 func makeNTargetItems(random rand.Rand, numItems, numLabels int) []*target.Item {
+	builder := labels.NewBuilder(labels.EmptyLabels())
 	items := make([]*target.Item, 0, numItems)
 	for i := 0; i < numItems; i++ {
 		items = append(items, target.NewItem(
 			randSeq(random, 80),
 			randSeq(random, 150),
-			makeNNewLabels(random, numLabels),
+			makeNNewLabels(builder, random, numLabels),
 			randSeq(random, 30),
 		))
 	}
@@ -270,10 +272,10 @@ func makeNTargetJSON(random rand.Rand, numItems, numLabels int) []*targetJSON {
 	return targets
 }
 
-func makeNNewLabels(random rand.Rand, n int) model.LabelSet {
-	labels := make(map[model.LabelName]model.LabelValue, n)
+func makeNNewLabels(builder *labels.Builder, random rand.Rand, n int) labels.Labels {
+	builder.Reset(labels.EmptyLabels())
 	for i := 0; i < n; i++ {
-		labels[model.LabelName(randSeq(random, 20))] = model.LabelValue(randSeq(random, 20))
+		builder.Set(randSeq(random, 20), randSeq(random, 20))
 	}
-	return labels
+	return builder.Labels()
 }

--- a/cmd/otel-allocator/server/server.go
+++ b/cmd/otel-allocator/server/server.go
@@ -34,8 +34,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	promcommconfig "github.com/prometheus/common/config"
-	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
 	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
@@ -67,8 +67,8 @@ type linkJSON struct {
 }
 
 type targetJSON struct {
-	TargetURL []string       `json:"targets"`
-	Labels    model.LabelSet `json:"labels"`
+	TargetURL []string      `json:"targets"`
+	Labels    labels.Labels `json:"labels"`
 }
 
 type Server struct {
@@ -374,7 +374,7 @@ func registerPprof(g *gin.RouterGroup) {
 
 func targetJsonFromTargetItem(item *target.Item) *targetJSON {
 	return &targetJSON{
-		TargetURL: item.TargetURL,
+		TargetURL: []string{item.TargetURL},
 		Labels:    item.Labels,
 	}
 }

--- a/cmd/otel-allocator/server/server_test.go
+++ b/cmd/otel-allocator/server/server_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,11 +42,11 @@ import (
 
 var (
 	logger       = logf.Log.WithName("server-unit-tests")
-	baseLabelSet = model.LabelSet{
-		"test_label": "test-value",
+	baseLabelSet = labels.Labels{
+		{Name: "test_label", Value: "test-value"},
 	}
-	testJobLabelSetTwo = model.LabelSet{
-		"test_label": "test-value2",
+	testJobLabelSetTwo = labels.Labels{
+		{Name: "test_label", Value: "test-value2"},
 	}
 	baseTargetItem       = target.NewItem("test-job", "test-url", baseLabelSet, "test-collector")
 	secondTargetItem     = target.NewItem("test-job", "test-url", baseLabelSet, "test-collector")
@@ -108,8 +109,8 @@ func TestServer_TargetsHandler(t *testing.T) {
 				items: []*targetJSON{
 					{
 						TargetURL: []string{"test-url"},
-						Labels: map[model.LabelName]model.LabelValue{
-							"test_label": "test-value",
+						Labels: labels.Labels{
+							{Name: "test_label", Value: "test-value"},
 						},
 					},
 				},
@@ -130,8 +131,8 @@ func TestServer_TargetsHandler(t *testing.T) {
 				items: []*targetJSON{
 					{
 						TargetURL: []string{"test-url"},
-						Labels: map[model.LabelName]model.LabelValue{
-							"test_label": "test-value",
+						Labels: labels.Labels{
+							{Name: "test_label", Value: "test-value"},
 						},
 					},
 				},
@@ -152,14 +153,14 @@ func TestServer_TargetsHandler(t *testing.T) {
 				items: []*targetJSON{
 					{
 						TargetURL: []string{"test-url"},
-						Labels: map[model.LabelName]model.LabelValue{
-							"test_label": "test-value",
+						Labels: labels.Labels{
+							{Name: "test_label", Value: "test-value"},
 						},
 					},
 					{
 						TargetURL: []string{"test-url2"},
-						Labels: map[model.LabelName]model.LabelValue{
-							"test_label": "test-value2",
+						Labels: labels.Labels{
+							{Name: "test_label", Value: "test-value2"},
 						},
 					},
 				},
@@ -572,7 +573,7 @@ func TestServer_JobHandler(t *testing.T) {
 		{
 			description: "one job",
 			targetItems: map[string]*target.Item{
-				"targetitem": target.NewItem("job1", "", model.LabelSet{}, ""),
+				"targetitem": target.NewItem("job1", "", labels.Labels{}, ""),
 			},
 			expectedCode: http.StatusOK,
 			expectedJobs: map[string]linkJSON{
@@ -582,11 +583,11 @@ func TestServer_JobHandler(t *testing.T) {
 		{
 			description: "multiple jobs",
 			targetItems: map[string]*target.Item{
-				"a": target.NewItem("job1", "", model.LabelSet{}, ""),
-				"b": target.NewItem("job2", "", model.LabelSet{}, ""),
-				"c": target.NewItem("job3", "", model.LabelSet{}, ""),
-				"d": target.NewItem("job3", "", model.LabelSet{}, ""),
-				"e": target.NewItem("job3", "", model.LabelSet{}, "")},
+				"a": target.NewItem("job1", "", labels.Labels{}, ""),
+				"b": target.NewItem("job2", "", labels.Labels{}, ""),
+				"c": target.NewItem("job3", "", labels.Labels{}, ""),
+				"d": target.NewItem("job3", "", labels.Labels{}, ""),
+				"e": target.NewItem("job3", "", labels.Labels{}, "")},
 			expectedCode: http.StatusOK,
 			expectedJobs: map[string]linkJSON{
 				"job1": newLink("job1"),

--- a/cmd/otel-allocator/target/discovery_test.go
+++ b/cmd/otel-allocator/target/discovery_test.go
@@ -87,7 +87,7 @@ func TestDiscovery(t *testing.T) {
 		err := manager.Watch(func(targets map[string]*Item) {
 			var result []string
 			for _, t := range targets {
-				result = append(result, t.TargetURL[0])
+				result = append(result, t.TargetURL)
 			}
 			results <- result
 		})

--- a/cmd/otel-allocator/target/target.go
+++ b/cmd/otel-allocator/target/target.go
@@ -15,26 +15,29 @@
 package target
 
 import (
-	"github.com/prometheus/common/model"
+	"strconv"
+
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 // nodeLabels are labels that are used to identify the node on which the given
 // target is residing. To learn more about these labels, please refer to:
 // https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config
 var (
-	nodeLabels = []model.LabelName{
+	nodeLabels = []string{
 		"__meta_kubernetes_pod_node_name",
 		"__meta_kubernetes_node_name",
 		"__meta_kubernetes_endpoint_node_name",
 	}
-	endpointSliceTargetKindLabel model.LabelName = "__meta_kubernetes_endpointslice_address_target_kind"
-	endpointSliceTargetNameLabel model.LabelName = "__meta_kubernetes_endpointslice_address_target_name"
+	endpointSliceTargetKindLabel = "__meta_kubernetes_endpointslice_address_target_kind"
+	endpointSliceTargetNameLabel = "__meta_kubernetes_endpointslice_address_target_name"
+	relevantLabelNames           = append(nodeLabels, endpointSliceTargetKindLabel, endpointSliceTargetNameLabel)
 )
 
 type Item struct {
 	JobName       string
-	TargetURL     []string
-	Labels        model.LabelSet
+	TargetURL     string
+	Labels        labels.Labels
 	CollectorName string
 	hash          string
 }
@@ -44,29 +47,30 @@ func (t *Item) Hash() string {
 }
 
 func (t *Item) GetNodeName() string {
+	relevantLabels := t.Labels.MatchLabels(true, relevantLabelNames...)
 	for _, label := range nodeLabels {
-		if val, ok := t.Labels[label]; ok {
-			return string(val)
+		if val := relevantLabels.Get(label); val != "" {
+			return val
 		}
 	}
 
-	if val := t.Labels[endpointSliceTargetKindLabel]; val != "Node" {
+	if val := relevantLabels.Get(endpointSliceTargetKindLabel); val != "Node" {
 		return ""
 	}
 
-	return string(t.Labels[endpointSliceTargetNameLabel])
+	return relevantLabels.Get(endpointSliceTargetNameLabel)
 }
 
 // NewItem Creates a new target item.
 // INVARIANTS:
 // * Item fields must not be modified after creation.
 // * Item should only be made via its constructor, never directly.
-func NewItem(jobName string, targetURL string, label model.LabelSet, collectorName string) *Item {
+func NewItem(jobName string, targetURL string, labels labels.Labels, collectorName string) *Item {
 	return &Item{
 		JobName:       jobName,
-		hash:          jobName + targetURL + label.Fingerprint().String(),
-		TargetURL:     []string{targetURL},
-		Labels:        label,
+		hash:          jobName + targetURL + strconv.FormatUint(labels.Hash(), 10),
+		TargetURL:     targetURL,
+		Labels:        labels,
 		CollectorName: collectorName,
 	}
 }


### PR DESCRIPTION
**Description:** 
Store labels for targets in the target allocator the same way Prometheus itself does - as a key+value list of type `labels.Labels` instead of a `model.Labelset` map. The former is what relabelling acts on, so we get to skip the conversion there, and building the list is faster as well. This makes looking up values of specific labels slower, but we don't really do that outside of determining the Node name.

I've modified the benchmark to actually drop half the targets during relabelling to make it more realistic.

Benchstat shows some nice gains:

```
goos: linux
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator
cpu: AMD Ryzen 9 7950X3D 16-Core Processor          
                                                      │ bench_targets_main.txt │      bench_targets_branch.txt       │
                                                      │         sec/op         │   sec/op     vs base                │
ProcessTargets/least-weighted-32                                   78.24m ± 1%   42.75m ± 1%  -45.36% (p=0.000 n=10)
ProcessTargets/consistent-hashing-32                               78.86m ± 0%   42.72m ± 1%  -45.83% (p=0.000 n=10)
ProcessTargets/per-node-32                                         78.71m ± 0%   42.86m ± 1%  -45.55% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node-32                        78.69m ± 1%   43.15m ± 1%  -45.17% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted-32                  79.11m ± 1%   43.25m ± 1%  -45.33% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing-32              79.05m ± 1%   42.86m ± 2%  -45.79% (p=0.000 n=10)
geomean                                                            78.78m        42.93m       -45.50%

                                                      │ bench_targets_main.txt │       bench_targets_branch.txt       │
                                                      │          B/op          │     B/op      vs base                │
ProcessTargets/least-weighted-32                                  45.14Mi ± 0%   40.41Mi ± 0%  -10.48% (p=0.000 n=10)
ProcessTargets/consistent-hashing-32                              45.15Mi ± 0%   40.41Mi ± 0%  -10.49% (p=0.000 n=10)
ProcessTargets/per-node-32                                        45.15Mi ± 0%   40.41Mi ± 0%  -10.49% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node-32                       45.38Mi ± 0%   40.44Mi ± 0%  -10.88% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted-32                 45.38Mi ± 0%   40.44Mi ± 0%  -10.88% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing-32             45.38Mi ± 0%   40.44Mi ± 0%  -10.88% (p=0.000 n=10)
geomean                                                           45.26Mi        40.43Mi       -10.68%

                                                      │ bench_targets_main.txt │      bench_targets_branch.txt       │
                                                      │       allocs/op        │  allocs/op   vs base                │
ProcessTargets/least-weighted-32                                  112.36k ± 0%   52.05k ± 0%  -53.67% (p=0.000 n=10)
ProcessTargets/consistent-hashing-32                              112.38k ± 0%   52.05k ± 0%  -53.68% (p=0.000 n=10)
ProcessTargets/per-node-32                                        112.38k ± 0%   52.06k ± 0%  -53.68% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node-32                       112.73k ± 0%   52.26k ± 0%  -53.64% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted-32                 112.73k ± 0%   52.26k ± 0%  -53.64% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing-32             112.74k ± 0%   52.26k ± 0%  -53.64% (p=0.000 n=10)
geomean                                                            112.6k        52.16k       -53.66%
```