### PR TITLE
Bump base memory requirements for python and go

### DIFF
--- a/.chloggen/bump-base-instrumentation-mem-limit.yaml
+++ b/.chloggen/bump-base-instrumentation-mem-limit.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Bump base memory requirements for python and go
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/bump-base-instrumentation-mem-limit.yaml
+++ b/.chloggen/bump-base-instrumentation-mem-limit.yaml
@@ -8,7 +8,7 @@ component: auto-instrumentation
 note: Bump base memory requirements for python and go
 
 # One or more tracking issues related to the change
-issues: []
+issues: [3479]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/apis/v1alpha1/instrumentation_webhook.go
+++ b/apis/v1alpha1/instrumentation_webhook.go
@@ -128,13 +128,13 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 	if r.Spec.Python.Resources.Limits == nil {
 		r.Spec.Python.Resources.Limits = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
 		}
 	}
 	if r.Spec.Python.Resources.Requests == nil {
 		r.Spec.Python.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
 		}
 	}
 	if r.Spec.DotNet.Image == "" {
@@ -158,13 +158,13 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 	if r.Spec.Go.Resources.Limits == nil {
 		r.Spec.Go.Resources.Limits = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
 		}
 	}
 	if r.Spec.Go.Resources.Requests == nil {
 		r.Spec.Go.Resources.Requests = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
 		}
 	}
 	if r.Spec.ApacheHttpd.Image == "" {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
  - When auto-instrumenting applications, I have noticed that default memory limits are too tight for some languages. This leads to the following:
    - Intermitent OOMKilled events in init container when auto-instrumenting python applications. Eventually the pods are able to start.
    - OOMKilled events for sidecar containers in go applications. The pods are not able to start.
  - 64Mi seems to be enough to fix these issues. While some tweaking by users may still be necessary, the operator should work out-of-the-box for all supported languages.

**Link to tracking Issue(s):**
https://github.com/open-telemetry/opentelemetry-operator/issues/3479