### PR TITLE
Add urllib3 upper limit to Python auto-instrumentation

### DIFF
--- a/.chloggen/cap-urllib3-for-py38-support.yaml
+++ b/.chloggen/cap-urllib3-for-py38-support.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add upper version limit to Python dependency urllib3
+
+# One or more tracking issues related to the change
+issues: [3616]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/autoinstrumentation/python/requirements.txt
+++ b/autoinstrumentation/python/requirements.txt
@@ -1,4 +1,9 @@
 opentelemetry-distro==0.50b0
+
+# We add a cap to urllib3 version else Python 3.8 support is dropped.
+# TODO: Update autoinstrumentation image builds to support all supported Python versions
+#       https://github.com/open-telemetry/opentelemetry-operator/issues/3712
+urllib3 < 2.3.0
 # We don't use the distro[otlp] option which automatically includes exporters since gRPC is not appropriate for
 # injected auto-instrumentation, where it has a strict dependency on the OS / Python version the artifact is built for.
 opentelemetry-exporter-otlp-proto-http==1.29.0

--- a/autoinstrumentation/python/requirements.txt
+++ b/autoinstrumentation/python/requirements.txt
@@ -1,6 +1,6 @@
 opentelemetry-distro==0.50b0
 
-# We add a cap to urllib3 version else Python 3.8 support is dropped.
+# We add an upper limit to urllib3 version else Python 3.8 support is dropped.
 # TODO: Update autoinstrumentation image builds to support all supported Python versions
 #       https://github.com/open-telemetry/opentelemetry-operator/issues/3712
 urllib3 < 2.3.0


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Adds an upper version limit to `urllib3` for Python auto-instrumentation. [Python OTLP HTTP exporter](https://github.com/open-telemetry/opentelemetry-operator/blob/main/autoinstrumentation/python/requirements.txt#L4) depends on [requests ~= 2.7](https://github.com/open-telemetry/opentelemetry-python/blob/main/exporter/opentelemetry-exporter-otlp-proto-http/pyproject.toml#L37) and that depends on ["urllib3>=1.21.1,<3"](https://github.com/psf/requests/blob/main/setup.py#L39). [urllib 2.3.0](https://github.com/urllib3/urllib3/releases/tag/2.3.0) is the latest and drops support of Python 3.8. We are still supporting Python 3.8.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #3616
- Short-term patch for: #3712

**Testing:** docker build finishes without error.

**Documentation:** <Describe the documentation added.>
