### PR TITLE
Fix embedded TargetAllocator CR labels

### DIFF
--- a/internal/controllers/builder_test.go
+++ b/internal/controllers/builder_test.go
@@ -3136,7 +3136,9 @@ service:
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test",
 						Namespace: "test",
-						Labels:    nil,
+						Labels: map[string]string{
+							"app.kubernetes.io/managed-by": "opentelemetry-operator",
+						},
 					},
 					Spec: v1alpha1.TargetAllocatorSpec{
 						FilterStrategy:     v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
@@ -3378,7 +3380,9 @@ service:
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test",
 						Namespace: "test",
-						Labels:    nil,
+						Labels: map[string]string{
+							"app.kubernetes.io/managed-by": "opentelemetry-operator",
+						},
 					},
 					Spec: v1alpha1.TargetAllocatorSpec{
 						FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,

--- a/internal/controllers/reconcile_test.go
+++ b/internal/controllers/reconcile_test.go
@@ -533,7 +533,9 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      params.Name,
 									Namespace: params.Namespace,
-									Labels:    nil,
+									Labels: map[string]string{
+										"app.kubernetes.io/managed-by": "opentelemetry-operator",
+									},
 								},
 								Spec: v1alpha1.TargetAllocatorSpec{
 									OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{},

--- a/internal/manifests/collector/targetallocator_test.go
+++ b/internal/manifests/collector/targetallocator_test.go
@@ -29,6 +29,17 @@ func TestTargetAllocator(t *testing.T) {
 			"label_key": "label_value",
 		},
 	}
+	expectedObjectMetadata := metav1.ObjectMeta{
+		Name:      "name",
+		Namespace: "namespace",
+		Annotations: map[string]string{
+			"annotation_key": "annotation_value",
+		},
+		Labels: map[string]string{
+			"app.kubernetes.io/managed-by": "opentelemetry-operator",
+			"label_key":                    "label_value",
+		},
+	}
 	replicas := int32(2)
 	runAsNonRoot := true
 	privileged := true
@@ -63,7 +74,7 @@ func TestTargetAllocator(t *testing.T) {
 				},
 			},
 			want: &v1alpha1.TargetAllocator{
-				ObjectMeta: objectMetadata,
+				ObjectMeta: expectedObjectMetadata,
 				Spec: v1alpha1.TargetAllocatorSpec{
 					GlobalConfig: v1beta1.AnyConfig{},
 				},
@@ -172,7 +183,7 @@ func TestTargetAllocator(t *testing.T) {
 				},
 			},
 			want: &v1alpha1.TargetAllocator{
-				ObjectMeta: objectMetadata,
+				ObjectMeta: expectedObjectMetadata,
 				Spec: v1alpha1.TargetAllocatorSpec{
 					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
 						Replicas:     &replicas,


### PR DESCRIPTION
**Description:**
Labels on the TargetAllocator CR created by the OpenTelemetryCollector CR are a bit tricky. If we inherit them the same way we do for other resources, the values will be incompatible with the current ones. They're also not semantically correct, as it doesn't make much sense that, for example, the standard name label would be the same for the TA CR.

Instead, I decided to add the `managed-by` label manually, but skip the rest. This doesn't affect any current functionality, and also gives the same result if the `operator.collector.targetallocatorcr` feature gate is enabled.


**Link to tracking Issue(s):**

- Related https://github.com/open-telemetry/opentelemetry-operator/issues/4025

**Testing:**
Modified existing tests.
