### PR TITLE
fix: apache instrumentation with lifecycle

### DIFF
--- a/.chloggen/fix_apache-instrumentation-with-lifecycle.yaml
+++ b/.chloggen/fix_apache-instrumentation-with-lifecycle.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Apache instrumentation sidecar fails to start if target container define lifecycle
+
+# One or more tracking issues related to the change
+issues: [3547]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/README.md
+++ b/README.md
@@ -538,9 +538,10 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   name: my-instrumentation
-  apache:
+spec:
+  apacheHttpd:
     image: your-customized-auto-instrumentation-image:apache-httpd
-    version: 2.2
+    version: "2.2"
     configPath: /your-custom-config-path
     attrs:
       - name: ApacheModuleOtelMaxQueueSize
@@ -560,6 +561,7 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   name: my-instrumentation
+spec:
   nginx:
     image: your-customized-auto-instrumentation-image:nginx # if custom instrumentation image is needed
     configFile: /my/custom-dir/custom-nginx.conf

--- a/pkg/instrumentation/apachehttpd.go
+++ b/pkg/instrumentation/apachehttpd.go
@@ -103,6 +103,8 @@ func injectApacheHttpdagent(_ logr.Logger, apacheSpec v1alpha1.ApacheHttpd, pod 
 		cloneContainer.LivenessProbe = nil
 		cloneContainer.ReadinessProbe = nil
 		cloneContainer.StartupProbe = nil
+		// remove lifecycle, since not supported on init containers
+		cloneContainer.Lifecycle = nil
 
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, *cloneContainer)
 

--- a/pkg/instrumentation/apachehttpd_test.go
+++ b/pkg/instrumentation/apachehttpd_test.go
@@ -215,7 +215,7 @@ func TestInjectApacheHttpdagent(t *testing.T) {
 				},
 			},
 		},
-		// === Test Removal of probes  =============================
+		// === Test Removal of probes and lifecycle =============================
 		{
 			name:        "Probes removed on clone init container",
 			ApacheHttpd: v1alpha1.ApacheHttpd{Image: "foo/bar:1"},
@@ -226,6 +226,7 @@ func TestInjectApacheHttpdagent(t *testing.T) {
 							ReadinessProbe: &corev1.Probe{},
 							StartupProbe:   &corev1.Probe{},
 							LivenessProbe:  &corev1.Probe{},
+							Lifecycle:      &corev1.Lifecycle{},
 						},
 					},
 				},
@@ -307,6 +308,7 @@ func TestInjectApacheHttpdagent(t *testing.T) {
 							ReadinessProbe: &corev1.Probe{},
 							StartupProbe:   &corev1.Probe{},
 							LivenessProbe:  &corev1.Probe{},
+							Lifecycle:      &corev1.Lifecycle{},
 						},
 					},
 				},

--- a/tests/e2e-instrumentation/instrumentation-apache-httpd/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-httpd/01-install-app.yaml
@@ -26,6 +26,11 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+        # following to test lifecycle removal in cloned init container
+        lifecycle:
+          postStart:
+            exec:
+              command: [ "/bin/sh", "-c", "echo Hello from the postStart handler" ]
         ports:
         - containerPort: 8080
         resources:


### PR DESCRIPTION
**Description:**

Apache instrumentation sidecar needs to remove lifecycle as it's not supported, same as https://github.com/open-telemetry/opentelemetry-operator/issues/2366

fix #3547 