### PR TITLE
[chore] Move k8s client init to target allocator main

### DIFF
--- a/cmd/otel-allocator/internal/collector/collector.go
+++ b/cmd/otel-allocator/internal/collector/collector.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/allocation"
@@ -33,12 +32,7 @@ type Watcher struct {
 	collectorsDiscovered         metric.Int64Gauge
 }
 
-func NewCollectorWatcher(logger logr.Logger, kubeConfig *rest.Config, collectorNotReadyGracePeriod time.Duration) (*Watcher, error) {
-	clientset, err := kubernetes.NewForConfig(kubeConfig)
-	if err != nil {
-		return &Watcher{}, err
-	}
-
+func NewCollectorWatcher(logger logr.Logger, client kubernetes.Interface, collectorNotReadyGracePeriod time.Duration) (*Watcher, error) {
 	meter := otel.GetMeterProvider().Meter("targetallocator")
 	collectorsDiscovered, err := meter.Int64Gauge("opentelemetry_allocator_collectors_discovered", metric.WithDescription("Number of collectors discovered."))
 	if err != nil {
@@ -46,7 +40,7 @@ func NewCollectorWatcher(logger logr.Logger, kubeConfig *rest.Config, collectorN
 	}
 	return &Watcher{
 		log:                          logger.WithValues("component", "opentelemetry-targetallocator"),
-		k8sClient:                    clientset,
+		k8sClient:                    client,
 		close:                        make(chan struct{}),
 		minUpdateInterval:            defaultMinUpdateInterval,
 		collectorNotReadyGracePeriod: collectorNotReadyGracePeriod,

--- a/cmd/otel-allocator/internal/collector/collector_test.go
+++ b/cmd/otel-allocator/internal/collector/collector_test.go
@@ -42,7 +42,7 @@ func (r *reportingGauge) Record(_ context.Context, value int64, _ ...metric.Reco
 
 func getTestPodWatcher(collectorNotReadyGracePeriod time.Duration) Watcher {
 	podWatcher := Watcher{
-		k8sClient:                    fake.NewSimpleClientset(),
+		k8sClient:                    fake.NewClientset(),
 		close:                        make(chan struct{}),
 		log:                          logger,
 		minUpdateInterval:            time.Millisecond,


### PR DESCRIPTION
Initialize the k8s clients in the main function and pass them to objects which need them. This way we can reuse the clients and test more easily.
