### PR TITLE
fix: same target from two different jobs missing in targetallocator

### DIFF
--- a/cmd/otel-allocator/internal/target/discovery_test.go
+++ b/cmd/otel-allocator/internal/target/discovery_test.go
@@ -6,7 +6,6 @@ package target
 import (
 	"context"
 	"errors"
-	"fmt"
 	"hash"
 	"sort"
 	"testing"
@@ -401,10 +400,6 @@ func TestDiscoveryTargetHashing(t *testing.T) {
 			assert.NoError(t, err)
 
 			gotTargets := <-results
-			fmt.Printf("got %d targets\n", len(gotTargets))
-			for i, target := range gotTargets {
-				fmt.Printf("target %d: %s %s %s %d\n", i, target.JobName, target.TargetURL, target.Labels, target.Hash())
-			}
 
 			// Verify that all targets have different hashes
 			targetHashes := make(map[ItemHash]bool)

--- a/cmd/otel-allocator/internal/target/discovery_test.go
+++ b/cmd/otel-allocator/internal/target/discovery_test.go
@@ -54,6 +54,13 @@ func TestDiscovery(t *testing.T) {
 			},
 			want: []string{"prom.domain:9004", "prom.domain:9005", "promfile.domain:1001", "promfile.domain:3000"},
 		},
+		{
+			name: "same targets in two different jobs",
+			args: args{
+				file: "./testdata/test_target_hash.yaml",
+			},
+			want: []string{"prom.domain:9001", "prom.domain:9001", "prom.domain:9002", "prom.domain:9002", "prom.domain:9003"},
+		},
 	}
 	scu := &mockScrapeConfigUpdater{}
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/cmd/otel-allocator/internal/target/discovery_test.go
+++ b/cmd/otel-allocator/internal/target/discovery_test.go
@@ -6,6 +6,7 @@ package target
 import (
 	"context"
 	"errors"
+	"fmt"
 	"hash"
 	"sort"
 	"testing"
@@ -344,6 +345,77 @@ func TestDiscovery_ScrapeConfigHashing(t *testing.T) {
 				assert.Equal(t, lastValidConfig, scu.mockCfg)
 			}
 
+		})
+	}
+}
+
+func TestDiscoveryTargetHashing(t *testing.T) {
+	type args struct {
+		file string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "same targets in two different jobs",
+			args: args{
+				file: "./testdata/test_target_hash.yaml",
+			},
+		},
+	}
+	scu := &mockScrapeConfigUpdater{}
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	registry := prometheus.NewRegistry()
+	sdMetrics, err := discovery.CreateAndRegisterSDMetrics(registry)
+	require.NoError(t, err)
+	d := discovery.NewManager(ctx, config.NopLogger, registry, sdMetrics)
+	results := make(chan []*Item)
+	manager := NewDiscoverer(ctrl.Log.WithName("test"), d, nil, scu, func(targets []*Item) {
+		var result []*Item
+		for _, t := range targets {
+			result = append(result, t)
+		}
+		results <- result
+	})
+
+	defer func() { manager.Close() }()
+	defer cancelFunc()
+
+	go func() {
+		err := d.Run()
+		assert.Error(t, err)
+	}()
+	go func() {
+		err := manager.Run()
+		assert.NoError(t, err)
+	}()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.CreateDefaultConfig()
+			err := config.LoadFromFile(tt.args.file, &cfg)
+			assert.NoError(t, err)
+			assert.True(t, len(cfg.PromConfig.ScrapeConfigs) > 0)
+			err = manager.ApplyConfig(allocatorWatcher.EventSourcePrometheusCR, cfg.PromConfig.ScrapeConfigs)
+			assert.NoError(t, err)
+
+			gotTargets := <-results
+			fmt.Printf("got %d targets\n", len(gotTargets))
+			for i, target := range gotTargets {
+				fmt.Printf("target %d: %s %s %s %d\n", i, target.JobName, target.TargetURL, target.Labels, target.Hash())
+			}
+
+			// Verify that all targets have different hashes
+			targetHashes := make(map[ItemHash]bool)
+			for _, target := range gotTargets {
+				hash := target.Hash()
+				if _, exists := targetHashes[hash]; exists {
+					t.Errorf("Duplicate hash %d found for target %s (%s)", hash, target.TargetURL, target.JobName)
+				}
+				targetHashes[hash] = true
+			}
+			assert.Equal(t, len(gotTargets), len(targetHashes), "Number of unique hashes should match number of targets")
 		})
 	}
 }

