### PR TITLE
Add serviceName Field to OpenTelemetryCollector CRD for StatefulSet Deployments

### DIFF
--- a/.chloggen/sts-headless-svc-naming.yaml
+++ b/.chloggen/sts-headless-svc-naming.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern
+component: collector
+
+# A brief description of the change
+note: "Fix the headless service name in StatefulSet mode. When not specified, defaults to '<name>-headless' for StatefulSet headless services."
+
+# One or more tracking issues related to the change
+issues: [4029]
+
+# Optional additional information
+subtext: |
+  The ServiceName field in the OpenTelemetryCollector spec can now be used to customize 
+  the headless service name when running in StatefulSet mode. This provides more 
+  flexibility in service naming while maintaining default behavior.

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -233,6 +233,11 @@ type OpenTelemetryCollectorSpec struct {
 	// +optional
 	InitContainers []v1.Container `json:"initContainers,omitempty"`
 
+	// ServiceName is the name of the Service to be used.
+	// If not specified, it will default to "<name>-headless".
+	// +optional
+	ServiceName string `json:"serviceName,omitempty"`
+
 	// AdditionalContainers allows injecting additional containers into the Collector's pod definition.
 	// These sidecar containers can be used for authentication proxies, log shipping sidecars, agents for shipping
 	// metrics to their cloud, or in general sidecars that do not support automatic injection. This option only

--- a/apis/v1beta1/opentelemetrycollector_types.go
+++ b/apis/v1beta1/opentelemetrycollector_types.go
@@ -130,6 +130,11 @@ type OpenTelemetryCollectorSpec struct {
 	// This is only applicable to Deployment mode.
 	// +optional
 	DeploymentUpdateStrategy appsv1.DeploymentStrategy `json:"deploymentUpdateStrategy,omitempty"`
+
+	// ServiceName is the name of the Service to be used.
+	// If not specified, it will default to "<name>-headless".
+	// +optional
+	ServiceName string `json:"serviceName,omitempty"`
 }
 
 // TargetAllocatorEmbedded defines the configuration for the Prometheus target allocator, embedded in the

--- a/internal/manifests/collector/service.go
+++ b/internal/manifests/collector/service.go
@@ -39,12 +39,17 @@ func (s ServiceType) String() string {
 }
 
 func HeadlessService(params manifests.Params) (*corev1.Service, error) {
+	// Use serviceName from spec if provided, otherwise default to <name>-headless for StatefulSets
+	serviceName := params.OtelCol.Spec.ServiceName
+	if serviceName == "" {
+		serviceName = naming.HeadlessService(params.OtelCol.Name)
+	}
 	h, err := Service(params)
 	if h == nil || err != nil {
 		return h, err
 	}
 
-	h.Name = naming.HeadlessService(params.OtelCol.Name)
+	h.Name = serviceName
 	h.Labels[headlessLabel] = valueExists
 	h.Labels[serviceTypeLabel] = HeadlessServiceType.String()
 

--- a/internal/manifests/collector/service_test.go
+++ b/internal/manifests/collector/service_test.go
@@ -270,6 +270,27 @@ func TestHeadlessService(t *testing.T) {
 	})
 }
 
