### PR TITLE
Check OpenTelemetryCollector status in e2e tests

### DIFF
--- a/tests/e2e/smoke-daemonset/00-assert.yaml
+++ b/tests/e2e/smoke-daemonset/00-assert.yaml
@@ -11,3 +11,12 @@ spec:
 status:
   numberMisscheduled: 0
   (desiredNumberScheduled == numberReady): true
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: daemonset-test
+status:
+  (starts_with(image, 'ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector')): true
+  (version != ''): true
+  # TODO: Check replicas here after resolving https://github.com/open-telemetry/opentelemetry-operator/issues/3930

--- a/tests/e2e/smoke-simplest-v1beta1/00-assert.yaml
+++ b/tests/e2e/smoke-simplest-v1beta1/00-assert.yaml
@@ -52,3 +52,14 @@ spec:
     port: 4318
     protocol: TCP
     targetPort: 4318
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+status:
+  (starts_with(image, 'ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector')): true
+  (version != ''): true
+  scale:
+    replicas: 1
+    statusReplicas: "1/1"

--- a/tests/e2e/smoke-statefulset/00-assert.yaml
+++ b/tests/e2e/smoke-statefulset/00-assert.yaml
@@ -5,3 +5,14 @@ metadata:
 status:
   replicas: 1
   readyReplicas: 1
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: stateful
+status:
+  (starts_with(image, 'ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector')): true
+  (version != ''): true
+  scale:
+    replicas: 1
+    statusReplicas: "1/1"

--- a/tests/e2e/smoke-statefulset/00-install.yaml
+++ b/tests/e2e/smoke-statefulset/00-install.yaml
@@ -1,15 +1,14 @@
-apiVersion: opentelemetry.io/v1alpha1
+apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: stateful
 spec:
   mode: statefulset
-  config: |
+  config:
     receivers:
       jaeger:
         protocols:
           grpc:
-    processors:
     exporters:
       debug:
     service:


### PR DESCRIPTION
We don't check the status at all in E2E tests, but it's quite easy to do with chainsaw.
