### PR TITLE
Build Python E2E test app with Python 3.9

### DIFF
--- a/.github/workflows/publish-test-e2e-images.yaml
+++ b/.github/workflows/publish-test-e2e-images.yaml
@@ -28,10 +28,17 @@ jobs:
     with:
       path: golang
       platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
-  python:
+  python-latest:
     uses: ./.github/workflows/reusable-publish-test-e2e-images.yaml
     with:
       path: python
+      platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+  python-oldest:
+    uses: ./.github/workflows/reusable-publish-test-e2e-images.yaml
+    with:
+      path: python
+      build-args: 'python_version=3.9'
+      tag-suffix: '-3.9'
       platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
   java:
     uses: ./.github/workflows/reusable-publish-test-e2e-images.yaml

--- a/.github/workflows/publish-test-e2e-images.yaml
+++ b/.github/workflows/publish-test-e2e-images.yaml
@@ -5,12 +5,14 @@ on:
     paths:
       - 'tests/test-e2e-apps/**'
       - '.github/workflows/publish-test-e2e-images.yaml'
+      - '.github/workflows/reusable-publish-test-e2e-images.yaml'
     branches:
       - main
   pull_request:
     paths:
       - 'tests/test-e2e-apps/**'
       - '.github/workflows/publish-test-e2e-images.yaml'
+      - '.github/workflows/reusable-publish-test-e2e-images.yaml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/reusable-publish-test-e2e-images.yaml
+++ b/.github/workflows/reusable-publish-test-e2e-images.yaml
@@ -9,6 +9,14 @@ on:
       platforms:
         type: string
         required: true
+      build-args:
+        type: string
+        required: false
+        default: ''
+      tag-suffix:
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -30,7 +38,7 @@ jobs:
           images: |
             ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-${{ inputs.path }}
           tags: |
-            type=ref,event=branch
+            type=ref,event=branch,suffix=${{ inputs.tag-suffix }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
@@ -59,6 +67,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           context: tests/test-e2e-apps/${{ inputs.path }}
           platforms: ${{ inputs.platforms }}
+          build-args: ${{ inputs.build-args }}
           push: ${{ github.event_name == 'push' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/reusable-publish-test-e2e-images.yaml
+++ b/.github/workflows/reusable-publish-test-e2e-images.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: |
-            ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-${{ inputs.path }}
+            ghcr.io/${{ github.repository }}/e2e-test-app-${{ inputs.path }}
           tags: |
             type=ref,event=branch,suffix=${{ inputs.tag-suffix }}
 

--- a/tests/test-e2e-apps/python/Dockerfile
+++ b/tests/test-e2e-apps/python/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:alpine3.18
+ARG python_version=3.13
+
+FROM python:${python_version}-alpine3.22
 
 WORKDIR /app
 


### PR DESCRIPTION
**Description:**

Build the Python e2e test app with Python 3.9 in addition to the current 3.14. This will allow us to verify that our instrumentation image covers all the Python versions supported by the upstream libraries.

**Link to tracking Issue(s):** 

- Relates: https://github.com/open-telemetry/opentelemetry-operator/issues/3712

**Testing**

Ran this successfully in my fork: https://github.com/swiatekm/opentelemetry-operator/actions/runs/16090653425.
The published tags can be found here: https://github.com/swiatekm/opentelemetry-operator/pkgs/container/opentelemetry-operator%2Fe2e-test-app-python/versions

