### PR TITLE
[chore] update alpine to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Get CA certificates from alpine package repo
-FROM alpine:3.20 as certificates
+FROM alpine:3.21 as certificates
 
 RUN apk --no-cache add ca-certificates
 


### PR DESCRIPTION
This is not immediately needed. This PR updates the docker image Alpine to 3.21 to avoid running into a situation where the certs downloaded from Alpine end up out of date.