### PR TITLE
Do not assign targets to a collector pod that are not Ready for accepting traffic more than a while

### DIFF
--- a/.chloggen/ta_not_assign_targets_to_bad_collectors.yaml
+++ b/.chloggen/ta_not_assign_targets_to_bad_collectors.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not assign targets to a collector pod that is not Ready for longer than a non-zero grace period
+
+# One or more tracking issues related to the change
+issues: [3781]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/internal/collector/collector.go
+++ b/cmd/otel-allocator/internal/collector/collector.go
@@ -31,23 +31,25 @@ var (
 )
 
 type Watcher struct {
-	log               logr.Logger
-	k8sClient         kubernetes.Interface
-	close             chan struct{}
-	minUpdateInterval time.Duration
+	log                          logr.Logger
+	k8sClient                    kubernetes.Interface
+	close                        chan struct{}
+	minUpdateInterval            time.Duration
+	collectorNotReadyGracePeriod time.Duration
 }
 
-func NewCollectorWatcher(logger logr.Logger, kubeConfig *rest.Config) (*Watcher, error) {
+func NewCollectorWatcher(logger logr.Logger, kubeConfig *rest.Config, collectorNotReadyGracePeriod time.Duration) (*Watcher, error) {
 	clientset, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
 		return &Watcher{}, err
 	}
 
 	return &Watcher{
-		log:               logger.WithValues("component", "opentelemetry-targetallocator"),
-		k8sClient:         clientset,
-		close:             make(chan struct{}),
-		minUpdateInterval: defaultMinUpdateInterval,
+		log:                          logger.WithValues("component", "opentelemetry-targetallocator"),
+		k8sClient:                    clientset,
+		close:                        make(chan struct{}),
+		minUpdateInterval:            defaultMinUpdateInterval,
+		collectorNotReadyGracePeriod: collectorNotReadyGracePeriod,
 	}, nil
 }
 
