### PR TITLE
[manager] Do not register the opampbridge webhook if the CRD is not present

### DIFF
--- a/.chloggen/fix_opampbridge.yaml
+++ b/.chloggen/fix_opampbridge.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: opampbridge
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not register the opampbridge webhook if the CRD is not present
+
+# One or more tracking issues related to the change
+issues: [4070]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/autodetect/main_test.go
+++ b/internal/autodetect/main_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/autodetectutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/opampbridge"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
@@ -372,6 +373,9 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 		TargetAllocatorAvailabilityFunc: func() (targetallocator.Availability, error) {
 			return targetallocator.Available, nil
 		},
+		OpAmpBridgeAvailabilityFunc: func() (opampbridge.Availability, error) {
+			return opampbridge.Available, nil
+		},
 	}
 	cfg := config.New()
 
@@ -381,6 +385,7 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 	require.Equal(t, autoRBAC.NotAvailable, cfg.CreateRBACPermissions)
 	require.Equal(t, certmanager.NotAvailable, cfg.CertManagerAvailability)
 	require.Equal(t, targetallocator.NotAvailable, cfg.TargetAllocatorAvailability)
+	require.Equal(t, opampbridge.NotAvailable, cfg.OpAmpBridgeAvailability)
 
 	// test
 	err := autodetect.ApplyAutoDetect(mock, &cfg, ctrl.Log.WithName("test"))
@@ -392,6 +397,7 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 	require.Equal(t, autoRBAC.Available, cfg.CreateRBACPermissions)
 	require.Equal(t, certmanager.Available, cfg.CertManagerAvailability)
 	require.Equal(t, targetallocator.Available, cfg.TargetAllocatorAvailability)
+	require.Equal(t, opampbridge.Available, cfg.OpAmpBridgeAvailability)
 }
 
 var _ autodetect.AutoDetect = (*mockAutoDetect)(nil)
