### PR TITLE
fix: target allocation unstable starting in v0.121

### DIFF
--- a/.chloggen/fix-4082.yaml
+++ b/.chloggen/fix-4082.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: ensure stable iteration order of target labels when generating hash
+
+# One or more tracking issues related to the change
+issues: [4082]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**
Ensure stable iteration order of target labels when generating hash.

- Resolves: #4082 

**Testing:**
Added a test to ensure stable iteration order of target labels during discovery.

**Documentation:**
None. Returning to previous behavior.