### PR TITLE
Docs: Update Allocator Docs to include Selectors

### DIFF
--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -200,7 +200,7 @@ prometheusCR:
   serviceMonitorSelector: {}
 ```
 
-This will make the TargetAllocator scrap all the Service and Pod Monitors inside of the cluster. If you need something more specific, you can also add a label filter:
+This will make the TargetAllocator scrape all the Service and Pod Monitors inside of the cluster. If you need something more specific, you can also add a label filter:
 
 ```yaml
 prometheusCR:

--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -189,6 +189,29 @@ The CRs can be filtered by labels as documented here: [api/opentelemetrycollecto
 
 Upstream documentation here: [PrometheusReceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver#opentelemetry-operator)
 
+### Pod/Service Monitor Selectors
+
+As of `v1beta1` of the OpenTelemetryOperator, a serviceMonitorSelector and podMonitorSelector must be included, even if you don’t intend to use it, like this:
+
+```yaml
+prometheusCR:
+  enabled: true
+  podMonitorSelector: {}
+  serviceMonitorSelector: {}
+```
+
+This will make the TargetAllocator scrap all the Service and Pod Monitors inside the cluster. If you need something more specific, you can also filter by labels:
+
+```yaml
+prometheusCR:
+  enabled: true
+  serviceMonitorSelector:
+    matchLabels:
+      app: my-app
+```
+
+By setting the value of `spec.targetAllocator.prometheusCR.serviceMonitorSelector.matchLabels` to `app: my-app`, it means that your ServiceMonitor resource must in turn have that same value in `metadata.labels`.
+
 ### RBAC
 
 Before the TargetAllocator can start scraping, you need to set up Kubernetes RBAC (role-based access controls) resources. This means that you need to have a `ServiceAccount` and corresponding ClusterRoles/Roles so that the TargetAllocator has access to all the necessary resources to pull metrics from.
@@ -496,3 +519,7 @@ Shards the received targets based on the discovered Collector instances
 
 ### Collector
 Client to watch for deployed Collector instances which will then provided to the Allocator. 
+
+# Troubleshooting
+
+For troubleshooting tips, please visit: [https://opentelemetry.io/docs/platforms/kubernetes/operator/troubleshooting/target-allocator/](https://opentelemetry.io/docs/platforms/kubernetes/operator/troubleshooting/target-allocator/)

--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -191,7 +191,7 @@ Upstream documentation here: [PrometheusReceiver](https://github.com/open-teleme
 
 ### Pod/Service Monitor Selectors
 
-As of `v1beta1` of the OpenTelemetryOperator, a serviceMonitorSelector and podMonitorSelector must be included, even if you don’t intend to use it, like this:
+As of `v1beta1` of the OpenTelemetryOperator, a `serviceMonitorSelector` and `podMonitorSelector` must be included, even if you don’t intend to use it, like this:
 
 ```yaml
 prometheusCR:
@@ -200,7 +200,7 @@ prometheusCR:
   serviceMonitorSelector: {}
 ```
 
-This will make the TargetAllocator scrap all the Service and Pod Monitors inside the cluster. If you need something more specific, you can also filter by labels:
+This will make the TargetAllocator scrap all the Service and Pod Monitors inside of the cluster. If you need something more specific, you can also add a label filter:
 
 ```yaml
 prometheusCR:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

* Update Allocator Docs to include Selectors
* Since that Readme is already referencing `opentelemetry.io/v1beta1` I found the information to be missing
* Took me a while to figure it out after visiting the [troubleshooting tips](https://opentelemetry.io/docs/platforms/kubernetes/operator/troubleshooting/target-allocator/#did-you-configure-a-servicemonitor-or-podmonitor-selector)
* Feel like this could help other people who land on that page as well.

**Link to tracking Issue(s):** <Issue number if applicable>

* N/A
* Let me know if an issue is needed, I can create one

**Testing:** <Describe what testing was performed and which tests were added.>

* Docs Only

**Documentation:** <Describe the documentation added.>

* Update Allocator Docs to include Selectors
* Add Link to Allocator Troubleshooting Tips
