### PR TITLE
Update Go version used in the CI using renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,18 @@
   "customManagers": [
     {
       "customType": "regex",
+      "description" : "Update Go versions used for building in the CI",
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "go",
+      "fileMatch": [
+        "(^|/)\\.github/workflows/.+\\.ya?ml$"
+      ],
+      "matchStrings": [
+        "go-version: \"~(?<currentValue>.+)\""
+      ]
+    },
+    {
+      "customType": "regex",
       "description" : "Update tool versions in the Makefile",
       "fileMatch": [
         "(^|/)Makefile$"
@@ -15,6 +27,12 @@
     }
   ],
   "packageRules": [
+    {
+      "matchDatasources": ["golang-version"],
+      "matchManagers": ["regex"],
+      "matchFileNames": [".github/workflows/*.yaml", ".github/workflows/*.yml"],
+      "commitMessageTopic": "go version in CI"
+    },
     {
       "matchManagers": ["regex"],
       "matchFileNames": ["Makefile"],


### PR DESCRIPTION
**Description:** <Describe what has changed.>

This should always be the latest version of Go, but should also be explicitly pinned at least at the minor level. Renovate can do this for us, and the maintenance burden of merging the update PRs should be minimal.

**Link to tracking Issue(s):**

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/3450

**Testing:**

Tested on my fork, here's an example update PR: https://github.com/swiatekm/opentelemetry-operator/pull/70.
