### PR TITLE
Fix TargetAllocatorList definition

### DIFF
--- a/apis/v1alpha1/targetallocator_types.go
+++ b/apis/v1alpha1/targetallocator_types.go
@@ -36,7 +36,7 @@ type TargetAllocator struct {
 type TargetAllocatorList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []v1beta1.OpenTelemetryCollector `json:"items"`
+	Items           []TargetAllocator `json:"items"`
 }
 
 // TargetAllocatorStatus defines the observed state of Target Allocator.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1349,7 +1349,7 @@ func (in *TargetAllocatorList) DeepCopyInto(out *TargetAllocatorList) {
 	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]v1beta1.OpenTelemetryCollector, len(*in))
+		*out = make([]TargetAllocator, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}


### PR DESCRIPTION
**Description:** 

The definition of the Go struct for TargetAllocator lists was incorrect. Interestingly, this doesn't affect the CRD itself, as the notion of a resource list is a built-in feature of the K8s API Server. It only affects the operator's own ability to use these lists, which it currently doesn't do. I noticed this while trying to enable the `operator.collector.targetallocatorcr` flag by default.
