### PR TITLE
Update api.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -28344,7 +28344,7 @@ All CR instances which the ServiceAccount has access to will be retrieved. This 
           PodMonitors to be selected for target discovery.
 This is a map of {key,value} pairs. Each {key,value} in the map is going to exactly match a label in a
 PodMonitor's meta labels. The requirements are ANDed.
-Empty or nil map matches all pod monitors.<br/>
+Empty map matches all pod monitors, nil selector matches no objects.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -28366,7 +28366,7 @@ Default: "30s"<br/>
           ServiceMonitors to be selected for target discovery.
 This is a map of {key,value} pairs. Each {key,value} in the map is going to exactly match a label in a
 ServiceMonitor's meta labels. The requirements are ANDed.
-Empty or nil map matches all service monitors.<br/>
+Empty map matches all service monitors, nil selector matches no objects.<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
Reference Prometheus operator Api spec, the pod/service monitorSelector nil will matches no objects.

**Description:** <Describe what has changed.>
Fix api.md,  PrometheusCR.ServiceMonitorSelector PodMonitorSelector nil will matches no objects

[Prometheus CR Document](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Prometheus)
