### PR TITLE
Fix status replicas

### DIFF
--- a/.chloggen/nikola-jokic_fix-status-replicas.yaml
+++ b/.chloggen/nikola-jokic_fix-status-replicas.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Set the `statusReplicas` field for the `DaemonSet`"
+
+# One or more tracking issues related to the change
+issues: [3930]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/status/collector/collector.go
+++ b/internal/status/collector/collector.go
@@ -80,6 +80,9 @@ func updateCollectorStatus(ctx context.Context, cli client.Client, changed *v1be
 		if err := cli.Get(ctx, objKey, obj); err != nil {
 			return fmt.Errorf("failed to get daemonSet status.replicas: %w", err)
 		}
+		replicas = obj.Status.DesiredNumberScheduled
+		readyReplicas = obj.Status.NumberReady
+		statusReplicas = strconv.Itoa(int(readyReplicas)) + "/" + strconv.Itoa(int(replicas))
 		statusImage = obj.Spec.Template.Spec.Containers[0].Image
 	}
 

--- a/internal/status/collector/collector_test.go
+++ b/internal/status/collector/collector_test.go
@@ -152,6 +152,10 @@ func createMockKubernetesClientDaemonset() client.Client {
 				},
 			},
 		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 1,
+			NumberReady:            1,
+		},
 	}
 	return fake.NewClientBuilder().WithObjects(daemonset).Build()
 }
@@ -176,6 +180,8 @@ func TestUpdateCollectorStatusDaemonsetMode(t *testing.T) {
 	err := updateCollectorStatus(ctx, cli, changed)
 	assert.NoError(t, err)
 
+	assert.Equal(t, int32(1), changed.Status.Scale.Replicas, "expected replicas to be 1")
+	assert.Equal(t, "1/1", changed.Status.Scale.StatusReplicas, "expected status replicas to be 1/1")
 	assert.Contains(t, changed.Status.Scale.Selector, "customLabel=customValue", "expected selector to contain customlabel=customValue")
 	assert.Equal(t, "app:latest", changed.Status.Image, "expected image to be app:latest")
 }

--- a/tests/e2e/smoke-daemonset/00-assert.yaml
+++ b/tests/e2e/smoke-daemonset/00-assert.yaml
@@ -19,4 +19,6 @@ metadata:
 status:
   (starts_with(image, 'ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector')): true
   (version != ''): true
-  # TODO: Check replicas here after resolving https://github.com/open-telemetry/opentelemetry-operator/issues/3930
+  scale:
+    replicas: 1
+    statusReplicas: "1/1"


### PR DESCRIPTION
**Description:** 
Fixing a bug - the `statusReplicas` field is not being set for the `DaemonSet`.


**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #3930

**Testing:** Ran tests and confirmed it manually

**Documentation:** Fixing the behavior documented [here](https://github.com/open-telemetry/opentelemetry-operator/blob/02e42e5db45616e982343a87cc6519df1c21578c/apis/v1beta1/opentelemetrycollector_types.go#L300).
