### PR TITLE
Fix flaky informer tests

### DIFF
--- a/cmd/otel-allocator/internal/collector/collector_test.go
+++ b/cmd/otel-allocator/internal/collector/collector_test.go
@@ -190,9 +190,9 @@ func Test_runWatch(t *testing.T) {
 				mapMutex.Lock()
 				defer mapMutex.Unlock()
 				assert.Len(collect, actual, len(tt.want))
-				assert.Equal(collect, actual, tt.want)
+				assert.Equal(collect, tt.want, actual)
 				assert.Equal(collect, testutil.ToFloat64(collectorsDiscovered), float64(len(actual)))
-			}, time.Second*3, time.Millisecond)
+			}, time.Second*30, time.Millisecond*100)
 		})
 	}
 }

--- a/cmd/otel-allocator/internal/watcher/promOperator_test.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator_test.go
@@ -1068,16 +1068,13 @@ func TestNamespaceLabelUpdate(t *testing.T) {
 		},
 	}})
 
-	select {
-	case <-events:
-	case <-time.After(1 * time.Minute):
-	}
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		got, err = w.LoadConfig(context.Background())
+		assert.NoError(t, err)
 
-	got, err = w.LoadConfig(context.Background())
-	assert.NoError(t, err)
-
-	sanitizeScrapeConfigsForTest(got.ScrapeConfigs)
-	assert.Equal(t, want_after.ScrapeConfigs, got.ScrapeConfigs)
+		sanitizeScrapeConfigsForTest(got.ScrapeConfigs)
+		assert.Equal(t, want_after.ScrapeConfigs, got.ScrapeConfigs)
+	}, time.Second*30, time.Millisecond*100)
 }
 
 func TestRateLimit(t *testing.T) {


### PR DESCRIPTION
Attempt to fix flaky unit tests. I'm fairly confident in the fix to `TestNamespaceLabelUpdate`, as the problem there was the fact that we could get an additional notification before the data was actually ready. The fix to the collector discovery test is a shot in the dark.
