### PR TITLE
Increase default instrumentation memory limit to 256Mi

### DIFF
--- a/.chloggen/feat_update-instrumentation-memory-limits.yaml
+++ b/.chloggen/feat_update-instrumentation-memory-limits.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Increase default instrumentation memory limit to 256Mi
+
+# One or more tracking issues related to the change
+issues: [3479]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1alpha1/instrumentation_webhook.go
+++ b/apis/v1alpha1/instrumentation_webhook.go
@@ -26,7 +26,7 @@ var (
 	_                                  admission.CustomDefaulter = &InstrumentationWebhook{}
 	initContainerDefaultLimitResources                           = corev1.ResourceList{
 		corev1.ResourceCPU:    resource.MustParse("500m"),
-		corev1.ResourceMemory: resource.MustParse("128Mi"),
+		corev1.ResourceMemory: resource.MustParse("256Mi"),
 	}
 	initContainerDefaultRequestedResources = corev1.ResourceList{
 		corev1.ResourceCPU:    resource.MustParse("1m"),
@@ -87,7 +87,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 	if r.Spec.Java.Resources.Limits == nil {
 		r.Spec.Java.Resources.Limits = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("64Mi"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		}
 	}
 	if r.Spec.Java.Resources.Requests == nil {
@@ -102,7 +102,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 	if r.Spec.NodeJS.Resources.Limits == nil {
 		r.Spec.NodeJS.Resources.Limits = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("128Mi"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		}
 	}
 	if r.Spec.NodeJS.Resources.Requests == nil {
@@ -117,7 +117,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 	if r.Spec.Python.Resources.Limits == nil {
 		r.Spec.Python.Resources.Limits = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("64Mi"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		}
 	}
 	if r.Spec.Python.Resources.Requests == nil {
@@ -132,7 +132,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 	if r.Spec.DotNet.Resources.Limits == nil {
 		r.Spec.DotNet.Resources.Limits = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("128Mi"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		}
 	}
 	if r.Spec.DotNet.Resources.Requests == nil {
@@ -147,7 +147,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 	if r.Spec.Go.Resources.Limits == nil {
 		r.Spec.Go.Resources.Limits = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("500m"),
-			corev1.ResourceMemory: resource.MustParse("64Mi"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
 		}
 	}
 	if r.Spec.Go.Resources.Requests == nil {

--- a/apis/v1alpha1/instrumentation_webhook_test.go
+++ b/apis/v1alpha1/instrumentation_webhook_test.go
@@ -116,37 +116,37 @@ func TestInstrumentationDefaultingWebhook(t *testing.T) {
 			config: []config.Option{},
 			verify: func(t *testing.T, inst *Instrumentation) {
 				assert.Equal(t, resource.MustParse("500m"), inst.Spec.Java.Resources.Limits[corev1.ResourceCPU])
-				assert.Equal(t, resource.MustParse("64Mi"), inst.Spec.Java.Resources.Limits[corev1.ResourceMemory])
+				assert.Equal(t, resource.MustParse("256Mi"), inst.Spec.Java.Resources.Limits[corev1.ResourceMemory])
 				assert.Equal(t, resource.MustParse("50m"), inst.Spec.Java.Resources.Requests[corev1.ResourceCPU])
 				assert.Equal(t, resource.MustParse("64Mi"), inst.Spec.Java.Resources.Requests[corev1.ResourceMemory])
 
 				assert.Equal(t, resource.MustParse("500m"), inst.Spec.NodeJS.Resources.Limits[corev1.ResourceCPU])
-				assert.Equal(t, resource.MustParse("128Mi"), inst.Spec.NodeJS.Resources.Limits[corev1.ResourceMemory])
+				assert.Equal(t, resource.MustParse("256Mi"), inst.Spec.NodeJS.Resources.Limits[corev1.ResourceMemory])
 				assert.Equal(t, resource.MustParse("50m"), inst.Spec.NodeJS.Resources.Requests[corev1.ResourceCPU])
 				assert.Equal(t, resource.MustParse("128Mi"), inst.Spec.NodeJS.Resources.Requests[corev1.ResourceMemory])
 
 				assert.Equal(t, resource.MustParse("500m"), inst.Spec.Python.Resources.Limits[corev1.ResourceCPU])
-				assert.Equal(t, resource.MustParse("64Mi"), inst.Spec.Python.Resources.Limits[corev1.ResourceMemory])
+				assert.Equal(t, resource.MustParse("256Mi"), inst.Spec.Python.Resources.Limits[corev1.ResourceMemory])
 				assert.Equal(t, resource.MustParse("50m"), inst.Spec.Python.Resources.Requests[corev1.ResourceCPU])
 				assert.Equal(t, resource.MustParse("64Mi"), inst.Spec.Python.Resources.Requests[corev1.ResourceMemory])
 
 				assert.Equal(t, resource.MustParse("500m"), inst.Spec.DotNet.Resources.Limits[corev1.ResourceCPU])
-				assert.Equal(t, resource.MustParse("128Mi"), inst.Spec.DotNet.Resources.Limits[corev1.ResourceMemory])
+				assert.Equal(t, resource.MustParse("256Mi"), inst.Spec.DotNet.Resources.Limits[corev1.ResourceMemory])
 				assert.Equal(t, resource.MustParse("50m"), inst.Spec.DotNet.Resources.Requests[corev1.ResourceCPU])
 				assert.Equal(t, resource.MustParse("128Mi"), inst.Spec.DotNet.Resources.Requests[corev1.ResourceMemory])
 
 				assert.Equal(t, resource.MustParse("500m"), inst.Spec.Go.Resources.Limits[corev1.ResourceCPU])
-				assert.Equal(t, resource.MustParse("64Mi"), inst.Spec.Go.Resources.Limits[corev1.ResourceMemory])
+				assert.Equal(t, resource.MustParse("256Mi"), inst.Spec.Go.Resources.Limits[corev1.ResourceMemory])
 				assert.Equal(t, resource.MustParse("50m"), inst.Spec.Go.Resources.Requests[corev1.ResourceCPU])
 				assert.Equal(t, resource.MustParse("64Mi"), inst.Spec.Go.Resources.Requests[corev1.ResourceMemory])
 
 				assert.Equal(t, resource.MustParse("500m"), inst.Spec.Nginx.Resources.Limits[corev1.ResourceCPU])
-				assert.Equal(t, resource.MustParse("128Mi"), inst.Spec.Nginx.Resources.Limits[corev1.ResourceMemory])
+				assert.Equal(t, resource.MustParse("256Mi"), inst.Spec.Nginx.Resources.Limits[corev1.ResourceMemory])
 				assert.Equal(t, resource.MustParse("1m"), inst.Spec.Nginx.Resources.Requests[corev1.ResourceCPU])
 				assert.Equal(t, resource.MustParse("128Mi"), inst.Spec.Nginx.Resources.Requests[corev1.ResourceMemory])
 
 				assert.Equal(t, resource.MustParse("500m"), inst.Spec.ApacheHttpd.Resources.Limits[corev1.ResourceCPU])
-				assert.Equal(t, resource.MustParse("128Mi"), inst.Spec.ApacheHttpd.Resources.Limits[corev1.ResourceMemory])
+				assert.Equal(t, resource.MustParse("256Mi"), inst.Spec.ApacheHttpd.Resources.Limits[corev1.ResourceMemory])
 				assert.Equal(t, resource.MustParse("1m"), inst.Spec.ApacheHttpd.Resources.Requests[corev1.ResourceCPU])
 				assert.Equal(t, resource.MustParse("128Mi"), inst.Spec.ApacheHttpd.Resources.Requests[corev1.ResourceMemory])
 


### PR DESCRIPTION
**Description:**

Increase default memory limit for instrumentation init containers to 256Mi. This should help mitigate #3479 while we investigate what's actually going on.

**Link to tracking Issue(s):**

- Mitigates #3479 

