### PR TITLE
fix(target-allocator): check for Prometheus CRDs before watching Service/Pod Monitors

### DIFF
--- a/.chloggen/fix-3726.yaml
+++ b/.chloggen/fix-3726.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: 'target allocator'
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: check for Prometheus CRDs before watching Service/Pod Monitors
+
+# One or more tracking issues related to the change
+issues: [3726]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/controllers/targetallocator_controller.go
+++ b/controllers/targetallocator_controller.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/targetallocator"
 	taStatus "github.com/open-telemetry/opentelemetry-operator/internal/status/targetallocator"
@@ -190,7 +191,7 @@ func (r *TargetAllocatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&policyV1.PodDisruptionBudget{})
 
-	if featuregate.PrometheusOperatorIsAvailable.IsEnabled() {
+	if featuregate.PrometheusOperatorIsAvailable.IsEnabled() && r.config.PrometheusCRAvailability() == prometheus.Available {
 		ctrlBuilder.Owns(&monitoringv1.ServiceMonitor{})
 		ctrlBuilder.Owns(&monitoringv1.PodMonitor{})
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Add an additional check for installed Prometheus CRDs before owning Service and Pod Monitor resources in the `TargetAllocator` controller.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #3726 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
