### PR TITLE
Add allocation_fallback_strategy option as fallback strategy for per-node strategy

### DIFF
--- a/.chloggen/add_fallback_strategy_for_per_node_strategy.yaml
+++ b/.chloggen/add_fallback_strategy_for_per_node_strategy.yaml
@@ -5,7 +5,7 @@ change_type: 'enhancement'
 component: target allocator
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Added allocation_fallback_strategy option as fallback strategy for per-node allocation strategy
+note: Added allocation_fallback_strategy option as fallback strategy for per-node allocation strategy, can be enabled with feature flag operator.targetallocator.fallbackstrategy
 
 # One or more tracking issues related to the change
 issues: [3477]
@@ -16,4 +16,6 @@ issues: [3477]
 subtext: |
   If using per-node allocation strategy, targets that are not attached to a node will not
   be allocated. As the per-node strategy is required when running as a daemonset, it is 
-  not possible to assign some targets under a daemonset deployment
+  not possible to assign some targets under a daemonset deployment.
+  Feature flag operator.targetallocator.fallbackstrategy has been added and results in consistent-hashing
+  being used as the fallback allocation strategy for "per-node" only at this time.

--- a/.chloggen/add_fallback_strategy_for_per_node_strategy.yaml
+++ b/.chloggen/add_fallback_strategy_for_per_node_strategy.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added least-weighted as fallback strategy for per-node allocation strategy
+
+# One or more tracking issues related to the change
+issues: [3477]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  If using per-node allocation strategy, targets that are not attached to a node will not
+  be allocated. As the per-node strategy is required when running as a daemonset, it is 
+  not possible to assign some targets under a daemonset deployment

--- a/.chloggen/add_fallback_strategy_for_per_node_strategy.yaml
+++ b/.chloggen/add_fallback_strategy_for_per_node_strategy.yaml
@@ -5,7 +5,7 @@ change_type: 'enhancement'
 component: target allocator
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Added consistent-hashing as fallback strategy for per-node allocation strategy
+note: Added allocation_fallback_strategy option as fallback strategy for per-node allocation strategy
 
 # One or more tracking issues related to the change
 issues: [3477]

--- a/.chloggen/add_fallback_strategy_for_per_node_strategy.yaml
+++ b/.chloggen/add_fallback_strategy_for_per_node_strategy.yaml
@@ -5,7 +5,7 @@ change_type: 'enhancement'
 component: target allocator
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Added least-weighted as fallback strategy for per-node allocation strategy
+note: Added consistent-hashing as fallback strategy for per-node allocation strategy
 
 # One or more tracking issues related to the change
 issues: [3477]

--- a/cmd/otel-allocator/allocation/allocator.go
+++ b/cmd/otel-allocator/allocation/allocator.go
@@ -76,6 +76,11 @@ func (a *allocator) SetFilter(filter Filter) {
 	a.filter = filter
 }
 
+// SetFallbackStrategy sets the fallback strategy to use.
+func (a *allocator) SetFallbackStrategy(strategy Strategy) {
+	a.strategy.SetFallbackStrategy(strategy)
+}
+
 // SetTargets accepts a list of targets that will be used to make
 // load balancing decisions. This method should be called when there are
 // new targets discovered or existing targets are shutdown.

--- a/cmd/otel-allocator/allocation/consistent_hashing.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing.go
@@ -83,3 +83,5 @@ func (s *consistentHashingStrategy) SetCollectors(collectors map[string]*Collect
 	s.consistentHasher = consistent.New(members, s.config)
 
 }
+
+func (s *consistentHashingStrategy) SetFallbackStrategy(fallbackStrategy Strategy) {}

--- a/cmd/otel-allocator/allocation/least_weighted.go
+++ b/cmd/otel-allocator/allocation/least_weighted.go
@@ -54,3 +54,5 @@ func (s *leastWeightedStrategy) GetCollectorForTarget(collectors map[string]*Col
 }
 
 func (s *leastWeightedStrategy) SetCollectors(_ map[string]*Collector) {}
+
+func (s *leastWeightedStrategy) SetFallbackStrategy(fallbackStrategy Strategy) {}

--- a/cmd/otel-allocator/allocation/per_node.go
+++ b/cmd/otel-allocator/allocation/per_node.go
@@ -29,11 +29,15 @@ type perNodeStrategy struct {
 	fallbackStrategy Strategy
 }
 
