### PR TITLE
[chore] unexport updateCollectorStatus function

### DIFF
--- a/internal/status/collector/collector.go
+++ b/internal/status/collector/collector.go
@@ -30,7 +30,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 )
 
-func UpdateCollectorStatus(ctx context.Context, cli client.Client, changed *v1beta1.OpenTelemetryCollector) error {
+func updateCollectorStatus(ctx context.Context, cli client.Client, changed *v1beta1.OpenTelemetryCollector) error {
 	if changed.Status.Version == "" {
 		// a version is not set, otherwise let the upgrade mechanism take care of it!
 		changed.Status.Version = version.OpenTelemetryCollector()

--- a/internal/status/collector/collector_test.go
+++ b/internal/status/collector/collector_test.go
@@ -42,7 +42,7 @@ func TestUpdateCollectorStatusUnsupported(t *testing.T) {
 		},
 	}
 
-	err := UpdateCollectorStatus(ctx, cli, changed)
+	err := updateCollectorStatus(ctx, cli, changed)
 	assert.NoError(t, err)
 
 	assert.Equal(t, int32(0), changed.Status.Scale.Replicas, "expected replicas to be 0")
@@ -89,7 +89,7 @@ func TestUpdateCollectorStatusDeploymentMode(t *testing.T) {
 		},
 	}
 
-	err := UpdateCollectorStatus(ctx, cli, changed)
+	err := updateCollectorStatus(ctx, cli, changed)
 	assert.NoError(t, err)
 
 	assert.Equal(t, int32(1), changed.Status.Scale.Replicas, "expected replicas to be 1")
@@ -137,7 +137,7 @@ func TestUpdateCollectorStatusStatefulset(t *testing.T) {
 		},
 	}
 
-	err := UpdateCollectorStatus(ctx, cli, changed)
+	err := updateCollectorStatus(ctx, cli, changed)
 	assert.NoError(t, err)
 
 	assert.Equal(t, int32(1), changed.Status.Scale.Replicas, "expected replicas to be 1")
@@ -184,7 +184,7 @@ func TestUpdateCollectorStatusDaemonsetMode(t *testing.T) {
 		},
 	}
 
-	err := UpdateCollectorStatus(ctx, cli, changed)
+	err := updateCollectorStatus(ctx, cli, changed)
 	assert.NoError(t, err)
 
 	assert.Contains(t, changed.Status.Scale.Selector, "customLabel=customValue", "expected selector to contain customlabel=customValue")

--- a/internal/status/collector/handle.go
+++ b/internal/status/collector/handle.go
@@ -58,7 +58,7 @@ func HandleReconcileStatus(ctx context.Context, log logr.Logger, params manifest
 		log.V(2).Error(upgradeErr, "failed to upgrade the OpenTelemetry CR")
 	}
 	changed = &upgraded
-	statusErr := UpdateCollectorStatus(ctx, params.Client, changed)
+	statusErr := updateCollectorStatus(ctx, params.Client, changed)
 	if statusErr != nil {
 		params.Recorder.Event(changed, eventTypeWarning, reasonStatusFailure, statusErr.Error())
 		return ctrl.Result{}, statusErr


### PR DESCRIPTION
This function is only used inside this package and called once. Unexporting it helps reduce the API to manage.