### PR TITLE
Fix flaky reconcile tests

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -34,6 +34,8 @@ jobs:
       run: make install-tools
 
     - name: "basic checks"
+      env:
+        KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: "true"  # Get control plane output in case of envtest errors
       run: make ci
 
   lint:

--- a/Makefile
+++ b/Makefile
@@ -611,7 +611,7 @@ CHAINSAW_VERSION ?= v0.2.12
 GOTESTSUM_VERSION ?= v1.12.2
 
 .PHONY: install-tools
-install-tools: kustomize golangci-lint kind controller-gen envtest crdoc kind operator-sdk chainsaw
+install-tools: kustomize golangci-lint kind controller-gen envtest crdoc operator-sdk chainsaw gotestsum
 
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.

--- a/internal/controllers/reconcile_test.go
+++ b/internal/controllers/reconcile_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -711,8 +712,7 @@ func TestOpenTelemetryCollectorReconciler_RemoveDisabled(t *testing.T) {
 	expectedStartingResourceCount := 7
 	startingCollector := &v1beta1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "placeholder",
-			Namespace: metav1.NamespaceDefault,
+			Name: "placeholder",
 		},
 		Spec: v1beta1.OpenTelemetryCollectorSpec{
 			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
@@ -803,12 +803,19 @@ func TestOpenTelemetryCollectorReconciler_RemoveDisabled(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			namespace, err := createRandomNamespace(k8sClient)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				delErr := k8sClient.Delete(context.Background(), namespace)
+				assert.NoError(t, delErr)
+			})
 			collectorName := sanitizeResourceName(tc.name)
 			collector := startingCollector.DeepCopy()
 			collector.Name = collectorName
+			collector.Namespace = namespace.Name
 			nsn := types.NamespacedName{Name: collector.Name, Namespace: collector.Namespace}
 			clientCtx := context.Background()
-			err := k8sClient.Create(clientCtx, collector)
+			err = k8sClient.Create(clientCtx, collector)
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				deleteErr := k8sClient.Delete(clientCtx, collector)
@@ -1561,4 +1568,19 @@ func sanitizeResourceName(name string) string {
 	re := regexp.MustCompile("[^a-z0-9-]")
 	sanitized = re.ReplaceAllString(sanitized, "-")
 	return sanitized
+}
+
+func createRandomNamespace(k8sClient client.Client) (*v1.Namespace, error) {
+	name := uuid.NewString()
+	namespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	err := k8sClient.Create(context.Background(), namespace)
+	if err != nil {
+		return nil, err
+	}
+	return namespace, nil
 }


### PR DESCRIPTION
`TestOpenTelemetryCollectorReconciler_RemoveDisabled` is the source of most of our flaky failures. This change attempts to fix it, as well as the upgrade test. I'm not actually sure what the root cause of the failures is, but the generic improvement I made in this PR appears to have fixed it. I've restarted the CI tests over 10 times and haven't gotten a failure.

I've also added `gotestsum` to the tools list in the Makefile.