### PR TITLE
[docs] fix inavlid link in cmd/otel-allocator/README.md

### DIFF
--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -98,7 +98,7 @@ The easiest way to do this is to grab a copy of the individual [`PodMonitor`](ht
 
 # Usage
 
-The `spec.targetAllocator:` controls the TargetAllocator general properties. Full API spec can be found here: [api.md#opentelemetrycollectorspectargetallocator](../../docs/api.md#opentelemetrycollectorspectargetallocator)
+The `spec.targetAllocator:` controls the TargetAllocator general properties. Full API spec can be found here: [api/opentelemetrycollectors.md](../../docs/api/opentelemetrycollectors.md)
 
 A basic example that deploys.
 ```yaml


### PR DESCRIPTION
**Description:** Fix incorrect link to api spec documentation in [cmd/otel-allocator/README.md](https://github.com/open-telemetry/opentelemetry-operator/blob/main/cmd/otel-allocator/README.md) 

