### PR TITLE
[chore] Bump required Go version to 1.22.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-operator
 
-go 1.22.0
+go 1.22.7
 
 retract v1.51.0
 


### PR DESCRIPTION
This is because go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp 1.33.0 requires it. This would unblock #3551.
