### PR TITLE
Run python instrumentation tests on older Python version

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-python/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/01-install-app.yaml
@@ -23,7 +23,7 @@ spec:
       - name: myapp
         ports:
         - containerPort: 8080
-        image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-python:main
+        image: ($APP_IMAGE)
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/e2e-instrumentation/instrumentation-python/app-request.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/app-request.yaml
@@ -1,0 +1,29 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: app-request
+spec:
+  try:
+  - command:
+      entrypoint: kubectl
+      env:
+        - name: LABEL_SELECTOR
+          value: ($LABEL_SELECTOR)
+      args:
+        - get
+        - pod
+        - -n
+        - ${NAMESPACE}
+        - -l
+        - ${LABEL_SELECTOR}
+        - -o
+        - jsonpath={.items[0].metadata.name}
+      outputs:
+        - name: podName
+          value: ($stdout)
+  - proxy:
+      apiVersion: v1
+      kind: Pod
+      name: ($podName)
+      namespace: ${NAMESPACE}
+      port: "8080"

--- a/tests/e2e-instrumentation/instrumentation-python/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/chainsaw-test.yaml
@@ -2,116 +2,83 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  creationTimestamp: null
   name: instrumentation-python
 spec:
+  bindings:
+    - name: LABEL_SELECTOR
+      value: app=my-python
   steps:
-  - name: step-00
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
+  - name: Setup instrumentation and collector
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
-  - name: step-01
+  - name: Install test app
     try:
     - apply:
+        bindings:
+          - name: APP_IMAGE_TAG
+            value: main
+          - name: APP_IMAGE
+            value: (join(':', ['ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-python', $APP_IMAGE_TAG]))
         file: 01-install-app.yaml
     - assert:
         file: 01-assert.yaml
     catch:
       - podLogs:
-          selector: app=my-python
+          selector: ($LABEL_SELECTOR)
   - name: Make a request to the app
-    try:
-      - command:
-          entrypoint: kubectl
-          args:
-            - get
-            - pod
-            - -n
-            - ${NAMESPACE}
-            - -l
-            - app=my-python
-            - -o
-            - jsonpath={.items[0].metadata.name}
-          outputs:
-          - name: podName
-            value: ($stdout)
-      - proxy:
-          apiVersion: v1
-          kind: Pod
-          name: ($podName)
-          namespace: ${NAMESPACE}
-          port: "8080"
+    use:
+      template: app-request.yaml
   - name: Wait for telemetry data
-    try:
-    - script:
-        env:
-          - name: LABEL_SELECTOR
-            value: "app=my-python"
-          - name: CONTAINER_NAME
-            value: "otc-container" 
-          - name: RETRY_TIMEOUT
-            value: "120"
-          - name: RETRY_SLEEP
-            value: "5"
-          - name: SEARCH_STRINGS_ENV
-            value: |
-              http.method: Str(GET)
-              k8s.container.name: Str(myapp)
-        timeout: 2m
-        content: ../../test-e2e-apps/scripts/check_pod_logs.sh
+    use:
+      template: wait-for-telemetry-data.yaml
   - name: Check the instrumented app has sent the telemetry data successfully
-    try:
-      - command:
-          entrypoint: kubectl
-          args:
-            - get
-            - pod
-            - -n
-            - ${NAMESPACE}
-            - -l
-            - app=my-python
-            - -o
-            - jsonpath={.items[0].metadata.name}
-          outputs:
-          - name: podName
-            value: ($stdout)
-      - script:
-          env:
-          - name: podName
-            value: ($podName)
-          content: |
-            #!/bin/bash
-            # set -ex
-            kubectl get --raw /api/v1/namespaces/$NAMESPACE/pods/${podName}:8888/proxy/metrics
-          outputs:
-          - name: metrics
-            value: (x_metrics_decode($stdout))
-          check:
-            ($error == null): true
-      - assert:
-          resource:
-            ($metrics[?as_string(metric."__name__") == 'otelcol_exporter_sent_spans_total'].value | [0] > `1`): true
-            ($metrics[?as_string(metric."__name__") == 'otelcol_receiver_accepted_spans_total'].value | [0] > `1`): true
-    catch:
-      - podLogs:
-          selector: app=my-python
-          container: otc-container
+    use:
+      template: check-telemetry-data.yaml
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: instrumentation-python-oldest
+spec:
+  bindings:
+    - name: LABEL_SELECTOR
+      value: app=my-python
+  steps:
+    - name: Add OpenShift namespace annotations
+      use:
+        template: ../../step-templates/openshift-namespace-annotations.yaml
+    - name: Setup instrumentation and collector
+      try:
+        - apply:
+            file: 00-install-collector.yaml
+        - apply:
+            file: 00-install-instrumentation.yaml
+    - name: Install test app
+      try:
+        - apply:
+            bindings:
+              - name: APP_IMAGE_TAG
+                value: main-3.9
+              - name: APP_IMAGE
+                value: (join(':', ['ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-python', $APP_IMAGE_TAG]))
+            file: 01-install-app.yaml
+        - assert:
+            file: 01-assert.yaml
+      catch:
+        - podLogs:
+            selector: $(LABEL_SELECTOR)
+    - name: Make a request to the app
+      use:
+        template: app-request.yaml
+    - name: Wait for telemetry data
+      use:
+        template: wait-for-telemetry-data.yaml
+    - name: Check the instrumented app has sent the telemetry data successfully
+      use:
+        template: check-telemetry-data.yaml

