### PR TITLE
Fix nginxCloneScriptTemplate for old shells

### DIFF
--- a/pkg/instrumentation/nginx.go
+++ b/pkg/instrumentation/nginx.go
@@ -96,7 +96,7 @@ func injectNginxSDK(_ logr.Logger, nginxSpec v1alpha1.Nginx, pod corev1.Pod, use
 		nginxCloneScriptTemplate :=
 			`
 cp -r %[2]s/* %[3]s &&
-export %[4]s=$( { nginx -v ; } 2>&1 ) && echo ${%[4]s##*/} > %[3]s/version.txt
+export %[4]s="$( { nginx -v ; } 2>&1 )" && echo ${%[4]s##*/} > %[3]s/version.txt
 `
 		nginxAgentCommands := prepareCommandFromTemplate(nginxCloneScriptTemplate,
 			nginxConfFile,


### PR DESCRIPTION
dash version 0.5.10.2-5 return error for export command with spaces after = symbol:
```
# export qwe=nginx version: nginx/1.20.1
dash: 10: export: version:: bad variable name
```

**Description:**
Fixing bug with nginxCloneScriptTemplate on old shells.
In my case I have third-party docker image with nginx and dash Version: 0.5.10.2-5 as shell.
It return error:
```
# export NGINX_VERSION=$( { nginx -v ; } 2>&1 ) && echo ${NGINX_VERSION##*/} > /opt/opentelemetry-webserver/source-conf/version.txt
dash: 11: export: version:: bad variable name
# nginx -v 
nginx version: nginx/1.20.1
# export NGINX_VERSION=nginx version: nginx/1.20.1
dash: 13: export: version:: bad variable name
# 
```
I suggest to quote result of `nginx-v` command for set variable command.

**Link to tracking Issue(s):**

- Resolves:  N/A

**Testing:**
Run instrumentation of robotshop/rs-web:latest image.

**Documentation:**
N/A
