### PR TITLE
[chore] add atoulme as triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,10 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 In addition to the [core responsibilities](https://github.com/open-telemetry/community/blob/main/community-membership.md) the operator project requires approvers and maintainers to be responsible for releasing the project. See [RELEASE.md](./RELEASE.md) for more information and release schedule.
 
+Triagers ([@open-telemetry/operator-triagers](https://github.com/orgs/open-telemetry/teams/operator-triagers)):
+
+- [Antoine Toulme](https://github.com/atoulme), Splunk
+
 Approvers ([@open-telemetry/operator-approvers](https://github.com/orgs/open-telemetry/teams/operator-approvers)):
 
 - [Tyler Helmuth](https://github.com/TylerHelmuth), Honeycomb


### PR DESCRIPTION
**Description:**
Adds atoulme as triager to README, a separate action to add @atoulme to the operator-triagers team can be done out of band.

**Link to tracking Issue(s):** 
Fixes #3727