### PR TITLE
Update dotnet e2e test image to .NET framework 8.0

### DIFF
--- a/tests/test-e2e-apps/dotnet/DiceRoller/DiceRoller.csproj
+++ b/tests/test-e2e-apps/dotnet/DiceRoller/DiceRoller.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/tests/test-e2e-apps/dotnet/Dockerfile
+++ b/tests/test-e2e-apps/dotnet/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0-bookworm-slim AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
 ARG TARGETARCH
 WORKDIR /source
 
@@ -19,7 +19,7 @@ WORKDIR /source/DiceRoller
 RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore
 
 # Stage 2: Create the runtime image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:7.0-bookworm-slim
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 
 # Environment variables for .NET runtime behavior
 ENV DOTNET_ROLL_FORWARD=Major


### PR DESCRIPTION
**Description:**

Bump the .NET framework version. The latest instrumentation version doesn't support 7.0 anymore, but the version we currently have as default does support 8.0.

**Link to tracking Issue(s):**
#4034 

