### PR TITLE
Update tools using renovate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -491,10 +491,15 @@ CHLOGGEN ?= $(LOCALBIN)/chloggen
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 CHAINSAW ?= $(LOCALBIN)/chainsaw
 
+# renovate: datasource=go depName=sigs.k8s.io/kustomize/kustomize/v5
 KUSTOMIZE_VERSION ?= v5.0.3
+# renovate: datasource=go depName=sigs.k8s.io/controller-tools/cmd/controller-gen
 CONTROLLER_TOOLS_VERSION ?= v0.16.1
+# renovate: datasource=go depName=github.com/golangci/golangci-lint/cmd/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.57.2
+# renovate: datasource=go depName=sigs.k8s.io/kind
 KIND_VERSION ?= v0.20.0
+# renovate: datasource=go depName=github.com/kyverno/chainsaw
 CHAINSAW_VERSION ?= v0.2.8
 
 .PHONY: install-tools

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "labels": ["dependencies"],
+  "enabledManagers": ["regex"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description" : "Update tool versions in the Makefile",
+      "fileMatch": [
+        "(^|/)Makefile$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:*\\??=\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["regex"],
+      "matchFileNames": ["Makefile"],
+      "commitMessageTopic": "tool {{depName}}"
+    }
+  ]
+}


### PR DESCRIPTION
**Description:**

Add a renovate configuration, enabling a single manager to update tool versions in the Makefile. The updates are enabled by adding a comment above the version declaration in the Makefile, specifying where to look for the dependency and how to update it.

I've ignored operator-sdk for now, because I'm not sure what the upgrade strategy should be there.

**Link to tracking Issue(s):**

#3450 

**Testing:**

I have this configuration active in my [fork](https://github.com/swiatekm/opentelemetry-operator/blob/main/renovate.json). Here's an example of a tool update PR: https://github.com/swiatekm/opentelemetry-operator/pull/71.
