### PR TITLE
[internal/config] remove all getters

### DIFF
--- a/apis/v1alpha1/instrumentation_webhook.go
+++ b/apis/v1alpha1/instrumentation_webhook.go
@@ -82,7 +82,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 		r.Labels = map[string]string{}
 	}
 	if r.Spec.Java.Image == "" {
-		r.Spec.Java.Image = w.cfg.AutoInstrumentationJavaImage()
+		r.Spec.Java.Image = w.cfg.AutoInstrumentationJavaImage
 	}
 	if r.Spec.Java.Resources.Limits == nil {
 		r.Spec.Java.Resources.Limits = corev1.ResourceList{
@@ -97,7 +97,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 		}
 	}
 	if r.Spec.NodeJS.Image == "" {
-		r.Spec.NodeJS.Image = w.cfg.AutoInstrumentationNodeJSImage()
+		r.Spec.NodeJS.Image = w.cfg.AutoInstrumentationNodeJSImage
 	}
 	if r.Spec.NodeJS.Resources.Limits == nil {
 		r.Spec.NodeJS.Resources.Limits = corev1.ResourceList{
@@ -112,7 +112,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 		}
 	}
 	if r.Spec.Python.Image == "" {
-		r.Spec.Python.Image = w.cfg.AutoInstrumentationPythonImage()
+		r.Spec.Python.Image = w.cfg.AutoInstrumentationPythonImage
 	}
 	if r.Spec.Python.Resources.Limits == nil {
 		r.Spec.Python.Resources.Limits = corev1.ResourceList{
@@ -127,7 +127,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 		}
 	}
 	if r.Spec.DotNet.Image == "" {
-		r.Spec.DotNet.Image = w.cfg.AutoInstrumentationDotNetImage()
+		r.Spec.DotNet.Image = w.cfg.AutoInstrumentationDotNetImage
 	}
 	if r.Spec.DotNet.Resources.Limits == nil {
 		r.Spec.DotNet.Resources.Limits = corev1.ResourceList{
@@ -142,7 +142,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 		}
 	}
 	if r.Spec.Go.Image == "" {
-		r.Spec.Go.Image = w.cfg.AutoInstrumentationGoImage()
+		r.Spec.Go.Image = w.cfg.AutoInstrumentationGoImage
 	}
 	if r.Spec.Go.Resources.Limits == nil {
 		r.Spec.Go.Resources.Limits = corev1.ResourceList{
@@ -157,7 +157,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 		}
 	}
 	if r.Spec.ApacheHttpd.Image == "" {
-		r.Spec.ApacheHttpd.Image = w.cfg.AutoInstrumentationApacheHttpdImage()
+		r.Spec.ApacheHttpd.Image = w.cfg.AutoInstrumentationApacheHttpdImage
 	}
 	if r.Spec.ApacheHttpd.Resources.Limits == nil {
 		r.Spec.ApacheHttpd.Resources.Limits = initContainerDefaultLimitResources
@@ -172,7 +172,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 		r.Spec.ApacheHttpd.ConfigPath = "/usr/local/apache2/conf"
 	}
 	if r.Spec.Nginx.Image == "" {
-		r.Spec.Nginx.Image = w.cfg.AutoInstrumentationNginxImage()
+		r.Spec.Nginx.Image = w.cfg.AutoInstrumentationNginxImage
 	}
 	if r.Spec.Nginx.Resources.Limits == nil {
 		r.Spec.Nginx.Resources.Limits = initContainerDefaultLimitResources
@@ -187,13 +187,13 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 	if r.Annotations == nil {
 		r.Annotations = map[string]string{}
 	}
-	r.Annotations[constants.AnnotationDefaultAutoInstrumentationJava] = w.cfg.AutoInstrumentationJavaImage()
-	r.Annotations[constants.AnnotationDefaultAutoInstrumentationNodeJS] = w.cfg.AutoInstrumentationNodeJSImage()
-	r.Annotations[constants.AnnotationDefaultAutoInstrumentationPython] = w.cfg.AutoInstrumentationPythonImage()
-	r.Annotations[constants.AnnotationDefaultAutoInstrumentationDotNet] = w.cfg.AutoInstrumentationDotNetImage()
-	r.Annotations[constants.AnnotationDefaultAutoInstrumentationGo] = w.cfg.AutoInstrumentationGoImage()
-	r.Annotations[constants.AnnotationDefaultAutoInstrumentationApacheHttpd] = w.cfg.AutoInstrumentationApacheHttpdImage()
-	r.Annotations[constants.AnnotationDefaultAutoInstrumentationNginx] = w.cfg.AutoInstrumentationNginxImage()
+	r.Annotations[constants.AnnotationDefaultAutoInstrumentationJava] = w.cfg.AutoInstrumentationJavaImage
+	r.Annotations[constants.AnnotationDefaultAutoInstrumentationNodeJS] = w.cfg.AutoInstrumentationNodeJSImage
+	r.Annotations[constants.AnnotationDefaultAutoInstrumentationPython] = w.cfg.AutoInstrumentationPythonImage
+	r.Annotations[constants.AnnotationDefaultAutoInstrumentationDotNet] = w.cfg.AutoInstrumentationDotNetImage
+	r.Annotations[constants.AnnotationDefaultAutoInstrumentationGo] = w.cfg.AutoInstrumentationGoImage
+	r.Annotations[constants.AnnotationDefaultAutoInstrumentationApacheHttpd] = w.cfg.AutoInstrumentationApacheHttpdImage
+	r.Annotations[constants.AnnotationDefaultAutoInstrumentationNginx] = w.cfg.AutoInstrumentationNginxImage
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,39 +28,69 @@ const (
 
 // Config holds the static configuration for this operator.
 type Config struct {
-	autoDetect                          autodetect.AutoDetect
-	logger                              logr.Logger
-	targetAllocatorImage                string
-	operatorOpAMPBridgeImage            string
-	autoInstrumentationPythonImage      string
-	collectorImage                      string
-	collectorConfigMapEntry             string
-	createRBACPermissions               autoRBAC.Availability
-	enableMultiInstrumentation          bool
-	enableApacheHttpdInstrumentation    bool
-	enableDotNetInstrumentation         bool
-	enableGoInstrumentation             bool
-	enableNginxInstrumentation          bool
-	enablePythonInstrumentation         bool
-	enableNodeJSInstrumentation         bool
-	enableJavaInstrumentation           bool
-	autoInstrumentationDotNetImage      string
-	autoInstrumentationGoImage          string
-	autoInstrumentationApacheHttpdImage string
-	autoInstrumentationNginxImage       string
-	targetAllocatorConfigMapEntry       string
-	operatorOpAMPBridgeConfigMapEntry   string
-	autoInstrumentationNodeJSImage      string
-	autoInstrumentationJavaImage        string
+	autoDetect autodetect.AutoDetect
+	logger     logr.Logger
+	// TargetAllocatorImage represents the flag to override the OpenTelemetry TargetAllocator container image.
+	TargetAllocatorImage string
+	// OperatorOpAMPBridgeImage represents the flag to override the OpAMPBridge container image.
+	OperatorOpAMPBridgeImage string
+	// AutoInstrumentationPythonImage is the OpenTelemetry Python auto-instrumentation container image.
+	AutoInstrumentationPythonImage string
+	// CollectorImage represents the flag to override the OpenTelemetry Collector container image.
+	CollectorImage string
+	// CollectorConfigMapEntry represents the configuration file name for the collector. Immutable.
+	CollectorConfigMapEntry string
+	// CreateRBACPermissions is true when the operator can create RBAC permissions for SAs running a collector instance. Immutable.
+	CreateRBACPermissions autoRBAC.Availability
+	// EnableMultiInstrumentation is true when the operator supports multi instrumentation.
+	EnableMultiInstrumentation bool
+	// EnableApacheHttpdAutoInstrumentation is true when the operator supports ApacheHttpd auto instrumentation.
+	EnableApacheHttpdInstrumentation bool
+	// EnableDotNetAutoInstrumentation is true when the operator supports dotnet auto instrumentation.
+	EnableDotNetInstrumentation bool
+	// EnableGoAutoInstrumentation is true when the operator supports Go auto instrumentation.
+	EnableGoAutoInstrumentation bool
+	// EnableNginxAutoInstrumentation is true when the operator supports nginx auto instrumentation.
+	EnableNginxAutoInstrumentation bool
+	// EnablePythonAutoInstrumentation is true when the operator supports dotnet auto instrumentation.
+	EnablePythonAutoInstrumentation bool
+	// EnableNodeJSAutoInstrumentation is true when the operator supports dotnet auto instrumentation.
+	EnableNodeJSAutoInstrumentation bool
+	// EnableJavaAutoInstrumentation is true when the operator supports java auto instrumentation.
+	EnableJavaAutoInstrumentation bool
+	// AutoInstrumentationDotNetImage is the OpenTelemetry DotNet auto-instrumentation container image.
+	AutoInstrumentationDotNetImage string
+	// AutoInstrumentationGoImage is the OpenTelemetry Go auto-instrumentation container image.
+	AutoInstrumentationGoImage string
+	// AutoInstrumentationApacheHttpdImage is the OpenTelemetry ApacheHttpd auto-instrumentation container image.
+	AutoInstrumentationApacheHttpdImage string
+	// AutoInstrumentationNginxImage is the OpenTelemetry Nginx auto-instrumentation container image.
+	AutoInstrumentationNginxImage string
+	// TargetAllocatorConfigMapEntry represents the configuration file name for the TargetAllocator. Immutable.
+	TargetAllocatorConfigMapEntry string
+	// OperatorOpAMPBridgeImageConfigMapEntry represents the configuration file name for the OpAMPBridge. Immutable.
+	OperatorOpAMPBridgeConfigMapEntry string
+	// AutoInstrumentationNodeJSImage is the OpenTelemetry NodeJS auto-instrumentation container image.
+	AutoInstrumentationNodeJSImage string
+	// AutoInstrumentationJavaImage returns OpenTelemetry Java auto-instrumentation container image.
+	AutoInstrumentationJavaImage string
 
-	openshiftRoutesAvailability openshift.RoutesAvailability
-	prometheusCRAvailability    prometheus.Availability
-	certManagerAvailability     certmanager.Availability
-	targetAllocatorAvailability targetallocator.Availability
-	collectorAvailability       collector.Availability
-	ignoreMissingCollectorCRDs  bool
-	labelsFilter                []string
-	annotationsFilter           []string
+	// OpenShiftRoutesAvailability represents the availability of the OpenShift Routes API.
+	OpenShiftRoutesAvailability openshift.RoutesAvailability
+	// PrometheusCRAvailability represents the availability of the Prometheus Operator CRDs.
+	PrometheusCRAvailability prometheus.Availability
+	// CertManagerAvailability represents the availability of the Cert-Manager.
+	CertManagerAvailability certmanager.Availability
+	// TargetAllocatorAvailability represents the availability of the TargetAllocator CRD.
+	TargetAllocatorAvailability targetallocator.Availability
+	// CollectorAvailability represents the availability of the OpenTelemetryCollector CRD.
+	CollectorAvailability collector.Availability
+	// IgnoreMissingCollectorCRDs is true if the operator can ignore missing OpenTelemetryCollector CRDs.
+	IgnoreMissingCollectorCRDs bool
+	// LabelsFilter Returns the filters converted to regex strings used to filter out unwanted labels from propagations.
+	LabelsFilter []string
+	// AnnotationsFilter Returns the filters converted to regex strings used to filter out unwanted labels from propagations.
+	AnnotationsFilter []string
 }
 
 // New constructs a new configuration based on the given options.
@@ -88,37 +118,37 @@ func New(opts ...Option) Config {
 
 	return Config{
 		autoDetect:                          o.autoDetect,
-		collectorImage:                      o.collectorImage,
-		collectorConfigMapEntry:             o.collectorConfigMapEntry,
-		enableMultiInstrumentation:          o.enableMultiInstrumentation,
-		enableApacheHttpdInstrumentation:    o.enableApacheHttpdInstrumentation,
-		enableDotNetInstrumentation:         o.enableDotNetInstrumentation,
-		enableGoInstrumentation:             o.enableGoInstrumentation,
-		enableNginxInstrumentation:          o.enableNginxInstrumentation,
-		enablePythonInstrumentation:         o.enablePythonInstrumentation,
-		enableNodeJSInstrumentation:         o.enableNodeJSInstrumentation,
-		enableJavaInstrumentation:           o.enableJavaInstrumentation,
-		targetAllocatorImage:                o.targetAllocatorImage,
-		operatorOpAMPBridgeImage:            o.operatorOpAMPBridgeImage,
-		targetAllocatorConfigMapEntry:       o.targetAllocatorConfigMapEntry,
-		operatorOpAMPBridgeConfigMapEntry:   o.operatorOpAMPBridgeConfigMapEntry,
+		CollectorImage:                      o.collectorImage,
+		CollectorConfigMapEntry:             o.collectorConfigMapEntry,
+		EnableMultiInstrumentation:          o.enableMultiInstrumentation,
+		EnableApacheHttpdInstrumentation:    o.enableApacheHttpdInstrumentation,
+		EnableDotNetInstrumentation:         o.enableDotNetInstrumentation,
+		EnableGoAutoInstrumentation:         o.enableGoInstrumentation,
+		EnableNginxAutoInstrumentation:      o.enableNginxInstrumentation,
+		EnablePythonAutoInstrumentation:     o.enablePythonInstrumentation,
+		EnableNodeJSAutoInstrumentation:     o.enableNodeJSInstrumentation,
+		EnableJavaAutoInstrumentation:       o.enableJavaInstrumentation,
+		TargetAllocatorImage:                o.targetAllocatorImage,
+		OperatorOpAMPBridgeImage:            o.operatorOpAMPBridgeImage,
+		TargetAllocatorConfigMapEntry:       o.targetAllocatorConfigMapEntry,
+		OperatorOpAMPBridgeConfigMapEntry:   o.operatorOpAMPBridgeConfigMapEntry,
 		logger:                              o.logger,
-		openshiftRoutesAvailability:         o.openshiftRoutesAvailability,
-		prometheusCRAvailability:            o.prometheusCRAvailability,
-		certManagerAvailability:             o.certManagerAvailability,
-		targetAllocatorAvailability:         o.targetAllocatorAvailability,
-		collectorAvailability:               o.collectorAvailability,
-		ignoreMissingCollectorCRDs:          o.ignoreMissingCollectorCRDs,
-		autoInstrumentationJavaImage:        o.autoInstrumentationJavaImage,
-		autoInstrumentationNodeJSImage:      o.autoInstrumentationNodeJSImage,
-		autoInstrumentationPythonImage:      o.autoInstrumentationPythonImage,
-		autoInstrumentationDotNetImage:      o.autoInstrumentationDotNetImage,
-		autoInstrumentationGoImage:          o.autoInstrumentationGoImage,
-		autoInstrumentationApacheHttpdImage: o.autoInstrumentationApacheHttpdImage,
-		autoInstrumentationNginxImage:       o.autoInstrumentationNginxImage,
-		labelsFilter:                        o.labelsFilter,
-		annotationsFilter:                   o.annotationsFilter,
-		createRBACPermissions:               o.createRBACPermissions,
+		OpenShiftRoutesAvailability:         o.openshiftRoutesAvailability,
+		PrometheusCRAvailability:            o.prometheusCRAvailability,
+		CertManagerAvailability:             o.certManagerAvailability,
+		TargetAllocatorAvailability:         o.targetAllocatorAvailability,
+		CollectorAvailability:               o.collectorAvailability,
+		IgnoreMissingCollectorCRDs:          o.ignoreMissingCollectorCRDs,
+		AutoInstrumentationJavaImage:        o.autoInstrumentationJavaImage,
+		AutoInstrumentationNodeJSImage:      o.autoInstrumentationNodeJSImage,
+		AutoInstrumentationPythonImage:      o.autoInstrumentationPythonImage,
+		AutoInstrumentationDotNetImage:      o.autoInstrumentationDotNetImage,
+		AutoInstrumentationGoImage:          o.autoInstrumentationGoImage,
+		AutoInstrumentationApacheHttpdImage: o.autoInstrumentationApacheHttpdImage,
+		AutoInstrumentationNginxImage:       o.autoInstrumentationNginxImage,
+		LabelsFilter:                        o.labelsFilter,
+		AnnotationsFilter:                   o.annotationsFilter,
+		CreateRBACPermissions:               o.createRBACPermissions,
 	}
 }
 
@@ -130,193 +160,43 @@ func (c *Config) AutoDetect() error {
 	if err != nil {
 		return err
 	}
-	c.openshiftRoutesAvailability = ora
+	c.OpenShiftRoutesAvailability = ora
 	c.logger.V(2).Info("openshift routes detected", "availability", ora)
 
 	pcrd, err := c.autoDetect.PrometheusCRsAvailability()
 	if err != nil {
 		return err
 	}
-	c.prometheusCRAvailability = pcrd
+	c.PrometheusCRAvailability = pcrd
 	c.logger.V(2).Info("prometheus cr detected", "availability", pcrd)
 
 	rAuto, err := c.autoDetect.RBACPermissions(context.Background())
 	if err != nil {
 		c.logger.V(2).Info("the rbac permissions are not set for the operator", "reason", err)
 	}
-	c.createRBACPermissions = rAuto
+	c.CreateRBACPermissions = rAuto
 	c.logger.V(2).Info("create rbac permissions detected", "availability", rAuto)
 
 	cmAvl, err := c.autoDetect.CertManagerAvailability(context.Background())
 	if err != nil {
 		c.logger.V(2).Info("the cert manager crd and permissions are not set for the operator", "reason", err)
 	}
-	c.certManagerAvailability = cmAvl
+	c.CertManagerAvailability = cmAvl
 	c.logger.V(2).Info("the cert manager crd and permissions are set for the operator", "availability", cmAvl)
 
 	taAvl, err := c.autoDetect.TargetAllocatorAvailability()
 	if err != nil {
 		return err
 	}
-	c.targetAllocatorAvailability = taAvl
+	c.TargetAllocatorAvailability = taAvl
 	c.logger.V(2).Info("determined TargetAllocator CRD availability", "availability", cmAvl)
 
 	coAvl, err := c.autoDetect.CollectorAvailability()
 	if err != nil {
 		return err
 	}
-	c.collectorAvailability = coAvl
+	c.CollectorAvailability = coAvl
 	c.logger.V(2).Info("determined Collector CRD availability", "availability", coAvl)
 
 	return nil
-}
-
-// CollectorImage represents the flag to override the OpenTelemetry Collector container image.
-func (c *Config) CollectorImage() string {
-	return c.collectorImage
-}
-
-// EnableMultiInstrumentation is true when the operator supports multi instrumentation.
-func (c *Config) EnableMultiInstrumentation() bool {
-	return c.enableMultiInstrumentation
-}
-
-// EnableApacheHttpdAutoInstrumentation is true when the operator supports ApacheHttpd auto instrumentation.
-func (c *Config) EnableApacheHttpdAutoInstrumentation() bool {
-	return c.enableApacheHttpdInstrumentation
-}
-
-// EnableDotNetAutoInstrumentation is true when the operator supports dotnet auto instrumentation.
-func (c *Config) EnableDotNetAutoInstrumentation() bool {
-	return c.enableDotNetInstrumentation
-}
-
-// EnableGoAutoInstrumentation is true when the operator supports Go auto instrumentation.
-func (c *Config) EnableGoAutoInstrumentation() bool {
-	return c.enableGoInstrumentation
-}
-
-// EnableNginxAutoInstrumentation is true when the operator supports nginx auto instrumentation.
-func (c *Config) EnableNginxAutoInstrumentation() bool {
-	return c.enableNginxInstrumentation
-}
-
-// EnableJavaAutoInstrumentation is true when the operator supports nginx auto instrumentation.
-func (c *Config) EnableJavaAutoInstrumentation() bool {
-	return c.enableJavaInstrumentation
-}
-
-// EnablePythonAutoInstrumentation is true when the operator supports dotnet auto instrumentation.
-func (c *Config) EnablePythonAutoInstrumentation() bool {
-	return c.enablePythonInstrumentation
-}
-
-// EnableNodeJSAutoInstrumentation is true when the operator supports dotnet auto instrumentation.
-func (c *Config) EnableNodeJSAutoInstrumentation() bool {
-	return c.enableNodeJSInstrumentation
-}
-
-// CollectorConfigMapEntry represents the configuration file name for the collector. Immutable.
-func (c *Config) CollectorConfigMapEntry() string {
-	return c.collectorConfigMapEntry
-}
-
-// CreateRBACPermissions is true when the operator can create RBAC permissions for SAs running a collector instance. Immutable.
-func (c *Config) CreateRBACPermissions() autoRBAC.Availability {
-	return c.createRBACPermissions
-}
-
-// TargetAllocatorImage represents the flag to override the OpenTelemetry TargetAllocator container image.
-func (c *Config) TargetAllocatorImage() string {
-	return c.targetAllocatorImage
-}
-
-// OperatorOpAMPBridgeImage represents the flag to override the OpAMPBridge container image.
-func (c *Config) OperatorOpAMPBridgeImage() string {
-	return c.operatorOpAMPBridgeImage
-}
-
-// TargetAllocatorConfigMapEntry represents the configuration file name for the TargetAllocator. Immutable.
-func (c *Config) TargetAllocatorConfigMapEntry() string {
-	return c.targetAllocatorConfigMapEntry
-}
-
-// OperatorOpAMPBridgeImageConfigMapEntry represents the configuration file name for the OpAMPBridge. Immutable.
-func (c *Config) OperatorOpAMPBridgeConfigMapEntry() string {
-	return c.operatorOpAMPBridgeConfigMapEntry
-}
-
-// OpenShiftRoutesAvailability represents the availability of the OpenShift Routes API.
-func (c *Config) OpenShiftRoutesAvailability() openshift.RoutesAvailability {
-	return c.openshiftRoutesAvailability
-}
-
-// PrometheusCRAvailability represents the availability of the Prometheus Operator CRDs.
-func (c *Config) PrometheusCRAvailability() prometheus.Availability {
-	return c.prometheusCRAvailability
-}
-
-// CertManagerAvailability represents the availability of the Cert-Manager.
-func (c *Config) CertManagerAvailability() certmanager.Availability {
-	return c.certManagerAvailability
-}
-
-// TargetAllocatorAvailability represents the availability of the TargetAllocator CRD.
-func (c *Config) TargetAllocatorAvailability() targetallocator.Availability {
-	return c.targetAllocatorAvailability
-}
-
-// CollectorAvailability represents the availability of the OpenTelemetryCollector CRD.
-func (c *Config) CollectorAvailability() collector.Availability {
-	return c.collectorAvailability
-}
-
-// IgnoreMissingCollectorCRDs is true if the operator can ignore missing OpenTelemetryCollector CRDs.
-func (c *Config) IgnoreMissingCollectorCRDs() bool {
-	return c.ignoreMissingCollectorCRDs
-}
-
-// AutoInstrumentationJavaImage returns OpenTelemetry Java auto-instrumentation container image.
-func (c *Config) AutoInstrumentationJavaImage() string {
-	return c.autoInstrumentationJavaImage
-}
-
-// AutoInstrumentationNodeJSImage returns OpenTelemetry NodeJS auto-instrumentation container image.
-func (c *Config) AutoInstrumentationNodeJSImage() string {
-	return c.autoInstrumentationNodeJSImage
-}
-
-// AutoInstrumentationPythonImage returns OpenTelemetry Python auto-instrumentation container image.
-func (c *Config) AutoInstrumentationPythonImage() string {
-	return c.autoInstrumentationPythonImage
-}
-
-// AutoInstrumentationDotNetImage returns OpenTelemetry DotNet auto-instrumentation container image.
-func (c *Config) AutoInstrumentationDotNetImage() string {
-	return c.autoInstrumentationDotNetImage
-}
-
-// AutoInstrumentationGoImage returns OpenTelemetry Go auto-instrumentation container image.
-func (c *Config) AutoInstrumentationGoImage() string {
-	return c.autoInstrumentationGoImage
-}
-
-// AutoInstrumentationApacheHttpdImage returns OpenTelemetry ApacheHttpd auto-instrumentation container image.
-func (c *Config) AutoInstrumentationApacheHttpdImage() string {
-	return c.autoInstrumentationApacheHttpdImage
-}
-
-// AutoInstrumentationNginxImage returns OpenTelemetry Nginx auto-instrumentation container image.
-func (c *Config) AutoInstrumentationNginxImage() string {
-	return c.autoInstrumentationNginxImage
-}
-
-// LabelsFilter Returns the filters converted to regex strings used to filter out unwanted labels from propagations.
-func (c *Config) LabelsFilter() []string {
-	return c.labelsFilter
-}
-
-// AnnotationsFilter Returns the filters converted to regex strings used to filter out unwanted labels from propagations.
-func (c *Config) AnnotationsFilter() []string {
-	return c.annotationsFilter
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,10 +30,10 @@ func TestNewConfig(t *testing.T) {
 	)
 
 	// test
-	assert.Equal(t, "some-image", cfg.CollectorImage())
-	assert.Equal(t, "some-config.yaml", cfg.CollectorConfigMapEntry())
-	assert.Equal(t, openshift.RoutesAvailable, cfg.OpenShiftRoutesAvailability())
-	assert.Equal(t, prometheus.Available, cfg.PrometheusCRAvailability())
+	assert.Equal(t, "some-image", cfg.CollectorImage)
+	assert.Equal(t, "some-config.yaml", cfg.CollectorConfigMapEntry)
+	assert.Equal(t, openshift.RoutesAvailable, cfg.OpenShiftRoutesAvailability)
+	assert.Equal(t, prometheus.Available, cfg.PrometheusCRAvailability)
 }
 
 func TestConfigChangesOnAutoDetect(t *testing.T) {
@@ -63,23 +63,23 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 	)
 
 	// sanity check
-	require.Equal(t, openshift.RoutesNotAvailable, cfg.OpenShiftRoutesAvailability())
-	require.Equal(t, prometheus.NotAvailable, cfg.PrometheusCRAvailability())
-	require.Equal(t, rbac.NotAvailable, cfg.CreateRBACPermissions())
-	require.Equal(t, certmanager.NotAvailable, cfg.CertManagerAvailability())
-	require.Equal(t, targetallocator.NotAvailable, cfg.TargetAllocatorAvailability())
-	require.Equal(t, collector.NotAvailable, cfg.CollectorAvailability())
+	require.Equal(t, openshift.RoutesNotAvailable, cfg.OpenShiftRoutesAvailability)
+	require.Equal(t, prometheus.NotAvailable, cfg.PrometheusCRAvailability)
+	require.Equal(t, rbac.NotAvailable, cfg.CreateRBACPermissions)
+	require.Equal(t, certmanager.NotAvailable, cfg.CertManagerAvailability)
+	require.Equal(t, targetallocator.NotAvailable, cfg.TargetAllocatorAvailability)
+	require.Equal(t, collector.NotAvailable, cfg.CollectorAvailability)
 
 	// test
 	err := cfg.AutoDetect()
 	require.NoError(t, err)
 
 	// verify
-	assert.Equal(t, openshift.RoutesAvailable, cfg.OpenShiftRoutesAvailability())
-	require.Equal(t, prometheus.Available, cfg.PrometheusCRAvailability())
-	require.Equal(t, rbac.Available, cfg.CreateRBACPermissions())
-	require.Equal(t, certmanager.Available, cfg.CertManagerAvailability())
-	require.Equal(t, targetallocator.Available, cfg.TargetAllocatorAvailability())
+	assert.Equal(t, openshift.RoutesAvailable, cfg.OpenShiftRoutesAvailability)
+	require.Equal(t, prometheus.Available, cfg.PrometheusCRAvailability)
+	require.Equal(t, rbac.Available, cfg.CreateRBACPermissions)
+	require.Equal(t, certmanager.Available, cfg.CertManagerAvailability)
+	require.Equal(t, targetallocator.Available, cfg.TargetAllocatorAvailability)
 }
 
 var _ autodetect.AutoDetect = (*mockAutoDetect)(nil)

--- a/internal/controllers/opentelemetrycollector_controller.go
+++ b/internal/controllers/opentelemetrycollector_controller.go
@@ -364,17 +364,17 @@ func (r *OpenTelemetryCollectorReconciler) GetOwnedResourceTypes() []client.Obje
 		&policyV1.PodDisruptionBudget{},
 	}
 
