### PR TITLE
Correct some broken links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The operator manages:
 ## Documentation
 
 - [Compatibility & Support docs](./docs/compatibility.md)
-- [API docs](./docs/api.md)
+- [API docs](./docs/api/README.md)
 - [Offical Telemetry Operator page](https://opentelemetry.io/docs/kubernetes/operator/)
 
 ## Helm Charts

--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -59,7 +59,7 @@ to use it with a collector running as a DaemonSet.
 [consistent_hashing]: https://blog.research.google/2017/04/consistent-hashing-with-bounded-loads.html
 ## Discovery of Prometheus Custom Resources
 
-The Target Allocator also provides for the discovery of [Prometheus Operator CRs](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md), namely the [ServiceMonitor and PodMonitor](https://github.com/open-telemetry/opentelemetry-operator/tree/main/cmd/otel-allocator#target-allocator). The ServiceMonitors and the PodMonitors purpose is to inform the Target Allocator (or PrometheusOperator) to add a new job to their scrape configuration. The Target Allocator then provides the jobs to the OTel Collector [Prometheus Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md). 
+The Target Allocator also provides for the discovery of [Prometheus Operator CRs](https://prometheus-operator.dev/docs/getting-started/design/), namely the [ServiceMonitor and PodMonitor](https://github.com/open-telemetry/opentelemetry-operator/tree/main/cmd/otel-allocator#target-allocator). The ServiceMonitors and the PodMonitors purpose is to inform the Target Allocator (or PrometheusOperator) to add a new job to their scrape configuration. The Target Allocator then provides the jobs to the OTel Collector [Prometheus Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md). 
 
 ```mermaid
 flowchart RL
@@ -94,7 +94,7 @@ Even though Prometheus is not required to be installed in your Kubernetes cluste
 
 The easiest way to do this is to grab a copy of the individual [`PodMonitor`](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml) YAML and [`ServiceMonitor`](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml) YAML custom resource definitions (CRDs) from the [Kube Prometheus Operator’s Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/charts).
 
-> ✨ For more information on configuring the `PodMonitor` and `ServiceMonitor`, check out the [PodMonitor API](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.PodMonitor) and the [ServiceMonitor API](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor).
+> ✨ For more information on configuring the `PodMonitor` and `ServiceMonitor`, check out the [PodMonitor API](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMonitor) and the [ServiceMonitor API](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.ServiceMonitor).
 
 # Usage
 
@@ -185,7 +185,7 @@ TargetAllocator discovery of PrometheusCRs can be turned on by setting
 `.spec.targetAllocator.prometheusCR.enabled` to `true`, which it presents as scrape configs
 and jobs on the `/scrape_configs` and `/jobs` endpoints respectively.
 
-The CRs can be filtered by labels as documented here: [api.md#opentelemetrycollectorspectargetallocatorprometheuscr](../../docs/api.md#opentelemetrycollectorspectargetallocatorprometheuscr)
+The CRs can be filtered by labels as documented here: [api/opentelemetrycollectors.md#opentelemetrycollectorspectargetallocatorprometheuscr](../../docs/api/opentelemetrycollectors.md#opentelemetrycollectorspectargetallocatorprometheuscr)
 
 Upstream documentation here: [PrometheusReceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver#opentelemetry-operator)
 


### PR DESCRIPTION
**Description:**

While reading the README I noticed that several of these links were outdated. 
Some links broken  due to the fallout from https://github.com/open-telemetry/opentelemetry-operator/pull/3696, and some due to changes in `prometheus-operator` docs. In the prometheus-operator docs I chose to link to the docs site, instead of docs source. I think either could be fine, and would be fine with a pushed commit that instead targets the raw docs on Github.

- Resolves: I didn't make an issue for this

**Testing:** No testing

**Documentation:** Just updated the links