+func TestHeadlessServiceWithCustomName(t *testing.T) {
+	t.Run("should return headless service with default name", func(t *testing.T) {
+		param := statefulsetParams()
+		actual, err := HeadlessService(param)
+		assert.NoError(t, err)
+		assert.Equal(t, actual.GetAnnotations()["service.beta.openshift.io/serving-cert-secret-name"], "test-collector-headless-tls")
+		assert.Equal(t, actual.Name, "test-collector-headless")
+		assert.Equal(t, actual.Spec.ClusterIP, "None")
+	})
+
+	t.Run("should return headless service with custom name", func(t *testing.T) {
+		param := statefulsetParams()
+		param.OtelCol.Spec.ServiceName = "custom-headless"
+		actual, err := HeadlessService(param)
+		assert.NoError(t, err)
+		assert.Equal(t, actual.GetAnnotations()["service.beta.openshift.io/serving-cert-secret-name"], "custom-headless-tls")
+		assert.Equal(t, actual.Name, "custom-headless")
+		assert.Equal(t, actual.Spec.ClusterIP, "None")
+	})
+}
+
 func TestMonitoringService(t *testing.T) {
 	t.Run("returned service should expose monitoring port in the default port", func(t *testing.T) {
 		expected := []v1.ServicePort{{

--- a/internal/manifests/collector/statefulset.go
+++ b/internal/manifests/collector/statefulset.go
@@ -27,6 +27,12 @@ func StatefulSet(params manifests.Params) (*appsv1.StatefulSet, error) {
 	if err != nil {
 		return nil, err
 	}
+	serviceName := naming.Service(params.OtelCol.Name)
+	if params.OtelCol.Spec.ServiceName != "" {
+		serviceName = params.OtelCol.Spec.ServiceName
+	} else {
+		serviceName = naming.HeadlessService(params.OtelCol.Name)
+	}
 
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -36,7 +42,7 @@ func StatefulSet(params manifests.Params) (*appsv1.StatefulSet, error) {
 			Annotations: annotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			ServiceName: naming.Service(params.OtelCol.Name),
+			ServiceName: serviceName,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, ComponentOpenTelemetryCollector),
 			},

--- a/internal/manifests/collector/statefulset_test.go
+++ b/internal/manifests/collector/statefulset_test.go
@@ -784,19 +784,19 @@ func TestStatefulSetServiceName(t *testing.T) {
 			name: "StatefulSet with default naming",
 			otelcol: v1beta1.OpenTelemetryCollector{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-sts",
+					Name: "my-instance",
 				},
 				Spec: v1beta1.OpenTelemetryCollectorSpec{
 					Mode: v1beta1.ModeStatefulSet,
 				},
 			},
-			expectedServiceName: "my-sts-collector-headless",
+			expectedServiceName: "my-instance-collector-headless",
 		},
 		{
 			name: "StatefulSet with custom service name",
 			otelcol: v1beta1.OpenTelemetryCollector{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "my-collector",
+					Name: "my-instance",
 				},
 				Spec: v1beta1.OpenTelemetryCollectorSpec{
 					Mode:        v1beta1.ModeStatefulSet,

--- a/internal/manifests/collector/statefulset_test.go
+++ b/internal/manifests/collector/statefulset_test.go
@@ -84,7 +84,7 @@ func TestStatefulSetNewDefault(t *testing.T) {
 	}
 
 	// assert correct service name
-	assert.Equal(t, "my-instance-collector", ss.Spec.ServiceName)
+	assert.Equal(t, "my-instance-collector-headless", ss.Spec.ServiceName)
 
 	// assert correct pod management policy
 	assert.Equal(t, appsv1.ParallelPodManagement, ss.Spec.PodManagementPolicy)
@@ -772,4 +772,53 @@ func TestStatefulSetTerminationGracePeriodSeconds(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, s2.Spec.Template.Spec.TerminationGracePeriodSeconds)
 	assert.Equal(t, gracePeriodSec, *s2.Spec.Template.Spec.TerminationGracePeriodSeconds)
+}
+
+func TestStatefulSetServiceName(t *testing.T) {
+	tests := []struct {
+		name                string
+		otelcol             v1beta1.OpenTelemetryCollector
+		expectedServiceName string
+	}{
+		{
+			name: "StatefulSet with default naming",
+			otelcol: v1beta1.OpenTelemetryCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-sts",
+				},
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					Mode: v1beta1.ModeStatefulSet,
+				},
+			},
+			expectedServiceName: "my-sts-collector-headless",
+		},
+		{
+			name: "StatefulSet with custom service name",
+			otelcol: v1beta1.OpenTelemetryCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-collector",
+				},
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					Mode:        v1beta1.ModeStatefulSet,
+					ServiceName: "custom-headless",
+				},
+			},
+			expectedServiceName: "custom-headless",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := config.New()
+			params := manifests.Params{
+				OtelCol: test.otelcol,
+				Config:  cfg,
+				Log:     testLogger,
+			}
+
+			ss, err := StatefulSet(params)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedServiceName, ss.Spec.ServiceName)
+		})
+	}
 }

--- a/internal/manifests/collector/suite_test.go
+++ b/internal/manifests/collector/suite_test.go
@@ -36,6 +36,10 @@ func deploymentParams() manifests.Params {
 	return paramsWithMode(v1beta1.ModeDeployment)
 }
 
+func statefulsetParams() manifests.Params {
+	return paramsWithMode(v1beta1.ModeStatefulSet)
+}
+
 func paramsWithMode(mode v1beta1.Mode) manifests.Params {
 	replicas := int32(2)
 	configYAML, err := os.ReadFile("testdata/test.yaml")


### PR DESCRIPTION
**Description:** 
Add support for custom service names in StatefulSet headless services

This PR fixes the handling of service names for StatefulSet mode in the OpenTelemetry Collector operator:
- Adds ability to specify custom service names via `spec.serviceName` field
- When running in StatefulSet mode and no service name is specified, defaults to `<name>-headless`
- When creating HeadlessService and no service name is specified, defaults to `<name>-headless`
- Maintains existing behavior for non-StatefulSet modes
- Ensures TLS secret names follow the service naming pattern

**Link to tracking Issue(s):** [4029](https://github.com/open-telemetry/opentelemetry-operator/issues/4029)

**Testing:** 
Added new test cases in `service_test.go` for headlessService creation and in `statefulset_test.go` for statefulset creation with custom and default service names:
- Test default headless service name generation for StatefulSet mode
- Test custom service name handling
- Test TLS secret name generation
- Verify ClusterIP is set to "None" for headless services

**Documentation:** 
