### PR TITLE
Fix timestamp conversion in opamp bridge

### DIFF
--- a/cmd/operator-opamp-bridge/agent/testdata/basic.yaml
+++ b/cmd/operator-opamp-bridge/agent/testdata/basic.yaml
@@ -4,6 +4,7 @@ metadata:
   name: simplest
   labels:
     "opentelemetry.io/opamp-managed": "true"
+  creationTimestamp: "1970-01-01T00:00:00Z"
 spec:
   config:
     receivers:

--- a/cmd/operator-opamp-bridge/agent/testdata/updated.yaml
+++ b/cmd/operator-opamp-bridge/agent/testdata/updated.yaml
@@ -4,6 +4,7 @@ metadata:
   name: simplest
   labels:
     "opentelemetry.io/opamp-managed": "test-bridge"
+  creationTimestamp: "1970-01-01T00:00:00Z"
 spec:
   config:
     receivers:


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Kubernetes (and Go in general) allow for signed unix timestamps representing dates before 01-01-1970. However, OpAMP only accepts unsigned timestamps. Until now, opamp bridge simply assumed the conversion could always be carried out. This change instead returns errors when either the bridge or the respective K8s resources have negative Unix timestamps.

Unblocks #3538 and building the operator with Go 1.23 by addressing gosec errors.
