### PR TITLE
Fix flaky controller tests

### DIFF
--- a/controllers/opentelemetrycollector_controller.go
+++ b/controllers/opentelemetrycollector_controller.go
@@ -113,7 +113,6 @@ func (r *OpenTelemetryCollectorReconciler) findOtelOwnedObjects(ctx context.Cont
 		default:
 		}
 	}
-
 	// at this point we don't know if the most recent ConfigMap will still be the most recent after reconciliation, or
 	// if a new one will be created. We keep one additional ConfigMap to account for this. The next reconciliation that
 	// doesn't spawn a new ConfigMap will delete the extra one we kept here.

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/yaml"
@@ -138,6 +139,9 @@ func TestMain(m *testing.M) {
 	var err error
 	ctx, cancel = context.WithCancel(context.TODO())
 	defer cancel()
+
+	// logging is useful for these tests
+	logf.SetLogger(zap.New())
 
 	// +kubebuilder:scaffold:scheme
 	utilruntime.Must(monitoringv1.AddToScheme(testScheme))


### PR DESCRIPTION
Fix a flaky controller test. I'm still not sure why it can take so long for this test to see that the ConfigMap was deleted, but it is a fact of life. 30 seconds looks like enough from local tests.

I've also enabled logging for these tests, as it really helps debugging failures. If this is annoying to have in the general unit test output, then maybe we can run these in a separate step?
