### PR TITLE
[target-allocator] Introduce per-zone allocation strategy to target allocator

### DIFF
--- a/.chloggen/targetallocator_zone_allocation.yaml
+++ b/.chloggen/targetallocator_zone_allocation.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add new "per zone" allocation strategy to target allocator. This strategy will assign targets from a specific zone to collectors from the same zone.
+
+# One or more tracking issues related to the change
+issues: [3759]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/allocation/allocator.go
+++ b/cmd/otel-allocator/allocation/allocator.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/diff"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
@@ -68,6 +69,10 @@ func (a *allocator) SetFilter(filter Filter) {
 // SetFallbackStrategy sets the fallback strategy to use.
 func (a *allocator) SetFallbackStrategy(strategy Strategy) {
 	a.strategy.SetFallbackStrategy(strategy)
+}
+
+func (a *allocator) SetKubeClient(kubeClient kubernetes.Interface) {
+	a.strategy.SetKubeClient(kubeClient)
 }
 
 // SetTargets accepts a list of targets that will be used to make

--- a/cmd/otel-allocator/allocation/consistent_hashing.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/buraksezer/consistent"
 	"github.com/cespare/xxhash/v2"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 )
@@ -74,3 +75,5 @@ func (s *consistentHashingStrategy) SetCollectors(collectors map[string]*Collect
 }
 
 func (s *consistentHashingStrategy) SetFallbackStrategy(fallbackStrategy Strategy) {}
+
+func (s *consistentHashingStrategy) SetKubeClient(kubeClient kubernetes.Interface) {}

--- a/cmd/otel-allocator/allocation/least_weighted.go
+++ b/cmd/otel-allocator/allocation/least_weighted.go
@@ -4,6 +4,8 @@
 package allocation
 
 import (
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 )
 
