### PR TITLE
Fix changelog entry

### DIFF
--- a/.chloggen/operator32.yaml
+++ b/.chloggen/operator32.yaml
@@ -5,10 +5,10 @@ change_type: 'enhancement'
 component: operator
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Support for Kubernetes `1.32`  version.
+note: Add support for Kubernetes `1.32`
 
 # One or more tracking issues related to the change
-issues: [ ]
+issues: [3544]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.


### PR DESCRIPTION
The original PR was tagged as [chore], but included an invalid changelog entry. It passed PR checks, but now causes an error on main.
