### PR TITLE
Fix renovate config for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -496,7 +496,7 @@ CHAINSAW ?= $(LOCALBIN)/chainsaw
 KUSTOMIZE_VERSION ?= v5.6.0
 # renovate: datasource=go depName=sigs.k8s.io/controller-tools/cmd/controller-gen
 CONTROLLER_TOOLS_VERSION ?= v0.17.1
-# renovate: datasource=go depName=github.com/golangci/golangci-lint/cmd/golangci-lint
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.63.4
 # renovate: datasource=go depName=sigs.k8s.io/kind
 KIND_VERSION ?= v0.26.0


### PR DESCRIPTION
golangci-lint stopped publishing the Go package we used to check the available versions. Use the github release instead.
