### PR TITLE
Make e2e dotnet tests run on latest instrumentation version

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/00-install-instrumentation.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/00-install-instrumentation.yaml
@@ -4,18 +4,14 @@ metadata:
   name: dotnet
 spec:
   env:
-    - name: OTEL_TRACES_EXPORTER
-      value: otlp
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4318
-    - name: OTEL_EXPORTER_OTLP_TIMEOUT
-      value: "20000"
     - name: OTEL_TRACES_SAMPLER
       value: always_on
-    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
-      value: "true"
   exporter:
     endpoint: http://localhost:4318
   propagators:
-    - jaeger
     - b3multi
+  dotnet:
+    env:
+      # Make the test faster by exporting metrics sooner
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        value: "30000"

--- a/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/01-assert.yaml
@@ -22,6 +22,8 @@ spec:
           fieldPath: status.podIP
     - name: ASPNETCORE_URLS
       value: http://+:8080
+    - name: OTEL_METRIC_EXPORT_INTERVAL
+      value: "30000"
     - name: CORECLR_ENABLE_PROFILING
       value: "1"
     - name: CORECLR_PROFILER
@@ -36,18 +38,12 @@ spec:
       value: /otel-auto-instrumentation-dotnet
     - name: DOTNET_SHARED_STORE
       value: /otel-auto-instrumentation-dotnet/store
-    - name: OTEL_TRACES_EXPORTER
-      value: otlp
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4318
-    - name: OTEL_EXPORTER_OTLP_TIMEOUT
-      value: "20000"
     - name: OTEL_TRACES_SAMPLER
       value: always_on
-    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
-      value: "true"
     - name: OTEL_SERVICE_NAME
       value: my-dotnet-multi
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4318
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
       valueFrom:
         fieldRef:
@@ -59,7 +55,7 @@ spec:
           apiVersion: v1
           fieldPath: spec.nodeName
     - name: OTEL_PROPAGATORS
-      value: jaeger,b3multi
+      value: b3multi
     - name: OTEL_RESOURCE_ATTRIBUTES
     name: myapp
     ports:
@@ -81,6 +77,8 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: status.podIP
+    - name: OTEL_METRIC_EXPORT_INTERVAL
+      value: "30000"
     - name: CORECLR_ENABLE_PROFILING
       value: "1"
     - name: CORECLR_PROFILER
@@ -95,18 +93,12 @@ spec:
       value: /otel-auto-instrumentation-dotnet
     - name: DOTNET_SHARED_STORE
       value: /otel-auto-instrumentation-dotnet/store
-    - name: OTEL_TRACES_EXPORTER
-      value: otlp
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4318
-    - name: OTEL_EXPORTER_OTLP_TIMEOUT
-      value: "20000"
     - name: OTEL_TRACES_SAMPLER
       value: always_on
-    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
-      value: "true"
     - name: OTEL_SERVICE_NAME
       value: my-dotnet-multi
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4318
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
       valueFrom:
         fieldRef:
@@ -118,7 +110,7 @@ spec:
           apiVersion: v1
           fieldPath: spec.nodeName
     - name: OTEL_PROPAGATORS
-      value: jaeger,b3multi
+      value: b3multi
     - name: OTEL_RESOURCE_ATTRIBUTES
     name: myrabbit
     volumeMounts:

--- a/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/02-assert.yaml
@@ -33,6 +33,8 @@ spec:
           fieldPath: status.podIP
     - name: ASPNETCORE_URLS
       value: http://+:8080
+    - name: OTEL_METRIC_EXPORT_INTERVAL
+      value: "30000"
     - name: CORECLR_ENABLE_PROFILING
       value: "1"
     - name: CORECLR_PROFILER
@@ -47,18 +49,12 @@ spec:
       value: /otel-auto-instrumentation-dotnet
     - name: DOTNET_SHARED_STORE
       value: /otel-auto-instrumentation-dotnet/store
-    - name: OTEL_TRACES_EXPORTER
-      value: otlp
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4318
-    - name: OTEL_EXPORTER_OTLP_TIMEOUT
-      value: "20000"
     - name: OTEL_TRACES_SAMPLER
       value: always_on
-    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
-      value: "true"
     - name: OTEL_SERVICE_NAME
       value: my-dotnet-multi
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4318
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
       valueFrom:
         fieldRef:
@@ -70,7 +66,7 @@ spec:
           apiVersion: v1
           fieldPath: spec.nodeName
     - name: OTEL_PROPAGATORS
-      value: jaeger,b3multi
+      value: b3multi
     - name: OTEL_RESOURCE_ATTRIBUTES
     name: myapp
     ports:

--- a/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/chainsaw-test.yaml
@@ -77,8 +77,8 @@ spec:
             value: "5"
           - name: SEARCH_STRINGS_ENV
             value: |
-              Name: process.runtime.dotnet.gc.collections.count
-              Description: Number of garbage collections that have occurred since process start
+              Name: process.cpu.time
+              Description: Total CPU seconds broken down by different states.
         timeout: 2m
         content: ../../test-e2e-apps/scripts/check_pod_logs.sh
   - name: Check the instrumented app has sent the telemetry data successfully
@@ -191,8 +191,8 @@ spec:
             value: "5"
           - name: SEARCH_STRINGS_ENV
             value: |
-              Name: process.runtime.dotnet.gc.collections.count
-              Description: Number of garbage collections that have occurred since process start
+              Name: process.cpu.time
+              Description: Total CPU seconds broken down by different states.
         timeout: 2m
         content: ../../test-e2e-apps/scripts/check_pod_logs.sh
   - name: Check the instrumented app has sent the telemetry data successfully

