### PR TITLE
[docs] API reference copyedits

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,3 +1,3 @@
 # API Reference
 
-Moved to [here](/docs/api).
+This [page has moved](api).

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,4 +1,4 @@
-# CRDs
+# API reference for CRDs
 
 - [Instrumentation](instrumentations.md)
 - [OpAMPBridge](opampbridges.md)


### PR DESCRIPTION
- Thanks again for solving https://github.com/open-telemetry/opentelemetry.io/issues/6200 by refactoring the API docs.
- This PRs suggests a few copyedits to the API pages:
  - Avoids the use of "here" as link text.
  - Adds "API reference" back into the (new) page title.

/cc @open-telemetry/docs-maintainers 