### PR TITLE
Delay hashing scrape targets

### DIFF
--- a/cmd/otel-allocator/benchmark_test.go
+++ b/cmd/otel-allocator/benchmark_test.go
@@ -140,7 +140,10 @@ func prepareBenchmarkData(numTargets, targetsPerGroup, groupsPerJob int) map[str
 	}
 	targets := []model.LabelSet{}
 	for i := 0; i < numTargets; i++ {
-		targets = append(targets, exampleTarget.Clone())
+		newTarget := exampleTarget.Clone()
+		// ensure each target has a unique label to avoid deduplication
+		newTarget["target_id"] = model.LabelValue(strconv.Itoa(i))
+		targets = append(targets, newTarget)
 	}
 	groups := make([]*targetgroup.Group, numGroups)
 	for i := 0; i < numGroups; i++ {

--- a/cmd/otel-allocator/benchmark_test.go
+++ b/cmd/otel-allocator/benchmark_test.go
@@ -28,65 +28,70 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/target"
 )
 
+var targetCounts = []int{1000, 10000, 100000, 800000}
+
 // BenchmarkProcessTargets benchmarks the whole target allocation pipeline. It starts with data the prometheus
 // discovery manager would normally output, and pushes it all the way into the allocator. It notably doe *not* check
 // the HTTP server afterward. Test data is chosen to be reasonably representative of what the Prometheus service discovery
 // outputs in the real world.
 func BenchmarkProcessTargets(b *testing.B) {
-	numTargets := 800000
 	targetsPerGroup := 5
 	groupsPerJob := 20
-	tsets := prepareBenchmarkData(numTargets, targetsPerGroup, groupsPerJob)
-	for _, strategy := range allocation.GetRegisteredAllocatorNames() {
-		b.Run(strategy, func(b *testing.B) {
-			targetDiscoverer := createTestDiscoverer(strategy, map[string][]*relabel.Config{})
-			targetDiscoverer.UpdateTsets(tsets)
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				targetDiscoverer.Reload()
-			}
-		})
+	for _, numTargets := range targetCounts {
+		tsets := prepareBenchmarkData(numTargets, targetsPerGroup, groupsPerJob)
+		for _, strategy := range allocation.GetRegisteredAllocatorNames() {
+			b.Run(fmt.Sprintf("%s/%d", strategy, numTargets), func(b *testing.B) {
+				targetDiscoverer := createTestDiscoverer(strategy, map[string][]*relabel.Config{})
+				targetDiscoverer.UpdateTsets(tsets)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					targetDiscoverer.Reload()
+				}
+			})
+		}
 	}
 }
 
 // BenchmarkProcessTargetsWithRelabelConfig is BenchmarkProcessTargets with a relabel config set. The relabel config
 // does not actually modify any records, but does force the prehook to perform any necessary conversions along the way.
 func BenchmarkProcessTargetsWithRelabelConfig(b *testing.B) {
-	numTargets := 800000
 	targetsPerGroup := 5
 	groupsPerJob := 20
-	tsets := prepareBenchmarkData(numTargets, targetsPerGroup, groupsPerJob)
-	prehookConfig := make(map[string][]*relabel.Config, len(tsets))
-	for jobName := range tsets {
-		// keep all targets in half the jobs, drop the rest
-		jobNrStr := strings.Split(jobName, "-")[1]
-		jobNr, err := strconv.Atoi(jobNrStr)
-		require.NoError(b, err)
-		var action relabel.Action
-		if jobNr%2 == 0 {
-			action = "keep"
-		} else {
-			action = "drop"
+	for _, numTargets := range targetCounts {
+		tsets := prepareBenchmarkData(numTargets, targetsPerGroup, groupsPerJob)
+		prehookConfig := make(map[string][]*relabel.Config, len(tsets))
+		for jobName := range tsets {
+			// keep all targets in half the jobs, drop the rest
+			jobNrStr := strings.Split(jobName, "-")[1]
+			jobNr, err := strconv.Atoi(jobNrStr)
+			require.NoError(b, err)
+			var action relabel.Action
+			if jobNr%2 == 0 {
+				action = "keep"
+			} else {
+				action = "drop"
+			}
+			prehookConfig[jobName] = []*relabel.Config{
+				{
+					Action:       action,
+					Regex:        relabel.MustNewRegexp(".*"),
+					SourceLabels: model.LabelNames{"__address__"},
+				},
+			}
 		}
-		prehookConfig[jobName] = []*relabel.Config{
-			{
-				Action:       action,
-				Regex:        relabel.MustNewRegexp(".*"),
-				SourceLabels: model.LabelNames{"__address__"},
-			},
+
+		for _, strategy := range allocation.GetRegisteredAllocatorNames() {
+			b.Run(fmt.Sprintf("%s/%d", strategy, numTargets), func(b *testing.B) {
+				targetDiscoverer := createTestDiscoverer(strategy, prehookConfig)
+				targetDiscoverer.UpdateTsets(tsets)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					targetDiscoverer.Reload()
+				}
+			})
 		}
 	}
 
-	for _, strategy := range allocation.GetRegisteredAllocatorNames() {
-		b.Run(strategy, func(b *testing.B) {
-			targetDiscoverer := createTestDiscoverer(strategy, prehookConfig)
-			targetDiscoverer.UpdateTsets(tsets)
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				targetDiscoverer.Reload()
-			}
-		})
-	}
 }
 
 func prepareBenchmarkData(numTargets, targetsPerGroup, groupsPerJob int) map[string][]*targetgroup.Group {

--- a/cmd/otel-allocator/internal/allocation/allocator_test.go
+++ b/cmd/otel-allocator/internal/allocation/allocator_test.go
@@ -174,10 +174,7 @@ func TestAllocationCollision(t *testing.T) {
 		firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstLabels, "")
 		secondTarget := target.NewItem("sample-name", "0.0.0.0:8000", secondLabels, "")
 
-		targetList := map[string]*target.Item{
-			firstTarget.Hash():  firstTarget,
-			secondTarget.Hash(): secondTarget,
-		}
+		targetList := []*target.Item{firstTarget, secondTarget}
 
 		// test that targets and collectors are added properly
 		allocator.SetTargets(targetList)

--- a/cmd/otel-allocator/internal/allocation/least_weighted_test.go
+++ b/cmd/otel-allocator/internal/allocation/least_weighted_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -128,7 +129,7 @@ func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 	for index := range targets {
 		shouldDelete := rand.Intn(toDelete) //nolint:gosec
 		if counter < shouldDelete {
-			delete(targets, index)
+			targets = slices.Delete(targets, index, index)
 		}
 		counter++
 	}
@@ -144,9 +145,7 @@ func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
 		assert.InDelta(t, i.NumTargets, count, math.Round(percent))
 	}
 	// adding targets at 'random'
-	for _, item := range MakeNNewTargets(13, 3, 100) {
-		targets[item.Hash()] = item
-	}
+	targets = append(targets, MakeNNewTargets(13, 3, 100)...)
 	s.SetTargets(targets)
 
 	targetItemLen = len(s.TargetItems())

--- a/cmd/otel-allocator/internal/allocation/per_node_test.go
+++ b/cmd/otel-allocator/internal/allocation/per_node_test.go
@@ -56,11 +56,11 @@ func TestAllocationPerNode(t *testing.T) {
 	thirdTarget := target.NewItem("sample-name", "0.0.0.0:8000", thirdLabels, "")
 	fourthTarget := target.NewItem("sample-name", "0.0.0.0:8000", fourthLabels, "")
 
-	targetList := map[string]*target.Item{
-		firstTarget.Hash():  firstTarget,
-		secondTarget.Hash(): secondTarget,
-		thirdTarget.Hash():  thirdTarget,
-		fourthTarget.Hash(): fourthTarget,
+	targetList := []*target.Item{
+		firstTarget,
+		secondTarget,
+		thirdTarget,
+		fourthTarget,
 	}
 
 	// test that targets and collectors are added properly
@@ -74,8 +74,8 @@ func TestAllocationPerNode(t *testing.T) {
 	assert.Len(t, actualItems, expectedTargetLen)
 
 	// verify allocation to nodes
-	for targetHash, item := range targetList {
-		actualItem, found := actualItems[targetHash]
+	for _, item := range targetList {
+		actualItem, found := actualItems[item.Hash()]
 		// if third target, should be skipped
 		assert.True(t, found, "target with hash %s not found", item.Hash())
 
@@ -83,7 +83,7 @@ func TestAllocationPerNode(t *testing.T) {
 		itemsForCollector := s.GetTargetsForCollectorAndJob(actualItem.CollectorName, actualItem.JobName)
 
 		// first two should be assigned one to each collector; if third target, should not be assigned
-		if targetHash == thirdTarget.Hash() {
+		if item.Hash() == thirdTarget.Hash() {
 			assert.Len(t, itemsForCollector, 0)
 			continue
 		}
@@ -123,11 +123,11 @@ func TestAllocationPerNodeUsingFallback(t *testing.T) {
 	thirdTarget := target.NewItem("sample-name", "0.0.0.0:8000", thirdLabels, "")
 	fourthTarget := target.NewItem("sample-name", "0.0.0.0:8000", fourthLabels, "")
 
-	targetList := map[string]*target.Item{
-		firstTarget.Hash():  firstTarget,
-		secondTarget.Hash(): secondTarget,
-		thirdTarget.Hash():  thirdTarget,
-		fourthTarget.Hash(): fourthTarget,
+	targetList := []*target.Item{
+		firstTarget,
+		secondTarget,
+		thirdTarget,
+		fourthTarget,
 	}
 
 	// test that targets and collectors are added properly
@@ -141,8 +141,8 @@ func TestAllocationPerNodeUsingFallback(t *testing.T) {
 	assert.Len(t, actualItems, expectedTargetLen)
 
 	// verify allocation to nodes
-	for targetHash, item := range targetList {
-		actualItem, found := actualItems[targetHash]
+	for _, item := range targetList {
+		actualItem, found := actualItems[item.Hash()]
 
 		assert.True(t, found, "target with hash %s not found", item.Hash())
 
@@ -151,7 +151,7 @@ func TestAllocationPerNodeUsingFallback(t *testing.T) {
 		// first two should be assigned one to each collector; if third target, it should be assigned
 		// according to the fallback strategy which may assign it to the otherwise empty collector or
 		// one of the others, depending on the strategy and collector loop order
-		if targetHash == thirdTarget.Hash() {
+		if item.Hash() == thirdTarget.Hash() {
 			assert.Empty(t, item.GetNodeName())
 			assert.NotZero(t, len(itemsForCollector))
 			continue

--- a/cmd/otel-allocator/internal/allocation/strategy.go
+++ b/cmd/otel-allocator/internal/allocation/strategy.go
@@ -50,7 +50,7 @@ var (
 type Option func(Allocator)
 
 type Filter interface {
-	Apply(map[string]*target.Item) map[string]*target.Item
+	Apply([]*target.Item) []*target.Item
 }
 
 func WithFilter(filter Filter) Option {
@@ -69,7 +69,7 @@ func WithFallbackStrategy(fallbackStrategy string) Option {
 	}
 }
 
-func RecordTargetsKept(targets map[string]*target.Item) {
+func RecordTargetsKept(targets []*target.Item) {
 	TargetsRemaining.Set(float64(len(targets)))
 }
 
@@ -90,7 +90,7 @@ func GetRegisteredAllocatorNames() []string {
 
 type Allocator interface {
 	SetCollectors(collectors map[string]*Collector)
-	SetTargets(targets map[string]*target.Item)
+	SetTargets(targets []*target.Item)
 	TargetItems() map[string]*target.Item
 	Collectors() map[string]*Collector
 	GetTargetsForCollectorAndJob(collector string, job string) []*target.Item

--- a/cmd/otel-allocator/internal/allocation/testutils.go
+++ b/cmd/otel-allocator/internal/allocation/testutils.go
@@ -24,8 +24,8 @@ func colIndex(index, numCols int) int {
 	return index % numCols
 }
 
-func MakeNNewTargets(n int, numCollectors int, startingIndex int) map[string]*target.Item {
-	toReturn := map[string]*target.Item{}
+func MakeNNewTargets(n int, numCollectors int, startingIndex int) []*target.Item {
+	toReturn := []*target.Item{}
 	for i := startingIndex; i < n+startingIndex; i++ {
 		collector := fmt.Sprintf("collector-%d", colIndex(i, numCollectors))
 		label := labels.Labels{
@@ -33,7 +33,7 @@ func MakeNNewTargets(n int, numCollectors int, startingIndex int) map[string]*ta
 			{Name: "total", Value: strconv.Itoa(n + startingIndex)},
 		}
 		newTarget := target.NewItem(fmt.Sprintf("test-job-%d", i), fmt.Sprintf("test-url-%d", i), label, collector)
-		toReturn[newTarget.Hash()] = newTarget
+		toReturn = append(toReturn, newTarget)
 	}
 	return toReturn
 }
@@ -51,8 +51,8 @@ func MakeNCollectors(n int, startingIndex int) map[string]*Collector {
 	return toReturn
 }
 
-func MakeNNewTargetsWithEmptyCollectors(n int, startingIndex int) map[string]*target.Item {
-	toReturn := map[string]*target.Item{}
+func MakeNNewTargetsWithEmptyCollectors(n int, startingIndex int) []*target.Item {
+	toReturn := []*target.Item{}
 	for i := startingIndex; i < n+startingIndex; i++ {
 		label := labels.Labels{
 			{Name: "i", Value: strconv.Itoa(i)},
@@ -60,7 +60,7 @@ func MakeNNewTargetsWithEmptyCollectors(n int, startingIndex int) map[string]*ta
 			{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
 		}
 		newTarget := target.NewItem(fmt.Sprintf("test-job-%d", i), fmt.Sprintf("test-url-%d", i), label, "")
-		toReturn[newTarget.Hash()] = newTarget
+		toReturn = append(toReturn, newTarget)
 	}
 	return toReturn
 }

--- a/cmd/otel-allocator/internal/prehook/prehook.go
+++ b/cmd/otel-allocator/internal/prehook/prehook.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Hook interface {
-	Apply(map[string]*target.Item) map[string]*target.Item
+	Apply([]*target.Item) []*target.Item
 	SetConfig(map[string][]*relabel.Config)
 	GetConfig() map[string][]*relabel.Config
 }

--- a/cmd/otel-allocator/internal/prehook/relabel_test.go
+++ b/cmd/otel-allocator/internal/prehook/relabel_test.go
@@ -167,9 +167,9 @@ func colIndex(index, numCols int) int {
 	return index % numCols
 }
 
-func makeNNewTargets(rCfgs []relabelConfigObj, n int, numCollectors int, startingIndex int) (map[string]*target.Item, int, map[string]*target.Item, map[string][]*relabel.Config) {
-	toReturn := map[string]*target.Item{}
-	expectedMap := make(map[string]*target.Item)
+func makeNNewTargets(rCfgs []relabelConfigObj, n int, numCollectors int, startingIndex int) ([]*target.Item, int, []*target.Item, map[string][]*relabel.Config) {
+	toReturn := []*target.Item{}
+	expected := []*target.Item{}
 	numItemsRemaining := n
 	relabelConfig := make(map[string][]*relabel.Config)
 	for i := startingIndex; i < n+startingIndex; i++ {
@@ -189,15 +189,14 @@ func makeNNewTargets(rCfgs []relabelConfigObj, n int, numCollectors int, startin
 
 		relabelConfig[jobName] = rCfgs[index].cfg
 
-		targetKey := newTarget.Hash()
 		if relabelConfigs[index].isDrop {
 			numItemsRemaining--
 		} else {
-			expectedMap[targetKey] = newTarget
+			expected = append(expected, newTarget)
 		}
-		toReturn[targetKey] = newTarget
+		toReturn = append(toReturn, newTarget)
 	}
-	return toReturn, numItemsRemaining, expectedMap, relabelConfig
+	return toReturn, numItemsRemaining, expected, relabelConfig
 }
 
 func TestApply(t *testing.T) {

--- a/cmd/otel-allocator/internal/server/mocks_test.go
+++ b/cmd/otel-allocator/internal/server/mocks_test.go
@@ -17,7 +17,7 @@ type mockAllocator struct {
 }
 
 func (m *mockAllocator) SetCollectors(_ map[string]*allocation.Collector)               {}
-func (m *mockAllocator) SetTargets(_ map[string]*target.Item)                           {}
+func (m *mockAllocator) SetTargets(_ []*target.Item)                                    {}
 func (m *mockAllocator) Collectors() map[string]*allocation.Collector                   { return nil }
 func (m *mockAllocator) GetTargetsForCollectorAndJob(_ string, _ string) []*target.Item { return nil }
 func (m *mockAllocator) SetFilter(_ allocation.Filter)                                  {}

--- a/cmd/otel-allocator/internal/server/server_test.go
+++ b/cmd/otel-allocator/internal/server/server_test.go
@@ -160,8 +160,12 @@ func TestServer_TargetsHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			listenAddr := ":8080"
 			s := NewServer(logger, tt.args.allocator, listenAddr)
+			targets := []*target.Item{}
+			for _, item := range tt.args.cMap {
+				targets = append(targets, item)
+			}
 			tt.args.allocator.SetCollectors(map[string]*allocation.Collector{"test-collector": {Name: "test-collector"}})
-			tt.args.allocator.SetTargets(tt.args.cMap)
+			tt.args.allocator.SetTargets(targets)
 			request := httptest.NewRequest("GET", fmt.Sprintf("/jobs/%s/targets?collector_id=%s", tt.args.job, tt.args.collector), nil)
 			w := httptest.NewRecorder()
 

--- a/cmd/otel-allocator/internal/target/discovery_test.go
+++ b/cmd/otel-allocator/internal/target/discovery_test.go
@@ -63,7 +63,7 @@ func TestDiscovery(t *testing.T) {
 	require.NoError(t, err)
 	d := discovery.NewManager(ctx, gokitlog.NewNopLogger(), registry, sdMetrics)
 	results := make(chan []string)
-	manager := NewDiscoverer(ctrl.Log.WithName("test"), d, nil, scu, func(targets map[string]*Item) {
+	manager := NewDiscoverer(ctrl.Log.WithName("test"), d, nil, scu, func(targets []*Item) {
 		var result []string
 		for _, t := range targets {
 			result = append(result, t.TargetURL)

--- a/cmd/otel-allocator/internal/target/target.go
+++ b/cmd/otel-allocator/internal/target/target.go
@@ -32,6 +32,9 @@ type Item struct {
 }
 
 func (t *Item) Hash() string {
+	if t.hash == "" {
+		t.hash = t.JobName + t.TargetURL + strconv.FormatUint(t.Labels.Hash(), 10)
+	}
 	return t.hash
 }
 
@@ -53,11 +56,9 @@ func (t *Item) GetNodeName() string {
 // NewItem Creates a new target item.
 // INVARIANTS:
 // * Item fields must not be modified after creation.
-// * Item should only be made via its constructor, never directly.
 func NewItem(jobName string, targetURL string, labels labels.Labels, collectorName string) *Item {
 	return &Item{
 		JobName:       jobName,
-		hash:          jobName + targetURL + strconv.FormatUint(labels.Hash(), 10),
 		TargetURL:     targetURL,
 		Labels:        labels,
 		CollectorName: collectorName,


### PR DESCRIPTION
**Description:**

Instead of hashing scrape targets when they're received from service discovery, wait until the allocator actually needs the hash. This has the following benefits

* We can avoid calculating hashes for targets filtered out by relabeling.
* We hold targets in a slice, which is more performant.
* It becomes easier to solve issues which rely on accessing post-relabelling target state, like #3617.

**Link to tracking Issue(s):** <Issue number if applicable>

Makes it much easier to resolve #3617.

**Testing:**

Existing unit and e2e tests suffice.