@@ -403,6 +409,14 @@ type mockAutoDetect struct {
 	CertManagerAvailabilityFunc     func(ctx context.Context) (certmanager.Availability, error)
 	TargetAllocatorAvailabilityFunc func() (targetallocator.Availability, error)
 	CollectorAvailabilityFunc       func() (collector.Availability, error)
+	OpAmpBridgeAvailabilityFunc     func() (opampbridge.Availability, error)
+}
+
+func (m *mockAutoDetect) OpAmpBridgeAvailablity() (opampbridge.Availability, error) {
+	if m.OpAmpBridgeAvailabilityFunc != nil {
+		return m.OpAmpBridgeAvailabilityFunc()
+	}
+	return opampbridge.NotAvailable, nil
 }
 
 func (m *mockAutoDetect) CollectorAvailability() (collector.Availability, error) {

--- a/internal/autodetect/opampbridge/operator.go
+++ b/internal/autodetect/opampbridge/operator.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package opampbridge
+
+// Availability represents that the OpAmpBridge CR is available in the cluster.
+type Availability int
+
+const (
+	// NotAvailable OpAmpBridge CR is not available in the cluster.
+	NotAvailable Availability = iota
+
+	// Available OpAmpBridge CR is available in the cluster.
+	Available
+)
+
+func (p Availability) String() string {
+	return [...]string{"NotAvailable", "Available"}[p]
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/opampbridge"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
@@ -81,6 +82,8 @@ type Config struct {
 	TargetAllocatorAvailability targetallocator.Availability
 	// CollectorAvailability represents the availability of the OpenTelemetryCollector CRD.
 	CollectorAvailability collector.Availability
+	// OpAmpBridgeAvailability represents the availability of the OpAmpBridge CRD.
+	OpAmpBridgeAvailability opampbridge.Availability
 	// IgnoreMissingCollectorCRDs is true if the operator can ignore missing OpenTelemetryCollector CRDs.
 	IgnoreMissingCollectorCRDs bool
 	// LabelsFilter Returns the filters converted to regex strings used to filter out unwanted labels from propagations.
@@ -99,6 +102,7 @@ func New(opts ...Option) Config {
 		certManagerAvailability:           certmanager.NotAvailable,
 		targetAllocatorAvailability:       targetallocator.NotAvailable,
 		collectorAvailability:             collector.NotAvailable,
+		opAmpBridgeAvailability:           opampbridge.NotAvailable,
 		collectorConfigMapEntry:           defaultCollectorConfigMapEntry,
 		targetAllocatorConfigMapEntry:     defaultTargetAllocatorConfigMapEntry,
 		operatorOpAMPBridgeConfigMapEntry: defaultOperatorOpAMPBridgeConfigMapEntry,
@@ -129,6 +133,7 @@ func New(opts ...Option) Config {
 		OperatorOpAMPBridgeConfigMapEntry:   o.operatorOpAMPBridgeConfigMapEntry,
 		logger:                              o.logger,
 		OpenShiftRoutesAvailability:         o.openshiftRoutesAvailability,
+		OpAmpBridgeAvailability:             o.opAmpBridgeAvailability,
 		PrometheusCRAvailability:            o.prometheusCRAvailability,
 		CertManagerAvailability:             o.certManagerAvailability,
 		TargetAllocatorAvailability:         o.targetAllocatorAvailability,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/opampbridge"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
@@ -58,6 +59,9 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 		CollectorAvailabilityFunc: func() (collector.Availability, error) {
 			return collector.Available, nil
 		},
+		OpAmpBridgeAvailabilityFunc: func() (opampbridge.Availability, error) {
+			return opampbridge.Available, nil
+		},
 	}
 	cfg := config.New()
 
@@ -68,6 +72,7 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 	require.Equal(t, certmanager.NotAvailable, cfg.CertManagerAvailability)
 	require.Equal(t, targetallocator.NotAvailable, cfg.TargetAllocatorAvailability)
 	require.Equal(t, collector.NotAvailable, cfg.CollectorAvailability)
+	require.Equal(t, opampbridge.NotAvailable, cfg.OpAmpBridgeAvailability)
 
 	// test
 	require.NoError(t, autodetect.ApplyAutoDetect(mock, &cfg, logr.Discard()))
@@ -78,6 +83,7 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 	require.Equal(t, rbac.Available, cfg.CreateRBACPermissions)
 	require.Equal(t, certmanager.Available, cfg.CertManagerAvailability)
 	require.Equal(t, targetallocator.Available, cfg.TargetAllocatorAvailability)
+	require.Equal(t, opampbridge.Available, cfg.OpAmpBridgeAvailability)
 }
 
 var _ autodetect.AutoDetect = (*mockAutoDetect)(nil)
@@ -89,6 +95,14 @@ type mockAutoDetect struct {
 	CertManagerAvailabilityFunc     func(ctx context.Context) (certmanager.Availability, error)
 	TargetAllocatorAvailabilityFunc func() (targetallocator.Availability, error)
 	CollectorAvailabilityFunc       func() (collector.Availability, error)
+	OpAmpBridgeAvailabilityFunc     func() (opampbridge.Availability, error)
+}
+
+func (m *mockAutoDetect) OpAmpBridgeAvailablity() (opampbridge.Availability, error) {
+	if m.OpAmpBridgeAvailabilityFunc != nil {
+		return m.OpAmpBridgeAvailabilityFunc()
+	}
+	return opampbridge.NotAvailable, nil
 }
 
 func (m *mockAutoDetect) FIPSEnabled(_ context.Context) bool {

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/opampbridge"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
@@ -49,6 +50,7 @@ type options struct {
 	certManagerAvailability             certmanager.Availability
 	targetAllocatorAvailability         targetallocator.Availability
 	collectorAvailability               collector.Availability
+	opAmpBridgeAvailability             opampbridge.Availability
 	ignoreMissingCollectorCRDs          bool
 	labelsFilter                        []string
 	annotationsFilter                   []string

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/opampbridge"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
@@ -94,6 +95,7 @@ type mockAutoDetect struct {
 	CertManagerAvailabilityFunc     func(ctx context.Context) (certmanager.Availability, error)
 	TargetAllocatorAvailabilityFunc func() (targetallocator.Availability, error)
 	CollectorCRDAvailabilityFunc    func() (collector.Availability, error)
+	OpAmpBridgeAvailabilityFunc     func() (opampbridge.Availability, error)
 }
 
 func (m *mockAutoDetect) FIPSEnabled(_ context.Context) bool {
@@ -140,6 +142,13 @@ func (m *mockAutoDetect) CollectorAvailability() (collector.Availability, error)
 		return m.CollectorCRDAvailabilityFunc()
 	}
 	return collector.Available, nil
+}
+
+func (m *mockAutoDetect) OpAmpBridgeAvailablity() (opampbridge.Availability, error) {
+	if m.OpAmpBridgeAvailabilityFunc != nil {
+		return m.OpAmpBridgeAvailabilityFunc()
+	}
+	return opampbridge.NotAvailable, nil
 }
 
 func TestMain(m *testing.M) {

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/opampbridge"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/targetallocator"
@@ -502,9 +503,11 @@ func main() {
 				}),
 		})
 
-		if err = otelv1alpha1.SetupOpAMPBridgeWebhook(mgr, cfg); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpAMPBridge")
-			os.Exit(1)
+		if cfg.OpAmpBridgeAvailability == opampbridge.Available {
+			if err = otelv1alpha1.SetupOpAMPBridgeWebhook(mgr, cfg); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "OpAMPBridge")
+				os.Exit(1)
+			}
 		}
 	} else {
 		ctrl.Log.Info("Webhooks are disabled, operator is running an unsupported mode", "ENABLE_WEBHOOKS", "false")


### PR DESCRIPTION
**Description:**
Check for CRD presence ; if absent, do not register the webhook.
