### PR TITLE
[target allocator] Use a uint64 hash instead of a string

### DIFF
--- a/cmd/otel-allocator/internal/allocation/strategy.go
+++ b/cmd/otel-allocator/internal/allocation/strategy.go
@@ -91,7 +91,7 @@ func GetRegisteredAllocatorNames() []string {
 type Allocator interface {
 	SetCollectors(collectors map[string]*Collector)
 	SetTargets(targets []*target.Item)
-	TargetItems() map[string]*target.Item
+	TargetItems() map[target.ItemHash]*target.Item
 	Collectors() map[string]*Collector
 	GetTargetsForCollectorAndJob(collector string, job string) []*target.Item
 	SetFilter(filter Filter)

--- a/cmd/otel-allocator/internal/allocation/strategy_test.go
+++ b/cmd/otel-allocator/internal/allocation/strategy_test.go
@@ -90,7 +90,7 @@ func TestCollectorDiff(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want diff.Changes[*Collector]
+		want diff.Changes[string, *Collector]
 	}{
 		{
 			name: "diff two collector maps",

--- a/cmd/otel-allocator/internal/diff/diff.go
+++ b/cmd/otel-allocator/internal/diff/diff.go
@@ -5,33 +5,33 @@ package diff
 
 // Changes is the result of the difference between two maps – items that are added and items that are removed
 // This map is used to reconcile state differences.
-type Changes[T Hasher] struct {
-	additions map[string]T
-	removals  map[string]T
+type Changes[K comparable, T Hasher[K]] struct {
+	additions map[K]T
+	removals  map[K]T
 }
 
-type Hasher interface {
-	Hash() string
+type Hasher[K comparable] interface {
+	Hash() K
 }
 
-func NewChanges[T Hasher](additions map[string]T, removals map[string]T) Changes[T] {
-	return Changes[T]{additions: additions, removals: removals}
+func NewChanges[K comparable, T Hasher[K]](additions map[K]T, removals map[K]T) Changes[K, T] {
+	return Changes[K, T]{additions: additions, removals: removals}
 }
 
-func (c Changes[T]) Additions() map[string]T {
+func (c Changes[K, T]) Additions() map[K]T {
 	return c.additions
 }
 
-func (c Changes[T]) Removals() map[string]T {
+func (c Changes[K, T]) Removals() map[K]T {
 	return c.removals
 }
 
 // Maps generates Changes for two maps with the same type signature by checking for any removals and then checking for
 // additions.
 // TODO: This doesn't need to create maps, it can return slices only. This function doesn't need to insert the values.
-func Maps[T Hasher](current, new map[string]T) Changes[T] {
-	additions := map[string]T{}
-	removals := map[string]T{}
+func Maps[K comparable, T Hasher[K]](current, new map[K]T) Changes[K, T] {
+	additions := map[K]T{}
+	removals := map[K]T{}
 	for key, newValue := range new {
 		if currentValue, found := current[key]; !found {
 			additions[key] = newValue
@@ -45,7 +45,7 @@ func Maps[T Hasher](current, new map[string]T) Changes[T] {
 			removals[key] = value
 		}
 	}
-	return Changes[T]{
+	return Changes[K, T]{
 		additions: additions,
 		removals:  removals,
 	}

--- a/cmd/otel-allocator/internal/diff/diff_test.go
+++ b/cmd/otel-allocator/internal/diff/diff_test.go
@@ -16,29 +16,29 @@ func (s HasherString) Hash() string {
 
 func TestDiffMaps(t *testing.T) {
 	type args struct {
-		current map[string]Hasher
-		new     map[string]Hasher
+		current map[string]Hasher[string]
+		new     map[string]Hasher[string]
 	}
 	tests := []struct {
 		name string
 		args args
-		want Changes[Hasher]
+		want Changes[string, Hasher[string]]
 	}{
 		{
 			name: "basic replacement",
 			args: args{
-				current: map[string]Hasher{
+				current: map[string]Hasher[string]{
 					"current": HasherString("one"),
 				},
-				new: map[string]Hasher{
+				new: map[string]Hasher[string]{
 					"new": HasherString("another"),
 				},
 			},
-			want: Changes[Hasher]{
-				additions: map[string]Hasher{
+			want: Changes[string, Hasher[string]]{
+				additions: map[string]Hasher[string]{
 					"new": HasherString("another"),
 				},
-				removals: map[string]Hasher{
+				removals: map[string]Hasher[string]{
 					"current": HasherString("one"),
 				},
 			},
@@ -46,41 +46,41 @@ func TestDiffMaps(t *testing.T) {
 		{
 			name: "single addition",
 			args: args{
-				current: map[string]Hasher{
+				current: map[string]Hasher[string]{
 					"current": HasherString("one"),
 				},
-				new: map[string]Hasher{
+				new: map[string]Hasher[string]{
 					"current": HasherString("one"),
 					"new":     HasherString("another"),
 				},
 			},
-			want: Changes[Hasher]{
-				additions: map[string]Hasher{
+			want: Changes[string, Hasher[string]]{
+				additions: map[string]Hasher[string]{
 					"new": HasherString("another"),
 				},
-				removals: map[string]Hasher{},
+				removals: map[string]Hasher[string]{},
 			},
 		},
 		{
 			name: "value change",
 			args: args{
-				current: map[string]Hasher{
+				current: map[string]Hasher[string]{
 					"k1":     HasherString("v1"),
 					"k2":     HasherString("v2"),
 					"change": HasherString("before"),
 				},
-				new: map[string]Hasher{
+				new: map[string]Hasher[string]{
 					"k1":     HasherString("v1"),
 					"k3":     HasherString("v3"),
 					"change": HasherString("after"),
 				},
 			},
-			want: Changes[Hasher]{
-				additions: map[string]Hasher{
+			want: Changes[string, Hasher[string]]{
+				additions: map[string]Hasher[string]{
 					"k3":     HasherString("v3"),
 					"change": HasherString("after"),
 				},
-				removals: map[string]Hasher{
+				removals: map[string]Hasher[string]{
 					"k2":     HasherString("v2"),
 					"change": HasherString("before"),
 				},

--- a/cmd/otel-allocator/internal/server/mocks_test.go
+++ b/cmd/otel-allocator/internal/server/mocks_test.go
@@ -13,7 +13,7 @@ var _ allocation.Allocator = &mockAllocator{}
 // mockAllocator implements the Allocator interface, but all funcs other than
 // TargetItems() are a no-op.
 type mockAllocator struct {
-	targetItems map[string]*target.Item
+	targetItems map[target.ItemHash]*target.Item
 }
 
 func (m *mockAllocator) SetCollectors(_ map[string]*allocation.Collector)               {}
@@ -23,6 +23,6 @@ func (m *mockAllocator) GetTargetsForCollectorAndJob(_ string, _ string) []*targ
 func (m *mockAllocator) SetFilter(_ allocation.Filter)                                  {}
 func (m *mockAllocator) SetFallbackStrategy(_ allocation.Strategy)                      {}
 
-func (m *mockAllocator) TargetItems() map[string]*target.Item {
+func (m *mockAllocator) TargetItems() map[target.ItemHash]*target.Item {
 	return m.targetItems
 }

--- a/cmd/otel-allocator/internal/server/server_test.go
+++ b/cmd/otel-allocator/internal/server/server_test.go
@@ -60,7 +60,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 	type args struct {
 		collector string
 		job       string
-		cMap      map[string]*target.Item
+		cMap      map[target.ItemHash]*target.Item
 		allocator allocation.Allocator
 	}
 	type want struct {
@@ -77,7 +77,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 			args: args{
 				collector: "test-collector",
 				job:       "test-job",
-				cMap:      map[string]*target.Item{},
+				cMap:      map[target.ItemHash]*target.Item{},
 				allocator: leastWeighted,
 			},
 			want: want{
@@ -89,7 +89,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 			args: args{
 				collector: "test-collector",
 				job:       "test-job",
-				cMap: map[string]*target.Item{
+				cMap: map[target.ItemHash]*target.Item{
 					baseTargetItem.Hash(): baseTargetItem,
 				},
 				allocator: leastWeighted,
@@ -110,7 +110,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 			args: args{
 				collector: "test-collector",
 				job:       "test-job",
-				cMap: map[string]*target.Item{
+				cMap: map[target.ItemHash]*target.Item{
 					baseTargetItem.Hash():   baseTargetItem,
 					secondTargetItem.Hash(): secondTargetItem,
 				},
@@ -132,7 +132,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 			args: args{
 				collector: "test-collector",
 				job:       "test-job",
-				cMap: map[string]*target.Item{
+				cMap: map[target.ItemHash]*target.Item{
 					baseTargetItem.Hash():       baseTargetItem,
 					testJobTargetItemTwo.Hash(): testJobTargetItemTwo,
 				},
@@ -547,7 +547,7 @@ func TestServer_ScrapeConfigsHandler(t *testing.T) {
 func TestServer_JobHandler(t *testing.T) {
 	tests := []struct {
 		description  string
-		targetItems  map[string]*target.Item
+		targetItems  map[target.ItemHash]*target.Item
 		expectedCode int
 		expectedJobs map[string]linkJSON
 	}{
@@ -559,14 +559,14 @@ func TestServer_JobHandler(t *testing.T) {
 		},
 		{
 			description:  "empty jobs",
-			targetItems:  map[string]*target.Item{},
+			targetItems:  map[target.ItemHash]*target.Item{},
 			expectedCode: http.StatusOK,
 			expectedJobs: make(map[string]linkJSON),
 		},
 		{
 			description: "one job",
-			targetItems: map[string]*target.Item{
-				"targetitem": target.NewItem("job1", "", labels.Labels{}, ""),
+			targetItems: map[target.ItemHash]*target.Item{
+				0: target.NewItem("job1", "", labels.Labels{}, ""),
 			},
 			expectedCode: http.StatusOK,
 			expectedJobs: map[string]linkJSON{
@@ -575,12 +575,12 @@ func TestServer_JobHandler(t *testing.T) {
 		},
 		{
 			description: "multiple jobs",
-			targetItems: map[string]*target.Item{
-				"a": target.NewItem("job1", "", labels.Labels{}, ""),
-				"b": target.NewItem("job2", "", labels.Labels{}, ""),
-				"c": target.NewItem("job3", "", labels.Labels{}, ""),
-				"d": target.NewItem("job3", "", labels.Labels{}, ""),
-				"e": target.NewItem("job3", "", labels.Labels{}, "")},
+			targetItems: map[target.ItemHash]*target.Item{
+				0: target.NewItem("job1", "", labels.Labels{}, ""),
+				1: target.NewItem("job2", "", labels.Labels{}, ""),
+				2: target.NewItem("job3", "", labels.Labels{}, ""),
+				3: target.NewItem("job3", "", labels.Labels{}, ""),
+				4: target.NewItem("job3", "", labels.Labels{}, "")},
 			expectedCode: http.StatusOK,
 			expectedJobs: map[string]linkJSON{
 				"job1": newLink("job1"),

--- a/cmd/otel-allocator/internal/target/target.go
+++ b/cmd/otel-allocator/internal/target/target.go
@@ -4,8 +4,6 @@
 package target
 
 import (
-	"strconv"
-
 	"github.com/prometheus/prometheus/model/labels"
 )
 
@@ -23,17 +21,19 @@ var (
 	relevantLabelNames           = append(nodeLabels, endpointSliceTargetKindLabel, endpointSliceTargetNameLabel)
 )
 
+type ItemHash uint64
+
 type Item struct {
 	JobName       string
 	TargetURL     string
 	Labels        labels.Labels
 	CollectorName string
-	hash          string
+	hash          ItemHash
 }
 
-func (t *Item) Hash() string {
-	if t.hash == "" {
-		t.hash = t.JobName + t.TargetURL + strconv.FormatUint(t.Labels.Hash(), 10)
+func (t *Item) Hash() ItemHash {
+	if t.hash == 0 {
+		t.hash = ItemHash(t.Labels.Hash())
 	}
 	return t.hash
 }


### PR DESCRIPTION
We use a (relatively long) string as our target hash for no good reason in the target allocator. Since what we're really hashing are labels, and these come with a built-in hash method that returns a uint64, we use that instead. This gives some impressive performance benefits for such a simple change:

```
goos: linux
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator
cpu: AMD Ryzen 9 7950X3D 16-Core Processor          
                                                             │ bench_main.txt │        bench_branch_hash.txt        │
                                                             │     sec/op     │   sec/op     vs base                │
ProcessTargets/per-node/1000-32                                   1.058m ± 3%   1.015m ± 3%   -4.12% (p=0.000 n=10)
ProcessTargets/least-weighted/1000-32                             1.064m ± 0%   1.015m ± 1%   -4.60% (p=0.000 n=10)
ProcessTargets/consistent-hashing/1000-32                         1.068m ± 2%   1.065m ± 4%        ~ (p=0.393 n=10)
ProcessTargets/least-weighted/10000-32                            7.564m ± 1%   7.186m ± 1%   -5.00% (p=0.000 n=10)
ProcessTargets/consistent-hashing/10000-32                        7.594m ± 1%   7.007m ± 2%   -7.73% (p=0.000 n=10)
ProcessTargets/per-node/10000-32                                  7.582m ± 3%   6.916m ± 3%   -8.79% (p=0.000 n=10)
ProcessTargets/least-weighted/100000-32                           82.35m ± 3%   70.92m ± 4%  -13.88% (p=0.000 n=10)
ProcessTargets/consistent-hashing/100000-32                       81.84m ± 4%   68.53m ± 2%  -16.26% (p=0.000 n=10)
ProcessTargets/per-node/100000-32                                 80.45m ± 3%   70.13m ± 3%  -12.83% (p=0.000 n=10)
ProcessTargets/least-weighted/800000-32                           875.1m ± 5%   709.9m ± 7%  -18.88% (p=0.000 n=10)
ProcessTargets/consistent-hashing/800000-32                       882.4m ± 6%   703.9m ± 9%  -20.22% (p=0.000 n=10)
ProcessTargets/per-node/800000-32                                 889.6m ± 3%   708.0m ± 5%  -20.41% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/1000-32            1.497m ± 1%   1.499m ± 1%        ~ (p=0.796 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/1000-32        1.473m ± 4%   1.498m ± 1%        ~ (p=0.684 n=10)
ProcessTargetsWithRelabelConfig/per-node/1000-32                  1.526m ± 3%   1.522m ± 1%        ~ (p=0.853 n=10)
ProcessTargetsWithRelabelConfig/per-node/10000-32                 11.72m ± 2%   11.00m ± 2%   -6.10% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/10000-32           11.88m ± 1%   10.90m ± 1%   -8.26% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/10000-32       11.85m ± 1%   10.83m ± 1%   -8.57% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/100000-32          116.6m ± 2%   110.1m ± 4%   -5.61% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/100000-32      116.4m ± 2%   110.1m ± 3%   -5.41% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node/100000-32                114.8m ± 2%   108.9m ± 3%   -5.12% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/800000-32          972.9m ± 4%   870.3m ± 3%  -10.54% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/800000-32      957.1m ± 3%   874.8m ± 2%   -8.60% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node/800000-32               1007.6m ± 2%   870.1m ± 3%  -13.65% (p=0.000 n=10)
geomean                                                           32.23m        29.43m        -8.68%

                                                             │ bench_main.txt │        bench_branch_hash.txt        │
                                                             │      B/op      │     B/op      vs base               │
ProcessTargets/per-node/1000-32                                  4.249Mi ± 0%   4.164Mi ± 0%  -2.00% (p=0.000 n=10)
ProcessTargets/least-weighted/1000-32                            4.249Mi ± 0%   4.164Mi ± 0%  -2.00% (p=0.000 n=10)
ProcessTargets/consistent-hashing/1000-32                        4.249Mi ± 0%   4.164Mi ± 0%  -2.00% (p=0.000 n=10)
ProcessTargets/least-weighted/10000-32                           42.39Mi ± 0%   41.57Mi ± 0%  -1.94% (p=0.000 n=10)
ProcessTargets/consistent-hashing/10000-32                       42.39Mi ± 0%   41.57Mi ± 0%  -1.94% (p=0.000 n=10)
ProcessTargets/per-node/10000-32                                 42.39Mi ± 0%   41.57Mi ± 0%  -1.95% (p=0.000 n=10)
ProcessTargets/least-weighted/100000-32                          424.0Mi ± 0%   415.6Mi ± 0%  -1.98% (p=0.000 n=10)
ProcessTargets/consistent-hashing/100000-32                      423.9Mi ± 0%   415.6Mi ± 0%  -1.97% (p=0.000 n=10)
ProcessTargets/per-node/100000-32                                423.9Mi ± 0%   415.6Mi ± 0%  -1.97% (p=0.000 n=10)
ProcessTargets/least-weighted/800000-32                          3.356Gi ± 0%   3.277Gi ± 0%  -2.35% (p=0.000 n=10)
ProcessTargets/consistent-hashing/800000-32                      3.356Gi ± 0%   3.277Gi ± 0%  -2.35% (p=0.000 n=10)
ProcessTargets/per-node/800000-32                                3.356Gi ± 0%   3.277Gi ± 0%  -2.35% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/1000-32           4.502Mi ± 0%   4.452Mi ± 0%  -1.12% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/1000-32       4.502Mi ± 0%   4.452Mi ± 0%  -1.12% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node/1000-32                 4.502Mi ± 0%   4.452Mi ± 0%  -1.12% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node/10000-32                44.97Mi ± 0%   44.48Mi ± 0%  -1.09% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/10000-32          44.97Mi ± 0%   44.48Mi ± 0%  -1.09% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/10000-32      44.97Mi ± 0%   44.48Mi ± 0%  -1.09% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/100000-32         449.9Mi ± 0%   444.8Mi ± 0%  -1.12% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/100000-32     449.9Mi ± 0%   444.8Mi ± 0%  -1.12% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node/100000-32               449.9Mi ± 0%   444.8Mi ± 0%  -1.12% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/800000-32         3.535Gi ± 1%   3.489Gi ± 0%  -1.28% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/800000-32     3.535Gi ± 0%   3.489Gi ± 0%  -1.28% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node/800000-32               3.561Gi ± 1%   3.489Gi ± 0%  -2.01% (p=0.000 n=10)
geomean                                                          131.0Mi        128.8Mi       -1.64%

                                                             │ bench_main.txt │        bench_branch_hash.txt        │
                                                             │   allocs/op    │  allocs/op   vs base                │
ProcessTargets/per-node/1000-32                                   5.311k ± 0%   3.312k ± 0%  -37.65% (p=0.000 n=10)
ProcessTargets/least-weighted/1000-32                             5.311k ± 0%   3.311k ± 0%  -37.66% (p=0.000 n=10)
ProcessTargets/consistent-hashing/1000-32                         5.311k ± 0%   3.311k ± 0%  -37.66% (p=0.000 n=10)
ProcessTargets/least-weighted/10000-32                            52.97k ± 0%   32.97k ± 0%  -37.76% (p=0.000 n=10)
ProcessTargets/consistent-hashing/10000-32                        52.97k ± 0%   32.97k ± 0%  -37.76% (p=0.000 n=10)
ProcessTargets/per-node/10000-32                                  52.97k ± 0%   32.97k ± 0%  -37.76% (p=0.000 n=10)
ProcessTargets/least-weighted/100000-32                           528.5k ± 0%   328.5k ± 0%  -37.85% (p=0.000 n=10)
ProcessTargets/consistent-hashing/100000-32                       528.5k ± 0%   328.5k ± 0%  -37.85% (p=0.000 n=10)
ProcessTargets/per-node/100000-32                                 528.5k ± 0%   328.5k ± 0%  -37.85% (p=0.000 n=10)
ProcessTargets/least-weighted/800000-32                           4.230M ± 0%   2.630M ± 0%  -37.82% (p=0.000 n=10)
ProcessTargets/consistent-hashing/800000-32                       4.230M ± 0%   2.630M ± 0%  -37.82% (p=0.000 n=10)
ProcessTargets/per-node/800000-32                                 4.230M ± 0%   2.630M ± 0%  -37.82% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/1000-32            7.303k ± 0%   6.303k ± 0%  -13.69% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/1000-32        7.303k ± 0%   6.303k ± 0%  -13.69% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node/1000-32                  7.303k ± 0%   6.303k ± 0%  -13.69% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node/10000-32                 72.93k ± 0%   62.93k ± 0%  -13.71% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/10000-32           72.93k ± 0%   62.93k ± 0%  -13.71% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/10000-32       72.93k ± 0%   62.93k ± 0%  -13.71% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/100000-32          728.3k ± 0%   628.3k ± 0%  -13.73% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/100000-32      728.3k ± 0%   628.3k ± 0%  -13.73% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node/100000-32                728.3k ± 0%   628.3k ± 0%  -13.73% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/least-weighted/800000-32          5.827M ± 0%   5.027M ± 0%  -13.73% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/consistent-hashing/800000-32      5.827M ± 0%   5.027M ± 0%  -13.73% (p=0.000 n=10)
ProcessTargetsWithRelabelConfig/per-node/800000-32                5.829M ± 0%   5.027M ± 0%  -13.76% (p=0.000 n=10)
geomean                                                           185.8k        136.2k       -26.72%

```
