### PR TITLE
[Chore] Update export-to-cluster-logging-lokistack test case to use otlphttp exporter

### DIFF
--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/check_logs.sh
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/check_logs.sh
@@ -4,24 +4,30 @@ TOKEN=$(oc -n openshift-logging create token otel-collector-deployment)
 LOKI_URL=$(oc -n openshift-logging get route logging-loki -o json | jq '.spec.host' -r)
 
 while true; do
-  LOG_OUTPUT=$(logcli -o raw --tls-skip-verify \
+  # Fetch logs
+  RAW_OUTPUT=$(logcli -o raw --tls-skip-verify \
   --bearer-token="${TOKEN}" \
   --addr "https://${LOKI_URL}/api/logs/v1/application" query '{log_type="application"}')
 
-  if echo "$LOG_OUTPUT" | jq -e '
-    . as $root |
-    select(
-      .body == "the message" and
-      .severity == "Info" and
-      .attributes.app == "server" and
-      .resources."k8s.container.name" == "telemetrygen" and
-      .resources."k8s.namespace.name" == "chainsaw-incllogs"
-    )
-  ' > /dev/null; then
+  # Extract the part of the output containing the common labels
+  COMMON_LABELS=$(echo "$RAW_OUTPUT" | grep "Common labels:")
+
+  # Log output for the actual log messages
+  LOG_OUTPUT=$(echo "$RAW_OUTPUT" | grep -v "Common labels:")
+
+  # Check if specific log messages exist
+  if echo "$COMMON_LABELS" | grep -q 'app="server"' && \
+    echo "$COMMON_LABELS" | grep -q 'k8s_container_name="telemetrygen"' && \
+    echo "$COMMON_LABELS" | grep -q 'k8s_namespace_name="chainsaw-incllogs"' && \
+    echo "$COMMON_LABELS" | grep -q 'kubernetes_container_name="telemetrygen"' && \
+    echo "$COMMON_LABELS" | grep -q 'kubernetes_namespace_name="chainsaw-incllogs"' && \ 
+    echo "$LOG_OUTPUT" | grep -q "the message"; then
     echo "Logs found:"
+    echo "$COMMON_LABELS"
     break
   else
     echo "Logs not found. Continuing to check..."
     sleep 5
   fi
 done
+

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/otel-collector.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/otel-collector.yaml
@@ -17,6 +17,9 @@ rules:
  - apiGroups: [""]
    resources: ["pods", "namespaces", "nodes"]
    verbs: ["get", "watch", "list"]
+ - apiGroups: ["apps"]
+   resources: ["replicasets"]
+   verbs: ["get", "list", "watch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -39,7 +42,7 @@ metadata:
   name: otel
   namespace: openshift-logging
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.107.0
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.116.1
   serviceAccount: otel-collector-deployment
   config:
     extensions:
@@ -51,66 +54,44 @@ spec:
           grpc: {}
           http: {}
     processors:
-      k8sattributes:
-        auth_type: "serviceAccount"
-        passthrough: false
-        extract:
-          metadata:
-            - k8s.pod.name
-            - k8s.container.name
-            - k8s.namespace.name
-          labels:
-          - tag_name: app.label.component
-            key: app.kubernetes.io/component
-            from: pod
-        pod_association:
-          - sources:
-              - from: resource_attribute
-                name: k8s.pod.name
-              - from: resource_attribute
-                name: k8s.container.name
-              - from: resource_attribute
-                name: k8s.namespace.name
-          - sources:
-              - from: connection
+      k8sattributes: {}
       resource:
         attributes:
-          - key: loki.format
-            action: insert
-            value: json
-          - key:  kubernetes_namespace_name
+          - key:  kubernetes.namespace_name
             from_attribute: k8s.namespace.name
             action: upsert
-          - key:  kubernetes_pod_name
+          - key:  kubernetes.pod_name
             from_attribute: k8s.pod.name
             action: upsert
-          - key: kubernetes_container_name
+          - key: kubernetes.container_name
             from_attribute: k8s.container.name
             action: upsert
           - key: log_type
             value: application
             action: upsert
-          - key: loki.resource.labels
-            value: log_type, kubernetes_namespace_name, kubernetes_pod_name, kubernetes_container_name
-            action: insert
       transform:
         log_statements:
           - context: log
             statements:
               - set(attributes["level"], ConvertCase(severity_text, "lower"))
-
     exporters:
-      loki:
-        endpoint: https://logging-loki-gateway-http.openshift-logging.svc.cluster.local:8080/api/logs/v1/application/loki/api/v1/push
+      otlphttp:
+        endpoint: https://logging-loki-gateway-http.openshift-logging.svc.cluster.local:8080/api/logs/v1/application/otlp
+        encoding: json
         tls:
           ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
         auth:
           authenticator: bearertokenauth
-
+      debug:
+        verbosity: detailed
     service:
       extensions: [bearertokenauth]
       pipelines:
         logs:
           receivers: [otlp]
           processors: [k8sattributes, transform, resource]
-          exporters: [loki]
+          exporters: [otlphttp]
+        logs/test:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The PR updates the export-to-cluster-logging-lokistack test case to use OTLP/http for sending logs to LokiStack

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: https://issues.redhat.com/browse/TRACING-5054 

**Testing:** <Describe what testing was performed and which tests were added.>

```
--- PASS: chainsaw (0.00s)
    --- PASS: chainsaw/export-to-cluster-logging-lokistack (157.85s)
PASS
Tests Summary...
- Passed  tests 1
- Failed  tests 0
- Skipped tests 0
Done.
```

**Documentation:** <Describe the documentation added.>
