### PR TITLE
Run E2E tests on instrumentation images built from the PR branch

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -65,6 +65,7 @@ jobs:
          - e2e
          - e2e-automatic-rbac
          - e2e-autoscale
+         - e2e-instrumentation-default
          - e2e-instrumentation
          - e2e-opampbridge
          - e2e-pdb
@@ -72,15 +73,20 @@ jobs:
          - e2e-targetallocator
          - e2e-targetallocator-cr
          - e2e-upgrade
+         - e2e-multi-instrumentation-default
          - e2e-multi-instrumentation
          - e2e-metadata-filters
          - e2e-ta-collector-mtls
          - e2e-crd-validations
        include:
+         - group: e2e-instrumentation-default
+           setup: "add-instrumentation-params prepare-e2e"
          - group: e2e-instrumentation
+           setup: "add-instrumentation-params add-instrumentation-images prepare-e2e"
+         - group: e2e-multi-instrumentation-default
            setup: "add-instrumentation-params prepare-e2e"
          - group: e2e-multi-instrumentation
-           setup: "add-instrumentation-params prepare-e2e"
+           setup: "add-instrumentation-params add-instrumentation-images prepare-e2e"
          - group: e2e-metadata-filters
            setup: "add-operator-arg OPERATOR_ARG='--annotations-filter=.*filter.out --annotations-filter=config.*.gke.io.* --labels-filter=.*filter.out' prepare-e2e"
          - group: e2e-ta-collector-mtls


### PR DESCRIPTION
**Description:**

Run E2E instrumentation tests on images built from the PR branch. This includes:

* Changing the names of existing instrumentation version variables in the Makefile. These now get a DEFAULT_ prefix.
* Adding variables and make targets for building instrumentation images locally.
* The ability to load these images into a kind cluster.
* Make targets to allow running these tests in our E2E test matrix.

Right now, the instrumentation images are added to the image archive used by E2E tests, but are not built by default locally.

**Link to tracking Issue(s):**

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/4034