--- a/tests/e2e-instrumentation/instrumentation-python/check-telemetry-data.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/check-telemetry-data.yaml
@@ -1,0 +1,44 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: check-telemetry-data
+spec:
+  try:
+    - command:
+        entrypoint: kubectl
+        env:
+          - name: LABEL_SELECTOR
+            value: ($LABEL_SELECTOR)
+        args:
+          - get
+          - pod
+          - -n
+          - ${NAMESPACE}
+          - -l
+          - ${LABEL_SELECTOR}
+          - -o
+          - jsonpath={.items[0].metadata.name}
+        outputs:
+          - name: podName
+            value: ($stdout)
+    - script:
+        env:
+          - name: podName
+            value: ($podName)
+        content: |
+          #!/bin/bash
+          # set -ex
+          kubectl get --raw /api/v1/namespaces/$NAMESPACE/pods/${podName}:8888/proxy/metrics
+        outputs:
+          - name: metrics
+            value: (x_metrics_decode($stdout))
+        check:
+          ($error == null): true
+    - assert:
+        resource:
+          ($metrics[?as_string(metric."__name__") == 'otelcol_exporter_sent_spans_total'].value | [0] > `1`): true
+          ($metrics[?as_string(metric."__name__") == 'otelcol_receiver_accepted_spans_total'].value | [0] > `1`): true
+  catch:
+    - podLogs:
+        selector: $(LABEL_SELECTOR)
+        container: otc-container

--- a/tests/e2e-instrumentation/instrumentation-python/wait-for-telemetry-data.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/wait-for-telemetry-data.yaml
@@ -1,0 +1,22 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: wait-for-telemetry-data
+spec:
+  try:
+  - script:
+      env:
+        - name: LABEL_SELECTOR
+          value: ($LABEL_SELECTOR)
+        - name: CONTAINER_NAME
+          value: "otc-container"
+        - name: RETRY_TIMEOUT
+          value: "120"
+        - name: RETRY_SLEEP
+          value: "5"
+        - name: SEARCH_STRINGS_ENV
+          value: |
+            http.method: Str(GET)
+            k8s.container.name: Str(myapp)
+      timeout: 2m
+      content: ../../test-e2e-apps/scripts/check_pod_logs.sh

--- a/tests/step-templates/openshift-namespace-annotations.yaml
+++ b/tests/step-templates/openshift-namespace-annotations.yaml
@@ -1,0 +1,23 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: openshift-namespace-annotations
+spec:
+  try:
+    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
+    - command:
+        entrypoint: kubectl
+        args:
+          - annotate
+          - namespace
+          - ${NAMESPACE}
+          - openshift.io/sa.scc.uid-range=1000/1000
+          - --overwrite
+    - command:
+        entrypoint: kubectl
+        args:
+          - annotate
+          - namespace
+          - ${NAMESPACE}
+          - openshift.io/sa.scc.supplemental-groups=3000/3000
+          - --overwrite


### PR DESCRIPTION
**Description:**

Python instrumentation libraries currently support Python 3.9. Run our instrumentation e2e tests on a test app running Python 3.9 to verify that our dependency manifest is valid for that version.

I've cleaned up the e2e test in question by using chainsaw step templates. We can do this for a lot more of our tests - let this PR serve as an example for future efforts.

**Link to tracking Issue(s):**

- Relates: https://github.com/open-telemetry/opentelemetry-operator/issues/3712

