### PR TITLE
[target allocator] Fix config loading priority

### DIFF
--- a/.chloggen/fix_ta-cmdline-values.yaml
+++ b/.chloggen/fix_ta-cmdline-values.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix config loading priority
+
+# One or more tracking issues related to the change
+issues: [3928]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otel-allocator/internal/config/config.go
+++ b/cmd/otel-allocator/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"math"
 	"os"
+	"path/filepath"
 	"reflect"
 	"time"
 
@@ -26,18 +27,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 const (
+	DefaultListenAddr                                  = ":8080"
+	DefaultHttpsListenAddr                             = ":8443"
 	DefaultResyncTime                                  = 5 * time.Minute
 	DefaultConfigFilePath               string         = "/conf/targetallocator.yaml"
 	DefaultCRScrapeInterval             model.Duration = model.Duration(time.Second * 30)
 	DefaultAllocationStrategy                          = "consistent-hashing"
 	DefaultFilterStrategy                              = "relabel-config"
 	DefaultCollectorNotReadyGracePeriod                = 0 * time.Second
+)
+
+var (
+	DefaultKubeConfigFilePath string = filepath.Join(homedir.HomeDir(), ".kube", "config")
 )
 
 // By default, scrape protocols include PrometheusText1_0_0, which only Prometheus >=3.0 supports.
