### PR TITLE
Enable usetesting and containedctx linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,11 +54,11 @@ linters:
         - -ST1019 # FIXME Importing the same package multiple times
         - -ST1023 # FIXME Redundant type in variable declaration
   enable:
+    - containedctx
     - depguard
     - errcheck
     - errorlint
     - exhaustive
-    - containedctx
     - godot
     - goheader
     - gosec

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -58,6 +58,7 @@ linters:
     - errcheck
     - errorlint
     - exhaustive
+    - containedctx
     - godot
     - goheader
     - gosec
@@ -65,6 +66,7 @@ linters:
     - ineffassign
     - misspell
     - staticcheck
+    - usetesting
     - unparam
     - unused
   exclusions:

--- a/autoinstrumentation/nodejs/package.json
+++ b/autoinstrumentation/nodejs/package.json
@@ -13,6 +13,6 @@
     },
     "dependencies": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/auto-instrumentations-node": "0.58.1"
+        "@opentelemetry/auto-instrumentations-node": "0.60.1"
     }
 }

--- a/cmd/operator-opamp-bridge/internal/agent/agent_test.go
+++ b/cmd/operator-opamp-bridge/internal/agent/agent_test.go
@@ -261,7 +261,6 @@ func TestAgent_getHealth(t *testing.T) {
 		configFile string
 	}
 	type args struct {
-		ctx context.Context
 		// List of mappings from namespace/name to a config file, tests are run in order of list
 		configs []map[string]string
 		healths map[uuid.UUID]*protobufs.ComponentHealth
@@ -280,7 +279,6 @@ func TestAgent_getHealth(t *testing.T) {
 				configFile: agentTestFileName,
 			},
 			args: args{
-				ctx:     context.Background(),
 				configs: nil,
 				podList: mockPodList,
 				healths: map[uuid.UUID]*protobufs.ComponentHealth{},
@@ -302,7 +300,6 @@ func TestAgent_getHealth(t *testing.T) {
 				configFile: agentTestFileName,
 			},
 			args: args{
-				ctx: context.Background(),
 				configs: []map[string]string{
 					{
 						testCollectorKey: collectorBasicFile,
@@ -346,7 +343,6 @@ func TestAgent_getHealth(t *testing.T) {
 				configFile: agentTestFileName,
 			},
 			args: args{
-				ctx: context.Background(),
 				configs: []map[string]string{
 					{
 						testCollectorKey:  collectorBasicFile,
@@ -388,7 +384,6 @@ func TestAgent_getHealth(t *testing.T) {
 				configFile: agentTestFileName,
 			},
 			args: args{
-				ctx: context.Background(),
 				configs: []map[string]string{
 					{
 						thirdCollectorKey: collectorBasicFile,
@@ -428,7 +423,6 @@ func TestAgent_getHealth(t *testing.T) {
 				configFile: agentTestFileName,
 			},
 			args: args{
-				ctx: context.Background(),
 				configs: []map[string]string{
 					{
 						thirdCollectorKey: collectorBasicFile,
@@ -485,11 +479,12 @@ func TestAgent_getHealth(t *testing.T) {
 			}
 
 			for i, configMap := range tt.args.configs {
+				ctx := context.Background()
 				var data *types.MessageData
 				data, err := getMessageDataFromConfigFile(configMap)
 				require.NoError(t, err, "should be able to load data")
-				agent.onMessage(tt.args.ctx, data)
-				effectiveConfig, err := agent.getEffectiveConfig(tt.args.ctx)
+				agent.onMessage(ctx, data)
+				effectiveConfig, err := agent.getEffectiveConfig(ctx)
 				require.NoError(t, err, "should be able to get effective config")
 				// We should only expect this to happen if we supply configuration
 				assert.Equal(t, effectiveConfig, mockClient.lastEffectiveConfig, "client's config should be updated")

--- a/internal/operator-metrics/metrics_test.go
+++ b/internal/operator-metrics/metrics_test.go
@@ -35,9 +35,8 @@ func TestNewOperatorMetrics(t *testing.T) {
 }
 
 func TestOperatorMetrics_Start(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "namespace")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "namespace")
 	require.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
 
 	_, err = tmpFile.WriteString("test-namespace")
 	require.NoError(t, err)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

I added 2 linter, usetesting and containedctx, to golangci-lint configuration. These can diagnose common Go bad practice in codes.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #issue-number

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
