### PR TITLE
[chore] Don't check changelog links in CI

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -65,16 +65,3 @@ jobs:
         run: |
           make chlog-validate \
             || { echo "New ./.chloggen/*.yaml file failed validation."; exit 1; }
-
-      # In order to validate any links in the yaml file, render the config to markdown
-      - name: Render .chloggen changelog entries
-        run: make chlog-preview > changelog_preview.md
-      - name: Install markdown-link-check
-        run: npm install -g markdown-link-check
-      - name: Run markdown-link-check
-        run: |
-          markdown-link-check \
-            --verbose \
-            --config .github/workflows/check_links_config.json \
-            changelog_preview.md \
-            || { echo "Check that anchor links are lowercase"; exit 1; }


### PR DESCRIPTION
Looking at some recent failures of the changelog workflow on PRs: https://github.com/open-telemetry/opentelemetry-operator/actions/workflows/changelog.yaml, I noticed the link check doesn't do anything useful. The changelog tool's preview command actually outputs the new changelog segment to stderr (and not stdout as the docs claim), so we're running markdown-link-check on some random chloggen output. 

Furthermore, it doesn't even make sense to check this - what we should do instead is check changelog links during releases, or check links in all of our docs at different points. For now, I'm removing the blocker.
