### PR TITLE
Update shellcheck version via renovate

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -11,7 +11,8 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-24.04
     env:
-      VERSION: v0.10.0
+      # renovate: datasource=github-releases depName=https://github.com/koalaman/shellcheck
+      SHELLCHECK_VERSION: v0.10.0
     steps:
       - uses: actions/checkout@v4
       - name: shellcheck ci scripts
@@ -21,7 +22,7 @@ jobs:
         with:
           scandir: ".ci"
           severity: warning
-          version: ${{ env.VERSION }}
+          version: ${{ env.SHELLCHECK_VERSION }}
       - name: shellcheck hack scripts
         uses: ludeeus/action-shellcheck@2.0.0
         env:
@@ -29,4 +30,4 @@ jobs:
         with:
           scandir: "hack"
           severity: warning
-          version: ${{ env.VERSION }}
+          version: ${{ env.SHELLCHECK_VERSION }}

--- a/renovate.json
+++ b/renovate.json
@@ -17,9 +17,10 @@
     },
     {
       "customType": "regex",
-      "description" : "Update tool versions in the Makefile",
+      "description" : "Update tool versions in the Makefile and Github Actions",
       "fileMatch": [
-        "(^|/)Makefile$"
+        "(^|/)Makefile$",
+        "(^|/)\\.github/workflows/.+\\.ya?ml$"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))\\s+[A-Za-z0-9_]+?_VERSION\\s*:*\\??=\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"


### PR DESCRIPTION
**Description:**
Update the shellcheck version in CI using renovate.

**Link to tracking Issue(s):** 

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/3676

