### PR TITLE
Refactor namespace selector handling in target allocator

### DIFF
--- a/cmd/otel-allocator/internal/config/config.go
+++ b/cmd/otel-allocator/internal/config/config.go
@@ -290,7 +290,11 @@ func CreateDefaultConfig() Config {
 		AllocationFallbackStrategy: "",
 		FilterStrategy:             DefaultFilterStrategy,
 		PrometheusCR: PrometheusCRConfig{
-			ScrapeInterval: DefaultCRScrapeInterval,
+			ScrapeInterval:                  DefaultCRScrapeInterval,
+			ServiceMonitorNamespaceSelector: &metav1.LabelSelector{},
+			PodMonitorNamespaceSelector:     &metav1.LabelSelector{},
+			ScrapeConfigNamespaceSelector:   &metav1.LabelSelector{},
+			ProbeNamespaceSelector:          &metav1.LabelSelector{},
 		},
 	}
 }

--- a/cmd/otel-allocator/internal/config/config_test.go
+++ b/cmd/otel-allocator/internal/config/config_test.go
@@ -51,8 +51,12 @@ func TestLoad(t *testing.T) {
 				},
 				FilterStrategy: DefaultFilterStrategy,
 				PrometheusCR: PrometheusCRConfig{
-					Enabled:        true,
-					ScrapeInterval: model.Duration(time.Second * 60),
+					Enabled:                         true,
+					ScrapeInterval:                  model.Duration(time.Second * 60),
+					ServiceMonitorNamespaceSelector: &metav1.LabelSelector{},
+					PodMonitorNamespaceSelector:     &metav1.LabelSelector{},
+					ScrapeConfigNamespaceSelector:   &metav1.LabelSelector{},
+					ProbeNamespaceSelector:          &metav1.LabelSelector{},
 				},
 				HTTPS: HTTPSServerConfig{
 					Enabled:         true,
@@ -142,7 +146,11 @@ func TestLoad(t *testing.T) {
 							"release": "test",
 						},
 					},
-					ScrapeInterval: DefaultCRScrapeInterval,
+					ServiceMonitorNamespaceSelector: &metav1.LabelSelector{},
+					PodMonitorNamespaceSelector:     &metav1.LabelSelector{},
+					ScrapeConfigNamespaceSelector:   &metav1.LabelSelector{},
+					ProbeNamespaceSelector:          &metav1.LabelSelector{},
+					ScrapeInterval:                  DefaultCRScrapeInterval,
 				},
 				PromConfig: &promconfig.Config{
 					GlobalConfig: promconfig.GlobalConfig{
@@ -213,7 +221,11 @@ func TestLoad(t *testing.T) {
 							"release": "test",
 						},
 					},
-					ScrapeInterval: DefaultCRScrapeInterval,
+					ServiceMonitorNamespaceSelector: &metav1.LabelSelector{},
+					PodMonitorNamespaceSelector:     &metav1.LabelSelector{},
+					ScrapeConfigNamespaceSelector:   &metav1.LabelSelector{},
+					ProbeNamespaceSelector:          &metav1.LabelSelector{},
+					ScrapeInterval:                  DefaultCRScrapeInterval,
 				},
 				PromConfig: &promconfig.Config{
 					GlobalConfig: promconfig.GlobalConfig{
@@ -308,7 +320,11 @@ func TestLoad(t *testing.T) {
 							},
 						},
 					},
-					ScrapeInterval: DefaultCRScrapeInterval,
+					ServiceMonitorNamespaceSelector: &metav1.LabelSelector{},
+					PodMonitorNamespaceSelector:     &metav1.LabelSelector{},
+					ScrapeConfigNamespaceSelector:   &metav1.LabelSelector{},
+					ProbeNamespaceSelector:          &metav1.LabelSelector{},
+					ScrapeInterval:                  DefaultCRScrapeInterval,
 				},
 				PromConfig: &promconfig.Config{
 					GlobalConfig: promconfig.GlobalConfig{
@@ -403,7 +419,11 @@ func TestLoad(t *testing.T) {
 							},
 						},
 					},
