### PR TITLE
[Chore] Fix assert for multi-cluster test

### DIFF
--- a/tests/e2e-openshift/multi-cluster/04-assert.yaml
+++ b/tests/e2e-openshift/multi-cluster/04-assert.yaml
@@ -4,9 +4,7 @@ metadata:
   name: generate-traces-http
   namespace: chainsaw-multi-cluster-send
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1
 
 ---
 apiVersion: batch/v1
@@ -15,6 +13,4 @@ metadata:
   name: generate-traces-grpc
   namespace: chainsaw-multi-cluster-send
 status:
-  conditions:
-    - status: "True"
-      type: Complete
+  succeeded: 1


### PR DESCRIPTION
**Description:** <Describe what has changed.>
For the multi-cluster test, the Kubernetes job completion status has changed in OCP 4.18 

```
status:
  completionTime: "2024-11-21T05:35:45Z"
  conditions:
  - lastProbeTime: "2024-11-21T05:35:45Z"
    lastTransitionTime: "2024-11-21T05:35:45Z"
    message: Reached expected number of succeeded pods
    reason: CompletionsReached
    status: "True"
    type: SuccessCriteriaMet
  - lastProbeTime: "2024-11-21T05:35:45Z"
    lastTransitionTime: "2024-11-21T05:35:45Z"
    message: Reached expected number of succeeded pods
    reason: CompletionsReached
    status: "True"
    type: Complete
  ready: 0
  startTime: "2024-11-21T05:35:41Z"
  succeeded: 1
  terminating: 0
  uncountedTerminatedPods: {} 
```

This condition is not available anymore:

```
status:
  conditions:
    - status: "True"
      type: Complete 
```

The PR updates the test to use an assert which works both with OCP 4.18 and older OCP versions. 
