### PR TITLE
Fix invalid manifests in e2e tests

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-nginx-contnr-secctx/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-contnr-secctx/01-install-app.yaml
@@ -22,7 +22,6 @@ spec:
         securityContext:
           runAsUser: 1000
           runAsGroup: 3000
-          fsGroup: 3000
         ports:
         - containerPort: 8765
         env:
@@ -33,7 +32,6 @@ spec:
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
             readOnly: true
-        imagePullPolicy: Always
         resources:
           limits:
             cpu: "1"

--- a/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/01-install-app.yaml
@@ -28,7 +28,6 @@ spec:
         securityContext:
           runAsUser: 1000
           runAsGroup: 3000
-          fsGroup: 3000
           runAsNonRoot: true
           allowPrivilegeEscalation: false
           seccompProfile:
@@ -57,7 +56,6 @@ spec:
         securityContext:
           runAsUser: 1000
           runAsGroup: 3000
-          fsGroup: 3000
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault

--- a/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/02-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/02-install-app.yaml
@@ -28,7 +28,6 @@ spec:
         securityContext:
           runAsUser: 1000
           runAsGroup: 3000
-          fsGroup: 3000
           runAsNonRoot: true
           allowPrivilegeEscalation: false
           seccompProfile:
@@ -45,7 +44,6 @@ spec:
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
             readOnly: true
-        imagePullPolicy: Always
         resources:
           limits:
             cpu: 500m
@@ -58,7 +56,6 @@ spec:
         securityContext:
           runAsUser: 1000
           runAsGroup: 3000
-          fsGroup: 3000
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault

--- a/tests/e2e-instrumentation/instrumentation-nodejs-volume/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-volume/01-assert.yaml
@@ -54,8 +54,6 @@ spec:
         - name: OTEL_RESOURCE_ATTRIBUTES
       name: myapp
       volumeMounts:
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          readOnly: true
         - mountPath: /otel-auto-instrumentation-nodejs
           name: opentelemetry-auto-instrumentation-nodejs
     - args:
@@ -64,8 +62,6 @@ spec:
   initContainers:
     - name: opentelemetry-auto-instrumentation-nodejs
   volumes:
-    - projected:
-        defaultMode: 420
     - name: opentelemetry-auto-instrumentation-nodejs
       ephemeral:
         volumeClaimTemplate:

--- a/tests/e2e-instrumentation/instrumentation-nodejs-volume/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-volume/01-install-app.yaml
@@ -29,4 +29,4 @@ spec:
         env:
         - name: NODE_PATH
           value: /usr/local/lib/node_modules
-    automountServiceAccountToken: false
+      automountServiceAccountToken: false

--- a/tests/e2e-targetallocator/targetallocator-features/00-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-features/00-install.yaml
@@ -93,7 +93,6 @@ spec:
       runAsUser: 1000
     prometheusCR:
       enabled: true
-      filterStrategy: ""
     securityContext:
       capabilities:
         add:


### PR DESCRIPTION
We have some invalid resource manifests in e2e tests. Kubernetes doesn't care, and just ignores the invalid fields, and so does chainsaw 0.2.8, but chainsaw 0.2.11 errors. Fix these problems so we can upgrade.
