### PR TITLE
Upgrade urllib3 upper limit following Python 3.8 support drop

### DIFF
--- a/autoinstrumentation/python/requirements.txt
+++ b/autoinstrumentation/python/requirements.txt
@@ -1,9 +1,6 @@
 opentelemetry-distro==0.55b1
 
-# We add an upper limit to urllib3 version else Python 3.8 support is dropped.
-# TODO: Update autoinstrumentation image builds to support all supported Python versions
-#       https://github.com/open-telemetry/opentelemetry-operator/issues/3712
-urllib3 <2.5.1
+urllib3 <2.6.0
 # We don't use the distro[otlp] option which automatically includes exporters since gRPC is not appropriate for
 # injected auto-instrumentation, where it has a strict dependency on the OS / Python version the artifact is built for.
 opentelemetry-exporter-otlp-proto-http==1.34.1


### PR DESCRIPTION
**Description:**

We can upgrade the urllib3 upper limit of the Python autoinstrumentation image because Python 3.8 support was dropped with this OTel Python upgrade: https://github.com/open-telemetry/opentelemetry-operator/pull/4092

**Link to tracking Issue(s):** <Issue number if applicable>

This doesn't resolve #3712 but cleans things up a bit. The upgrade PR resolves the issue because all Python versions support (Python 3.9+) should work with the pre-installed dependencies now.

**Testing:**

I built a custom operator image in a similar way using Dockerfile with Python 3.11 in [debian](https://github.com/open-telemetry/opentelemetry-operator/blob/de7d1ebc602bb6dc291b759c437fca676b9b6f1d/autoinstrumentation/python/Dockerfile#L12) and [alpine](https://github.com/open-telemetry/opentelemetry-operator/blob/de7d1ebc602bb6dc291b759c437fca676b9b6f1d/autoinstrumentation/python/Dockerfile#L20), with this upper bound upgrade. I applied it to containers using Python 3.12 and autoinstrumentation still works.

**Documentation:**

None. Removed a comment.
