### PR TITLE
Comment out autoinstrumentation-php in versions.txt

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -34,7 +34,7 @@ autoinstrumentation-go=v0.19.0-alpha
 
 # Represents the current release of PHP instrumentation.
 # Should match autoinstrumentation/php/version.txt
-autoinstrumentation-PHP=1.1.0
+# autoinstrumentation-PHP=1.1.0
 
 # Represents the current release of Apache HTTPD instrumentation.
 # Should match autoinstrumentation/apache-httpd/version.txt


### PR DESCRIPTION
**Description:** <Describe what has changed.>
PHP was recently added to [versions.txt](https://github.com/open-telemetry/opentelemetry-operator/blob/main/versions.txt#L37), which is great for progressing towards expanding language support. However, I’d like to keep versions.txt focused on features that are currently available in the operator.

Our downstream project relies on versions.txt for CI/CD, ensuring that only functional and accessible Docker images are referenced. Since PHP support isn’t ready yet, this is causing CI/CD failures due to the lack of a defined PHP image and the operator not having support for PHP implemented.

To avoid breaking CI/CD, this PR comments out the PHP version until official support is available.
