### PR TITLE
[chore] Add stop-kind make target to delete the cluster created by start-kind

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,8 @@ The tests are located under `tests/e2e` and are written to be used with `chainsa
 
 To revert the changes made by the `make prepare-e2e` run `make reset`.
 
+To delete the kind cluster created by `make prepare-e2e` run `make stop-kind`.
+
 ### OpenShift End to End tests
 To run the end-to-end tests written for OpenShift, you'll need a OpenShift cluster.
 

--- a/Makefile
+++ b/Makefile
@@ -428,6 +428,12 @@ ifeq (true,$(START_KIND_CLUSTER))
 	$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config $(KIND_CONFIG) || true
 endif
 
+.PHONY: stop-kind
+stop-kind: kind
+ifeq (true,$(START_KIND_CLUSTER))
+	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
+endif
+
 .PHONY: install-metrics-server
 install-metrics-server:
 	./hack/install-metrics-server.sh


### PR DESCRIPTION
**Description:**

Add a make target to delete the cluster generated by the `start-kind` target.

Add instructions on the CONTRIBUTING.md file to help the end user to clean up their environment after the tests.

**Link to tracking Issue(s):**

- Resolves: #4033

**Testing:**

```
make start-kind
make stop-kind
```
