### PR TITLE
chore: replace gcr.io for kube-rbac-proxy image

### DIFF
--- a/.chloggen/chore_change-kube-rbac-proxy-image-registry.yaml
+++ b/.chloggen/chore_change-kube-rbac-proxy-image-registry.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Replace references to gcr.io/kubebuilder/kube-rbac-proxy with quay.io/brancz/kube-rbac-proxy
+
+# One or more tracking issues related to the change
+issues: [3485]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -514,7 +514,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+                image: quay.io/brancz/kube-rbac-proxy:v0.13.1
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -522,7 +522,7 @@ spec:
                 - --tls-private-key-file=/var/run/tls/server/tls.key
                 - --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA256
                 - --tls-min-version=VersionTLS12
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+                image: quay.io/brancz/kube-rbac-proxy:v0.13.1
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.13.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/tests/e2e-upgrade/upgrade-test/opentelemetry-operator-v0.86.0.yaml
+++ b/tests/e2e-upgrade/upgrade-test/opentelemetry-operator-v0.86.0.yaml
@@ -8348,7 +8348,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+          image: quay.io/brancz/kube-rbac-proxy:v0.13.1
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443


### PR DESCRIPTION
This pull request updates the kube-rbac-proxy dependency to use the image hosted on quay.io/brancz/kube-rbac-proxy.

Why is this change necessary? 

- 	[Deprecation](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown) of gcr.io: Images hosted under gcr.io will no longer be available after March 18, 2025.

- 	[Announcement from kubebuilder](https://book.kubebuilder.io/reference/metrics#metrics)

What does this PR do?

-  Replaces references to gcr.io/kubebuilder/kube-rbac-proxy with quay.io/brancz/kube-rbac-proxy.