@@ -227,9 +235,10 @@ func LoadFromCLI(target *Config, flagSet *pflag.FlagSet) error {
 	klog.SetLogger(target.RootLogger)
 	ctrl.SetLogger(target.RootLogger)
 
-	target.KubeConfigFilePath, err = getKubeConfigFilePath(flagSet)
-	if err != nil {
-		return err
+	if kubeConfigFilePath, changed, flagErr := getKubeConfigFilePath(flagSet); flagErr != nil {
+		return flagErr
+	} else if changed {
+		target.KubeConfigFilePath = kubeConfigFilePath
 	}
 	clusterConfig, err := clientcmd.BuildConfigFromFlags("", target.KubeConfigFilePath)
 	if err != nil {
@@ -245,9 +254,10 @@ func LoadFromCLI(target *Config, flagSet *pflag.FlagSet) error {
 	}
 	target.ClusterConfig = clusterConfig
 
-	target.ListenAddr, err = getListenAddr(flagSet)
-	if err != nil {
-		return err
+	if listenAddr, changed, flagErr := getListenAddr(flagSet); flagErr != nil {
+		return flagErr
+	} else if changed {
+		target.ListenAddr = listenAddr
 	}
 
 	if prometheusCREnabled, changed, flagErr := getPrometheusCREnabled(flagSet); flagErr != nil {
@@ -335,6 +345,11 @@ func unmarshal(cfg *Config, configFile string) error {
 
 func CreateDefaultConfig() Config {
 	return Config{
+		ListenAddr:         DefaultListenAddr,
+		KubeConfigFilePath: DefaultKubeConfigFilePath,
+		HTTPS: HTTPSServerConfig{
+			ListenAddr: DefaultHttpsListenAddr,
+		},
 		AllocationStrategy:         DefaultAllocationStrategy,
 		AllocationFallbackStrategy: "",
 		FilterStrategy:             DefaultFilterStrategy,
@@ -349,11 +364,11 @@ func CreateDefaultConfig() Config {
 	}
 }
 
-func Load() (*Config, error) {
+func Load(args []string) (*Config, error) {
 	var err error
 
 	flagSet := getFlagSet(pflag.ExitOnError)
-	err = flagSet.Parse(os.Args)
+	err = flagSet.Parse(args)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/otel-allocator/internal/config/flags.go
+++ b/cmd/otel-allocator/internal/config/flags.go
@@ -5,10 +5,8 @@ package config
 
 import (
 	"flag"
-	"path/filepath"
 
 	"github.com/spf13/pflag"
-	"k8s.io/client-go/util/homedir"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
@@ -32,11 +30,11 @@ var zapCmdLineOpts zap.Options
 func getFlagSet(errorHandling pflag.ErrorHandling) *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet(targetAllocatorName, errorHandling)
 	flagSet.String(configFilePathFlagName, DefaultConfigFilePath, "The path to the config file.")
-	flagSet.String(listenAddrFlagName, ":8080", "The address where this service serves.")
+	flagSet.String(listenAddrFlagName, DefaultListenAddr, "The address where this service serves.")
 	flagSet.Bool(prometheusCREnabledFlagName, false, "Enable Prometheus CRs as target sources")
-	flagSet.String(kubeConfigPathFlagName, filepath.Join(homedir.HomeDir(), ".kube", "config"), "absolute path to the KubeconfigPath file")
+	flagSet.String(kubeConfigPathFlagName, DefaultKubeConfigFilePath, "absolute path to the KubeconfigPath file")
 	flagSet.Bool(httpsEnabledFlagName, false, "Enable HTTPS additional server")
-	flagSet.String(listenAddrHttpsFlagName, ":8443", "The address where this service serves over HTTPS.")
+	flagSet.String(listenAddrHttpsFlagName, DefaultHttpsListenAddr, "The address where this service serves over HTTPS.")
 	flagSet.String(httpsCAFilePathFlagName, "", "The path to the HTTPS server TLS CA file.")
 	flagSet.String(httpsTLSCertFilePathFlagName, "", "The path to the HTTPS server TLS certificate file.")
 	flagSet.String(httpsTLSKeyFilePathFlagName, "", "The path to the HTTPS server TLS key file.")
@@ -50,64 +48,54 @@ func getConfigFilePath(flagSet *pflag.FlagSet) (string, error) {
 	return flagSet.GetString(configFilePathFlagName)
 }
 
-func getKubeConfigFilePath(flagSet *pflag.FlagSet) (string, error) {
-	return flagSet.GetString(kubeConfigPathFlagName)
+func getKubeConfigFilePath(flagSet *pflag.FlagSet) (value string, changed bool, err error) {
+	return getFlagValueAndChangedString(flagSet, kubeConfigPathFlagName)
 }
 
-func getListenAddr(flagSet *pflag.FlagSet) (string, error) {
-	return flagSet.GetString(listenAddrFlagName)
+func getListenAddr(flagSet *pflag.FlagSet) (value string, changed bool, err error) {
+	return getFlagValueAndChangedString(flagSet, listenAddrFlagName)
 }
 
 func getPrometheusCREnabled(flagSet *pflag.FlagSet) (value bool, changed bool, err error) {
-	if changed = flagSet.Changed(prometheusCREnabledFlagName); !changed {
-		value, err = false, nil
-		return
-	}
-	value, err = flagSet.GetBool(prometheusCREnabledFlagName)
-	return
+	return getFlagValueAndChangedBool(flagSet, prometheusCREnabledFlagName)
 }
 
 func getHttpsListenAddr(flagSet *pflag.FlagSet) (value string, changed bool, err error) {
-	if changed = flagSet.Changed(listenAddrHttpsFlagName); !changed {
-		value, err = ":8443", nil
-		return
-	}
-	value, err = flagSet.GetString(listenAddrHttpsFlagName)
-	return
+	return getFlagValueAndChangedString(flagSet, listenAddrHttpsFlagName)
 }
 
 func getHttpsEnabled(flagSet *pflag.FlagSet) (value bool, changed bool, err error) {
-	if changed = flagSet.Changed(httpsEnabledFlagName); !changed {
-		value, err = false, nil
-		return
-	}
-	value, err = flagSet.GetBool(httpsEnabledFlagName)
-	return
+	return getFlagValueAndChangedBool(flagSet, httpsEnabledFlagName)
 }
 
 func getHttpsCAFilePath(flagSet *pflag.FlagSet) (value string, changed bool, err error) {
-	if changed = flagSet.Changed(httpsCAFilePathFlagName); !changed {
-		value, err = "", nil
-		return
-	}
-	value, err = flagSet.GetString(httpsCAFilePathFlagName)
-	return
+	return getFlagValueAndChangedString(flagSet, httpsCAFilePathFlagName)
 }
 
 func getHttpsTLSCertFilePath(flagSet *pflag.FlagSet) (value string, changed bool, err error) {
-	if changed = flagSet.Changed(httpsTLSCertFilePathFlagName); !changed {
-		value, err = "", nil
-		return
-	}
-	value, err = flagSet.GetString(httpsTLSCertFilePathFlagName)
-	return
+	return getFlagValueAndChangedString(flagSet, httpsTLSCertFilePathFlagName)
 }
 
 func getHttpsTLSKeyFilePath(flagSet *pflag.FlagSet) (value string, changed bool, err error) {
-	if changed = flagSet.Changed(httpsTLSKeyFilePathFlagName); !changed {
+	return getFlagValueAndChangedString(flagSet, httpsTLSKeyFilePathFlagName)
+}
+
+// getFlagValueAndChanged returns the given flag's string value and whether it was changed.
+func getFlagValueAndChangedString(flagSet *pflag.FlagSet, flagName string) (value string, changed bool, err error) {
+	if changed = flagSet.Changed(flagName); !changed {
 		value, err = "", nil
 		return
 	}
-	value, err = flagSet.GetString(httpsTLSKeyFilePathFlagName)
+	value, err = flagSet.GetString(flagName)
+	return
+}
+
+// getFlagValueAndChanged returns the given flag's string value and whether it was changed.
+func getFlagValueAndChangedBool(flagSet *pflag.FlagSet, flagName string) (value bool, changed bool, err error) {
+	if changed = flagSet.Changed(flagName); !changed {
+		value, err = false, nil
+		return
+	}
+	value, err = flagSet.GetBool(flagName)
 	return
 }

--- a/cmd/otel-allocator/internal/config/flags_test.go
+++ b/cmd/otel-allocator/internal/config/flags_test.go
@@ -39,20 +39,26 @@ func TestFlagGetters(t *testing.T) {
 			name:          "GetKubeConfigFilePath",
 			flagArgs:      []string{"--" + kubeConfigPathFlagName, filepath.Join("~", ".kube", "config")},
 			expectedValue: filepath.Join("~", ".kube", "config"),
-			getterFunc:    func(fs *pflag.FlagSet) (interface{}, error) { return getKubeConfigFilePath(fs) },
+			getterFunc: func(fs *pflag.FlagSet) (interface{}, error) {
+				value, _, err := getKubeConfigFilePath(fs)
+				return value, err
+			},
 		},
 		{
 			name:          "GetListenAddr",
 			flagArgs:      []string{"--" + listenAddrFlagName, ":8081"},
 			expectedValue: ":8081",
-			getterFunc:    func(fs *pflag.FlagSet) (interface{}, error) { return getListenAddr(fs) },
+			getterFunc: func(fs *pflag.FlagSet) (interface{}, error) {
+				value, _, err := getListenAddr(fs)
+				return value, err
+			},
 		},
 		{
 			name:          "GetPrometheusCREnabled",
 			flagArgs:      []string{"--" + prometheusCREnabledFlagName, "true"},
 			expectedValue: true,
 			getterFunc: func(fs *pflag.FlagSet) (interface{}, error) {
-				_, value, err := getPrometheusCREnabled(fs)
+				value, _, err := getPrometheusCREnabled(fs)
 				return value, err
 			},
 		},

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -52,7 +52,7 @@ func main() {
 		interrupts      = make(chan os.Signal, 1)
 		errChan         = make(chan error)
 	)
-	cfg, err := config.Load()
+	cfg, err := config.Load(os.Args)
 	if err != nil {
 		fmt.Printf("Failed to load config: %v", err)
 		os.Exit(1)


### PR DESCRIPTION
**Description:**

Fix the target allocator's config loading priority to reflect our intent. We had a problem where some values were taken from command-line flag defaults even if the flags weren't set, making it impossible to set them through the config file.

To achieve this, I've:

* Set all the defaults in the defaulting function.
* Use flag values only if they're actually set, for flags where this wasn't the case.
* Add tests for the config loading priority.

**Link to tracking Issue(s):**

Partially fixes #3928.
