### PR TITLE
Stop unnecessarily caching in the CI lint workflow

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -62,8 +62,6 @@ jobs:
       with:
         path: |
           /home/runner/.cache/golangci-lint
-          /home/runner/go/pkg/mod
-          ./bin
         key: golangcilint-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           golangcilint-


### PR DESCRIPTION
Our lint action produces annoying warnings because it tries to restore the Go module cache unnecessarily. See: https://github.com/open-telemetry/opentelemetry-operator/actions/runs/11745657003 for example.

Instead, only preserve golangci-lint's own cache.
