### PR TITLE
[target allocator] Fix user-defined volumes

### DIFF
--- a/.chloggen/fix_ta-volume.yaml
+++ b/.chloggen/fix_ta-volume.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix user-defined volumes in the TargetAllocator CR
+
+# One or more tracking issues related to the change
+issues: [3992]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/targetallocator/volume.go
+++ b/internal/manifests/targetallocator/volume.go
@@ -40,5 +40,7 @@ func Volumes(cfg config.Config, instance v1alpha1.TargetAllocator) []corev1.Volu
 		})
 	}
 
+	volumes = append(volumes, instance.Spec.Volumes...)
+
 	return volumes
 }

--- a/internal/manifests/targetallocator/volume_test.go
+++ b/internal/manifests/targetallocator/volume_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
@@ -35,6 +36,32 @@ func TestVolumeNewDefault(t *testing.T) {
 
 	// check that it's the ta-internal volume, with the config map
 	assert.Equal(t, naming.TAConfigMapVolume(), volumes[0].Name)
+}
+
+func TestUserDefinedVolume(t *testing.T) {
+	ta := v1alpha1.TargetAllocator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-targetallocator",
+		},
+		Spec: v1alpha1.TargetAllocatorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+				Volumes: []corev1.Volume{
+					{
+						Name: "custom-volume",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+			},
+		},
+	}
+	cfg := config.New()
+
+	volumes := Volumes(cfg, ta)
+
+	assert.Len(t, volumes, 2)
+	assert.Contains(t, volumes, ta.Spec.Volumes[0])
 }
 
 func TestVolumeWithTargetAllocatorMTLS(t *testing.T) {

--- a/tests/e2e-targetallocator-cr/01-assert.yaml
+++ b/tests/e2e-targetallocator-cr/01-assert.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    deployment.kubernetes.io/revision: "1"
+    deployment.kubernetes.io/revision: "2"
   labels:
     app.kubernetes.io/component: opentelemetry-targetallocator
     app.kubernetes.io/managed-by: opentelemetry-operator
@@ -29,6 +29,8 @@ spec:
     spec:
       containers:
         - env:
+            - name: TEST_ENV
+              value: test
             - name: OTELCOL_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -61,6 +63,8 @@ spec:
           volumeMounts:
             - mountPath: /conf
               name: ta-internal
+            - mountPath: /usr/share/testvolume
+              name: testvolume
       serviceAccountName: cr-targetallocator
       volumes:
         - configMap:
@@ -70,6 +74,9 @@ spec:
                 path: targetallocator.yaml
             name: cr-targetallocator
           name: ta-internal
+        - name: testvolume
+          emptyDir: {}
+
 status:
   readyReplicas: 1
   replicas: 1

--- a/tests/e2e-targetallocator-cr/01-install.yaml
+++ b/tests/e2e-targetallocator-cr/01-install.yaml
@@ -39,3 +39,4 @@ spec:
       name: testvolume
   volumes:
     - name: testvolume
+      emptyDir: {}


### PR DESCRIPTION
**Description:**

Fixed a bug which caused user-defined volumes for the Target Allocator CR to be ignored. Also fixed an e2e test which failed to catch the issue due to unrelated problems.

**Link to tracking Issue(s):**

- Resolves: #3992 

**Testing:**

Added a unit test and fixed an existing e2e test.
