### PR TITLE
Don't match ConfigMaps by full names in e2e tests

### DIFF
--- a/tests/e2e-ta-collector-mtls/ta-collector-mtls/00-assert.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-collector-mtls/00-assert.yaml
@@ -69,7 +69,7 @@ data:
                                   port: 8888
 kind: ConfigMap
 metadata:
-  name: prometheus-cr-collector-84db057e
+  (starts_with(name, 'prometheus-cr-collector-')): true
 ---
 apiVersion: v1
 kind: Pod

--- a/tests/e2e-ta-collector-mtls/ta-disabled/00-assert.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-disabled/00-assert.yaml
@@ -48,4 +48,4 @@ data:
             - jaeger
 kind: ConfigMap
 metadata:
-  name: prometheus-cr-collector-5a741df8
+  (starts_with(name, 'prometheus-cr-collector-')): true

--- a/tests/e2e-targetallocator/targetallocator-features/00-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-features/00-assert.yaml
@@ -20,7 +20,7 @@ spec:
           items:
           - key: collector.yaml
             path: collector.yaml
-          name: stateful-collector-76928b61
+          (starts_with(name, 'stateful-collector-')): true
         name: otc-internal
       - emptyDir: {}
         name: testvolume

--- a/tests/e2e-targetallocator/targetallocator-kubernetessd/00-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-kubernetessd/00-assert.yaml
@@ -15,7 +15,7 @@ metadata:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-kubernetessd-collector-45af7c16
+  (starts_with(name, 'prometheus-kubernetessd-collector-')): true
 data:
   collector.yaml: |
     exporters:

--- a/tests/e2e/managed-reconcile/02-assert.yaml
+++ b/tests/e2e/managed-reconcile/02-assert.yaml
@@ -52,7 +52,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: simplest-collector-d5e146a9
+  (starts_with(name, 'simplest-collector-')): true
 data:
   collector.yaml: |
     receivers:

--- a/tests/e2e/multiple-configmaps/00-assert.yaml
+++ b/tests/e2e/multiple-configmaps/00-assert.yaml
@@ -25,7 +25,7 @@ spec:
       volumes:
         - name: otc-internal
           configMap:
-            name: simplest-with-configmaps-collector-d5e146a9
+            (starts_with(name, 'simplest-with-configmaps-collector-')): true
             items:
               - key: collector.yaml
                 path: collector.yaml

--- a/tests/e2e/smoke-targetallocator/00-assert.yaml
+++ b/tests/e2e/smoke-targetallocator/00-assert.yaml
@@ -60,4 +60,4 @@ data:
                                   port: 8888
 kind: ConfigMap
 metadata:
-  name: stateful-collector-5a741df8
+  (starts_with(name, 'stateful-collector-')): true

--- a/tests/e2e/statefulset-features/00-assert.yaml
+++ b/tests/e2e/statefulset-features/00-assert.yaml
@@ -21,7 +21,7 @@ spec:
            items:
            - key: collector.yaml
              path: collector.yaml
-           name: stateful-collector-45c637b7
+           (starts_with(name, 'stateful-collector-')): true
          name: otc-internal
        - emptyDir: {}
          name: testvolume

--- a/tests/e2e/statefulset-features/01-assert.yaml
+++ b/tests/e2e/statefulset-features/01-assert.yaml
@@ -20,7 +20,7 @@ spec:
            items:
            - key: collector.yaml
              path: collector.yaml
-           name: stateful-collector-45c637b7
+           (starts_with(name, 'stateful-collector-')): true
          name: otc-internal
        - emptyDir: {}
          name: testvolume


### PR DESCRIPTION
ConfigMap names contain a hash of the content, so they change whenever said content changes, leading to confusing test failures. If tests need check the content, they should do so directly.