--- a/tests/e2e-instrumentation/instrumentation-dotnet-musl/00-install-instrumentation.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-musl/00-install-instrumentation.yaml
@@ -4,18 +4,14 @@ metadata:
   name: dotnet
 spec:
   env:
-    - name: OTEL_TRACES_EXPORTER
-      value: otlp
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4318
-    - name: OTEL_EXPORTER_OTLP_TIMEOUT
-      value: "20000"
     - name: OTEL_TRACES_SAMPLER
       value: always_on
-    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
-      value: "true"
   exporter:
     endpoint: http://localhost:4318
   propagators:
-    - jaeger
     - b3multi
+  dotnet:
+    env:
+      # Make the test faster by exporting metrics sooner
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        value: "30000"

--- a/tests/e2e-instrumentation/instrumentation-dotnet-musl/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-musl/01-assert.yaml
@@ -21,6 +21,8 @@ spec:
           fieldPath: status.podIP
     - name: ASPNETCORE_URLS
       value: http://+:8080
+    - name: OTEL_METRIC_EXPORT_INTERVAL
+      value: "30000"
     - name: CORECLR_ENABLE_PROFILING
       value: "1"
     - name: CORECLR_PROFILER
@@ -35,18 +37,12 @@ spec:
       value: /otel-auto-instrumentation-dotnet
     - name: DOTNET_SHARED_STORE
       value: /otel-auto-instrumentation-dotnet/store
-    - name: OTEL_TRACES_EXPORTER
-      value: otlp
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4318
-    - name: OTEL_EXPORTER_OTLP_TIMEOUT
-      value: "20000"
     - name: OTEL_TRACES_SAMPLER
       value: always_on
-    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
-      value: "true"
     - name: OTEL_SERVICE_NAME
       value: my-dotnet-musl
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4318
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
       valueFrom:
         fieldRef:
@@ -58,7 +54,7 @@ spec:
           apiVersion: v1
           fieldPath: spec.nodeName
     - name: OTEL_PROPAGATORS
-      value: jaeger,b3multi
+      value: b3multi
     - name: OTEL_RESOURCE_ATTRIBUTES
     name: myapp
     ports:

--- a/tests/e2e-instrumentation/instrumentation-dotnet/00-install-instrumentation.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet/00-install-instrumentation.yaml
@@ -4,18 +4,14 @@ metadata:
   name: dotnet
 spec:
   env:
-    - name: OTEL_TRACES_EXPORTER
-      value: otlp
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4318
-    - name: OTEL_EXPORTER_OTLP_TIMEOUT
-      value: "20000"
     - name: OTEL_TRACES_SAMPLER
       value: always_on
-    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
-      value: "true"
   exporter:
     endpoint: http://localhost:4318
   propagators:
-    - jaeger
     - b3multi
+  dotnet:
+    env:
+      # Make the test faster by exporting metrics sooner
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        value: "30000"

--- a/tests/e2e-instrumentation/instrumentation-dotnet/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet/01-assert.yaml
@@ -21,6 +21,8 @@ spec:
           fieldPath: status.podIP
     - name: ASPNETCORE_URLS
       value: http://+:8080
+    - name: OTEL_METRIC_EXPORT_INTERVAL
+      value: "30000"
     - name: CORECLR_ENABLE_PROFILING
       value: "1"
     - name: CORECLR_PROFILER
@@ -35,18 +37,12 @@ spec:
       value: /otel-auto-instrumentation-dotnet
     - name: DOTNET_SHARED_STORE
       value: /otel-auto-instrumentation-dotnet/store
-    - name: OTEL_TRACES_EXPORTER
-      value: otlp
-    - name: OTEL_EXPORTER_OTLP_ENDPOINT
-      value: http://localhost:4318
-    - name: OTEL_EXPORTER_OTLP_TIMEOUT
-      value: "20000"
     - name: OTEL_TRACES_SAMPLER
       value: always_on
-    - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
-      value: "true"
     - name: OTEL_SERVICE_NAME
       value: my-dotnet
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://localhost:4318
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
       valueFrom:
         fieldRef:
@@ -58,7 +54,7 @@ spec:
           apiVersion: v1
           fieldPath: spec.nodeName
     - name: OTEL_PROPAGATORS
-      value: jaeger,b3multi
+      value: b3multi
     - name: OTEL_RESOURCE_ATTRIBUTES
     name: myapp
     ports:

--- a/tests/e2e-instrumentation/instrumentation-dotnet/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet/chainsaw-test.yaml
@@ -75,8 +75,8 @@ spec:
             value: "5"
           - name: SEARCH_STRINGS_ENV
             value: |
-              Name: process.runtime.dotnet.gc.collections.count
-              Description: Number of garbage collections that have occurred since process start
+              Name: process.cpu.time
+              Description: Total CPU seconds broken down by different states.
         timeout: 2m
         content: ../../test-e2e-apps/scripts/check_pod_logs.sh
   - name: Check the instrumented app has sent the telemetry data successfully


### PR DESCRIPTION
**Description:**

Update the dotnet e2e tests to run on the latest instrumentation version, in addition to our default. This involved:

* Checking a different metric
* Dropping some unnecessary settings
* Removing the jaeger propagator, which isn't supported anymore
* Setting a lower metric export interval to make the test faster

**Link to tracking Issue(s):**

#4034

