### PR TITLE
Remove operator.observability.prometheus feature gate flag from OpenShift bundle and remove feature flag references.

### DIFF
--- a/.chloggen/remove_invalid_featuregate_refs.yaml
+++ b/.chloggen/remove_invalid_featuregate_refs.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove invalid `operator.observability.prometheus` feature flag references
+
+# One or more tracking issues related to the change
+issues: [4159]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Fixed operator installation failure caused by references to the non-existent `operator.observability.prometheus` feature flag.
+  Removed the flag from the bundle and cleaned up API and documentation references.

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -522,7 +522,6 @@ type PodDisruptionBudgetSpec struct {
 // MetricsConfigSpec defines a metrics config.
 type MetricsConfigSpec struct {
 	// EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.
-	// The operator.observability.prometheus feature gate must be enabled to use this feature.
 	//
 	// +optional
 	// +kubebuilder:validation:Optional

--- a/apis/v1beta1/opentelemetrycollector_types.go
+++ b/apis/v1beta1/opentelemetrycollector_types.go
@@ -280,7 +280,6 @@ type ObservabilitySpec struct {
 // MetricsConfigSpec defines a metrics config.
 type MetricsConfigSpec struct {
 	// EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.
-	// The operator.observability.prometheus feature gate must be enabled to use this feature.
 	//
 	// +optional
 	// +kubebuilder:validation:Optional

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -174,8 +174,6 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: ObservabilitySpec defines how telemetry data gets handled.
@@ -186,8 +184,6 @@ spec:
         path: targetAllocator.observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: targetAllocator.observability.metrics.enableMetrics
       version: v1alpha1
@@ -224,8 +220,6 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: ObservabilitySpec defines how telemetry data gets handled.
@@ -236,8 +230,6 @@ spec:
         path: targetAllocator.observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: targetAllocator.observability.metrics.enableMetrics
       version: v1beta1
@@ -276,14 +268,10 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       version: v1alpha1

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -174,8 +174,6 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: ObservabilitySpec defines how telemetry data gets handled.
@@ -186,8 +184,6 @@ spec:
         path: targetAllocator.observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: targetAllocator.observability.metrics.enableMetrics
       version: v1alpha1
@@ -224,8 +220,6 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: ObservabilitySpec defines how telemetry data gets handled.
@@ -236,8 +230,6 @@ spec:
         path: targetAllocator.observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: targetAllocator.observability.metrics.enableMetrics
       version: v1beta1
@@ -276,14 +268,10 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       version: v1alpha1
@@ -527,7 +515,6 @@ spec:
                 - --enable-nginx-instrumentation=true
                 - --enable-go-instrumentation=true
                 - --openshift-create-dashboard=true
-                - --feature-gates=+operator.observability.prometheus
                 - --enable-cr-metrics=true
                 - --create-sm-operator-metrics=true
                 env:

--- a/config/manifests/community/bases/opentelemetry-operator.clusterserviceversion.yaml
+++ b/config/manifests/community/bases/opentelemetry-operator.clusterserviceversion.yaml
@@ -56,8 +56,6 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: ObservabilitySpec defines how telemetry data gets handled.
@@ -68,8 +66,6 @@ spec:
         path: targetAllocator.observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: targetAllocator.observability.metrics.enableMetrics
       version: v1beta1
@@ -136,8 +132,6 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: ObservabilitySpec defines how telemetry data gets handled.
@@ -148,8 +142,6 @@ spec:
         path: targetAllocator.observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: targetAllocator.observability.metrics.enableMetrics
       version: v1alpha1
@@ -188,14 +180,10 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       version: v1alpha1

--- a/config/manifests/openshift/bases/opentelemetry-operator.clusterserviceversion.yaml
+++ b/config/manifests/openshift/bases/opentelemetry-operator.clusterserviceversion.yaml
@@ -56,8 +56,6 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: ObservabilitySpec defines how telemetry data gets handled.
@@ -68,8 +66,6 @@ spec:
         path: targetAllocator.observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: targetAllocator.observability.metrics.enableMetrics
       version: v1beta1
@@ -136,8 +132,6 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: ObservabilitySpec defines how telemetry data gets handled.
@@ -148,8 +142,6 @@ spec:
         path: targetAllocator.observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: targetAllocator.observability.metrics.enableMetrics
       version: v1alpha1
@@ -188,14 +180,10 @@ spec:
         path: observability.metrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       - description: EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar
           mode) should be created for the service managed by the OpenTelemetry Operator.
-          The operator.observability.prometheus feature gate must be enabled to use
-          this feature.
         displayName: Create ServiceMonitors for OpenTelemetry Collector
         path: observability.metrics.enableMetrics
       version: v1alpha1

--- a/config/overlays/openshift/manager-patch.yaml
+++ b/config/overlays/openshift/manager-patch.yaml
@@ -8,6 +8,5 @@
     - --enable-nginx-instrumentation=true
     - '--enable-go-instrumentation=true'
     - '--openshift-create-dashboard=true'
-    - '--feature-gates=+operator.observability.prometheus'
     - '--enable-cr-metrics=true'
     - '--create-sm-operator-metrics=true'

--- a/docs/api/opentelemetrycollectors.md
+++ b/docs/api/opentelemetrycollectors.md
@@ -9789,8 +9789,7 @@ Metrics defines the metrics configuration for operands.
         <td><b>enableMetrics</b></td>
         <td>boolean</td>
         <td>
-          EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.
-The operator.observability.prometheus feature gate must be enabled to use this feature.<br/>
+          EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -12969,8 +12968,7 @@ Metrics defines the metrics configuration for operands.
         <td><b>enableMetrics</b></td>
         <td>boolean</td>
         <td>
-          EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.
-The operator.observability.prometheus feature gate must be enabled to use this feature.<br/>
+          EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -29416,8 +29414,7 @@ Metrics defines the metrics configuration for operands.
         <td><b>enableMetrics</b></td>
         <td>boolean</td>
         <td>
-          EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.
-The operator.observability.prometheus feature gate must be enabled to use this feature.<br/>
+          EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -32826,8 +32823,7 @@ Metrics defines the metrics configuration for operands.
         <td><b>enableMetrics</b></td>
         <td>boolean</td>
         <td>
-          EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.
-The operator.observability.prometheus feature gate must be enabled to use this feature.<br/>
+          EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/docs/api/targetallocators.md
+++ b/docs/api/targetallocators.md
@@ -8811,8 +8811,7 @@ Metrics defines the metrics configuration for operands.
         <td><b>enableMetrics</b></td>
         <td>boolean</td>
         <td>
-          EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.
-The operator.observability.prometheus feature gate must be enabled to use this feature.<br/>
+          EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.<br/>
         </td>
         <td>false</td>
       </tr></tbody>


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The PR fixes the failing operator install due to the operator.observability.prometheus feature flag by removing the flag from the bundle and remove the references for the flag from API and docs. 

```
% operator-sdk run bundle --timeout=5m --security-context-config=restricted quay.io/rhn_support_ikanse/opentelemetry-operator-bundle:latest
INFO[0034] Creating a File-Based Catalog of the bundle "quay.io/rhn_support_ikanse/opentelemetry-operator-bundle:latest" 
INFO[0038] Generated a valid File-Based Catalog         
INFO[0044] Created registry pod: quay-io-rhn-support-ikanse-opentelemetry-operator-bundle-latest 
INFO[0044] Created CatalogSource: opentelemetry-operator-catalog 
INFO[0045] OperatorGroup "operator-sdk-og" created      
INFO[0045] Created Subscription: opentelemetry-operator-v0-127-0-sub 
INFO[0054] Approved InstallPlan install-slw9n for the Subscription: opentelemetry-operator-v0-127-0-sub 
INFO[0054] Waiting for ClusterServiceVersion "opentelemetry-operator/opentelemetry-operator.v0.127.0" to reach 'Succeeded' phase 
INFO[0055]   Found ClusterServiceVersion "opentelemetry-operator/opentelemetry-operator.v0.127.0" phase: Pending 
INFO[0059]   Found ClusterServiceVersion "opentelemetry-operator/opentelemetry-operator.v0.127.0" phase: InstallReady 
INFO[0062]   Found ClusterServiceVersion "opentelemetry-operator/opentelemetry-operator.v0.127.0" phase: Installing 
FATA[0300] Failed to run bundle: error waiting for CSV to install: deployment opentelemetry-operator-controller-manager has error: client rate limiter Wait returned an error: context deadline exceeded
 
% oc get pods
NAME                                                              READY   STATUS             RESTARTS       AGE
956e1ffe92f9de63e94e5826eb2fa5226746e0eb0906770b6786d5447dhdqr4   0/1     Completed          0              5m23s
opentelemetry-operator-controller-manager-58b478b59-8n9kq         1/2     CrashLoopBackOff   5 (2m9s ago)   5m10s
quay-io-rhn-support-ikanse-opentelemetry-operator-bundle-latest   1/1     Running            0              5m29s

% oc logs opentelemetry-operator-controller-manager-58b478b59-8n9kq
Defaulted container "manager" out of: manager, kube-rbac-proxy
panic: invalid argument "+operator.observability.prometheus" for "--feature-gates" flag: no such feature gate "operator.observability.prometheus". valid gates: [operator.collector.default.config operator.collector.targetallocatorcr operator.golang.flags operator.sidecarcontainers.native operator.targetallocator.fallbackstrategy operator.targetallocator.mtls]

goroutine 1 [running]:
main.main()
	/Users/ikanse/opentelemetry-operator/main.go:92 +0x35ce

```

Resolves https://github.com/open-telemetry/opentelemetry-operator/issues/4159