### PR TITLE
[chore] Clean up tool caching in CI

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: bin
-        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
+        key: tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
 
     - name: Install tools
       run: make install-tools
@@ -45,15 +45,15 @@ jobs:
 
     - name: Set up Go
       uses: actions/setup-go@v5
+      id: setup-go
       with:
         go-version: "~1.24.1"
 
     - name: Cache tools
       uses: actions/cache@v4
-      id: setup-go
       with:
         path: bin
-        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
+        key: tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
 
     - name: Install tools
       run: make install-tools

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -62,13 +62,16 @@ jobs:
       id: setup-go
       with:
         go-version: "~1.24.1"
+
     - name: Cache tools
       uses: actions/cache@v4
       with:
         path: bin
-        key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
+        key: tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
+
     - name: Install tools
       run: make install-tools
+
     - name: Prepare e2e tests
       env:
         KUBE_VERSION: ${{ matrix.kube-version }}

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: bin
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
+          key: tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
 
       - name: Install tools
         run: make install-tools


### PR DESCRIPTION
Give the tools cache a more descriptive name and add a missing step id to the lint step.

It looks like the lint step is currently failing on main due to getting oomkilled, hopefully this will improve it.