### PR TITLE
[chore] use t.Setenv across tests

### DIFF
--- a/cmd/operator-opamp-bridge/internal/config/config_test.go
+++ b/cmd/operator-opamp-bridge/internal/config/config_test.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -206,8 +205,7 @@ func TestLoad(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.args.envVariables != nil {
 				for key, value := range tt.args.envVariables {
-					err := os.Setenv(key, value)
-					assert.NoError(t, err)
+					t.Setenv(key, value)
 				}
 			}
 			got := NewConfig(logr.Discard())

--- a/internal/manifests/collector/container_test.go
+++ b/internal/manifests/collector/container_test.go
@@ -4,7 +4,6 @@
 package collector
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -529,9 +528,7 @@ func TestContainerDefaultEnvVars(t *testing.T) {
 }
 
 func TestContainerProxyEnvVars(t *testing.T) {
-	err := os.Setenv("NO_PROXY", "localhost")
-	require.NoError(t, err)
-	defer os.Unsetenv("NO_PROXY")
+	t.Setenv("NO_PROXY", "localhost")
 	otelcol := v1beta1.OpenTelemetryCollector{
 		Spec: v1beta1.OpenTelemetryCollectorSpec{},
 	}
@@ -1031,12 +1028,8 @@ func TestGetEnvironmentVariables(t *testing.T) {
 				{Name: "no_proxy", Value: "localhost"},
 			},
 			before: func() {
-				require.NoError(t, os.Setenv("HTTP_PROXY", "http://proxy.example.com"))
-				require.NoError(t, os.Setenv("NO_PROXY", "localhost"))
-			},
-			cleanup: func() {
-				require.NoError(t, os.Unsetenv("HTTP_PROXY"))
-				require.NoError(t, os.Unsetenv("NO_PROXY"))
+				t.Setenv("HTTP_PROXY", "http://proxy.example.com")
+				t.Setenv("NO_PROXY", "localhost")
 			},
 		},
 		{

--- a/internal/manifests/collector/container_test.go
+++ b/internal/manifests/collector/container_test.go
@@ -891,8 +891,7 @@ func TestGetEnvironmentVariables(t *testing.T) {
 		otelcol              v1beta1.OpenTelemetryCollector
 		enableSetGolangFlags bool
 		expectedEnvVars      []corev1.EnvVar
-		cleanup              func()
-		before               func()
+		before               func(t *testing.T)
 	}{
 		{
 			name: "default environment variables",
@@ -1027,7 +1026,7 @@ func TestGetEnvironmentVariables(t *testing.T) {
 				{Name: "NO_PROXY", Value: "localhost"},
 				{Name: "no_proxy", Value: "localhost"},
 			},
-			before: func() {
+			before: func(t *testing.T) {
 				t.Setenv("HTTP_PROXY", "http://proxy.example.com")
 				t.Setenv("NO_PROXY", "localhost")
 			},
@@ -1130,15 +1129,12 @@ service:
 			}
 
 			if test.before != nil {
-				test.before()
+				test.before(t)
 			}
 
 			envVars := getContainerEnvVars(test.otelcol, testLogger)
 			assert.ElementsMatch(t, test.expectedEnvVars, envVars)
 
-			if test.cleanup != nil {
-				t.Cleanup(test.cleanup)
-			}
 		})
 	}
 }

--- a/internal/manifests/targetallocator/container_test.go
+++ b/internal/manifests/targetallocator/container_test.go
@@ -4,7 +4,6 @@
 package targetallocator
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -201,9 +200,7 @@ func TestContainerHasEnvVars(t *testing.T) {
 }
 
 func TestContainerHasProxyEnvVars(t *testing.T) {
-	err := os.Setenv("NO_PROXY", "localhost")
-	require.NoError(t, err)
-	defer os.Unsetenv("NO_PROXY")
+	t.Setenv("NO_PROXY", "localhost")
 
 	// prepare
 	targetAllocator := v1alpha1.TargetAllocator{


### PR DESCRIPTION
Test change only. Prefer to use t.Setenv for all env var setting in tests.