### PR TITLE
Fix another flaky controller test

### DIFF
--- a/controllers/reconcile_test.go
+++ b/controllers/reconcile_test.go
@@ -648,6 +648,13 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 			if deletionTimestamp != nil {
 				err := k8sClient.Delete(testContext, &tt.args.params, client.PropagationPolicy(metav1.DeletePropagationForeground))
 				assert.NoError(t, err)
+				// wait until the reconciler sees the deletion
+				assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+					actual := &v1beta1.OpenTelemetryCollector{}
+					err := reconciler.Get(testContext, nsn, actual)
+					assert.NoError(collect, err)
+					assert.NotNil(t, actual.GetDeletionTimestamp())
+				}, time.Second*5, time.Millisecond)
 			}
 			req := k8sreconcile.Request{
 				NamespacedName: nsn,


### PR DESCRIPTION
Another flaky test due to #3494. This one has been causing CI test runs to fail recently, and I think it's the last one in need of a fix. The problem, yet again, is that our controller client now serves GET requests from a cache, so we need to wait for changes to resources in the envtest API Server to propagate before doing checks in tests.
