### PR TITLE
Promote the `operator.collector.targetallocatorcr` feature flag to Beta

### DIFF
--- a/.chloggen/feat_enable-collector-tacr.yaml
+++ b/.chloggen/feat_enable-collector-tacr.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote the operator.collector.targetallocatorcr feature flag to Beta
+
+# One or more tracking issues related to the change
+issues: [2422]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  As a result of this change, when the target allocator section is enabled in the Collector CR, 
+  this now creates a TargetAllocator CR instead of generating the manifests directly. Behavior should otherwise be
+  unchanged. You can go back to the previous behaviour by passing the 
+  `--feature-gates=-operator.collector.targetallocatorcr` command-line option to the operator.

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -89,10 +89,6 @@ jobs:
          - group: e2e-native-sidecar
            setup: "add-operator-arg OPERATOR_ARG='--feature-gates=operator.sidecarcontainers.native' prepare-e2e"
            kube-version: "1.29"
-         - group: e2e-targetallocator
-           setup: "enable-targetallocator-cr prepare-e2e"
-         - group: e2e-targetallocator-cr
-           setup: "enable-targetallocator-cr prepare-e2e"
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/Makefile
+++ b/Makefile
@@ -226,11 +226,6 @@ add-rbac-permissions-to-operator: manifests kustomize
 	cd config/rbac && $(KUSTOMIZE) edit add patch --kind ClusterRole --name manager-role --path extra-permissions-operator/replicationcontrollers.yaml
 	cd config/rbac && $(KUSTOMIZE) edit add patch --kind ClusterRole --name manager-role --path extra-permissions-operator/resourcequotas.yaml
 
-.PHONY: enable-targetallocator-cr
-enable-targetallocator-cr:
-	@$(MAKE) add-operator-arg OPERATOR_ARG='--feature-gates=operator.collector.targetallocatorcr'
-	cd config/crd && $(KUSTOMIZE) edit add resource bases/opentelemetry.io_targetallocators.yaml
-
 # Deploy controller in the current Kubernetes context, configured in ~/.kube/config
 .PHONY: deploy
 deploy: set-image-controller

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -18,7 +18,7 @@ var (
 	// TargetAllocator CRs instead of generating the manifests for its resources directly.
 	CollectorUsesTargetAllocatorCR = featuregate.GlobalRegistry().MustRegister(
 		"operator.collector.targetallocatorcr",
-		featuregate.StageAlpha,
+		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("causes collector reconciliation to create a target allocator CR instead of creating resources directly"),
 		featuregate.WithRegisterFromVersion("v0.112.0"),
 	)


### PR DESCRIPTION
**Description:**
As a result of this change, when the target allocator section is enabled in the Collector CR, this now creates a TargetAllocator CR instead of generating the manifests directly. Behavior should otherwise be unchanged.

**Link to tracking Issue(s):** 

#2422 

**Testing:**
Tests already exists for this behaviour. We simply stop running them with it disabled.