@@ -124,6 +126,12 @@ func (k *Watcher) runOnCollectors(store cache.Store, fn func(collectors map[stri
 		if pod.Spec.NodeName == "" {
 			continue
 		}
+
+		// pod healthiness check will always be disabled if CollectorNotReadyGracePeriod is set to 0 * time.Second
+		if k.isPodUnhealthy(pod, k.collectorNotReadyGracePeriod) {
+			continue
+		}
+
 		collectorMap[pod.Name] = allocation.NewCollector(pod.Name, pod.Spec.NodeName)
 	}
 	collectorsDiscovered.Set(float64(len(collectorMap)))
@@ -132,4 +140,26 @@ func (k *Watcher) runOnCollectors(store cache.Store, fn func(collectors map[stri
 
 func (k *Watcher) Close() {
 	close(k.close)
+}
+
+func (k *Watcher) isPodUnhealthy(pod *v1.Pod, collectorNotReadyGracePeriod time.Duration) bool {
+	if collectorNotReadyGracePeriod == 0*time.Second {
+		return false
+	}
+
+	isPodUnhealthy := false
+	timeNow := time.Now()
+	// stop assigning targets to a non-Running pod that has lasted for a specific period
+	if pod.Status.Phase != v1.PodRunning &&
+		pod.Status.StartTime != nil &&
+		(timeNow.Sub(pod.Status.StartTime.Time) > collectorNotReadyGracePeriod) {
+		isPodUnhealthy = true
+	}
+	// stop assigning targets to a non-Ready pod that has lasted for a specific period
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == v1.PodReady && condition.Status != v1.ConditionTrue && (timeNow.Sub(condition.LastTransitionTime.Time) > collectorNotReadyGracePeriod) {
+			isPodUnhealthy = true
+		}
+	}
+	return isPodUnhealthy
 }

--- a/cmd/otel-allocator/internal/collector/collector_test.go
+++ b/cmd/otel-allocator/internal/collector/collector_test.go
@@ -29,12 +29,13 @@ var labelSelector = metav1.LabelSelector{
 	MatchLabels: labelMap,
 }
 
-func getTestPodWatcher() Watcher {
+func getTestPodWatcher(collectorNotReadyGracePeriod time.Duration) Watcher {
 	podWatcher := Watcher{
-		k8sClient:         fake.NewSimpleClientset(),
-		close:             make(chan struct{}),
-		log:               logger,
-		minUpdateInterval: time.Millisecond,
+		k8sClient:                    fake.NewSimpleClientset(),
+		close:                        make(chan struct{}),
+		log:                          logger,
+		minUpdateInterval:            time.Millisecond,
+		collectorNotReadyGracePeriod: collectorNotReadyGracePeriod,
 	}
 	return podWatcher
 }
@@ -49,14 +50,51 @@ func pod(name string) *v1.Pod {
 		Spec: v1.PodSpec{
 			NodeName: "test-node",
 		},
+		Status: v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{{
+			Type:   v1.PodReady,
+			Status: v1.ConditionTrue,
+		}}},
+	}
+}
+
+func podWithPodPhaseAndStartTime(name string, podPhase v1.PodPhase, startTime time.Time) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-ns",
+			Labels:    labelMap,
+		},
+		Spec: v1.PodSpec{
+			NodeName: "test-node",
+		},
+		Status: v1.PodStatus{Phase: podPhase, StartTime: &metav1.Time{Time: startTime}},
+	}
+}
+
+func podWithPodReadyConditionStatusAndLastTransitionTime(name string, podConditionStatus v1.ConditionStatus, lastTransitionTime time.Time) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-ns",
+			Labels:    labelMap,
+		},
+		Spec: v1.PodSpec{
+			NodeName: "test-node",
+		},
+		Status: v1.PodStatus{Conditions: []v1.PodCondition{{
+			Type:               v1.PodReady,
+			Status:             podConditionStatus,
+			LastTransitionTime: metav1.Time{Time: lastTransitionTime},
+		}}},
 	}
 }
 
 func Test_runWatch(t *testing.T) {
 	namespace := "test-ns"
 	type args struct {
-		kubeFn       func(t *testing.T, podWatcher Watcher)
-		collectorMap map[string]*allocation.Collector
+		collectorNotReadyGracePeriod time.Duration
+		kubeFn                       func(t *testing.T, podWatcher Watcher)
+		collectorMap                 map[string]*allocation.Collector
 	}
 	tests := []struct {
 		name string
@@ -66,6 +104,7 @@ func Test_runWatch(t *testing.T) {
 		{
 			name: "pod add",
 			args: args{
+				collectorNotReadyGracePeriod: 0 * time.Second,
 				kubeFn: func(t *testing.T, podWatcher Watcher) {
 					for _, k := range []string{"test-pod1", "test-pod2", "test-pod3"} {
 						p := pod(k)
@@ -93,6 +132,7 @@ func Test_runWatch(t *testing.T) {
 		{
 			name: "pod delete",
 			args: args{
+				collectorNotReadyGracePeriod: 0 * time.Second,
 				kubeFn: func(t *testing.T, podWatcher Watcher) {
 					for _, k := range []string{"test-pod2", "test-pod3"} {
 						err := podWatcher.k8sClient.CoreV1().Pods(namespace).Delete(context.Background(), k, metav1.DeleteOptions{})
@@ -124,7 +164,7 @@ func Test_runWatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			podWatcher := getTestPodWatcher()
+			podWatcher := getTestPodWatcher(tt.args.collectorNotReadyGracePeriod)
 			defer func() {
 				close(podWatcher.close)
 			}()
@@ -157,9 +197,254 @@ func Test_runWatch(t *testing.T) {
 	}
 }
 
+func Test_gracePeriodWithNonRunningPodPhase(t *testing.T) {
+	namespace := "test-ns"
+	type args struct {
+		collectorNotReadyGracePeriod time.Duration
+		collectorMap                 map[string]*allocation.Collector
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]*allocation.Collector
+	}{
+		{
+			name: "collector healthiness check disabled",
+			args: args{
+				collectorNotReadyGracePeriod: 0 * time.Second,
+				collectorMap: map[string]*allocation.Collector{
+					"test-pod-running": {
+						Name:     "test-pod-running",
+						NodeName: "test-node",
+					},
+					"test-pod-unknown-within-grace-period": {
+						Name:     "test-pod-unknown-within-grace-period",
+						NodeName: "test-node",
+					},
+					"test-pod-pending-over-grace-period": {
+						Name:     "test-pod-pending-over-grace-period",
+						NodeName: "test-node",
+					},
+				},
+			},
+			want: map[string]*allocation.Collector{
+				"test-pod-running": {
+					Name:     "test-pod-running",
+					NodeName: "test-node",
+				},
+				"test-pod-unknown-within-grace-period": {
+					Name:     "test-pod-unknown-within-grace-period",
+					NodeName: "test-node",
+				},
+				"test-pod-pending-over-grace-period": {
+					Name:     "test-pod-pending-over-grace-period",
+					NodeName: "test-node",
+				},
+			},
+		},
+		{
+			name: "collector healthiness check enabled",
+			args: args{
+				collectorNotReadyGracePeriod: 30 * time.Second,
+				collectorMap: map[string]*allocation.Collector{
+					"test-pod-running": {
+						Name:     "test-pod-running",
+						NodeName: "test-node",
+					},
+					"test-pod-unknown-within-grace-period": {
+						Name:     "test-pod-unknown-within-grace-period",
+						NodeName: "test-node",
+					},
+					"test-pod-pending-over-grace-period": {
+						Name:     "test-pod-pending-over-grace-period",
+						NodeName: "test-node",
+					},
+				},
+			},
+			want: map[string]*allocation.Collector{
+				"test-pod-running": {
+					Name:     "test-pod-running",
+					NodeName: "test-node",
+				},
+				"test-pod-unknown-within-grace-period": {
+					Name:     "test-pod-unknown-within-grace-period",
+					NodeName: "test-node",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timeNow := time.Now()
+			podWatcher := getTestPodWatcher(tt.args.collectorNotReadyGracePeriod)
+			defer func() {
+				close(podWatcher.close)
+			}()
+			var actual map[string]*allocation.Collector
+			mapMutex := sync.Mutex{}
+			for _, k := range tt.args.collectorMap {
+				var p *v1.Pod
+				switch k.Name {
+				case "test-pod-running":
+					p = podWithPodPhaseAndStartTime(k.Name, v1.PodRunning, timeNow)
+				case "test-pod-unknown-within-grace-period":
+					p = podWithPodPhaseAndStartTime(k.Name, v1.PodUnknown,
+						timeNow.Add(-1*podWatcher.collectorNotReadyGracePeriod).Add(podWatcher.collectorNotReadyGracePeriod/2))
+				case "test-pod-pending-over-grace-period":
+					p = podWithPodPhaseAndStartTime(k.Name, v1.PodPending,
+						timeNow.Add(-1*podWatcher.collectorNotReadyGracePeriod).Add(-podWatcher.collectorNotReadyGracePeriod/2))
+				}
+				_, err := podWatcher.k8sClient.CoreV1().Pods("test-ns").Create(context.Background(), p, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			go func(podWatcher Watcher) {
+				err := podWatcher.Watch(namespace, &labelSelector, func(colMap map[string]*allocation.Collector) {
+					mapMutex.Lock()
+					defer mapMutex.Unlock()
+					actual = colMap
+				})
+				require.NoError(t, err)
+			}(podWatcher)
+
+			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+				mapMutex.Lock()
+				defer mapMutex.Unlock()
+				assert.Len(collect, actual, len(tt.want))
+				assert.Equal(collect, actual, tt.want)
+				assert.Equal(collect, testutil.ToFloat64(collectorsDiscovered), float64(len(actual)))
+			}, time.Second*3, time.Millisecond)
+		})
+	}
+}
+
+func Test_gracePeriodWithNonReadyPodCondition(t *testing.T) {
+	namespace := "test-ns"
+	type args struct {
+		collectorNotReadyGracePeriod time.Duration
+		collectorMap                 map[string]*allocation.Collector
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want map[string]*allocation.Collector
+	}{
+		{
+			name: "collector healthiness check disabled",
+			args: args{
+				collectorNotReadyGracePeriod: 0 * time.Second,
+				collectorMap: map[string]*allocation.Collector{
+					"test-pod-ready": {
+						Name:     "test-pod-ready",
+						NodeName: "test-node",
+					},
+					"test-pod-non-ready-within-grace-period": {
+						Name:     "test-pod-non-ready-within-grace-period",
+						NodeName: "test-node",
+					},
+					"test-pod-non-ready-over-grace-period": {
+						Name:     "test-pod-non-ready-over-grace-period",
+						NodeName: "test-node",
+					},
+				},
+			},
+			want: map[string]*allocation.Collector{
+				"test-pod-ready": {
+					Name:     "test-pod-ready",
+					NodeName: "test-node",
+				},
+				"test-pod-non-ready-within-grace-period": {
+					Name:     "test-pod-non-ready-within-grace-period",
+					NodeName: "test-node",
+				},
+				"test-pod-non-ready-over-grace-period": {
+					Name:     "test-pod-non-ready-over-grace-period",
+					NodeName: "test-node",
+				},
+			},
+		},
+		{
+			name: "collector healthiness check enabled",
+			args: args{
+				collectorNotReadyGracePeriod: 30 * time.Second,
+				collectorMap: map[string]*allocation.Collector{
+					"test-pod-ready": {
+						Name:     "test-pod-ready",
+						NodeName: "test-node",
+					},
+					"test-pod-non-ready-within-grace-period": {
+						Name:     "test-pod-non-ready-within-grace-period",
+						NodeName: "test-node",
+					},
+					"test-pod-non-ready-over-grace-period": {
+						Name:     "test-pod-non-ready-over-grace-period",
+						NodeName: "test-node",
+					},
+				},
+			},
+			want: map[string]*allocation.Collector{
+				"test-pod-ready": {
+					Name:     "test-pod-ready",
+					NodeName: "test-node",
+				},
+				"test-pod-non-ready-within-grace-period": {
+					Name:     "test-pod-non-ready-within-grace-period",
+					NodeName: "test-node",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timeNow := time.Now()
+			podWatcher := getTestPodWatcher(tt.args.collectorNotReadyGracePeriod)
+			defer func() {
+				close(podWatcher.close)
+			}()
+			var actual map[string]*allocation.Collector
+			mapMutex := sync.Mutex{}
+			for _, k := range tt.args.collectorMap {
+				var p *v1.Pod
+				switch k.Name {
+				case "test-pod-ready":
+					p = podWithPodReadyConditionStatusAndLastTransitionTime(k.Name, v1.ConditionTrue, timeNow)
+				case "test-pod-non-ready-within-grace-period":
+					p = podWithPodReadyConditionStatusAndLastTransitionTime(k.Name, v1.ConditionFalse,
+						timeNow.Add(-1*podWatcher.collectorNotReadyGracePeriod).Add(podWatcher.collectorNotReadyGracePeriod/2))
+				case "test-pod-non-ready-over-grace-period":
+					p = podWithPodReadyConditionStatusAndLastTransitionTime(k.Name, v1.ConditionFalse,
+						timeNow.Add(-1*podWatcher.collectorNotReadyGracePeriod).Add(-podWatcher.collectorNotReadyGracePeriod/2))
+				}
+				_, err := podWatcher.k8sClient.CoreV1().Pods("test-ns").Create(context.Background(), p, metav1.CreateOptions{})
+				assert.NoError(t, err)
+			}
+
+			go func(podWatcher Watcher) {
+				err := podWatcher.Watch(namespace, &labelSelector, func(colMap map[string]*allocation.Collector) {
+					mapMutex.Lock()
+					defer mapMutex.Unlock()
+					actual = colMap
+				})
+				require.NoError(t, err)
+			}(podWatcher)
+
+			assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+				mapMutex.Lock()
+				defer mapMutex.Unlock()
+				assert.Len(collect, actual, len(tt.want))
+				assert.Equal(collect, actual, tt.want)
+				assert.Equal(collect, testutil.ToFloat64(collectorsDiscovered), float64(len(actual)))
+			}, time.Second*3, time.Millisecond)
+		})
+	}
+}
+
 // this tests runWatch in the case of watcher channel closing.
 func Test_closeChannel(t *testing.T) {
-	podWatcher := getTestPodWatcher()
+	podWatcher := getTestPodWatcher(0 * time.Second)
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/cmd/otel-allocator/internal/config/config.go
+++ b/cmd/otel-allocator/internal/config/config.go
@@ -29,26 +29,28 @@ import (
 )
 
 const (
-	DefaultResyncTime                        = 5 * time.Minute
-	DefaultConfigFilePath     string         = "/conf/targetallocator.yaml"
-	DefaultCRScrapeInterval   model.Duration = model.Duration(time.Second * 30)
-	DefaultAllocationStrategy                = "consistent-hashing"
-	DefaultFilterStrategy                    = "relabel-config"
+	DefaultResyncTime                                  = 5 * time.Minute
+	DefaultConfigFilePath               string         = "/conf/targetallocator.yaml"
+	DefaultCRScrapeInterval             model.Duration = model.Duration(time.Second * 30)
+	DefaultAllocationStrategy                          = "consistent-hashing"
+	DefaultFilterStrategy                              = "relabel-config"
+	DefaultCollectorNotReadyGracePeriod                = 0 * time.Second
 )
 
 type Config struct {
-	ListenAddr                 string                `yaml:"listen_addr,omitempty"`
-	KubeConfigFilePath         string                `yaml:"kube_config_file_path,omitempty"`
-	ClusterConfig              *rest.Config          `yaml:"-"`
-	RootLogger                 logr.Logger           `yaml:"-"`
-	CollectorSelector          *metav1.LabelSelector `yaml:"collector_selector,omitempty"`
-	CollectorNamespace         string                `yaml:"collector_namespace,omitempty"`
-	PromConfig                 *promconfig.Config    `yaml:"config"`
-	AllocationStrategy         string                `yaml:"allocation_strategy,omitempty"`
-	AllocationFallbackStrategy string                `yaml:"allocation_fallback_strategy,omitempty"`
-	FilterStrategy             string                `yaml:"filter_strategy,omitempty"`
-	PrometheusCR               PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
-	HTTPS                      HTTPSServerConfig     `yaml:"https,omitempty"`
+	ListenAddr                   string                `yaml:"listen_addr,omitempty"`
+	KubeConfigFilePath           string                `yaml:"kube_config_file_path,omitempty"`
+	ClusterConfig                *rest.Config          `yaml:"-"`
+	RootLogger                   logr.Logger           `yaml:"-"`
+	CollectorSelector            *metav1.LabelSelector `yaml:"collector_selector,omitempty"`
+	CollectorNamespace           string                `yaml:"collector_namespace,omitempty"`
+	PromConfig                   *promconfig.Config    `yaml:"config"`
+	AllocationStrategy           string                `yaml:"allocation_strategy,omitempty"`
+	AllocationFallbackStrategy   string                `yaml:"allocation_fallback_strategy,omitempty"`
+	FilterStrategy               string                `yaml:"filter_strategy,omitempty"`
+	PrometheusCR                 PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
+	HTTPS                        HTTPSServerConfig     `yaml:"https,omitempty"`
+	CollectorNotReadyGracePeriod time.Duration         `yaml:"collector_not_ready_grace_period,omitempty"`
 }
 
 type PrometheusCRConfig struct {
@@ -292,6 +294,7 @@ func CreateDefaultConfig() Config {
 		PrometheusCR: PrometheusCRConfig{
 			ScrapeInterval: DefaultCRScrapeInterval,
 		},
+		CollectorNotReadyGracePeriod: DefaultCollectorNotReadyGracePeriod,
 	}
 }
 

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -96,7 +96,7 @@ func main() {
 	discoveryManager = discovery.NewManager(discoveryCtx, gokitlog.NewNopLogger(), prometheus.DefaultRegisterer, sdMetrics)
 
 	targetDiscoverer = target.NewDiscoverer(log, discoveryManager, allocatorPrehook, srv, allocator.SetTargets)
-	collectorWatcher, collectorWatcherErr := collector.NewCollectorWatcher(log, cfg.ClusterConfig)
+	collectorWatcher, collectorWatcherErr := collector.NewCollectorWatcher(log, cfg.ClusterConfig, cfg.CollectorNotReadyGracePeriod)
 	if collectorWatcherErr != nil {
 		setupLog.Error(collectorWatcherErr, "Unable to initialize collector watcher")
 		os.Exit(1)


### PR DESCRIPTION
**Description:**

Ideally, TargetAllocator should not assign targets to an unhealthy pod that is not ready for accepting traffic.

By discussing with Mikolaj in [#3781](https://github.com/open-telemetry/opentelemetry-operator/issues/3781), we believe that it will be a good idea to NOT assign targets to an unhealthy collector pod that has been staying in the bad state for a grace period of `30s` or something.

Note that the `unhealthy` here not only necessarily means `Pod Phase is non-Running`, but more of saying the pod's `PodCondition Ready is non-True`.
- `Running` is a Pod Phase that is defined as: "The Pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting."
- `Ready` is a Pod Condition that is defined as: "The Pod is able to serve requests and should be added to the load balancing pools of all matching Services."

Although I believe the check on `Ready` PodCondition is already covering  the check on `Running` PodPhase, but I am fine to keep both of them as of now. Let me know your opinion if you have a strong one.

**Link to tracking Issue(s):**

Resolves: [#3781](https://github.com/open-telemetry/opentelemetry-operator/issues/3781)

**Testing:**

Unit Test:
- I added two unit tests that
   - `given three pods (1) a running pod (2) a non-running pod but is still within grace period (3) a non-running pod and is already over grace period`, the test passed.
   - `given three pods (1) a ready pod (2) a non-ready pod but is still within grace period (3) a non-ready pod and is already over grace period`, the test passed.
- Also I want to call out that existing unit tests are not impacted.

Local Test:
- I built a docker image with this change and verified that if a pod is non-running for too long, TargetAllocator will not assign any more targets to it.

Local Test Step By Step:
1. Initial State was 10 available collector pods and two target-allocator pods with the change in this PR
```
otel-collector-with-ta-kube-state-metrics-collector-0             1/1     Running       0            31h
otel-collector-with-ta-kube-state-metrics-collector-1             1/1     Running       0            31h
otel-collector-with-ta-kube-state-metrics-collector-2             1/1     Running       0            31h
otel-collector-with-ta-kube-state-metrics-collector-3             1/1     Running       0            31h
otel-collector-with-ta-kube-state-metrics-collector-4             1/1     Running       0            31h
otel-collector-with-ta-kube-state-metrics-collector-5             1/1     Running       0            31h
otel-collector-with-ta-kube-state-metrics-collector-6             1/1     Running       0            31h
otel-collector-with-ta-kube-state-metrics-collector-7             1/1     Running       0            31h
otel-collector-with-ta-kube-state-metrics-collector-8             1/1     Running       0            31h
otel-collector-with-ta-kube-state-metrics-collector-9             1/1     Running       0            61s
otel-collector-with-ta-kube-state-metrics-targetallocator-kp5xm   1/1     Running       0            5m15s
otel-collector-with-ta-kube-state-metrics-targetallocator-p9kvl   1/1     Running       0            3m50s
```

By port-forwarding to `http://localhost:8080/jobs/kube-state-metrics/targets`, I could see 10 collectors are candidates.

![Screenshot 2025-03-14 at 7 04 47 PM](https://github.com/user-attachments/assets/19b54a1a-c679-4ef0-9254-7a49ea0064a9)

2. I changed collectors to use a bad image and then `collector-9` went into non-Running state
```
otel-collector-with-ta-kube-state-metrics-collector-0             1/1     Running        0            31h
otel-collector-with-ta-kube-state-metrics-collector-1             1/1     Running        0            31h
otel-collector-with-ta-kube-state-metrics-collector-2             1/1     Running        0            31h
otel-collector-with-ta-kube-state-metrics-collector-3             1/1     Running        0            31h
otel-collector-with-ta-kube-state-metrics-collector-4             1/1     Running        0            31h
otel-collector-with-ta-kube-state-metrics-collector-5             1/1     Running        0            31h
otel-collector-with-ta-kube-state-metrics-collector-6             1/1     Running        0            31h
otel-collector-with-ta-kube-state-metrics-collector-7             1/1     Running        0            31h
otel-collector-with-ta-kube-state-metrics-collector-8             1/1     Running        0            31h
otel-collector-with-ta-kube-state-metrics-collector-9             0/1     ErrImagePull   0            37s
otel-collector-with-ta-kube-state-metrics-targetallocator-kp5xm   1/1     Running        0            5m55s
otel-collector-with-ta-kube-state-metrics-targetallocator-p9kvl   1/1     Running        0            4m30s
```

Pod Condition of `Ready` also went `False` in a bit.

![image](https://github.com/user-attachments/assets/49cdcc2f-971e-4306-8f28-efb0275ac5a7)


By port-forwarding to `http://localhost:8080/jobs/kube-state-metrics/targets`, I could only see 9 collectors are candidates.

![Screenshot 2025-03-14 at 7 08 53 PM](https://github.com/user-attachments/assets/ed19e053-2abb-4fee-8e54-d223f7148071)