@@ -45,3 +47,5 @@ func (s *leastWeightedStrategy) GetCollectorForTarget(collectors map[string]*Col
 func (s *leastWeightedStrategy) SetCollectors(_ map[string]*Collector) {}
 
 func (s *leastWeightedStrategy) SetFallbackStrategy(fallbackStrategy Strategy) {}
+
+func (s *leastWeightedStrategy) SetKubeClient(kubeClient kubernetes.Interface) {}

--- a/cmd/otel-allocator/allocation/per_node.go
+++ b/cmd/otel-allocator/allocation/per_node.go
@@ -6,6 +6,8 @@ package allocation
 import (
 	"fmt"
 
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 )
 
@@ -28,6 +30,8 @@ func newPerNodeStrategy() Strategy {
 func (s *perNodeStrategy) SetFallbackStrategy(fallbackStrategy Strategy) {
 	s.fallbackStrategy = fallbackStrategy
 }
+
+func (s *perNodeStrategy) SetKubeClient(kubeClient kubernetes.Interface) {}
 
 func (s *perNodeStrategy) GetName() string {
 	return perNodeStrategyName

--- a/cmd/otel-allocator/allocation/per_zone.go
+++ b/cmd/otel-allocator/allocation/per_zone.go
@@ -1,0 +1,189 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package allocation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/buraksezer/consistent"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
+)
+
+const perZoneStrategyName = "per-zone"
+const cacheTTL = 120 * time.Minute
+
+type zonedNode struct {
+	nodeName string
+	zone     string
+}
+
+type collectorZonedNode struct {
+	zonedNode
+	collector string
+}
+
+type targetZonedNode struct {
+	zonedNode
+	target string
+}
+
+func collectorZonedNodeKeyFunc(object interface{}) (string, error) {
+	return object.(collectorZonedNode).collector, nil
+}
+
+func targetZonedNodeKeyFunc(object interface{}) (string, error) {
+	return object.(targetZonedNode).target, nil
+}
+
+var _ Strategy = &perZoneStrategy{}
+
+type perZoneStrategy struct {
+	kubeClient             kubernetes.Interface
+	config                 consistent.Config
+	collectorToZonedNode   cache.Store
+	targetToZonedNode      cache.Store
+	consistentHasherByZone map[string]*consistent.Consistent
+}
+
+func newPerZoneStrategy() Strategy {
+	config := consistent.Config{
+		PartitionCount:    1061,
+		ReplicationFactor: 5,
+		Load:              1.1,
+		Hasher:            hasher{},
+	}
+	perZoneStrategy := &perZoneStrategy{
+		config:                 config,
+		consistentHasherByZone: make(map[string]*consistent.Consistent),
+		collectorToZonedNode:   cache.NewTTLStore(collectorZonedNodeKeyFunc, cacheTTL),
+		targetToZonedNode:      cache.NewTTLStore(targetZonedNodeKeyFunc, cacheTTL),
+	}
+	return perZoneStrategy
+}
+
+func (s *perZoneStrategy) GetCollectorForTarget(collectors map[string]*Collector, item *target.Item) (*Collector, error) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	targetUrl := item.TargetURL
+	targetNodeName := item.GetNodeName()
+	node, exist, err := s.targetToZonedNode.GetByKey(targetUrl)
+	if err != nil {
+		fmt.Printf("failed to retrieve target zoned node from cache: %s", err)
+	}
+	if !exist || node.(targetZonedNode).zonedNode.nodeName != item.GetNodeName() {
+		k8sNode, err := s.retrieveK8sNode(ctx, targetNodeName)
+		if err != nil {
+			return nil, fmt.Errorf("err retrieving k8s node %q for target %q: %w\n", item.GetNodeName(), targetUrl, err)
+		}
+		targetNodeZone, azLabelExist := k8sNode.ObjectMeta.Labels[v1.LabelTopologyZone]
+		if !azLabelExist {
+			return nil, fmt.Errorf("succeeded to find the target node %s in the cluster but it doesn't support zone awareness", targetNodeName)
+		}
+		node = targetZonedNode{
+			zonedNode: zonedNode{
+				nodeName: targetNodeName,
+				zone:     targetNodeZone,
+			},
+			target: targetUrl,
+		}
+		err = s.targetToZonedNode.Add(node)
+		if err != nil {
+			fmt.Printf("error adding a cache for the node and zone information that relates to target %q: %s", targetUrl, err)
+		}
+	}
+
+	zonedConsistentHasher, exist := s.consistentHasherByZone[node.(targetZonedNode).zonedNode.zone]
+	if !exist {
+		return nil, fmt.Errorf("unknown zone %q", node.(targetZonedNode).zonedNode.zone)
+	}
+	member := zonedConsistentHasher.LocateKey([]byte(targetUrl))
+	collectorName := member.String()
+	collector, exist := collectors[collectorName]
+	if !exist {
+		return nil, fmt.Errorf("unknown collector %q", collectorName)
+	}
+	return collector, nil
+}
+
+func (s *perZoneStrategy) SetCollectors(collectors map[string]*Collector) {
+	clear(s.consistentHasherByZone)
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	collectorsByZone := make(map[string][]string)
+
+	for _, collector := range collectors {
+		collectorNodeName := collector.NodeName
+		collectorName := collector.Name
+		node, exist, err := s.collectorToZonedNode.GetByKey(collectorName)
+		if err != nil {
+			fmt.Printf("failed to retrieve collector zoned node from cache: %s", err)
+		}
+		if !exist || node.(collectorZonedNode).zonedNode.nodeName != collector.NodeName {
+			k8sNode, err := s.retrieveK8sNode(ctx, collectorNodeName)
+			if err != nil {
+				fmt.Printf("error retrieving k8s node %q for collector %q: %s\n", collectorNodeName, collectorName, err)
+				continue
+			}
+			collectorNodeZone, exist := k8sNode.ObjectMeta.Labels[v1.LabelTopologyZone]
+			if !exist {
+				fmt.Printf("succeeded to find the collector node %q for collector %q in the cluster but it doesn't support zone awareness\n", collectorNodeName, collectorName)
+				continue
+			}
+			node = collectorZonedNode{
+				zonedNode: zonedNode{
+					nodeName: collectorNodeName,
+					zone:     collectorNodeZone,
+				},
+				collector: collectorName,
+			}
+			err = s.collectorToZonedNode.Add(node)
+			if err != nil {
+				fmt.Printf("error adding a cache for the node and zone information that relates to collector %q: %s \n", collectorName, err)
+			}
+		}
+		collectorsByZone[node.(collectorZonedNode).zonedNode.zone] = append(collectorsByZone[node.(collectorZonedNode).zonedNode.zone], collectorName)
+	}
+
+	var members []consistent.Member
+	for zone, collectorNames := range collectorsByZone {
+		members = make([]consistent.Member, 0, len(collectors))
+		for _, collectorName := range collectorNames {
+			members = append(members, collectors[collectorName])
+		}
+		s.consistentHasherByZone[zone] = consistent.New(members, s.config)
+	}
+}
+
+func (s *perZoneStrategy) GetName() string {
+	return perZoneStrategyName
+}
+
+func (s *perZoneStrategy) SetFallbackStrategy(fallbackStrategy Strategy) {}
+
+func (s *perZoneStrategy) SetKubeClient(kubeClient kubernetes.Interface) {
+	s.kubeClient = kubeClient
+}
+
+func (s *perZoneStrategy) retrieveK8sNode(ctx context.Context, nodeName string) (*v1.Node, error) {
+	var node *v1.Node
+	var err error
+	if node, err = s.kubeClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{}); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("could not find the node %q in the cluster\n", nodeName)
+		}
+		return nil, fmt.Errorf("error when finding the node %q in the cluster, see error %w\n", nodeName, err)
+	}
+	return node, nil
+}

