### PR TITLE
Update the operator metrics test to pass for the Helm Chart

### DIFF
--- a/tests/e2e/operator-metrics/chainsaw-test.yaml
+++ b/tests/e2e/operator-metrics/chainsaw-test.yaml
@@ -12,7 +12,6 @@ spec:
             - get
             - pods
             - -A
-            - -l control-plane=controller-manager
             - -l app.kubernetes.io/name=opentelemetry-operator
             - -o 
             - jsonpath={.items[0].metadata.namespace}
@@ -32,7 +31,7 @@ spec:
               - -n
               - $otelnamespace
               - -l
-              - control-plane=controller-manager
+              - app.kubernetes.io/name=opentelemetry-operator
               - -o
               - jsonpath={.items[0].metadata.name}
             outputs:


### PR DESCRIPTION
The operator Helm Chart runs the operator e2e tests in its CI. However, it uses different labels for the operator Pod, and the test fails. Relax the label selector we use in the operator metrics test so it can pass with the default Helm Chart installation.

See https://github.com/open-telemetry/opentelemetry-helm-charts/pull/1728 for an example of the failure.

