### PR TITLE
[target allocator] Make update interval configurable

### DIFF
--- a/.chloggen/feat_make-update-interval-configurable.yaml
+++ b/.chloggen/feat_make-update-interval-configurable.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: make update interval configurable in the target-allocator collector.
+
+# One or more tracking issues related to the change
+issues: [3666]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Note that the default update interval is 5s, it can be set via configuration file or cli flag.

--- a/cmd/otel-allocator/collector/collector_test.go
+++ b/cmd/otel-allocator/collector/collector_test.go
@@ -42,10 +42,10 @@ var labelSelector = metav1.LabelSelector{
 
 func getTestPodWatcher() Watcher {
 	podWatcher := Watcher{
-		k8sClient:         fake.NewSimpleClientset(),
-		close:             make(chan struct{}),
-		log:               logger,
-		minUpdateInterval: time.Millisecond,
+		k8sClient:      fake.NewSimpleClientset(),
+		close:          make(chan struct{}),
+		log:            logger,
+		updateInterval: time.Millisecond,
 	}
 	return podWatcher
 }

--- a/cmd/otel-allocator/config/config.go
+++ b/cmd/otel-allocator/config/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	FilterStrategy             string                `yaml:"filter_strategy,omitempty"`
 	PrometheusCR               PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
 	HTTPS                      HTTPSServerConfig     `yaml:"https,omitempty"`
+	UpdateInterval             time.Duration         `yaml:"update_interval,omitempty"`
 }
 
 type PrometheusCRConfig struct {
@@ -110,6 +111,11 @@ func LoadFromCLI(target *Config, flagSet *pflag.FlagSet) error {
 	target.ClusterConfig = clusterConfig
 
 	target.ListenAddr, err = getListenAddr(flagSet)
+	if err != nil {
+		return err
+	}
+
+	target.UpdateInterval, err = getUpdateInterval(flagSet)
 	if err != nil {
 		return err
 	}

--- a/cmd/otel-allocator/config/config_test.go
+++ b/cmd/otel-allocator/config/config_test.go
@@ -113,6 +113,7 @@ func TestLoad(t *testing.T) {
 						},
 					},
 				},
+				UpdateInterval: time.Second * 60,
 			},
 			wantErr: assert.NoError,
 		},

--- a/cmd/otel-allocator/config/flags.go
+++ b/cmd/otel-allocator/config/flags.go
@@ -17,6 +17,7 @@ package config
 import (
 	"flag"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/util/homedir"
@@ -35,6 +36,8 @@ const (
 	httpsCAFilePathFlagName      = "https-ca-file"
 	httpsTLSCertFilePathFlagName = "https-tls-cert-file"
 	httpsTLSKeyFilePathFlagName  = "https-tls-key-file"
+	updateIntervalFlagName       = "update-interval"
+	defaultUpdateInterval        = 5 * time.Second
 )
 
 // We can't bind this flag to our FlagSet, so we need to handle it separately.
@@ -51,6 +54,7 @@ func getFlagSet(errorHandling pflag.ErrorHandling) *pflag.FlagSet {
 	flagSet.String(httpsCAFilePathFlagName, "", "The path to the HTTPS server TLS CA file.")
 	flagSet.String(httpsTLSCertFilePathFlagName, "", "The path to the HTTPS server TLS certificate file.")
 	flagSet.String(httpsTLSKeyFilePathFlagName, "", "The path to the HTTPS server TLS key file.")
+	flagSet.Duration(updateIntervalFlagName, defaultUpdateInterval, "The interval in seconds to run a watch action, the default is 5s.")
 	zapFlagSet := flag.NewFlagSet("", flag.ErrorHandling(errorHandling))
 	zapCmdLineOpts.BindFlags(zapFlagSet)
 	flagSet.AddGoFlagSet(zapFlagSet)
@@ -121,4 +125,8 @@ func getHttpsTLSKeyFilePath(flagSet *pflag.FlagSet) (value string, changed bool,
 	}
 	value, err = flagSet.GetString(httpsTLSKeyFilePathFlagName)
 	return
+}
+
+func getUpdateInterval(flagSet *pflag.FlagSet) (time.Duration, error) {
+	return flagSet.GetDuration(updateIntervalFlagName)
 }

--- a/cmd/otel-allocator/config/flags_test.go
+++ b/cmd/otel-allocator/config/flags_test.go
@@ -17,6 +17,7 @@ package config
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
@@ -90,6 +91,12 @@ func TestFlagGetters(t *testing.T) {
 				value, _, err := getHttpsTLSKeyFilePath(fs)
 				return value, err
 			},
+		},
+		{
+			name:          "GetUpdateInterval",
+			flagArgs:      []string{"--" + updateIntervalFlagName, "10s"},
+			expectedValue: 10 * time.Second,
+			getterFunc:    func(fs *pflag.FlagSet) (interface{}, error) { return getUpdateInterval(fs) },
 		},
 	}
 

--- a/cmd/otel-allocator/config/testdata/config_test.yaml
+++ b/cmd/otel-allocator/config/testdata/config_test.yaml
@@ -23,3 +23,4 @@ config:
     - targets: ["prom.domain:9001", "prom.domain:9002", "prom.domain:9003"]
       labels:
         my: label
+update_interval: 60s

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -107,7 +107,7 @@ func main() {
 	discoveryManager = discovery.NewManager(discoveryCtx, gokitlog.NewNopLogger(), prometheus.DefaultRegisterer, sdMetrics)
 
 	targetDiscoverer = target.NewDiscoverer(log, discoveryManager, allocatorPrehook, srv, allocator.SetTargets)
-	collectorWatcher, collectorWatcherErr := collector.NewCollectorWatcher(log, cfg.ClusterConfig)
+	collectorWatcher, collectorWatcherErr := collector.NewCollectorWatcher(log, cfg.ClusterConfig, cfg.UpdateInterval)
 	if collectorWatcherErr != nil {
 		setupLog.Error(collectorWatcherErr, "Unable to initialize collector watcher")
 		os.Exit(1)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #3666

1. Make update interval configurable for target allocator.
2. Add new parameter update-interval to cli flag, the default value is 5s.
3. Add tests for all changes.