--- a/cmd/otel-allocator/allocation/per_zone_test.go
+++ b/cmd/otel-allocator/allocation/per_zone_test.go
@@ -1,0 +1,210 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package allocation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
+)
+
+var loggerPerZone = logf.Log.WithName("unit-tests")
+
+func TestAllocationPerZone(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-0",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-0",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-1",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-1",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-2",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-2",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-3",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-1",
+				},
+			},
+		})
+
+	perZoneStrategy := newPerZoneStrategy()
+	perZoneAllocator := newAllocator(loggerPerZone, perZoneStrategy, WithKubeClient(kubeClient))
+
+	cols := MakeNCollectors(3, 0)
+	perZoneAllocator.SetCollectors(cols)
+
+	firstTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
+	}
+	secondTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-1"},
+	}
+	thirdTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-2"},
+	}
+	forthTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-3"},
+	}
+
+	firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstTargetLabels, "")
+	secondTarget := target.NewItem("sample-name", "0.0.0.1:8000", secondTargetLabels, "")
+	thirdTarget := target.NewItem("sample-name", "0.0.0.2:8000", thirdTargetLabels, "")
+	fourthTarget := target.NewItem("sample-name", "0.0.0.3:8000", forthTargetLabels, "")
+
+	targetList := map[string]*target.Item{
+		firstTarget.Hash():  firstTarget,
+		secondTarget.Hash(): secondTarget,
+		thirdTarget.Hash():  thirdTarget,
+		fourthTarget.Hash(): fourthTarget,
+	}
+
+	perZoneAllocator.SetTargets(targetList)
+
+	actualItems := perZoneAllocator.TargetItems()
+	expectedTargetLen := len(targetList)
+	assert.Len(t, actualItems, expectedTargetLen)
+
+	// verify allocation to nodes
+	for targetHash, item := range targetList {
+		actualItem, found := actualItems[targetHash]
+		assert.True(t, found, "target with hash %s not found", item.Hash())
+
+		itemsForCollector := perZoneAllocator.GetTargetsForCollectorAndJob(actualItem.CollectorName, actualItem.JobName)
+
+		if targetHash == firstTarget.Hash() {
+			assert.Len(t, itemsForCollector, 1)
+			assert.Equal(t, actualItem.CollectorName, "collector-0")
+			continue
+		}
+		if targetHash == secondTarget.Hash() {
+			assert.Len(t, itemsForCollector, 2)
+			assert.Equal(t, actualItem.CollectorName, "collector-1")
+			continue
+		}
+		if targetHash == thirdTarget.Hash() {
+			assert.Len(t, itemsForCollector, 1)
+			assert.Equal(t, actualItem.CollectorName, "collector-2")
+			continue
+		}
+		if targetHash == fourthTarget.Hash() {
+			assert.Len(t, itemsForCollector, 2)
+			assert.Equal(t, actualItem.CollectorName, "collector-1")
+			continue
+		}
+	}
+}
+
+// Test with no collector in a specific zone.
+func TestTargetsWithZoneDoesNotHaveCollectors(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-0",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-0",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-1",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-1",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-2",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-2",
+				},
+			},
+		})
+
+	perZoneStrategy := newPerZoneStrategy()
+	perZoneAllocator := newAllocator(loggerPerZone, perZoneStrategy, WithKubeClient(kubeClient))
+
+	cols := MakeNCollectors(2, 0)
+	perZoneAllocator.SetCollectors(cols)
+
+	firstTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
+	}
+	secondTargetLabels := labels.Labels{
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-1"},
+	}
+	thirdTargetLabels := labels.Labels{ // won't have a collector in the zone-2
+		{Name: "__meta_kubernetes_pod_node_name", Value: "node-2"},
+	}
+
+	firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstTargetLabels, "")
+	secondTarget := target.NewItem("sample-name", "0.0.0.1:8000", secondTargetLabels, "")
+	thirdTarget := target.NewItem("sample-name", "0.0.0.2:8000", thirdTargetLabels, "")
+
+	targetList := map[string]*target.Item{
+		firstTarget.Hash():  firstTarget,
+		secondTarget.Hash(): secondTarget,
+		thirdTarget.Hash():  thirdTarget,
+	}
+
+	perZoneAllocator.SetTargets(targetList)
+
+	mapString := fmt.Sprintf("%v", perZoneAllocator.TargetItems())
+	fmt.Println(mapString)
+
+	actualItems := perZoneAllocator.TargetItems()
+	expectedTargetLen := len(targetList)
+	assert.Len(t, actualItems, expectedTargetLen)
+
+	// verify allocation to nodes
+	for targetHash, item := range targetList {
+		actualItem, found := actualItems[targetHash]
+		assert.True(t, found, "target with hash %s not found", item.Hash())
+
+		itemsForCollector := perZoneAllocator.GetTargetsForCollectorAndJob(actualItem.CollectorName, actualItem.JobName)
+
+		if targetHash == firstTarget.Hash() {
+			assert.Len(t, itemsForCollector, 1)
+			assert.Equal(t, actualItem.CollectorName, "collector-0")
+			continue
+		}
+		if targetHash == secondTarget.Hash() {
+			assert.Len(t, itemsForCollector, 1)
+			assert.Equal(t, actualItem.CollectorName, "collector-1")
+			continue
+		}
+		if targetHash == thirdTarget.Hash() {
+			assert.Len(t, itemsForCollector, 0)
+			assert.Equal(t, actualItem.CollectorName, "")
+			continue
+		}
+	}
+}