-func newPerNodeStrategy(fallbackStrategy Strategy) Strategy {
+func newPerNodeStrategy() Strategy {
 	return &perNodeStrategy{
 		collectorByNode:  make(map[string]*Collector),
-		fallbackStrategy: fallbackStrategy,
+		fallbackStrategy: nil,
 	}
+}
+
+func (s *perNodeStrategy) SetFallbackStrategy(fallbackStrategy Strategy) {
+	s.fallbackStrategy = fallbackStrategy
 }
 
 func (s *perNodeStrategy) GetName() string {
@@ -42,7 +46,7 @@ func (s *perNodeStrategy) GetName() string {
 
 func (s *perNodeStrategy) GetCollectorForTarget(collectors map[string]*Collector, item *target.Item) (*Collector, error) {
 	targetNodeName := item.GetNodeName()
-	if targetNodeName == "" {
+	if targetNodeName == "" && s.fallbackStrategy != nil {
 		return s.fallbackStrategy.GetCollectorForTarget(collectors, item)
 	}
 
@@ -60,5 +64,8 @@ func (s *perNodeStrategy) SetCollectors(collectors map[string]*Collector) {
 			s.collectorByNode[collector.NodeName] = collector
 		}
 	}
-	s.fallbackStrategy.SetCollectors(collectors)
+
+	if s.fallbackStrategy != nil {
+		s.fallbackStrategy.SetCollectors(collectors)
+	}
 }

--- a/cmd/otel-allocator/allocation/per_node_test.go
+++ b/cmd/otel-allocator/allocation/per_node_test.go
@@ -154,7 +154,7 @@ func TestAllocationPerNodeUsingFallback(t *testing.T) {
 	// verify allocation to nodes
 	for targetHash, item := range targetList {
 		actualItem, found := actualItems[targetHash]
-		// if third target, should be skipped
+		// if third target, should be allocated by the fallback strategy
 		assert.True(t, found, "target with hash %s not found", item.Hash())
 
 		// only the first two targets should be allocated

--- a/cmd/otel-allocator/allocation/per_node_test.go
+++ b/cmd/otel-allocator/allocation/per_node_test.go
@@ -118,7 +118,7 @@ func TestAllocationPerNodeUsingFallback(t *testing.T) {
 		{Name: "test", Value: "test2"},
 		{Name: "__meta_kubernetes_node_name", Value: "node-1"},
 	}
-	// no label, should be skipped
+	// no label, should be allocated by the fallback strategy
 	thirdLabels := labels.Labels{
 		{Name: "test", Value: "test3"},
 	}

--- a/cmd/otel-allocator/allocation/per_node_test.go
+++ b/cmd/otel-allocator/allocation/per_node_test.go
@@ -147,7 +147,7 @@ func TestAllocationPerNodeUsingFallback(t *testing.T) {
 	// verify length
 	actualItems := s.TargetItems()
 
-	// one target should be skipped
+	// all targets should be allocated
 	expectedTargetLen := len(targetList)
 	assert.Len(t, actualItems, expectedTargetLen)
 

--- a/cmd/otel-allocator/allocation/per_node_test.go
+++ b/cmd/otel-allocator/allocation/per_node_test.go
@@ -154,10 +154,9 @@ func TestAllocationPerNodeUsingFallback(t *testing.T) {
 	// verify allocation to nodes
 	for targetHash, item := range targetList {
 		actualItem, found := actualItems[targetHash]
-		// if third target, should be allocated by the fallback strategy
+
 		assert.True(t, found, "target with hash %s not found", item.Hash())
 
-		// only the first two targets should be allocated
 		itemsForCollector := s.GetTargetsForCollectorAndJob(actualItem.CollectorName, actualItem.JobName)
 
 		// first two should be assigned one to each collector; if third target, it should be assigned

--- a/cmd/otel-allocator/allocation/per_node_test.go
+++ b/cmd/otel-allocator/allocation/per_node_test.go
@@ -97,7 +97,7 @@ func TestAllocationPerNode(t *testing.T) {
 		// one of the others, depending on the strategy and collector loop order
 		if targetHash == thirdTarget.Hash() {
 			assert.Empty(t, item.GetNodeName())
-			assert.LessOrEqual(t, len(itemsForCollector), 2)
+			assert.NotZero(t, len(itemsForCollector))
 			continue
 		}
 

--- a/cmd/otel-allocator/allocation/per_node_test.go
+++ b/cmd/otel-allocator/allocation/per_node_test.go
@@ -36,7 +36,7 @@ func GetTargetsWithNodeName(targets []*target.Item) (targetsWithNodeName []*targ
 }
 
 // Tests that four targets, with one of them lacking node labels, are assigned except for the
-// target that lacks node labels
+// target that lacks node labels.
 func TestAllocationPerNode(t *testing.T) {
 	// prepare allocator with initial targets and collectors
 	s, _ := New("per-node", loggerPerNode)
@@ -103,7 +103,7 @@ func TestAllocationPerNode(t *testing.T) {
 	}
 }
 
-// Tests that four targets, with one of them missing node labels, are all assigned
+// Tests that four targets, with one of them missing node labels, are all assigned.
 func TestAllocationPerNodeUsingFallback(t *testing.T) {
 	// prepare allocator with initial targets and collectors
 	s, _ := New("per-node", loggerPerNode, WithFallbackStrategy(consistentHashingStrategyName))

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -149,7 +149,7 @@ func init() {
 		panic(err)
 	}
 	err = Register(perNodeStrategyName, func(log logr.Logger, opts ...AllocationOption) Allocator {
-		return newAllocator(log, newPerNodeStrategy(newleastWeightedStrategy()), opts...)
+		return newAllocator(log, newPerNodeStrategy(newConsistentHashingStrategy()), opts...)
 	})
 	if err != nil {
 		panic(err)

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -29,6 +29,8 @@ import (
 type AllocatorProvider func(log logr.Logger, opts ...AllocationOption) Allocator
 
 var (
+	strategies = map[string]Strategy{}
+
 	registry = map[string]AllocatorProvider{}
 
 	// TargetsPerCollector records how many targets have been assigned to each collector.
@@ -67,6 +69,16 @@ func WithFilter(filter Filter) AllocationOption {
 	}
 }
 
+func WithFallbackStrategy(fallbackStrategy string) AllocationOption {
+	var strategy, ok = strategies[fallbackStrategy]
+	if fallbackStrategy != "" && !ok {
+		panic(fmt.Errorf("unregistered strategy used as fallback: %s", fallbackStrategy))
+	}
+	return func(allocator Allocator) {
+		allocator.SetFallbackStrategy(strategy)
+	}
+}
+
 func RecordTargetsKept(targets map[string]*target.Item) {
 	targetsRemaining.Add(float64(len(targets)))
 }
@@ -101,6 +113,7 @@ type Allocator interface {
 	Collectors() map[string]*Collector
 	GetTargetsForCollectorAndJob(collector string, job string) []*target.Item
 	SetFilter(filter Filter)
+	SetFallbackStrategy(strategy Strategy)
 }
 
 type Strategy interface {
@@ -110,6 +123,8 @@ type Strategy interface {
 	// SetCollectors call. Strategies which don't need this information can just ignore it.
 	SetCollectors(map[string]*Collector)
 	GetName() string
+	// Add fallback strategy for strategies whose main allocation method can sometimes leave targets unassigned
+	SetFallbackStrategy(Strategy)
 }
 
 var _ consistent.Member = Collector{}
@@ -136,22 +151,18 @@ func NewCollector(name, node string) *Collector {
 }
 
 func init() {
-	err := Register(leastWeightedStrategyName, func(log logr.Logger, opts ...AllocationOption) Allocator {
-		return newAllocator(log, newleastWeightedStrategy(), opts...)
-	})
-	if err != nil {
-		panic(err)
+	strategies = map[string]Strategy{
+		leastWeightedStrategyName:     newleastWeightedStrategy(),
+		consistentHashingStrategyName: newConsistentHashingStrategy(),
+		perNodeStrategyName:           newPerNodeStrategy(),
 	}
-	err = Register(consistentHashingStrategyName, func(log logr.Logger, opts ...AllocationOption) Allocator {
-		return newAllocator(log, newConsistentHashingStrategy(), opts...)
-	})
-	if err != nil {
-		panic(err)
-	}
-	err = Register(perNodeStrategyName, func(log logr.Logger, opts ...AllocationOption) Allocator {
-		return newAllocator(log, newPerNodeStrategy(newConsistentHashingStrategy()), opts...)
-	})
-	if err != nil {
-		panic(err)
+
+	for strategyName, strategy := range strategies {
+		err := Register(strategyName, func(log logr.Logger, opts ...AllocationOption) Allocator {
+			return newAllocator(log, strategy, opts...)
+		})
+		if err != nil {
+			panic(err)
+		}
 	}
 }

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -149,7 +149,7 @@ func init() {
 		panic(err)
 	}
 	err = Register(perNodeStrategyName, func(log logr.Logger, opts ...AllocationOption) Allocator {
-		return newAllocator(log, newPerNodeStrategy(), opts...)
+		return newAllocator(log, newPerNodeStrategy(newleastWeightedStrategy()), opts...)
 	})
 	if err != nil {
 		panic(err)

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -46,16 +46,17 @@ const (
 )
 
 type Config struct {
-	ListenAddr         string                `yaml:"listen_addr,omitempty"`
-	KubeConfigFilePath string                `yaml:"kube_config_file_path,omitempty"`
-	ClusterConfig      *rest.Config          `yaml:"-"`
-	RootLogger         logr.Logger           `yaml:"-"`
-	CollectorSelector  *metav1.LabelSelector `yaml:"collector_selector,omitempty"`
-	PromConfig         *promconfig.Config    `yaml:"config"`
-	AllocationStrategy string                `yaml:"allocation_strategy,omitempty"`
-	FilterStrategy     string                `yaml:"filter_strategy,omitempty"`
-	PrometheusCR       PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
-	HTTPS              HTTPSServerConfig     `yaml:"https,omitempty"`
+	ListenAddr                 string                `yaml:"listen_addr,omitempty"`
+	KubeConfigFilePath         string                `yaml:"kube_config_file_path,omitempty"`
+	ClusterConfig              *rest.Config          `yaml:"-"`
+	RootLogger                 logr.Logger           `yaml:"-"`
+	CollectorSelector          *metav1.LabelSelector `yaml:"collector_selector,omitempty"`
+	PromConfig                 *promconfig.Config    `yaml:"config"`
+	AllocationStrategy         string                `yaml:"allocation_strategy,omitempty"`
+	AllocationFallbackStrategy string                `yaml:"allocation_fallback_strategy,omitempty"`
+	FilterStrategy             string                `yaml:"filter_strategy,omitempty"`
+	PrometheusCR               PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
+	HTTPS                      HTTPSServerConfig     `yaml:"https,omitempty"`
 }
 
 type PrometheusCRConfig struct {
@@ -165,8 +166,9 @@ func unmarshal(cfg *Config, configFile string) error {
 
 func CreateDefaultConfig() Config {
 	return Config{
-		AllocationStrategy: DefaultAllocationStrategy,
-		FilterStrategy:     DefaultFilterStrategy,
+		AllocationStrategy:         DefaultAllocationStrategy,
+		AllocationFallbackStrategy: "",
+		FilterStrategy:             DefaultFilterStrategy,
 		PrometheusCR: PrometheusCRConfig{
 			ScrapeInterval: DefaultCRScrapeInterval,
 		},

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -81,7 +81,7 @@ func main() {
 	log := ctrl.Log.WithName("allocator")
 
 	allocatorPrehook = prehook.New(cfg.FilterStrategy, log)
-	allocator, err = allocation.New(cfg.AllocationStrategy, log, allocation.WithFilter(allocatorPrehook))
+	allocator, err = allocation.New(cfg.AllocationStrategy, log, allocation.WithFilter(allocatorPrehook), allocation.WithFallbackStrategy(cfg.AllocationFallbackStrategy))
 	if err != nil {
 		setupLog.Error(err, "Unable to initialize allocation strategy")
 		os.Exit(1)

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -81,7 +81,13 @@ func main() {
 	log := ctrl.Log.WithName("allocator")
 
 	allocatorPrehook = prehook.New(cfg.FilterStrategy, log)
-	allocator, err = allocation.New(cfg.AllocationStrategy, log, allocation.WithFilter(allocatorPrehook), allocation.WithFallbackStrategy(cfg.AllocationFallbackStrategy))
+
+	var allocationOptions []allocation.AllocationOption
+	allocationOptions = append(allocationOptions, allocation.WithFilter(allocatorPrehook))
+	if cfg.AllocationFallbackStrategy != "" {
+		allocationOptions = append(allocationOptions, allocation.WithFallbackStrategy(cfg.AllocationFallbackStrategy))
+	}
+	allocator, err = allocation.New(cfg.AllocationStrategy, log, allocationOptions...)
 	if err != nil {
 		setupLog.Error(err, "Unable to initialize allocation strategy")
 		os.Exit(1)

--- a/cmd/otel-allocator/server/mocks_test.go
+++ b/cmd/otel-allocator/server/mocks_test.go
@@ -32,6 +32,7 @@ func (m *mockAllocator) SetTargets(_ map[string]*target.Item)                   
 func (m *mockAllocator) Collectors() map[string]*allocation.Collector                   { return nil }
 func (m *mockAllocator) GetTargetsForCollectorAndJob(_ string, _ string) []*target.Item { return nil }
 func (m *mockAllocator) SetFilter(_ allocation.Filter)                                  {}
+func (m *mockAllocator) SetFallbackStrategy(_ allocation.Strategy)                      {}
 
 func (m *mockAllocator) TargetItems() map[string]*target.Item {
 	return m.targetItems

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -90,6 +90,11 @@ func ConfigMap(params Params) (*corev1.ConfigMap, error) {
 	} else {
 		taConfig["allocation_strategy"] = v1beta1.TargetAllocatorAllocationStrategyConsistentHashing
 	}
+
+	if featuregate.EnableTargetAllocatorFallbackStrategy.IsEnabled() {
+		taConfig["allocation_fallback_strategy"] = v1beta1.TargetAllocatorAllocationStrategyConsistentHashing
+	}
+
 	taConfig["filter_strategy"] = taSpec.FilterStrategy
 
 	if taSpec.PrometheusCR.Enabled {

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -297,6 +297,63 @@ prometheus_cr:
 		assert.Equal(t, expectedLabels, actual.Labels)
 		assert.Equal(t, expectedData, actual.Data)
 	})
+
+	t.Run("should return expected target allocator config map allocation fallback strategy", func(t *testing.T) {
+		expectedLabels["app.kubernetes.io/component"] = "opentelemetry-targetallocator"
+		expectedLabels["app.kubernetes.io/name"] = "my-instance-targetallocator"
+
+		cfg := config.New(config.WithCertManagerAvailability(certmanager.Available))
+
+		flgs := featuregate.Flags(colfg.GlobalRegistry())
+		err := flgs.Parse([]string{"--feature-gates=operator.targetallocator.fallbackstrategy"})
+		require.NoError(t, err)
+
+		testParams := Params{
+			Collector:       collector,
+			TargetAllocator: targetAllocator,
+			Config:          cfg,
+		}
+
+		expectedData := map[string]string{
+			targetAllocatorFilename: `allocation_fallback_strategy: consistent-hashing
+allocation_strategy: consistent-hashing
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: default.my-instance
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  matchexpressions: []
+config:
+  scrape_configs:
+  - job_name: otel-collector
+    scrape_interval: 10s
+    static_configs:
+    - targets:
+      - 0.0.0.0:8888
+      - 0.0.0.0:9999
+filter_strategy: relabel-config
+https:
+  ca_file_path: /tls/ca.crt
+  enabled: true
+  listen_addr: :8443
+  tls_cert_file_path: /tls/tls.crt
+  tls_key_file_path: /tls/tls.key
+prometheus_cr:
+  enabled: true
+  pod_monitor_selector: null
+  scrape_interval: 30s
+  service_monitor_selector: null
+`,
+		}
+
+		actual, err := ConfigMap(testParams)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "my-instance-targetallocator", actual.Name)
+		assert.Equal(t, expectedLabels, actual.Labels)
+		assert.Equal(t, expectedData, actual.Data)
+	})
 }
 
 func TestGetScrapeConfigsFromOtelConfig(t *testing.T) {

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -67,6 +67,14 @@ var (
 		featuregate.WithRegisterDescription("enables mTLS between the target allocator and the collector"),
 		featuregate.WithRegisterFromVersion("v0.111.0"),
 	)
+	// EnableTargetAllocatorFallbackStrategy is the feature gate that enables consistent-hashing as the fallback
+	// strategy for allocation strategies that might not assign all jobs (per-node).
+	EnableTargetAllocatorFallbackStrategy = featuregate.GlobalRegistry().MustRegister(
+		"operator.targetallocator.mtls",
+		featuregate.StageAlpha,
+		featuregate.WithRegisterDescription("enables fallback allocation strategy for the target allocator"),
+		featuregate.WithRegisterFromVersion("v0.114.0"),
+	)
 	// EnableConfigDefaulting is the feature gate that enables the operator to default the endpoint for known components.
 	EnableConfigDefaulting = featuregate.GlobalRegistry().MustRegister(
 		"operator.collector.default.config",

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -70,7 +70,7 @@ var (
 	// EnableTargetAllocatorFallbackStrategy is the feature gate that enables consistent-hashing as the fallback
 	// strategy for allocation strategies that might not assign all jobs (per-node).
 	EnableTargetAllocatorFallbackStrategy = featuregate.GlobalRegistry().MustRegister(
-		"operator.targetallocator.mtls",
+		"operator.targetallocator.fallbackstrategy",
 		featuregate.StageAlpha,
 		featuregate.WithRegisterDescription("enables fallback allocation strategy for the target allocator"),
 		featuregate.WithRegisterFromVersion("v0.114.0"),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Adds allocation_fallback_strategy option as fallback strategy for per-node strategy, such that targets that are not related to a specific node can be assigned. 

The fallback strategy is configurable via the config option allocation_fallback_strategy

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #3477 

**Testing:** <Describe what testing was performed and which tests were added.>

Fixed per-node tests to expect non-node target to be assigned according to fallback strategy

**Documentation:** <Describe the documentation added.>