-	if r.config.CreateRBACPermissions() == rbac.Available {
+	if r.config.CreateRBACPermissions == rbac.Available {
 		ownedResources = append(ownedResources, &rbacv1.ClusterRole{})
 		ownedResources = append(ownedResources, &rbacv1.ClusterRoleBinding{})
 	}
 
-	if featuregate.PrometheusOperatorIsAvailable.IsEnabled() && r.config.PrometheusCRAvailability() == prometheus.Available {
+	if featuregate.PrometheusOperatorIsAvailable.IsEnabled() && r.config.PrometheusCRAvailability == prometheus.Available {
 		ownedResources = append(ownedResources, &monitoringv1.PodMonitor{})
 		ownedResources = append(ownedResources, &monitoringv1.ServiceMonitor{})
 	}
 
-	if r.config.OpenShiftRoutesAvailability() == openshift.RoutesAvailable {
+	if r.config.OpenShiftRoutesAvailability == openshift.RoutesAvailable {
 		ownedResources = append(ownedResources, &routev1.Route{})
 	}
 
@@ -385,7 +385,7 @@ const collectorFinalizer = "opentelemetrycollector.opentelemetry.io/finalizer"
 
 func (r *OpenTelemetryCollectorReconciler) finalizeCollector(ctx context.Context, params manifests.Params) error {
 	// The cluster scope objects do not have owner reference. They need to be deleted explicitly
-	if params.Config.CreateRBACPermissions() == rbac.Available {
+	if params.Config.CreateRBACPermissions == rbac.Available {
 		objects, err := r.findClusterRoleObjects(ctx, params)
 		if err != nil {
 			return err

--- a/internal/controllers/targetallocator_controller.go
+++ b/internal/controllers/targetallocator_controller.go
@@ -191,7 +191,7 @@ func (r *TargetAllocatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&policyV1.PodDisruptionBudget{})
 
-	if featuregate.PrometheusOperatorIsAvailable.IsEnabled() && r.config.PrometheusCRAvailability() == prometheus.Available {
+	if featuregate.PrometheusOperatorIsAvailable.IsEnabled() && r.config.PrometheusCRAvailability == prometheus.Available {
 		ctrlBuilder.Owns(&monitoringv1.ServiceMonitor{})
 		ctrlBuilder.Owns(&monitoringv1.PodMonitor{})
 	}

--- a/internal/manifests/collector/collector.go
+++ b/internal/manifests/collector/collector.go
@@ -58,7 +58,7 @@ func Build(params manifests.Params) ([]client.Object, error) {
 		}
 	}
 
-	if params.Config.CreateRBACPermissions() == rbac.Available {
+	if params.Config.CreateRBACPermissions == rbac.Available {
 		manifestFactories = append(manifestFactories,
 			manifests.Factory(ClusterRole),
 			manifests.Factory(ClusterRoleBinding),
@@ -100,7 +100,7 @@ func Build(params manifests.Params) ([]client.Object, error) {
 
 func needsCheckSaPermissions(params manifests.Params) bool {
 	return params.ErrorAsWarning &&
-		params.Config.CreateRBACPermissions() == rbac.NotAvailable &&
+		params.Config.CreateRBACPermissions == rbac.NotAvailable &&
 		params.Reviewer != nil &&
 		params.OtelCol.Spec.ServiceAccount != ""
 }

--- a/internal/manifests/collector/configmap.go
+++ b/internal/manifests/collector/configmap.go
@@ -27,14 +27,14 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 	collectorName := naming.Collector(params.OtelCol.Name)
 	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, collectorName, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, []string{})
 
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}
 
 	replaceCfgOpts := []ta.TAOption{}
 
-	if params.OtelCol.Spec.TargetAllocator.Enabled && params.Config.CertManagerAvailability() == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
+	if params.OtelCol.Spec.TargetAllocator.Enabled && params.Config.CertManagerAvailability == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
 		replaceCfgOpts = append(replaceCfgOpts, ta.WithTLSConfig(
 			filepath.Join(constants.TACollectorTLSDirPath, constants.TACollectorCAFileName),
 			filepath.Join(constants.TACollectorTLSDirPath, constants.TACollectorTLSCertFileName),

--- a/internal/manifests/collector/container.go
+++ b/internal/manifests/collector/container.go
@@ -29,7 +29,7 @@ const maxPortLen = 15
 func Container(cfg config.Config, logger logr.Logger, otelcol v1beta1.OpenTelemetryCollector, addConfig bool) corev1.Container {
 	image := otelcol.Spec.Image
 	if len(image) == 0 {
-		image = cfg.CollectorImage()
+		image = cfg.CollectorImage
 	}
 
 	ports := getContainerPorts(logger, otelcol)
@@ -53,7 +53,7 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1beta1.OpenTeleme
 			logger.Info("the 'config' flag isn't allowed and is being ignored")
 			delete(argsMap, "config")
 		}
-		args = append(args, fmt.Sprintf("--config=/conf/%s", cfg.CollectorConfigMapEntry()))
+		args = append(args, fmt.Sprintf("--config=/conf/%s", cfg.CollectorConfigMapEntry))
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{
 				Name:      naming.ConfigMapVolume(),
@@ -61,7 +61,7 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1beta1.OpenTeleme
 			})
 	}
 
-	if otelcol.Spec.TargetAllocator.Enabled && cfg.CertManagerAvailability() == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
+	if otelcol.Spec.TargetAllocator.Enabled && cfg.CertManagerAvailability == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
 		volumeMounts = append(volumeMounts,
 			corev1.VolumeMount{
 				Name:      naming.TAClientCertificate(otelcol.Name),

--- a/internal/manifests/collector/daemonset.go
+++ b/internal/manifests/collector/daemonset.go
@@ -16,14 +16,14 @@ import (
 // DaemonSet builds the deployment for the given instance.
 func DaemonSet(params manifests.Params) (*appsv1.DaemonSet, error) {
 	name := naming.Collector(params.OtelCol.Name)
-	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter)
 
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}
 
-	podAnnotations, err := manifestutils.PodAnnotations(params.OtelCol, params.Config.AnnotationsFilter())
+	podAnnotations, err := manifestutils.PodAnnotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/collector/deployment.go
+++ b/internal/manifests/collector/deployment.go
@@ -16,13 +16,13 @@ import (
 // Deployment builds the deployment for the given instance.
 func Deployment(params manifests.Params) (*appsv1.Deployment, error) {
 	name := naming.Collector(params.OtelCol.Name)
-	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter)
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}
 
-	podAnnotations, err := manifestutils.PodAnnotations(params.OtelCol, params.Config.AnnotationsFilter())
+	podAnnotations, err := manifestutils.PodAnnotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/collector/horizontalpodautoscaler.go
+++ b/internal/manifests/collector/horizontalpodautoscaler.go
@@ -16,8 +16,8 @@ import (
 
 func HorizontalPodAutoscaler(params manifests.Params) (*autoscalingv2.HorizontalPodAutoscaler, error) {
 	name := naming.Collector(params.OtelCol.Name)
-	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter)
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/collector/ingress.go
+++ b/internal/manifests/collector/ingress.go
@@ -19,7 +19,7 @@ import (
 
 func Ingress(params manifests.Params) (*networkingv1.Ingress, error) {
 	name := naming.Ingress(params.OtelCol.Name)
-	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter)
 	if params.OtelCol.Spec.Ingress.Type != v1beta1.IngressTypeIngress {
 		return nil, nil
 	}

--- a/internal/manifests/collector/poddisruptionbudget.go
+++ b/internal/manifests/collector/poddisruptionbudget.go
@@ -31,8 +31,8 @@ func PodDisruptionBudget(params manifests.Params) (*policyV1.PodDisruptionBudget
 	}
 
 	name := naming.Collector(params.OtelCol.Name)
-	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter)
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/collector/podmonitor.go
+++ b/internal/manifests/collector/podmonitor.go
@@ -82,7 +82,7 @@ func shouldCreatePodMonitor(params manifests.Params) bool {
 	if !params.OtelCol.Spec.Observability.Metrics.EnableMetrics {
 		l.V(2).Info("Metrics disabled for this OTEL Collector. PodMonitor will not ve created")
 		return false
-	} else if params.Config.PrometheusCRAvailability() == prometheus.NotAvailable {
+	} else if params.Config.PrometheusCRAvailability == prometheus.NotAvailable {
 		l.V(2).Info("Cannot enable PodMonitor when prometheus CRDs are unavailable")
 		return false
 	} else if params.OtelCol.Spec.Mode != v1beta1.ModeSidecar {

--- a/internal/manifests/collector/rbac.go
+++ b/internal/manifests/collector/rbac.go
@@ -25,9 +25,9 @@ func ClusterRole(params manifests.Params) (*rbacv1.ClusterRole, error) {
 	}
 
 	name := naming.ClusterRole(params.OtelCol.Name, params.OtelCol.Namespace)
-	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter)
 
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -51,9 +51,9 @@ func ClusterRoleBinding(params manifests.Params) (*rbacv1.ClusterRoleBinding, er
 	}
 
 	name := naming.ClusterRoleBinding(params.OtelCol.Name, params.OtelCol.Namespace)
-	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter)
 
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/collector/route.go
+++ b/internal/manifests/collector/route.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Routes(params manifests.Params) ([]*routev1.Route, error) {
-	if params.OtelCol.Spec.Ingress.Type != v1beta1.IngressTypeRoute || params.Config.OpenShiftRoutesAvailability() != openshift.RoutesAvailable {
+	if params.OtelCol.Spec.Ingress.Type != v1beta1.IngressTypeRoute || params.Config.OpenShiftRoutesAvailability != openshift.RoutesAvailable {
 		return nil, nil
 	}
 

--- a/internal/manifests/collector/service.go
+++ b/internal/manifests/collector/service.go
@@ -67,7 +67,7 @@ func MonitoringService(params manifests.Params) (*corev1.Service, error) {
 	labels[monitoringLabel] = valueExists
 	labels[serviceTypeLabel] = MonitoringServiceType.String()
 
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func ExtensionService(params manifests.Params) (*corev1.Service, error) {
 	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, []string{})
 	labels[serviceTypeLabel] = ExtensionServiceType.String()
 
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func Service(params manifests.Params) (*corev1.Service, error) {
 	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, []string{})
 	labels[serviceTypeLabel] = BaseServiceType.String()
 
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/collector/service_test.go
+++ b/internal/manifests/collector/service_test.go
@@ -520,7 +520,7 @@ func serviceWithInternalTrafficPolicy(name string, ports []v1beta1.PortsSpec, in
 	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, []string{})
 	labels[serviceTypeLabel] = BaseServiceType.String()
 
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return v1.Service{}
 	}

--- a/internal/manifests/collector/serviceaccount.go
+++ b/internal/manifests/collector/serviceaccount.go
@@ -31,7 +31,7 @@ func ServiceAccount(params manifests.Params) (*corev1.ServiceAccount, error) {
 	name := naming.ServiceAccount(params.OtelCol.Name)
 	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, []string{})
 
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/collector/servicemonitor.go
+++ b/internal/manifests/collector/servicemonitor.go
@@ -82,7 +82,7 @@ func shouldCreateServiceMonitor(params manifests.Params) bool {
 	if !params.OtelCol.Spec.Observability.Metrics.EnableMetrics {
 		l.V(2).Info("Metrics disabled for this OTEL Collector. ServiceMonitor will not ve created")
 		return false
-	} else if params.Config.PrometheusCRAvailability() == prometheus.NotAvailable {
+	} else if params.Config.PrometheusCRAvailability == prometheus.NotAvailable {
 		l.V(2).Info("Cannot enable ServiceMonitor when prometheus CRDs are unavailable")
 		return false
 	} else if params.OtelCol.Spec.Mode == v1beta1.ModeSidecar {

--- a/internal/manifests/collector/statefulset.go
+++ b/internal/manifests/collector/statefulset.go
@@ -16,14 +16,14 @@ import (
 // StatefulSet builds the statefulset for the given instance.
 func StatefulSet(params manifests.Params) (*appsv1.StatefulSet, error) {
 	name := naming.Collector(params.OtelCol.Name)
-	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter())
+	labels := manifestutils.Labels(params.OtelCol.ObjectMeta, name, params.OtelCol.Spec.Image, ComponentOpenTelemetryCollector, params.Config.LabelsFilter)
 
-	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter())
+	annotations, err := manifestutils.Annotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}
 
-	podAnnotations, err := manifestutils.PodAnnotations(params.OtelCol, params.Config.AnnotationsFilter())
+	podAnnotations, err := manifestutils.PodAnnotations(params.OtelCol, params.Config.AnnotationsFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manifests/collector/volume.go
+++ b/internal/manifests/collector/volume.go
@@ -25,14 +25,14 @@ func Volumes(cfg config.Config, otelcol v1beta1.OpenTelemetryCollector) []corev1
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
 				Items: []corev1.KeyToPath{{
-					Key:  cfg.CollectorConfigMapEntry(),
-					Path: cfg.CollectorConfigMapEntry(),
+					Key:  cfg.CollectorConfigMapEntry,
+					Path: cfg.CollectorConfigMapEntry,
 				}},
 			},
 		},
 	}}
 
-	if otelcol.Spec.TargetAllocator.Enabled && cfg.CertManagerAvailability() == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
+	if otelcol.Spec.TargetAllocator.Enabled && cfg.CertManagerAvailability == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
 		volumes = append(volumes, corev1.Volume{
 			Name: naming.TAClientCertificate(otelcol.Name),
 			VolumeSource: corev1.VolumeSource{

--- a/internal/manifests/opampbridge/container.go
+++ b/internal/manifests/opampbridge/container.go
@@ -18,7 +18,7 @@ import (
 func Container(cfg config.Config, logger logr.Logger, opampBridge v1alpha1.OpAMPBridge) corev1.Container {
 	image := opampBridge.Spec.Image
 	if len(image) == 0 {
-		image = cfg.OperatorOpAMPBridgeImage()
+		image = cfg.OperatorOpAMPBridgeImage
 	}
 
 	volumeMounts := []corev1.VolumeMount{{

--- a/internal/manifests/opampbridge/deployment.go
+++ b/internal/manifests/opampbridge/deployment.go
@@ -16,13 +16,13 @@ import (
 // Deployment builds the deployment for the given instance.
 func Deployment(params manifests.Params) *appsv1.Deployment {
 	name := naming.OpAMPBridge(params.OpAMPBridge.Name)
-	labels := manifestutils.Labels(params.OpAMPBridge.ObjectMeta, name, params.OpAMPBridge.Spec.Image, ComponentOpAMPBridge, params.Config.LabelsFilter())
+	labels := manifestutils.Labels(params.OpAMPBridge.ObjectMeta, name, params.OpAMPBridge.Spec.Image, ComponentOpAMPBridge, params.Config.LabelsFilter)
 	configMap, err := ConfigMap(params)
 	if err != nil {
 		params.Log.Info("failed to construct OpAMPBridge ConfigMap for annotations")
 		configMap = nil
 	}
-	annotations := Annotations(params.OpAMPBridge, configMap, params.Config.AnnotationsFilter())
+	annotations := Annotations(params.OpAMPBridge, configMap, params.Config.AnnotationsFilter)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,

--- a/internal/manifests/opampbridge/volume.go
+++ b/internal/manifests/opampbridge/volume.go
@@ -20,8 +20,8 @@ func Volumes(cfg config.Config, opampBridge v1alpha1.OpAMPBridge) []corev1.Volum
 				LocalObjectReference: corev1.LocalObjectReference{Name: naming.OpAMPBridgeConfigMap(opampBridge.Name)},
 				Items: []corev1.KeyToPath{
 					{
-						Key:  cfg.OperatorOpAMPBridgeConfigMapEntry(),
-						Path: cfg.OperatorOpAMPBridgeConfigMapEntry(),
+						Key:  cfg.OperatorOpAMPBridgeConfigMapEntry,
+						Path: cfg.OperatorOpAMPBridgeConfigMapEntry,
 					},
 				},
 			},

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -113,7 +113,7 @@ func ConfigMap(params Params) (*corev1.ConfigMap, error) {
 		taConfig["prometheus_cr"] = prometheusCRConfig
 	}
 
-	if params.Config.CertManagerAvailability() == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
+	if params.Config.CertManagerAvailability == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
 		taConfig["https"] = map[string]interface{}{
 			"enabled":            true,
 			"listen_addr":        ":8443",

--- a/internal/manifests/targetallocator/container.go
+++ b/internal/manifests/targetallocator/container.go
@@ -24,7 +24,7 @@ import (
 func Container(cfg config.Config, logger logr.Logger, instance v1alpha1.TargetAllocator) corev1.Container {
 	image := instance.Spec.Image
 	if len(image) == 0 {
-		image = cfg.TargetAllocatorImage()
+		image = cfg.TargetAllocatorImage
 	}
 
 	ports := make([]corev1.ContainerPort, 0)
@@ -119,7 +119,7 @@ func Container(cfg config.Config, logger logr.Logger, instance v1alpha1.TargetAl
 		},
 	}
 
-	if cfg.CertManagerAvailability() == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
+	if cfg.CertManagerAvailability == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
 		ports = append(ports, corev1.ContainerPort{
 			Name:          "https",
 			ContainerPort: 8443,

--- a/internal/manifests/targetallocator/deployment.go
+++ b/internal/manifests/targetallocator/deployment.go
@@ -22,7 +22,7 @@ func Deployment(params Params) (*appsv1.Deployment, error) {
 		params.Log.Info("failed to construct target allocator config map for annotations")
 		configMap = nil
 	}
-	annotations := Annotations(params.TargetAllocator, configMap, params.Config.AnnotationsFilter())
+	annotations := Annotations(params.TargetAllocator, configMap, params.Config.AnnotationsFilter)
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/manifests/targetallocator/poddisruptionbudget.go
+++ b/internal/manifests/targetallocator/poddisruptionbudget.go
@@ -49,7 +49,7 @@ func PodDisruptionBudget(params Params) (*policyV1.PodDisruptionBudget, error) {
 		params.Log.Info("failed to construct target allocator config map for annotations")
 		configMap = nil
 	}
-	annotations := Annotations(params.TargetAllocator, configMap, params.Config.AnnotationsFilter())
+	annotations := Annotations(params.TargetAllocator, configMap, params.Config.AnnotationsFilter)
 
 	objectMeta := metav1.ObjectMeta{
 		Name:        name,

--- a/internal/manifests/targetallocator/service.go
+++ b/internal/manifests/targetallocator/service.go
@@ -25,7 +25,7 @@ func Service(params Params) *corev1.Service {
 		Port:       80,
 		TargetPort: intstr.FromString("http")})
 
-	if params.Config.CertManagerAvailability() == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
+	if params.Config.CertManagerAvailability == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
 		ports = append(ports, corev1.ServicePort{
 			Name:       "targetallocation-https",
 			Port:       443,

--- a/internal/manifests/targetallocator/targetallocator.go
+++ b/internal/manifests/targetallocator/targetallocator.go
@@ -36,7 +36,7 @@ func Build(params Params) ([]client.Object, error) {
 		resourceFactories = append(resourceFactories, manifests.FactoryWithoutError(ServiceMonitor))
 	}
 
-	if params.Config.CertManagerAvailability() == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
+	if params.Config.CertManagerAvailability == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
 		resourceFactories = append(resourceFactories,
 			manifests.FactoryWithoutError(SelfSignedIssuer),
 			manifests.FactoryWithoutError(CACertificate),

--- a/internal/manifests/targetallocator/volume.go
+++ b/internal/manifests/targetallocator/volume.go
@@ -22,14 +22,14 @@ func Volumes(cfg config.Config, instance v1alpha1.TargetAllocator) []corev1.Volu
 				LocalObjectReference: corev1.LocalObjectReference{Name: naming.TAConfigMap(instance.Name)},
 				Items: []corev1.KeyToPath{
 					{
-						Key:  cfg.TargetAllocatorConfigMapEntry(),
-						Path: cfg.TargetAllocatorConfigMapEntry(),
+						Key:  cfg.TargetAllocatorConfigMapEntry,
+						Path: cfg.TargetAllocatorConfigMapEntry,
 					}},
 			},
 		},
 	}}
 
-	if cfg.CertManagerAvailability() == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
+	if cfg.CertManagerAvailability == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {
 		volumes = append(volumes, corev1.Volume{
 			Name: naming.TAServerCertificate(instance.Name),
 			VolumeSource: corev1.VolumeSource{

--- a/main.go
+++ b/main.go
@@ -331,19 +331,19 @@ func main() {
 		setupLog.Error(err, "failed to autodetect config variables")
 	}
 	// Only add these to the scheme if they are available
-	if cfg.PrometheusCRAvailability() == prometheus.Available {
+	if cfg.PrometheusCRAvailability == prometheus.Available {
 		setupLog.Info("Prometheus CRDs are installed, adding to scheme.")
 		utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	} else {
 		setupLog.Info("Prometheus CRDs are not installed, skipping adding to scheme.")
 	}
-	if cfg.OpenShiftRoutesAvailability() == openshift.RoutesAvailable {
+	if cfg.OpenShiftRoutesAvailability == openshift.RoutesAvailable {
 		setupLog.Info("Openshift CRDs are installed, adding to scheme.")
 		utilruntime.Must(routev1.Install(scheme))
 	} else {
 		setupLog.Info("Openshift CRDs are not installed, skipping adding to scheme.")
 	}
-	if cfg.CertManagerAvailability() == certmanager.Available {
+	if cfg.CertManagerAvailability == certmanager.Available {
 		setupLog.Info("Cert-Manager is available to the operator, adding to scheme.")
 		utilruntime.Must(cmv1.AddToScheme(scheme))
 
@@ -353,17 +353,17 @@ func main() {
 	} else {
 		setupLog.Info("Cert-Manager is not available to the operator, skipping adding to scheme.")
 	}
-	if cfg.CollectorAvailability() == collector.Available {
+	if cfg.CollectorAvailability == collector.Available {
 		setupLog.Info("OpenTelemetryCollectorCRDSs are available to the operator")
 	} else {
 		setupLog.Info("OpenTelemetryCollectorCRDSs are not available to the operator")
-		if !cfg.IgnoreMissingCollectorCRDs() {
+		if !cfg.IgnoreMissingCollectorCRDs {
 			setupLog.Error(errors.New("missing OpenTelemetryCollector CRDs"), "The OpenTelemetryCollector CRDs are not present in the cluster. Set ignore_missing_collector_crds to true or install the CRDs in the cluster.")
 			os.Exit(1)
 		}
 	}
-	if cfg.AnnotationsFilter() != nil {
-		for _, basePattern := range cfg.AnnotationsFilter() {
+	if cfg.AnnotationsFilter != nil {
+		for _, basePattern := range cfg.AnnotationsFilter {
 			_, compileErr := regexp.Compile(basePattern)
 			if compileErr != nil {
 				setupLog.Error(compileErr, "could not compile the regexp pattern for Annotations filter")
@@ -371,8 +371,8 @@ func main() {
 		}
 	}
 
-	if cfg.LabelsFilter() != nil {
-		for _, basePattern := range cfg.LabelsFilter() {
+	if cfg.LabelsFilter != nil {
+		for _, basePattern := range cfg.LabelsFilter {
 			_, compileErr := regexp.Compile(basePattern)
 			if compileErr != nil {
 				setupLog.Error(compileErr, "could not compile the regexp pattern for Labels filter")
@@ -387,7 +387,7 @@ func main() {
 	}
 
 	var collectorReconciler *controllers.OpenTelemetryCollectorReconciler
-	if cfg.CollectorAvailability() == collector.Available {
+	if cfg.CollectorAvailability == collector.Available {
 		collectorReconciler = controllers.NewReconciler(controllers.Params{
 			Client:   mgr.GetClient(),
 			Log:      ctrl.Log.WithName("controllers").WithName("OpenTelemetryCollector"),
@@ -404,7 +404,7 @@ func main() {
 		}
 	}
 
-	if cfg.TargetAllocatorAvailability() == targetallocator.Available {
+	if cfg.TargetAllocatorAvailability == targetallocator.Available {
 		if err = controllers.NewTargetAllocatorReconciler(
 			mgr.GetClient(),
 			mgr.GetScheme(),
@@ -428,7 +428,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if cfg.PrometheusCRAvailability() == prometheus.Available && createSMOperatorMetrics {
+	if cfg.PrometheusCRAvailability == prometheus.Available && createSMOperatorMetrics {
 		operatorMetrics, opError := operatormetrics.NewOperatorMetrics(mgr.GetConfig(), scheme, ctrl.Log.WithName("operator-metrics-sm"))
 		if opError != nil {
 			setupLog.Error(opError, "Failed to create the operator metrics SM")
@@ -454,7 +454,7 @@ func main() {
 			}
 		}
 
-		if cfg.CollectorAvailability() == collector.Available {
+		if cfg.CollectorAvailability == collector.Available {
 			bv := func(ctx context.Context, collector otelv1beta1.OpenTelemetryCollector) admission.Warnings {
 				var warnings admission.Warnings
 				params, newErr := collectorReconciler.GetParams(ctx, collector)
@@ -483,7 +483,7 @@ func main() {
 				os.Exit(1)
 			}
 		}
-		if cfg.TargetAllocatorAvailability() == targetallocator.Available {
+		if cfg.TargetAllocatorAvailability == targetallocator.Available {
 			if err = otelv1alpha1.SetupTargetAllocatorWebhook(mgr, cfg, reviewer); err != nil {
 				setupLog.Error(err, "unable to create webhook", "webhook", "TargetAllocator")
 				os.Exit(1)

--- a/pkg/instrumentation/golang.go
+++ b/pkg/instrumentation/golang.go
@@ -29,7 +29,7 @@ func injectGoSDK(goSpec v1alpha1.Go, pod corev1.Pod, cfg config.Config, instSpec
 	// skip instrumentation when more than one container is provided
 	containerNames := ""
 	ok := false
-	if cfg.EnableMultiInstrumentation() {
+	if cfg.EnableMultiInstrumentation {
 		containerNames, ok = pod.Annotations[annotationInjectGoContainersName]
 	} else {
 		containerNames, ok = pod.Annotations[annotationInjectContainerName]

--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -284,7 +284,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 		logger.Error(err, "failed to select an OpenTelemetry Instrumentation instance for this pod")
 		return pod, err
 	}
-	if pm.config.EnableJavaAutoInstrumentation() || inst == nil {
+	if pm.config.EnableJavaAutoInstrumentation || inst == nil {
 		insts.Java.Instrumentation = inst
 	} else {
 		logger.Error(nil, "support for Java auto instrumentation is not enabled")
@@ -296,7 +296,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 		logger.Error(err, "failed to select an OpenTelemetry Instrumentation instance for this pod")
 		return pod, err
 	}
-	if pm.config.EnableNodeJSAutoInstrumentation() || inst == nil {
+	if pm.config.EnableNodeJSAutoInstrumentation || inst == nil {
 		insts.NodeJS.Instrumentation = inst
 	} else {
 		logger.Error(nil, "support for NodeJS auto instrumentation is not enabled")
@@ -308,7 +308,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 		logger.Error(err, "failed to select an OpenTelemetry Instrumentation instance for this pod")
 		return pod, err
 	}
-	if pm.config.EnablePythonAutoInstrumentation() || inst == nil {
+	if pm.config.EnablePythonAutoInstrumentation || inst == nil {
 		insts.Python.Instrumentation = inst
 		insts.Python.AdditionalAnnotations = map[string]string{annotationPythonPlatform: annotationValue(ns.ObjectMeta, pod.ObjectMeta, annotationPythonPlatform)}
 	} else {
@@ -321,7 +321,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 		logger.Error(err, "failed to select an OpenTelemetry Instrumentation instance for this pod")
 		return pod, err
 	}
-	if pm.config.EnableDotNetAutoInstrumentation() || inst == nil {
+	if pm.config.EnableDotNetInstrumentation || inst == nil {
 		insts.DotNet.Instrumentation = inst
 		insts.DotNet.AdditionalAnnotations = map[string]string{annotationDotNetRuntime: annotationValue(ns.ObjectMeta, pod.ObjectMeta, annotationDotNetRuntime)}
 	} else {
@@ -334,7 +334,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 		logger.Error(err, "failed to select an OpenTelemetry Instrumentation instance for this pod")
 		return pod, err
 	}
-	if pm.config.EnableGoAutoInstrumentation() || inst == nil {
+	if pm.config.EnableGoAutoInstrumentation || inst == nil {
 		insts.Go.Instrumentation = inst
 	} else {
 		logger.Error(err, "support for Go auto instrumentation is not enabled")
@@ -346,7 +346,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 		logger.Error(err, "failed to select an OpenTelemetry Instrumentation instance for this pod")
 		return pod, err
 	}
-	if pm.config.EnableApacheHttpdAutoInstrumentation() || inst == nil {
+	if pm.config.EnableApacheHttpdInstrumentation || inst == nil {
 		insts.ApacheHttpd.Instrumentation = inst
 	} else {
 		logger.Error(nil, "support for Apache HTTPD auto instrumentation is not enabled")
@@ -358,7 +358,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 		logger.Error(err, "failed to select an OpenTelemetry Instrumentation instance for this pod")
 		return pod, err
 	}
-	if pm.config.EnableNginxAutoInstrumentation() || inst == nil {
+	if pm.config.EnableNginxAutoInstrumentation || inst == nil {
 		insts.Nginx.Instrumentation = inst
 	} else {
 		logger.Error(nil, "support for Nginx auto instrumentation is not enabled")
@@ -392,7 +392,7 @@ func (pm *instPodMutator) Mutate(ctx context.Context, ns corev1.Namespace, pod c
 	}
 
 	// We retrieve the annotation for podname
-	if pm.config.EnableMultiInstrumentation() {
+	if pm.config.EnableMultiInstrumentation {
 		err = insts.setLanguageSpecificContainers(ns.ObjectMeta, pod.ObjectMeta)
 		if err != nil {
 			return pod, err

--- a/pkg/instrumentation/upgrade/upgrade.go
+++ b/pkg/instrumentation/upgrade/upgrade.go
@@ -38,25 +38,25 @@ type InstrumentationUpgrade struct {
 
 func NewInstrumentationUpgrade(client client.Client, logger logr.Logger, recorder record.EventRecorder, cfg config.Config) *InstrumentationUpgrade {
 	defaultAnnotationToConfig := map[string]autoInstConfig{
-		constants.AnnotationDefaultAutoInstrumentationApacheHttpd: {constants.FlagApacheHttpd, cfg.EnableApacheHttpdAutoInstrumentation()},
-		constants.AnnotationDefaultAutoInstrumentationDotNet:      {constants.FlagDotNet, cfg.EnableDotNetAutoInstrumentation()},
-		constants.AnnotationDefaultAutoInstrumentationGo:          {constants.FlagGo, cfg.EnableGoAutoInstrumentation()},
-		constants.AnnotationDefaultAutoInstrumentationNginx:       {constants.FlagNginx, cfg.EnableNginxAutoInstrumentation()},
-		constants.AnnotationDefaultAutoInstrumentationPython:      {constants.FlagPython, cfg.EnablePythonAutoInstrumentation()},
-		constants.AnnotationDefaultAutoInstrumentationNodeJS:      {constants.FlagNodeJS, cfg.EnableNodeJSAutoInstrumentation()},
-		constants.AnnotationDefaultAutoInstrumentationJava:        {constants.FlagJava, cfg.EnableJavaAutoInstrumentation()},
+		constants.AnnotationDefaultAutoInstrumentationApacheHttpd: {constants.FlagApacheHttpd, cfg.EnableApacheHttpdInstrumentation},
+		constants.AnnotationDefaultAutoInstrumentationDotNet:      {constants.FlagDotNet, cfg.EnableDotNetInstrumentation},
+		constants.AnnotationDefaultAutoInstrumentationGo:          {constants.FlagGo, cfg.EnableGoAutoInstrumentation},
+		constants.AnnotationDefaultAutoInstrumentationNginx:       {constants.FlagNginx, cfg.EnableNginxAutoInstrumentation},
+		constants.AnnotationDefaultAutoInstrumentationPython:      {constants.FlagPython, cfg.EnablePythonAutoInstrumentation},
+		constants.AnnotationDefaultAutoInstrumentationNodeJS:      {constants.FlagNodeJS, cfg.EnableNodeJSAutoInstrumentation},
+		constants.AnnotationDefaultAutoInstrumentationJava:        {constants.FlagJava, cfg.EnableJavaAutoInstrumentation},
 	}
 
 	return &InstrumentationUpgrade{
 		Client:                     client,
 		Logger:                     logger,
-		DefaultAutoInstJava:        cfg.AutoInstrumentationJavaImage(),
-		DefaultAutoInstNodeJS:      cfg.AutoInstrumentationNodeJSImage(),
-		DefaultAutoInstPython:      cfg.AutoInstrumentationPythonImage(),
-		DefaultAutoInstDotNet:      cfg.AutoInstrumentationDotNetImage(),
-		DefaultAutoInstGo:          cfg.AutoInstrumentationGoImage(),
-		DefaultAutoInstApacheHttpd: cfg.AutoInstrumentationApacheHttpdImage(),
-		DefaultAutoInstNginx:       cfg.AutoInstrumentationNginxImage(),
+		DefaultAutoInstJava:        cfg.AutoInstrumentationJavaImage,
+		DefaultAutoInstNodeJS:      cfg.AutoInstrumentationNodeJSImage,
+		DefaultAutoInstPython:      cfg.AutoInstrumentationPythonImage,
+		DefaultAutoInstDotNet:      cfg.AutoInstrumentationDotNetImage,
+		DefaultAutoInstGo:          cfg.AutoInstrumentationGoImage,
+		DefaultAutoInstApacheHttpd: cfg.AutoInstrumentationApacheHttpdImage,
+		DefaultAutoInstNginx:       cfg.AutoInstrumentationNginxImage,
 		Recorder:                   recorder,
 		defaultAnnotationToConfig:  defaultAnnotationToConfig,
 	}


### PR DESCRIPTION
Getters in Go are not particularly recommended. See Effective Go: https://go.dev/doc/effective_go#Getters

This change is an opinionated take removing all Config getters, and using fields instead as exported. Because Config is a struct in an internal package, there is no breaking change in the API since it's not exposed outside the controllers.

This is half of the changes introduced in #3958, with a mechanical change of swapping getters with field access.