--- a/cmd/otel-allocator/internal/target/target.go
+++ b/cmd/otel-allocator/internal/target/target.go
@@ -4,6 +4,7 @@
 package target
 
 import (
+	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/prometheus/model/labels"
 )
 
@@ -33,7 +34,7 @@ type Item struct {
 
 func (t *Item) Hash() ItemHash {
 	if t.hash == 0 {
-		t.hash = ItemHash(t.Labels.Hash())
+		t.hash = ItemHash(LabelsHashWithJobName(t.Labels, t.JobName))
 	}
 	return t.hash
 }
@@ -63,4 +64,42 @@ func NewItem(jobName string, targetURL string, labels labels.Labels, collectorNa
 		Labels:        labels,
 		CollectorName: collectorName,
 	}
+}
+
+// LabelsHashWithJobName computes a hash of the labels and the job name.
+// Same logic as Prometheus labels.Hash: https://github.com/prometheus/prometheus/blob/8fd46f74aa0155e4d5aa30654f9c02e564e03743/model/labels/labels.go#L72
+// but adds in the job name since this is not in the labelset from the discovery manager.
+// The scrape manager adds it later. Address is already included in the labels, so it is not needed here.
+func LabelsHashWithJobName(ls labels.Labels, jobName string) uint64 {
+	var sep byte = '\xff'
+	var seps = []byte{sep}
+
+	// Use xxhash.Sum64(b) for fast path as it's faster.
+	b := make([]byte, 0, 1024)
+
+	// Differs from Prometheus implementation by adding job name.
+	b = append(b, jobName...)
+	b = append(b, sep)
+
+	for i, v := range ls {
+		if len(b)+len(v.Name)+len(v.Value)+2 >= cap(b) {
+			// If labels entry is 1KB+ do not allocate whole entry.
+			h := xxhash.New()
+			_, _ = h.Write(b)
+			for _, v := range ls[i:] {
+				_, _ = h.WriteString(v.Name)
+				_, _ = h.Write(seps)
+				_, _ = h.WriteString(v.Value)
+				_, _ = h.Write(seps)
+			}
+			return h.Sum64()
+		}
+
+		b = append(b, v.Name...)
+		b = append(b, sep)
+		b = append(b, v.Value...)
+		b = append(b, sep)
+	}
+
+	return xxhash.Sum64(b)
 }

--- a/cmd/otel-allocator/internal/target/testdata/test_target_hash.yaml
+++ b/cmd/otel-allocator/internal/target/testdata/test_target_hash.yaml
@@ -1,0 +1,14 @@
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/instance: default.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+config:
+  scrape_configs:
+  - job_name: prometheus
+    metrics_path: /metrics
+    static_configs:
+    - targets: ["prom.domain:9001", "prom.domain:9002", "prom.domain:9003"]
+  - job_name: prometheus2
+    metrics_path: /metrics2
+    static_configs:
+    - targets: ["prom.domain:9001", "prom.domain:9002"]

--- a/go.mod
+++ b/go.mod
@@ -227,6 +227,7 @@ require (
 )
 
 require (
+	github.com/cespare/xxhash v1.1.0
 	github.com/goccy/go-yaml v1.17.1
 	go.opentelemetry.io/contrib/otelconf v0.15.0
 )

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7r
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
+github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -73,6 +75,8 @@ github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7
 github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cert-manager/cert-manager v1.17.1 h1:Aig+lWMoLsmpGd9TOlTvO4t0Ah3D+/vGB37x/f+ZKt0=
 github.com/cert-manager/cert-manager v1.17.1/go.mod h1:zeG4D+AdzqA7hFMNpYCJgcQ2VOfFNBa+Jzm3kAwiDU4=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
+github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -493,6 +497,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Use the Prometheus labels hash logic, but add in the job name to the hash as well. As discussed in the issue below, this is a temporary solution to have the same behavior by re-using the Prometheus code until we decide on a final implementation.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #4044

**Testing:** Added a unit test for this scenario. Added a test that fails with the current code and passes with the changes in this PR.

**Documentation:** None, this is returning to previous behavior.