--- a/cmd/otel-allocator/allocation/testutils.go
+++ b/cmd/otel-allocator/allocation/testutils.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
@@ -68,9 +71,51 @@ func MakeNNewTargetsWithEmptyCollectors(n int, startingIndex int) map[string]*ta
 func RunForAllStrategies(t *testing.T, f func(t *testing.T, allocator Allocator)) {
 	allocatorNames := GetRegisteredAllocatorNames()
 	logger := logf.Log.WithName("unit-tests")
+	kubeClient := fake.NewSimpleClientset(
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-0",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-0",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-1",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-1",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-2",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-2",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-3",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-3",
+				},
+			},
+		},
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-4",
+				Labels: map[string]string{
+					corev1.LabelTopologyZone: "zone-4",
+				},
+			},
+		},
+	)
 	for _, allocatorName := range allocatorNames {
 		t.Run(allocatorName, func(t *testing.T) {
-			allocator, err := New(allocatorName, logger)
+			allocator, err := New(allocatorName, logger, WithKubeClient(kubeClient))
 			require.NoError(t, err)
 			f(t, allocator)
 		})

--- a/cmd/otel-allocator/server/mocks_test.go
+++ b/cmd/otel-allocator/server/mocks_test.go
@@ -4,6 +4,8 @@
 package server
 
 import (
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/allocation"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
 )
@@ -22,6 +24,7 @@ func (m *mockAllocator) Collectors() map[string]*allocation.Collector           
 func (m *mockAllocator) GetTargetsForCollectorAndJob(_ string, _ string) []*target.Item { return nil }
 func (m *mockAllocator) SetFilter(_ allocation.Filter)                                  {}
 func (m *mockAllocator) SetFallbackStrategy(_ allocation.Strategy)                      {}
+func (m *mockAllocator) SetKubeClient(kubeConfig kubernetes.Interface)                  {}
 
 func (m *mockAllocator) TargetItems() map[string]*target.Item {
 	return m.targetItems


### PR DESCRIPTION
#### Description:
Resolves https://github.com/open-telemetry/opentelemetry-operator/issues/3759.

A per-zone allocation strategy implements an allocation strategy that only assigns targets from a specific zone to collectors from the same zone.

#### Testing:
Added unit tests

Built image locally and tested

#### Allocation metrics look good
```
opentelemetry_allocator_targets_per_collector{collector_name="otel-collector-with-ta-kube-state-metrics-collector-0",strategy="per-zone"} 0
opentelemetry_allocator_targets_per_collector{collector_name="otel-collector-with-ta-kube-state-metrics-collector-1",strategy="per-zone"} 1
opentelemetry_allocator_targets_per_collector{collector_name="otel-collector-with-ta-kube-state-metrics-collector-2",strategy="per-zone"} 2
opentelemetry_allocator_targets_per_collector{collector_name="otel-collector-with-ta-kube-state-metrics-collector-3",strategy="per-zone"} 2
opentelemetry_allocator_targets_per_collector{collector_name="otel-collector-with-ta-kube-state-metrics-collector-4",strategy="per-zone"} 2
opentelemetry_allocator_targets_per_collector{collector_name="otel-collector-with-ta-kube-state-metrics-collector-6",strategy="per-zone"} 0
opentelemetry_allocator_targets_per_collector{collector_name="otel-collector-with-ta-kube-state-metrics-collector-7",strategy="per-zone"} 0
opentelemetry_allocator_targets_per_collector{collector_name="otel-collector-with-ta-kube-state-metrics-collector-8",strategy="per-zone"} 3

opentelemetry_allocator_targets_remaining 10

opentelemetry_allocator_targets_unassigned 0
```

#### zone allocation looks correct
1. 4 KSM from us-west-2a, 3 KSM from us-west-2b, 3 KSM from us-west-2c
2. `opentelemetry_allocator_targets_per_collector` tells us that
  - collector-3, collector-4, collector-5, collector-9 from us-west-2a are collecting 4 targets
  - collector-6, collector-7, collector-8 from us-west-2b are collecting 3 targets
  - collector-0, collector-1, collector-2 from us-west-2c are collecting 3 targets

```
Pod Zone

otel-collector-with-ta-kube-state-metrics-collector-0 us-west-2c
otel-collector-with-ta-kube-state-metrics-collector-1 us-west-2c
otel-collector-with-ta-kube-state-metrics-collector-2 us-west-2c
otel-collector-with-ta-kube-state-metrics-collector-3 us-west-2a
otel-collector-with-ta-kube-state-metrics-collector-4 us-west-2a
otel-collector-with-ta-kube-state-metrics-collector-5 us-west-2a
otel-collector-with-ta-kube-state-metrics-collector-6 us-west-2b
otel-collector-with-ta-kube-state-metrics-collector-7 us-west-2b
otel-collector-with-ta-kube-state-metrics-collector-8 us-west-2b
otel-collector-with-ta-kube-state-metrics-collector-9 us-west-2a

sharded-kube-state-metrics-0 us-west-2c
sharded-kube-state-metrics-1 us-west-2c
sharded-kube-state-metrics-2 us-west-2b
sharded-kube-state-metrics-3 us-west-2b
sharded-kube-state-metrics-4 us-west-2c
sharded-kube-state-metrics-5 us-west-2a
sharded-kube-state-metrics-6 us-west-2b
sharded-kube-state-metrics-7 us-west-2a
sharded-kube-state-metrics-8 us-west-2a
sharded-kube-state-metrics-9 us-west-2a
```