-					ScrapeInterval: DefaultCRScrapeInterval,
+					ServiceMonitorNamespaceSelector: &metav1.LabelSelector{},
+					PodMonitorNamespaceSelector:     &metav1.LabelSelector{},
+					ScrapeConfigNamespaceSelector:   &metav1.LabelSelector{},
+					ProbeNamespaceSelector:          &metav1.LabelSelector{},
+					ScrapeInterval:                  DefaultCRScrapeInterval,
 				},
 				PromConfig: &promconfig.Config{
 					GlobalConfig: promconfig.GlobalConfig{

--- a/cmd/otel-allocator/internal/watcher/promOperator.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator.go
@@ -65,6 +65,9 @@ func NewPrometheusCRWatcher(ctx context.Context, logger logr.Logger, cfg allocat
 
 	// TODO: We should make these durations configurable
 	prom := &monitoringv1.Prometheus{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cfg.CollectorNamespace,
+		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 				ScrapeInterval:                  monitoringv1.Duration(cfg.PrometheusCR.ScrapeInterval.String()),

--- a/cmd/otel-allocator/internal/watcher/promOperator_test.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator_test.go
@@ -43,7 +43,7 @@ var defaultScrapeProtocols = []promconfig.ScrapeProtocol{
 }
 
 func TestLoadConfig(t *testing.T) {
-
+	namespace := "test"
 	tests := []struct {
 		name            string
 		serviceMonitors []*monitoringv1.ServiceMonitor
@@ -60,7 +60,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.ServiceMonitorSpec{
 						JobLabel: "test",
@@ -76,7 +76,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "simple",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.PodMonitorSpec{
 						JobLabel: "test",
@@ -109,7 +109,7 @@ func TestLoadConfig(t *testing.T) {
 							&kubeDiscovery.SDConfig{
 								Role: "endpointslice",
 								NamespaceDiscovery: kubeDiscovery.NamespaceDiscovery{
-									Names:               []string{"test"},
+									Names:               []string{namespace},
 									IncludeOwnNamespace: false,
 								},
 								HTTPClientConfig: config.DefaultHTTPClientConfig,
@@ -131,7 +131,7 @@ func TestLoadConfig(t *testing.T) {
 							&kubeDiscovery.SDConfig{
 								Role: "pod",
 								NamespaceDiscovery: kubeDiscovery.NamespaceDiscovery{
-									Names:               []string{"test"},
+									Names:               []string{namespace},
 									IncludeOwnNamespace: false,
 								},
 								HTTPClientConfig: config.DefaultHTTPClientConfig,
@@ -149,7 +149,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "auth",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.ServiceMonitorSpec{
 						JobLabel: "auth",
@@ -202,7 +202,7 @@ func TestLoadConfig(t *testing.T) {
 							&kubeDiscovery.SDConfig{
 								Role: "endpointslice",
 								NamespaceDiscovery: kubeDiscovery.NamespaceDiscovery{
-									Names:               []string{"test"},
+									Names:               []string{namespace},
 									IncludeOwnNamespace: false,
 								},
 								HTTPClientConfig: config.DefaultHTTPClientConfig,
@@ -227,7 +227,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "bearer",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.PodMonitorSpec{
 						JobLabel: "bearer",
@@ -270,7 +270,7 @@ func TestLoadConfig(t *testing.T) {
 							&kubeDiscovery.SDConfig{
 								Role: "pod",
 								NamespaceDiscovery: kubeDiscovery.NamespaceDiscovery{
-									Names:               []string{"test"},
+									Names:               []string{namespace},
 									IncludeOwnNamespace: false,
 								},
 								HTTPClientConfig: config.DefaultHTTPClientConfig,
@@ -295,7 +295,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "valid-sm",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.ServiceMonitorSpec{
 						JobLabel: "test",
@@ -311,7 +311,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "valid-pm",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.PodMonitorSpec{
 						JobLabel: "test",
@@ -325,7 +325,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "invalid-pm",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.PodMonitorSpec{
 						JobLabel: "test",
@@ -366,7 +366,7 @@ func TestLoadConfig(t *testing.T) {
 							&kubeDiscovery.SDConfig{
 								Role: "endpointslice",
 								NamespaceDiscovery: kubeDiscovery.NamespaceDiscovery{
-									Names:               []string{"test"},
+									Names:               []string{namespace},
 									IncludeOwnNamespace: false,
 								},
 								HTTPClientConfig: config.DefaultHTTPClientConfig,
@@ -388,7 +388,7 @@ func TestLoadConfig(t *testing.T) {
 							&kubeDiscovery.SDConfig{
 								Role: "pod",
 								NamespaceDiscovery: kubeDiscovery.NamespaceDiscovery{
-									Names:               []string{"test"},
+									Names:               []string{namespace},
 									IncludeOwnNamespace: false,
 								},
 								HTTPClientConfig: config.DefaultHTTPClientConfig,
@@ -406,7 +406,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "valid-sm",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.ServiceMonitorSpec{
 						JobLabel: "test",
@@ -420,7 +420,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "invalid-sm",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.ServiceMonitorSpec{
 						JobLabel: "test",
@@ -444,7 +444,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "valid-pm",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.PodMonitorSpec{
 						JobLabel: "test",
@@ -477,7 +477,7 @@ func TestLoadConfig(t *testing.T) {
 							&kubeDiscovery.SDConfig{
 								Role: "endpointslice",
 								NamespaceDiscovery: kubeDiscovery.NamespaceDiscovery{
-									Names:               []string{"test"},
+									Names:               []string{namespace},
 									IncludeOwnNamespace: false,
 								},
 								HTTPClientConfig: config.DefaultHTTPClientConfig,
@@ -499,7 +499,7 @@ func TestLoadConfig(t *testing.T) {
 							&kubeDiscovery.SDConfig{
 								Role: "pod",
 								NamespaceDiscovery: kubeDiscovery.NamespaceDiscovery{
-									Names:               []string{"test"},
+									Names:               []string{namespace},
 									IncludeOwnNamespace: false,
 								},
 								HTTPClientConfig: config.DefaultHTTPClientConfig,
@@ -517,7 +517,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "sm-1",
-						Namespace: "test",
+						Namespace: namespace,
 						Labels: map[string]string{
 							"testsvc": "testsvc",
 						},
@@ -537,7 +537,7 @@ func TestLoadConfig(t *testing.T) {
 						Namespace: "test",
 					},
 					Spec: monitoringv1.ServiceMonitorSpec{
-						JobLabel: "test",
+						JobLabel: namespace,
 						Endpoints: []monitoringv1.Endpoint{
 							{
 								Port: "web",
@@ -570,7 +570,7 @@ func TestLoadConfig(t *testing.T) {
 							&kubeDiscovery.SDConfig{
 								Role: "endpointslice",
 								NamespaceDiscovery: kubeDiscovery.NamespaceDiscovery{
-									Names:               []string{"test"},
+									Names:               []string{namespace},
 									IncludeOwnNamespace: false,
 								},
 								HTTPClientConfig: config.DefaultHTTPClientConfig,
@@ -588,7 +588,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pm-1",
-						Namespace: "test",
+						Namespace: namespace,
 						Labels: map[string]string{
 							"testpod": "testpod",
 						},
@@ -605,7 +605,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pm-2",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.PodMonitorSpec{
 						JobLabel: "test",
@@ -641,7 +641,7 @@ func TestLoadConfig(t *testing.T) {
 							&kubeDiscovery.SDConfig{
 								Role: "pod",
 								NamespaceDiscovery: kubeDiscovery.NamespaceDiscovery{
-									Names:               []string{"test"},
+									Names:               []string{namespace},
 									IncludeOwnNamespace: false,
 								},
 								HTTPClientConfig: config.DefaultHTTPClientConfig,
@@ -659,7 +659,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "scrapeconfig-test-1",
-						Namespace: "test",
+						Namespace: namespace,
 						Labels: map[string]string{
 							"testpod": "testpod",
 						},
@@ -723,7 +723,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "probe-test-1",
-						Namespace: "test",
+						Namespace: namespace,
 						Labels: map[string]string{
 							"testpod": "testpod",
 						},
@@ -771,7 +771,7 @@ func TestLoadConfig(t *testing.T) {
 										},
 									},
 									Labels: map[model.LabelName]model.LabelValue{
-										"namespace": "test",
+										"namespace": model.LabelValue(namespace),
 									},
 									Source: "0",
 								},
@@ -803,7 +803,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "sm-2",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.ServiceMonitorSpec{
 						JobLabel: "test",
@@ -873,7 +873,7 @@ func TestLoadConfig(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "pm-2",
-						Namespace: "test",
+						Namespace: namespace,
 					},
 					Spec: monitoringv1.PodMonitorSpec{
 						JobLabel: "test",
@@ -926,7 +926,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			w, _ := getTestPrometheusCRWatcher(t, tt.serviceMonitors, tt.podMonitors, tt.probes, tt.scrapeConfigs, tt.cfg)
+			w, _ := getTestPrometheusCRWatcher(t, namespace, tt.serviceMonitors, tt.podMonitors, tt.probes, tt.scrapeConfigs, tt.cfg)
 
 			// Start namespace informers in order to populate cache.
 			go w.nsInformer.Run(w.stopChannel)
@@ -957,6 +957,7 @@ func TestLoadConfig(t *testing.T) {
 
 func TestNamespaceLabelUpdate(t *testing.T) {
 	var err error
+	namespace := "test"
 	podMonitors := []*monitoringv1.PodMonitor{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -975,7 +976,7 @@ func TestNamespaceLabelUpdate(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pm-2",
-				Namespace: "test",
+				Namespace: namespace,
 			},
 			Spec: monitoringv1.PodMonitorSpec{
 				JobLabel: "test",
@@ -1031,7 +1032,7 @@ func TestNamespaceLabelUpdate(t *testing.T) {
 		ScrapeConfigs: []*promconfig.ScrapeConfig{},
 	}
 
-	w, source := getTestPrometheusCRWatcher(t, nil, podMonitors, nil, nil, cfg)
+	w, source := getTestPrometheusCRWatcher(t, namespace, nil, podMonitors, nil, nil, cfg)
 	events := make(chan Event, 1)
 	eventInterval := 5 * time.Millisecond
 
@@ -1079,10 +1080,11 @@ func TestNamespaceLabelUpdate(t *testing.T) {
 
 func TestRateLimit(t *testing.T) {
 	var err error
+	namespace := "test"
 	serviceMonitor := &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "simple",
-			Namespace: "test",
+			Namespace: namespace,
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			JobLabel: "test",
@@ -1097,7 +1099,7 @@ func TestRateLimit(t *testing.T) {
 	eventInterval := 500 * time.Millisecond
 	cfg := allocatorconfig.Config{}
 
-	w, _ := getTestPrometheusCRWatcher(t, nil, nil, nil, nil, cfg)
+	w, _ := getTestPrometheusCRWatcher(t, namespace, nil, nil, nil, nil, cfg)
 	defer w.Close()
 	w.eventInterval = eventInterval
 
@@ -1158,7 +1160,15 @@ func TestRateLimit(t *testing.T) {
 
 // getTestPrometheusCRWatcher creates a test instance of PrometheusCRWatcher with fake clients
 // and test secrets.
-func getTestPrometheusCRWatcher(t *testing.T, svcMonitors []*monitoringv1.ServiceMonitor, podMonitors []*monitoringv1.PodMonitor, probes []*monitoringv1.Probe, scrapeConfigs []*promv1alpha1.ScrapeConfig, cfg allocatorconfig.Config) (*PrometheusCRWatcher, *fcache.FakeControllerSource) {
+func getTestPrometheusCRWatcher(
+	t *testing.T,
+	namespace string,
+	svcMonitors []*monitoringv1.ServiceMonitor,
+	podMonitors []*monitoringv1.PodMonitor,
+	probes []*monitoringv1.Probe,
+	scrapeConfigs []*promv1alpha1.ScrapeConfig,
+	cfg allocatorconfig.Config,
+) (*PrometheusCRWatcher, *fcache.FakeControllerSource) {
 	mClient := fakemonitoringclient.NewSimpleClientset()
 	for _, sm := range svcMonitors {
 		if sm != nil {
@@ -1225,6 +1235,9 @@ func getTestPrometheusCRWatcher(t *testing.T, svcMonitors []*monitoringv1.Servic
 	serviceDiscoveryRole := monitoringv1.ServiceDiscoveryRole("EndpointSlice")
 
 	prom := &monitoringv1.Prometheus{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 				ScrapeInterval:                  monitoringv1.Duration("30s"),


### PR DESCRIPTION
**Description:**

Currently namespace selectors work correctly in target allocator by accident. By default, Prometheus config generation which we import from prometheus-operator only watches the Prometheus CR namespace for ServiceMonitors. We don't set that, and it just so happens that the config generation code treats that as "all namespaces". This is not the case anymore in newer versions of prometheus-operator, and so we are forced to fix this problem.

This PR explicitly sets default selectors to "all namespaces" in the target allocator config. We also set our internal Prometheus CR namespace to the collector namespace. This doesn't change anything by default, but it makes target allocator behave more similarly to Prometheus.

**Link to tracking Issue(s):**

Part of https://github.com/open-telemetry/opentelemetry-operator/issues/3782.

