### PR TITLE
Fix permissions for E2E test image publishing

### DIFF
--- a/.github/workflows/reusable-publish-test-e2e-images.yaml
+++ b/.github/workflows/reusable-publish-test-e2e-images.yaml
@@ -12,6 +12,9 @@ on:
 
 permissions:
   contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   publish-e2e-image:


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-operator/pull/3870 explicitly set permissions for a bunch of workflows, and then https://github.com/open-telemetry/opentelemetry-operator/pull/3871 added some missing permissions for image publishing. However, it missed the publishing step for E2E test images, resulting in failures like [this one](https://github.com/open-telemetry/opentelemetry-operator/actions/runs/14592777292).

Add the missing permissions.
