### PR TITLE
Add GOTEST_OPTS for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,14 @@ endif
 # by default, do not run the manager with webhooks enabled. This only affects local runs, not the build or in-cluster deployments.
 ENABLE_WEBHOOKS ?= false
 
+# Additional flags for go test command
+GOTEST_EXTRA_OPTS ?=
+
 # If we are running in CI, run go test in verbose mode
 ifeq (,$(CI))
-GOTEST_OPTS=-race
+GOTEST_OPTS=-race $(if $(GOTEST_EXTRA_OPTS),$(GOTEST_EXTRA_OPTS))
 else
-GOTEST_OPTS=-race -v
+GOTEST_OPTS=-race -v $(if $(GOTEST_EXTRA_OPTS),$(GOTEST_EXTRA_OPTS))
 endif
 
 START_KIND_CLUSTER ?= true


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Currently, we can't pass arguments to the go test command, but it would be useful if we could—for example, `-coverprofile=cover.out` or `-run TestSomeFunc` . To support this, I've added a variable called GOTEST_OPTS to pass the options. Thanks for your review!

**Link to tracking Issue(s):** <Issue number if applicable>

N/A

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
