### PR TITLE
[chore] Add clarifying note for NGINX in versions.txt

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -41,5 +41,6 @@ autoinstrumentation-go=v0.21.0
 autoinstrumentation-apache-httpd=1.0.4
 
 # Represents the current release of Apache Nginx instrumentation.
+# Intentionally uses the same image and version as Apache HTTPD.
 # Should match autoinstrumentation/apache-httpd/version.txt
 autoinstrumentation-nginx=1.0.4


### PR DESCRIPTION
This question keeps coming up. Whether NGINX referencing the Apache image is a mistake. It’s intentional, so I’m adding a small comment to clarify this for future readers and avoid confusion.