### PR TITLE
Bridge HA mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ config/rbac/certmanager-permissions/
 build
 node_modules
 package-lock.json
+.tool-versions

--- a/cmd/operator-opamp-bridge/config/config.go
+++ b/cmd/operator-opamp-bridge/config/config.go
@@ -90,6 +90,7 @@ type Config struct {
 	Capabilities      map[Capability]bool `yaml:"capabilities"`
 	HeartbeatInterval time.Duration       `yaml:"heartbeatInterval,omitempty"`
 	Name              string              `yaml:"name,omitempty"`
+	Namespace         string              `yaml:"namespace,omitempty"`
 	AgentDescription  AgentDescription    `yaml:"description,omitempty"`
 }
 
@@ -163,6 +164,13 @@ func (c *Config) GetAgentVersion() string {
 
 func (c *Config) GetInstanceId() uuid.UUID {
 	return c.instanceId
+}
+
+func (c *Config) GetNamespace() string {
+	if len(c.Namespace) > 0 {
+		return c.Namespace
+	}
+	return "default"
 }
 
 func (c *Config) GetDescription() *protobufs.AgentDescription {

--- a/cmd/operator-opamp-bridge/leader/leader.go
+++ b/cmd/operator-opamp-bridge/leader/leader.go
@@ -1,0 +1,107 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package leader
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"go.uber.org/atomic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+const (
+	lockName = "bridge.opentelemetry.io"
+)
+
+type Elector struct {
+	logger logr.Logger
+
+	leaderElector *leaderelection.LeaderElector
+	done          chan struct{}
+	isLeader      atomic.Bool
+	callback      func(bool)
+}
+
+func NewElector(logger logr.Logger, cfg *rest.Config, lockNamespace string, callback func(bool)) (*Elector, error) {
+	uid := uuid.New()
+	l, err := rl.NewFromKubeconfig(
+		rl.LeasesResourceLock,
+		lockNamespace,
+		lockName,
+		rl.ResourceLockConfig{
+			Identity: uid.String(),
+		},
+		cfg,
+		time.Second*10,
+	)
+	if err != nil {
+		return nil, err
+	}
+	elector := &Elector{
+		logger:   logger,
+		done:     make(chan struct{}, 1),
+		callback: callback,
+	}
+	el, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:          l,
+		LeaseDuration: time.Second * 15,
+		RenewDeadline: time.Second * 10,
+		RetryPeriod:   time.Second * 2,
+		Name:          lockName,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: elector.onStartedLeading,
+			OnStoppedLeading: elector.onStoppedLeading,
+			OnNewLeader:      elector.onNewLeader,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	elector.leaderElector = el
+	return elector, nil
+}
+
+func (e *Elector) Start(ctx context.Context) {
+	ctxWithCancel, cancel := context.WithCancel(ctx)
+
+	go func() {
+		e.leaderElector.Run(ctxWithCancel)
+	}()
+
+	for {
+		<-e.done
+		e.logger.Info("stopping leader election")
+		cancel()
+		return
+	}
+}
+
+func (e *Elector) Stop() {
+	close(e.done)
+}
+
+func (e *Elector) onStartedLeading(ctx context.Context) {
+	e.logger.Info("elected leader")
+	e.isLeader.Store(true)
+	e.callback(true)
+}
+
+func (e *Elector) onStoppedLeading() {
+	e.logger.Info("no longer leader")
+	e.isLeader.Store(false)
+	e.callback(false)
+}
+
+func (e *Elector) onNewLeader(identity string) {
+	e.logger.Info("new leader elected", "identity", identity)
+}
+
+func (e *Elector) IsLeader() bool {
+	return e.isLeader.Load()
+}

--- a/cmd/operator-opamp-bridge/leader/leader_test.go
+++ b/cmd/operator-opamp-bridge/leader/leader_test.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package leader
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+)
+
+var (
+	l = logr.Discard()
+)
+
+func TestElector(t *testing.T) {
+	cfg := &rest.Config{}
+	lockNamespace := "default"
+	curState := false
+	c := func(s bool) {
+		curState = s
+	}
+	elector, err := NewElector(l, cfg, lockNamespace, c)
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	go elector.Start(ctx)
+	time.Sleep(1 * time.Second)
+
+	assert.False(t, elector.IsLeader())
+	assert.False(t, curState)
+	elector.onStartedLeading(ctx)
+	assert.True(t, elector.IsLeader())
+	assert.True(t, curState)
+	elector.onStoppedLeading()
+	assert.False(t, elector.IsLeader())
+	assert.False(t, curState)
+	elector.Stop()
+	time.Sleep(1 * time.Second)
+}


### PR DESCRIPTION
**Description:**

Enables the bridge to run in HA mode by using leader election to determine which bridge pod is allowed to do remote configuration.

**Link to tracking Issue(s):**

- Resolves: #3822 

**Testing:** Unit

**Documentation:** n/a

Blocked by https://github.com/open-telemetry/opamp-go/pull/366