### PR TITLE
Ensure caches are synchronized in reconciler tests

### DIFF
--- a/controllers/reconcile_test.go
+++ b/controllers/reconcile_test.go
@@ -1362,7 +1362,7 @@ func createTestReconciler(t *testing.T, ctx context.Context, cfg config.Config) 
 	require.NoError(t, err)
 	go func() {
 		startErr := runtimeCluster.Start(ctx)
-		require.NoError(t, startErr)
+		assert.NoError(t, startErr)
 	}()
 
 	cacheClient := runtimeCluster.GetClient()
@@ -1375,6 +1375,8 @@ func createTestReconciler(t *testing.T, ctx context.Context, cfg config.Config) 
 	})
 	err = reconciler.SetupCaches(runtimeCluster)
 	require.NoError(t, err)
+	synced := runtimeCluster.GetCache().WaitForCacheSync(ctx)
+	require.True(t, synced, "caches didn't sync successfully")
 	return reconciler
 }
 


### PR DESCRIPTION
**Description:**
Caches are started asynchronously, and we should wait for them to be synchronized before proceeding with the test logic. In real execution, controller-runtime takes care of this for us, but in tests which only use the reconciler, we need to do it ourselves.

This should fix some test flakiness. For example https://github.com/open-telemetry/opentelemetry-operator/actions/runs/13451902458/job/37587720704:

```
reconcile_test.go:1262: 
        	Error Trace:	/home/runner/work/opentelemetry-operator/opentelemetry-operator/controllers/reconcile_test.go:1262
        	Error:      	Received unexpected error:
        	            	the cache is not started, can not read objects
        	Test:       	TestOpenTelemetryCollectorReconciler_Finalizer
--- FAIL: TestOpenTelemetryCollectorReconciler_Finalizer (0.07s)
```

