### PR TITLE
[webhook] do not crash if collector CRD is not present in the cluster

### DIFF
--- a/.chloggen/keep_going_if_collector_crd_is_not_present.yaml
+++ b/.chloggen/keep_going_if_collector_crd_is_not_present.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: webhook
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not exit if the collector CRD is missing.
+
+# One or more tracking issues related to the change
+issues: [3568]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Skip registering the webhook and keep the operator working.

--- a/.chloggen/keep_going_if_collector_crd_is_not_present.yaml
+++ b/.chloggen/keep_going_if_collector_crd_is_not_present.yaml
@@ -1,11 +1,11 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bug_fix
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
 component: webhook
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Do not exit if the collector CRD is missing.
+note: Allow to run the operator without the OpenTelemetry CRDs present
 
 # One or more tracking issues related to the change
 issues: [3568]
@@ -14,4 +14,4 @@ issues: [3568]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  Skip registering the webhook and keep the operator working.
+  Skip registering the webhook and keep the operator working in case the OpenTelemetryCollector CRDs are not deployed.

--- a/internal/autodetect/collector/operator.go
+++ b/internal/autodetect/collector/operator.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package collector
+
+// Availability represents that the OpenTelemetryCollector CR is available in the cluster.
+type Availability int
+
+const (
+	// NotAvailable OpenTelemetryCollector CR is not available in the cluster.
+	NotAvailable Availability = iota
+
+	// Available OpenTelemetryCollector CR is available in the cluster.
+	Available
+)
+
+func (p Availability) String() string {
+	return [...]string{"NotAvailable", "Available"}[p]
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
@@ -56,6 +57,7 @@ type Config struct {
 	prometheusCRAvailability    prometheus.Availability
 	certManagerAvailability     certmanager.Availability
 	targetAllocatorAvailability targetallocator.Availability
+	collectorAvailability       collector.Availability
 	labelsFilter                []string
 	annotationsFilter           []string
 }
@@ -69,6 +71,7 @@ func New(opts ...Option) Config {
 		createRBACPermissions:             autoRBAC.NotAvailable,
 		certManagerAvailability:           certmanager.NotAvailable,
 		targetAllocatorAvailability:       targetallocator.NotAvailable,
+		collectorAvailability:             collector.NotAvailable,
 		collectorConfigMapEntry:           defaultCollectorConfigMapEntry,
 		targetAllocatorConfigMapEntry:     defaultTargetAllocatorConfigMapEntry,
 		operatorOpAMPBridgeConfigMapEntry: defaultOperatorOpAMPBridgeConfigMapEntry,
@@ -103,6 +106,7 @@ func New(opts ...Option) Config {
 		prometheusCRAvailability:            o.prometheusCRAvailability,
 		certManagerAvailability:             o.certManagerAvailability,
 		targetAllocatorAvailability:         o.targetAllocatorAvailability,
+		collectorAvailability:               o.collectorAvailability,
 		autoInstrumentationJavaImage:        o.autoInstrumentationJavaImage,
 		autoInstrumentationNodeJSImage:      o.autoInstrumentationNodeJSImage,
 		autoInstrumentationPythonImage:      o.autoInstrumentationPythonImage,
@@ -154,6 +158,13 @@ func (c *Config) AutoDetect() error {
 	}
 	c.targetAllocatorAvailability = taAvl
 	c.logger.V(2).Info("determined TargetAllocator CRD availability", "availability", cmAvl)
+
+	coAvl, err := c.autoDetect.CollectorAvailability()
+	if err != nil {
+		return err
+	}
+	c.collectorAvailability = coAvl
+	c.logger.V(2).Info("determined Collector CRD availability", "availability", coAvl)
 
 	return nil
 }
@@ -251,6 +262,11 @@ func (c *Config) CertManagerAvailability() certmanager.Availability {
 // TargetAllocatorAvailability represents the availability of the TargetAllocator CRD.
 func (c *Config) TargetAllocatorAvailability() targetallocator.Availability {
 	return c.targetAllocatorAvailability
+}
+
+// CollectorAvailability represents the availability of the OpenTelemetryCollector CRD.
+func (c *Config) CollectorAvailability() collector.Availability {
+	return c.collectorAvailability
 }
 
 // AutoInstrumentationJavaImage returns OpenTelemetry Java auto-instrumentation container image.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	certManagerAvailability     certmanager.Availability
 	targetAllocatorAvailability targetallocator.Availability
 	collectorAvailability       collector.Availability
+	ignoreMissingCollectorCRDs  bool
 	labelsFilter                []string
 	annotationsFilter           []string
 }
@@ -107,6 +108,7 @@ func New(opts ...Option) Config {
 		certManagerAvailability:             o.certManagerAvailability,
 		targetAllocatorAvailability:         o.targetAllocatorAvailability,
 		collectorAvailability:               o.collectorAvailability,
+		ignoreMissingCollectorCRDs:          o.ignoreMissingCollectorCRDs,
 		autoInstrumentationJavaImage:        o.autoInstrumentationJavaImage,
 		autoInstrumentationNodeJSImage:      o.autoInstrumentationNodeJSImage,
 		autoInstrumentationPythonImage:      o.autoInstrumentationPythonImage,
@@ -267,6 +269,11 @@ func (c *Config) TargetAllocatorAvailability() targetallocator.Availability {
 // CollectorAvailability represents the availability of the OpenTelemetryCollector CRD.
 func (c *Config) CollectorAvailability() collector.Availability {
 	return c.collectorAvailability
+}
+
+// IgnoreMissingCollectorCRDs is true if the operator can ignore missing OpenTelemetryCollector CRDs.
+func (c *Config) IgnoreMissingCollectorCRDs() bool {
+	return c.ignoreMissingCollectorCRDs
 }
 
 // AutoInstrumentationJavaImage returns OpenTelemetry Java auto-instrumentation container image.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
@@ -53,6 +54,9 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 		TargetAllocatorAvailabilityFunc: func() (targetallocator.Availability, error) {
 			return targetallocator.Available, nil
 		},
+		CollectorAvailabilityFunc: func() (collector.Availability, error) {
+			return collector.Available, nil
+		},
 	}
 	cfg := config.New(
 		config.WithAutoDetect(mock),
@@ -64,6 +68,7 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 	require.Equal(t, rbac.NotAvailable, cfg.CreateRBACPermissions())
 	require.Equal(t, certmanager.NotAvailable, cfg.CertManagerAvailability())
 	require.Equal(t, targetallocator.NotAvailable, cfg.TargetAllocatorAvailability())
+	require.Equal(t, collector.NotAvailable, cfg.CollectorAvailability())
 
 	// test
 	err := cfg.AutoDetect()
@@ -85,6 +90,7 @@ type mockAutoDetect struct {
 	RBACPermissionsFunc             func(ctx context.Context) (rbac.Availability, error)
 	CertManagerAvailabilityFunc     func(ctx context.Context) (certmanager.Availability, error)
 	TargetAllocatorAvailabilityFunc func() (targetallocator.Availability, error)
+	CollectorAvailabilityFunc       func() (collector.Availability, error)
 }
 
 func (m *mockAutoDetect) FIPSEnabled(_ context.Context) bool {
@@ -124,4 +130,11 @@ func (m *mockAutoDetect) TargetAllocatorAvailability() (targetallocator.Availabi
 		return m.TargetAllocatorAvailabilityFunc()
 	}
 	return targetallocator.NotAvailable, nil
+}
+
+func (m *mockAutoDetect) CollectorAvailability() (collector.Availability, error) {
+	if m.CollectorAvailabilityFunc != nil {
+		return m.CollectorAvailabilityFunc()
+	}
+	return collector.NotAvailable, nil
 }

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
@@ -49,6 +50,7 @@ type options struct {
 	prometheusCRAvailability            prometheus.Availability
 	certManagerAvailability             certmanager.Availability
 	targetAllocatorAvailability         targetallocator.Availability
+	collectorAvailability               collector.Availability
 	labelsFilter                        []string
 	annotationsFilter                   []string
 }

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -51,6 +51,7 @@ type options struct {
 	certManagerAvailability             certmanager.Availability
 	targetAllocatorAvailability         targetallocator.Availability
 	collectorAvailability               collector.Availability
+	ignoreMissingCollectorCRDs          bool
 	labelsFilter                        []string
 	annotationsFilter                   []string
 }
@@ -227,5 +228,11 @@ func WithEncodeLevelFormat(s string) zapcore.LevelEncoder {
 		return zapcore.LowercaseLevelEncoder
 	} else {
 		return zapcore.CapitalLevelEncoder
+	}
+}
+
+func WithIgnoreMissingCollectorCRDs(b bool) Option {
+	return func(o *options) {
+		o.ignoreMissingCollectorCRDs = b
 	}
 }

--- a/internal/controllers/reconcile_test.go
+++ b/internal/controllers/reconcile_test.go
@@ -795,7 +795,7 @@ func TestOpenTelemetryCollectorReconciler_RemoveDisabled(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	reconciler := createTestReconciler(t, testCtx, config.New(
-		config.WithAutoDetect(&mockAutoDetect{CollectorAvailabilityFunc: func() (collector.Availability, error) {
+		config.WithAutoDetect(&mockAutoDetect{CollectorCRDAvailabilityFunc: func() (collector.Availability, error) {
 			return collector.Available, nil
 		}}),
 		config.WithCollectorImage("default-collector"),

--- a/internal/controllers/reconcile_test.go
+++ b/internal/controllers/reconcile_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
@@ -794,6 +795,9 @@ func TestOpenTelemetryCollectorReconciler_RemoveDisabled(t *testing.T) {
 	testCtx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	reconciler := createTestReconciler(t, testCtx, config.New(
+		config.WithAutoDetect(&mockAutoDetect{CollectorAvailabilityFunc: func() (collector.Availability, error) {
+			return collector.Available, nil
+		}}),
 		config.WithCollectorImage("default-collector"),
 		config.WithTargetAllocatorImage("default-ta-allocator"),
 		config.WithOpenShiftRoutesAvailability(openshift.RoutesAvailable),

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -93,7 +93,7 @@ type mockAutoDetect struct {
 	RBACPermissionsFunc             func(ctx context.Context) (autoRBAC.Availability, error)
 	CertManagerAvailabilityFunc     func(ctx context.Context) (certmanager.Availability, error)
 	TargetAllocatorAvailabilityFunc func() (targetallocator.Availability, error)
-	CollectorAvailabilityFunc       func() (collector.Availability, error)
+	CollectorCRDAvailabilityFunc    func() (collector.Availability, error)
 }
 
 func (m *mockAutoDetect) FIPSEnabled(_ context.Context) bool {
@@ -136,8 +136,8 @@ func (m *mockAutoDetect) TargetAllocatorAvailability() (targetallocator.Availabi
 }
 
 func (m *mockAutoDetect) CollectorAvailability() (collector.Availability, error) {
-	if m.CollectorAvailabilityFunc != nil {
-		return m.CollectorAvailabilityFunc()
+	if m.CollectorCRDAvailabilityFunc != nil {
+		return m.CollectorCRDAvailabilityFunc()
 	}
 	return collector.Available, nil
 }

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
@@ -92,6 +93,7 @@ type mockAutoDetect struct {
 	RBACPermissionsFunc             func(ctx context.Context) (autoRBAC.Availability, error)
 	CertManagerAvailabilityFunc     func(ctx context.Context) (certmanager.Availability, error)
 	TargetAllocatorAvailabilityFunc func() (targetallocator.Availability, error)
+	CollectorAvailabilityFunc       func() (collector.Availability, error)
 }
 
 func (m *mockAutoDetect) FIPSEnabled(_ context.Context) bool {
@@ -131,6 +133,13 @@ func (m *mockAutoDetect) TargetAllocatorAvailability() (targetallocator.Availabi
 		return m.TargetAllocatorAvailabilityFunc()
 	}
 	return targetallocator.NotAvailable, nil
+}
+
+func (m *mockAutoDetect) CollectorAvailability() (collector.Availability, error) {
+	if m.CollectorAvailabilityFunc != nil {
+		return m.CollectorAvailabilityFunc()
+	}
+	return collector.Available, nil
 }
 
 func TestMain(m *testing.M) {

--- a/main.go
+++ b/main.go
@@ -358,7 +358,7 @@ func main() {
 	} else {
 		setupLog.Info("OpenTelemetryCollectorCRDSs are not available to the operator")
 		if !cfg.IgnoreMissingCollectorCRDs() {
-			setupLog.Error(errors.New("missing OpenTelemetryCRDs"), "The OpenTelemetryCollector CRDs are not present in the cluster. Set ignore_missing_collector_crds to true or install the CRDs in the cluster.")
+			setupLog.Error(errors.New("missing OpenTelemetryCollector CRDs"), "The OpenTelemetryCollector CRDs are not present in the cluster. Set ignore_missing_collector_crds to true or install the CRDs in the cluster.")
 			os.Exit(1)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -354,7 +354,7 @@ func main() {
 		setupLog.Info("Cert-Manager is not available to the operator, skipping adding to scheme.")
 	}
 	if cfg.CollectorAvailability() == collector.Available {
-		setupLog.Info("OpenTelemetryCollectorCRDSs is available to the operator")
+		setupLog.Info("OpenTelemetryCollectorCRDSs are available to the operator")
 	} else {
 		setupLog.Info("OpenTelemetryCollectorCRDSs are not available to the operator")
 		if !cfg.IgnoreMissingCollectorCRDs() {


### PR DESCRIPTION
**Description:** 
Skip registering the webhook and keep the operator working.

**Link to tracking Issue(s):**
Related to #3568 - after merging this, adding an option to disable watching with the collector CRD is easy.

