### PR TITLE
[target allocator] Allow setting collector namespace via the config file

### DIFF
--- a/.chloggen/feat_ta-namespace-setting.yaml
+++ b/.chloggen/feat_ta-namespace-setting.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow setting the collector namespace via the config file
+
+# One or more tracking issues related to the change
+issues: [3782]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/internal/config/testdata/config_test.yaml
+++ b/cmd/otel-allocator/internal/config/testdata/config_test.yaml
@@ -1,3 +1,4 @@
+collector_namespace: default
 collector_selector:
   matchlabels:
     app.kubernetes.io/instance: default.test

--- a/cmd/otel-allocator/internal/config/testdata/pod_service_selector_camelcase_expressions_test.yaml
+++ b/cmd/otel-allocator/internal/config/testdata/pod_service_selector_camelcase_expressions_test.yaml
@@ -1,3 +1,4 @@
+collector_namespace: default
 collector_selector:
   matchExpressions:
   - key: "app.kubernetes.io/instance"

--- a/cmd/otel-allocator/internal/config/testdata/pod_service_selector_camelcase_test.yaml
+++ b/cmd/otel-allocator/internal/config/testdata/pod_service_selector_camelcase_test.yaml
@@ -1,3 +1,4 @@
+collector_namespace: default
 collector_selector:
   matchLabels:
     app.kubernetes.io/instance: default.test

--- a/cmd/otel-allocator/internal/config/testdata/pod_service_selector_expressions_test.yaml
+++ b/cmd/otel-allocator/internal/config/testdata/pod_service_selector_expressions_test.yaml
@@ -1,3 +1,4 @@
+collector_namespace: default
 collector_selector:
   matchexpressions:
   - key: "app.kubernetes.io/instance"

--- a/cmd/otel-allocator/internal/config/testdata/pod_service_selector_test.yaml
+++ b/cmd/otel-allocator/internal/config/testdata/pod_service_selector_test.yaml
@@ -1,3 +1,4 @@
+collector_namespace: default
 collector_selector:
   matchlabels:
     app.kubernetes.io/instance: default.test

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -168,7 +168,7 @@ func main() {
 		})
 	runGroup.Add(
 		func() error {
-			err := collectorWatcher.Watch(cfg.CollectorSelector, allocator.SetCollectors)
+			err := collectorWatcher.Watch(cfg.CollectorNamespace, cfg.CollectorSelector, allocator.SetCollectors)
 			setupLog.Info("Collector watcher exited")
 			return err
 		},


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Currently, setting the collector namespace for the target allocator is done via an environment variable. This variable is read in the module that uses it, rather than during configuration loading. Make this namespace part of the config and only read the environment variable during config loading.

**Link to tracking Issue(s):**
Part of https://github.com/open-telemetry/opentelemetry-operator/issues/3782.

