### PR TITLE
[manager] Run the mutating webhook with configuration, disabling instrumentation CRDs.

### DIFF
--- a/.chloggen/crds_wip.yaml
+++ b/.chloggen/crds_wip.yaml
@@ -1,0 +1,35 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow to run the mutating webhook using static configuration, without the need for CRDs.
+
+# One or more tracking issues related to the change
+issues: [4201]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  With this change, you can deploy the manager as a mutating webhook without setting up a v1alpha1.Instrumentation custom resource
+  or the v1alpha1.Instrumentation CRD.
+  
+  Instead, you can now set up instrumentation by configuring the manager via its config file with these settings:
+  ```yaml
+    ignore-missing-collector-crds: true 
+    enable-instrumentation-crds: false # Ignore that the CRD is not registered.
+    enable-multi-instrumentation: false
+    instrumentations: # Static configuration for our instrumentation
+      spec:
+        exporter:
+          endpoint: http://collector.default.svc:4318
+        propagators:
+          - tracecontext
+          - baggage
+          - b3
+        java:
+          image: "java-autoinstrumentation:dev"
+  ```

--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -71,6 +71,7 @@ jobs:
         - e2e-autoscale
         - e2e-instrumentation-default
         - e2e-instrumentation
+        - e2e-no-crds
         - e2e-opampbridge
         - e2e-pdb
         - e2e-prometheuscr
@@ -102,6 +103,8 @@ jobs:
           setup: "add-rbac-permissions-to-operator prepare-e2e"
         - group: e2e-ta-standalone
           setup: "prepare-e2e-ta-standalone"
+        - group: e2e-no-crds
+          setup: "prepare-e2e-no-crds"
 
     steps:
     - name: Check out code into the Go module directory

--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,18 @@ deploy: install-gateway-api-crds set-image-controller
 undeploy: set-image-controller
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
+##@ Deploy without CRDs
+# Deploy controller in the current Kubernetes context, configured in ~/.kube/config
+.PHONY: deploy-no-crds
+deploy-no-crds: set-image-controller
+	$(KUSTOMIZE) build config/no-crds | INSTRUMENTATION_JAVA_IMG=$(INSTRUMENTATION_JAVA_IMG) envsubst | kubectl apply -f -
+	kubectl rollout status deployment/opentelemetry-operator-controller-manager -n opentelemetry-operator-system --timeout=300s
+
+# Undeploy controller in the current Kubernetes context, configured in ~/.kube/config
+.PHONY: undeploy-no-crds
+undeploy-no-crds: set-image-controller
+	$(KUSTOMIZE) build config/no-crds | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
 # Generates the released manifests
 .PHONY: release-artifacts
 release-artifacts: set-image-controller
@@ -409,6 +421,11 @@ e2e-instrumentation-default: e2e-instrumentation
 .PHONY: e2e-instrumentation
 e2e-instrumentation: chainsaw
 	$(CHAINSAW) test --test-dir ./tests/e2e-instrumentation --report-name e2e-instrumentation
+
+# no-crds end-to-tests
+.PHONY: e2e-no-crds
+e2e-no-crds: chainsaw
+	$(CHAINSAW) test --test-dir ./tests/e2e-no-crds --report-name e2e-no-crds
 
 # Log operator pod information for debugging
 .PHONY: e2e-log-operator
@@ -499,6 +516,10 @@ e2e-ta-standalone: kustomize gotestsum
 # Prepare environment for e2e tests
 .PHONY: prepare-e2e
 prepare-e2e: chainsaw set-image-controller add-image-targetallocator add-image-opampbridge start-kind cert-manager install-metrics-server install-gateway-api-crds install-targetallocator-prometheus-crds load-image-all deploy
+	@mkdir -p ./.testresults/e2e
+
+.PHONY: prepare-e2e-no-crds
+prepare-e2e-no-crds: chainsaw set-image-controller add-image-targetallocator add-image-opampbridge start-kind cert-manager install-metrics-server install-targetallocator-prometheus-crds load-image-all deploy-no-crds
 	@mkdir -p ./.testresults/e2e
 
 # Run operator-sdk scorecard tests for bundles

--- a/config/no-crds/config.yaml
+++ b/config/no-crds/config.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: manager-config
+data:
+  config.yaml: |
+    ignore-missing-collector-crds: true
+    enable-instrumentation-crds: false
+    enable-multi-instrumentation: false
+    instrumentations:
+      spec:
+        env:
+          - name: OTEL_TRACES_SAMPLER
+            value: always_on
+            # This is the default protocol in 2.x, whereas in 1.x it's grpc. Set this here so the test can pass on both.
+          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+            value: http/protobuf
+            # This exporter is enabled by default in 2.x, but disabled in 1.x.
+          - name: OTEL_LOGS_EXPORTER
+            value: none
+        exporter:
+          endpoint: http://collector:4318
+        propagators:
+          - jaeger
+          - b3
+        java:
+          env:
+            - name: OTEL_JAVAAGENT_DEBUG
+              value: "true"
+            - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
+              value: "false"
+          image: ${INSTRUMENTATION_JAVA_IMG} # Interpolated via envsubst in make file

--- a/config/no-crds/kustomization.yaml
+++ b/config/no-crds/kustomization.yaml
@@ -1,0 +1,61 @@
+# Adds namespace to all resources.
+namespace: opentelemetry-operator-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: opentelemetry-operator-
+
+# Labels to add to all resources and selectors.
+
+# The /metrics endpoint is protected by controller-runtime's built-in
+# authentication and authorization using the FilterProvider option.
+
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+- fieldref:
+    fieldPath: metadata.namespace
+  name: CERTIFICATE_NAMESPACE
+  objref:
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+    version: v1
+- fieldref: {}
+  name: CERTIFICATE_NAME
+  objref:
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+    version: v1
+- fieldref:
+    fieldPath: metadata.namespace
+  name: SERVICE_NAMESPACE
+  objref:
+    kind: Service
+    name: webhook-service
+    version: v1
+- fieldref: {}
+  name: SERVICE_NAME
+  objref:
+    kind: Service
+    name: webhook-service
+    version: v1
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../rbac
+- ../manager
+- ../webhook
+- ../certmanager
+- config.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: opentelemetry-operator
+patches:
+- path: manager_webhook_patch.yaml
+- path: webhookcainjection_patch.yaml

--- a/config/no-crds/manager_webhook_patch.yaml
+++ b/config/no-crds/manager_webhook_patch.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /etc/config.yaml
+          name: config
+          subPath: config.yaml
+        command:
+          - /manager
+          - --config-file
+          - /etc/config.yaml
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: opentelemetry-operator-controller-manager-service-cert
+      - name: config
+        configMap:
+          name: manager-config

--- a/config/no-crds/webhookcainjection_patch.yaml
+++ b/config/no-crds/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/gatewayapi"
@@ -139,6 +140,10 @@ type Config struct {
 	FeatureGates string `yaml:"feature-gates"`
 	// Internal contains configuration that is propagated and cannot be accessed from the operator configuration.
 	Internal Internal `yaml:"-"`
+	// Instrumentation is the set of instrumentations to use if CRDs are not present
+	Instrumentation v1alpha1.Instrumentation `yaml:"instrumentations"`
+	// EnableInstrumentationCRDs enables looking for instrumentation CRDs.
+	EnableInstrumentationCRDs bool `yaml:"enable-instrumentation-crds"`
 }
 
 // Internal contains configuration that is propagated and cannot be accessed from the operator configuration.
@@ -215,6 +220,7 @@ func New() Config {
 		Internal: Internal{
 			NativeSidecarSupport: false,
 		},
+		EnableInstrumentationCRDs: true,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,6 +36,7 @@ func TestToStringMap(t *testing.T) {
 		"enable-apache-httpd-instrumentation":     "false",
 		"enable-cr-metrics":                       "false",
 		"enable-dot-net-auto-instrumentation":     "false",
+		"enable-instrumentation-crds":             "false",
 		"enable-go-auto-instrumentation":          "false",
 		"enable-java-auto-instrumentation":        "false",
 		"enable-leader-election":                  "false",

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -30,3 +30,14 @@ func TestSomeChanges(t *testing.T) {
 	assert.Equal(t, "foobar:1", actual.AutoInstrumentationGoImage)
 	assert.Equal(t, "bar:1", actual.AutoInstrumentationApacheHttpdImage)
 }
+
+func TestInstrumentationInConfigFile(t *testing.T) {
+	f, err := os.ReadFile("testdata/config_instrumentation.yaml")
+	require.NoError(t, err)
+	actual := Config{}
+	require.NoError(t, yaml.Unmarshal(f, &actual))
+	assert.Equal(t, "foo:1", actual.AutoInstrumentationDotNetImage)
+	assert.Equal(t, "foobar:1", actual.AutoInstrumentationGoImage)
+	assert.Equal(t, "bar:1", actual.AutoInstrumentationApacheHttpdImage)
+	assert.Equal(t, "myjavainstrumentation:latest", actual.Instrumentation.Spec.Java.Image)
+}

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -50,3 +50,4 @@ zap:
   level-key: level
   level-format: uppercase
 enable-webhooks: true
+enable-instrumentation-crds: true

--- a/internal/config/testdata/config_instrumentation.yaml
+++ b/internal/config/testdata/config_instrumentation.yaml
@@ -1,0 +1,14 @@
+auto-instrumentation-dot-net-image: foo:1
+auto-instrumentation-go-image: foobar:1
+auto-instrumentation-apache-httpd-image: bar:1
+instrumentations:
+  spec:
+    resource:
+      resourceAttributes:
+        foo: bar
+    java:
+      image: myjavainstrumentation:latest
+      env:
+        - name: foo
+          value: myenvvalue
+

--- a/internal/controllers/reconcile_test.go
+++ b/internal/controllers/reconcile_test.go
@@ -618,6 +618,7 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 				PrometheusCRAvailability:      prometheus.Available,
 				TargetAllocatorConfigMapEntry: "remoteconfiguration.yaml",
 				CollectorConfigMapEntry:       "collector.yaml",
+				EnableInstrumentationCRDs:     true,
 			}
 			reconciler := createTestReconciler(t, testCtx, cfg)
 
@@ -787,6 +788,7 @@ func TestOpenTelemetryCollectorReconciler_RemoveDisabled(t *testing.T) {
 		CollectorConfigMapEntry:     "collector.yaml",
 		OpenShiftRoutesAvailability: openshift.RoutesAvailable,
 		PrometheusCRAvailability:    prometheus.Available,
+		EnableInstrumentationCRDs:   true,
 	}
 	reconciler := createTestReconciler(t, testCtx, cfg)
 
@@ -910,6 +912,7 @@ func TestOpenTelemetryCollectorReconciler_VersionedConfigMaps(t *testing.T) {
 		TargetAllocatorImage:        "default-ta-allocator",
 		CollectorConfigMapEntry:     "collector.yaml",
 		OpenShiftRoutesAvailability: openshift.RoutesAvailable,
+		EnableInstrumentationCRDs:   true,
 	}
 	reconciler := createTestReconciler(t, testCtx, cfg)
 
@@ -1105,6 +1108,7 @@ func TestOpAMPBridgeReconciler_Reconcile(t *testing.T) {
 				OperatorOpAMPBridgeConfigMapEntry: "remoteconfiguration.yaml",
 				CollectorConfigMapEntry:           "collector.yaml",
 				TargetAllocatorConfigMapEntry:     "targetallocator.yaml",
+				EnableInstrumentationCRDs:         true,
 			}
 			reconciler := controllers.NewOpAMPBridgeReconciler(controllers.OpAMPBridgeReconcilerParams{
 				Client:   k8sClient,
@@ -1254,6 +1258,7 @@ service:
 		CreateRBACPermissions:             autoRBAC.Available,
 		CollectorConfigMapEntry:           "collector.yaml",
 		OperatorOpAMPBridgeConfigMapEntry: "remoteconfiguration.yaml",
+		EnableInstrumentationCRDs:         true,
 	}
 	reconciler := createTestReconciler(t, testCtx, cfg)
 
@@ -1309,6 +1314,7 @@ func TestUpgrade(t *testing.T) {
 		TargetAllocatorImage:          "default-ta-allocator",
 		CollectorConfigMapEntry:       "collector.yaml",
 		TargetAllocatorConfigMapEntry: "remoteconfiguration.yaml",
+		EnableInstrumentationCRDs:     true,
 	}
 	reconciler := createTestReconcilerWithVersion(
 		t, testCtx,

--- a/internal/instrumentation/podmutator.go
+++ b/internal/instrumentation/podmutator.go
@@ -367,6 +367,9 @@ func (pm *instPodMutator) getInstrumentationInstance(ctx context.Context, ns cor
 	}
 
 	if strings.EqualFold(instValue, "true") {
+		if !pm.config.EnableInstrumentationCRDs {
+			return &pm.config.Instrumentation, nil
+		}
 		return pm.selectInstrumentationInstanceFromNamespace(ctx, ns)
 	}
 

--- a/internal/instrumentation/podmutator_test.go
+++ b/internal/instrumentation/podmutator_test.go
@@ -679,6 +679,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:     true,
 				EnableJavaAutoInstrumentation: false,
 			},
 		},
@@ -865,6 +866,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnableNodeJSAutoInstrumentation: truee,
 			},
 		},
@@ -1139,6 +1141,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnableNodeJSAutoInstrumentation: truee,
 			},
 		},
@@ -1427,6 +1430,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnablePythonAutoInstrumentation: truee,
 			},
 		},
@@ -1733,6 +1737,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnablePythonAutoInstrumentation: truee,
 			},
 		},
@@ -2027,6 +2032,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnableDotNetAutoInstrumentation: truee,
 			},
 		},
@@ -2225,6 +2231,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnableDotNetAutoInstrumentation: truee,
 			},
 		},
@@ -2535,6 +2542,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnableDotNetAutoInstrumentation: truee,
 			},
 		},
@@ -2616,6 +2624,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnableDotNetAutoInstrumentation: false,
 			},
 		},
@@ -2794,6 +2803,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:   true,
 				EnableGoAutoInstrumentation: truee,
 			},
 		},
@@ -2877,6 +2887,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:   true,
 				EnableGoAutoInstrumentation: false,
 			},
 		},
@@ -3046,6 +3057,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:        true,
 				EnableApacheHttpdInstrumentation: truee,
 			},
 		},
@@ -3123,6 +3135,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:        true,
 				EnableApacheHttpdInstrumentation: false,
 			},
 		},
@@ -3300,6 +3313,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:      true,
 				EnableNginxAutoInstrumentation: truee,
 			},
 		},
@@ -3383,6 +3397,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnableMultiInstrumentation:      truee,
 				EnableNodeJSAutoInstrumentation: truee,
 				EnablePythonAutoInstrumentation: truee,
@@ -3516,6 +3531,9 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			err: `instrumentations.opentelemetry.io "doesnotexists" not found`,
+			config: config.Config{
+				EnableInstrumentationCRDs: true,
+			},
 		},
 		{
 			name: "multi instrumentation for multiple containers feature gate enabled",
@@ -4288,6 +4306,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnableMultiInstrumentation:      truee,
 				EnableJavaAutoInstrumentation:   truee,
 				EnableNodeJSAutoInstrumentation: truee,
@@ -4448,6 +4467,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnableMultiInstrumentation:      false,
 				EnableJavaAutoInstrumentation:   false,
 				EnableNodeJSAutoInstrumentation: false,
@@ -4598,6 +4618,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:     true,
 				EnableMultiInstrumentation:    truee,
 				EnableJavaAutoInstrumentation: false,
 			},
@@ -4796,6 +4817,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnableMultiInstrumentation:      truee,
 				EnableDotNetAutoInstrumentation: truee,
 			},
@@ -4899,6 +4921,7 @@ func TestMutatePod(t *testing.T) {
 				},
 			},
 			config: config.Config{
+				EnableInstrumentationCRDs:       true,
 				EnableMultiInstrumentation:      truee,
 				EnableDotNetAutoInstrumentation: false,
 				EnableNodeJSAutoInstrumentation: false,
@@ -4985,6 +5008,7 @@ func TestMutatePod(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, test.expected, pod)
 			} else {
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.err)
 			}
 		})

--- a/main.go
+++ b/main.go
@@ -369,10 +369,12 @@ func main() {
 		}
 	}
 
-	err = addDependencies(ctx, mgr, cfg)
-	if err != nil {
-		setupLog.Error(err, "failed to add/run bootstrap dependencies to the controller manager")
-		os.Exit(1)
+	if cfg.EnableInstrumentationCRDs {
+		err = addInstrumentationUpgrader(ctx, mgr, cfg)
+		if err != nil {
+			setupLog.Error(err, "failed to add/run bootstrap dependencies to the controller manager")
+			os.Exit(1)
+		}
 	}
 
 	var collectorReconciler *controllers.OpenTelemetryCollectorReconciler
@@ -636,7 +638,7 @@ func enableOperatorNetworkPolicy(cfg config.Config, clientset kubernetes.Interfa
 	return nil
 }
 
-func addDependencies(_ context.Context, mgr ctrl.Manager, cfg config.Config) error {
+func addInstrumentationUpgrader(_ context.Context, mgr ctrl.Manager, cfg config.Config) error {
 	// adds the upgrade mechanism to be executed once the manager is ready
 	err := mgr.Add(manager.RunnableFunc(func(c context.Context) error {
 		u := instrumentationupgrade.NewInstrumentationUpgrade(

--- a/tests/e2e-no-crds/instrumentation-no-crds/00-install-collector.yaml
+++ b/tests/e2e-no-crds/instrumentation-no-crds/00-install-collector.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: collector-config
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "0.0.0.0:4317"
+          http:
+            endpoint: "0.0.0.0:4318"
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          exporters: [debug]
+        traces:
+          receivers: [otlp]
+          exporters: [debug]
+        logs:
+          receivers: [otlp]
+          exporters: [debug]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: collector
+  template:
+    metadata:
+      name: collector
+      labels:
+        app: collector
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - image: otel/opentelemetry-collector-contrib:latest
+          name: collector
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/otelcol-contrib/config.yaml
+              subPath: config.yaml
+          ports:
+            - containerPort: 4317
+              name: otlp
+            - containerPort: 4318
+              name: otlphttp
+      volumes:
+        - name: config-volume
+          configMap:
+            name: collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: collector
+spec:
+  ports:
+    - port: 4317
+      protocol: TCP
+      targetPort: otlp
+      name: otlp
+    - port: 4318
+      protocol: TCP
+      targetPort: otlphttp
+      name: otlphttp
+  selector:
+    app: collector

--- a/tests/e2e-no-crds/instrumentation-no-crds/01-assert.yaml
+++ b/tests/e2e-no-crds/instrumentation-no-crds/01-assert.yaml
@@ -1,0 +1,91 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    instrumentation.opentelemetry.io/inject-java: "true"
+  labels:
+    app: my-java
+spec:
+  containers:
+  - env:
+    - name: OTEL_NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: OTEL_POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    - name: OTEL_JAVAAGENT_DEBUG
+      value: "true"
+    - name: OTEL_INSTRUMENTATION_JDBC_ENABLED
+      value: "false"
+    - name: OTEL_TRACES_SAMPLER
+      value: always_on
+    - name: OTEL_EXPORTER_OTLP_PROTOCOL
+      value: http/protobuf
+    - name: OTEL_LOGS_EXPORTER
+      value: none
+    - name: JAVA_TOOL_OPTIONS
+      value: ' -javaagent:/otel-auto-instrumentation-java-myapp/javaagent.jar'
+    - name: OTEL_SERVICE_NAME
+      value: my-java
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://collector:4318
+    - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
+    - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: spec.nodeName
+    - name: OTEL_PROPAGATORS
+      value: jaeger,b3
+    - name: OTEL_RESOURCE_ATTRIBUTES
+    name: myapp
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      readOnly: true
+    - mountPath: /otel-auto-instrumentation-java-myapp
+      name: opentelemetry-auto-instrumentation-java
+  initContainers:
+  - name: opentelemetry-auto-instrumentation-java
+status:
+  containerStatuses:
+  - name: myapp
+    ready: true
+    started: true
+  initContainerStatuses:
+  - name: opentelemetry-auto-instrumentation-java
+    ready: true
+  phase: Running
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: collector
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: collector
+spec:
+  ports:
+    - port: 4317
+      protocol: TCP
+      targetPort: otlp
+      name: otlp
+    - port: 4318
+      protocol: TCP
+      targetPort: otlphttp
+      name: otlphttp

--- a/tests/e2e-no-crds/instrumentation-no-crds/01-install-app.yaml
+++ b/tests/e2e-no-crds/instrumentation-no-crds/01-install-app.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-java
+spec:
+  selector:
+    matchLabels:
+      app: my-java
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: my-java
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "true"
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 3000
+      containers:
+      - name: myapp
+        ports:
+        - containerPort: 8080
+        image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-java:main
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          timeoutSeconds: 2
+          failureThreshold: 3

--- a/tests/e2e-no-crds/instrumentation-no-crds/chainsaw-test.yaml
+++ b/tests/e2e-no-crds/instrumentation-no-crds/chainsaw-test.yaml
@@ -1,0 +1,107 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: instrumentation-no-crds
+spec:
+  steps:
+  - name: step-00
+    try:
+    - apply:
+        file: 00-install-collector.yaml
+  - name: step-01
+    try:
+    - apply:
+        file: 01-install-app.yaml
+    - assert:
+        file: 01-assert.yaml
+    catch:
+      - podLogs:
+          selector: app=my-java
+  - name: Make a request to the app
+    try:
+      - command:
+          entrypoint: kubectl
+          args:
+            - get
+            - pod
+            - -n
+            - ${NAMESPACE}
+            - -l
+            - app=my-java
+            - -o
+            - jsonpath={.items[0].metadata.name}
+          outputs:
+          - name: podName
+            value: ($stdout)
+      - proxy:
+          apiVersion: v1
+          kind: Pod
+          name: ($podName)
+          namespace: ${NAMESPACE}
+          port: "8080"
+  - name: Wait for telemetry data
+    try:
+    - command:
+        entrypoint: kubectl
+        args:
+          - get
+          - pod
+          - -n
+          - ${NAMESPACE}
+          - -l
+          - app=my-java
+          - -o
+          - jsonpath={.items[0].spec.initContainers[0].image}
+        outputs:
+          - name: instrumentationImage
+            value: ($stdout)
+    - script:
+        bindings:
+          - name: instrumentationVersion
+            value: (split($instrumentationImage,':')[1])
+          - name: instrumentationMajorVersion
+            value: (to_number(split($instrumentationVersion,'.')[0]))
+          - name: jvmProcessMemoryMetricName
+            value: (($instrumentationMajorVersion < `2` && 'process.runtime.jvm.memory.usage') || 'jvm.memory.used')
+        env:
+          - name: LABEL_SELECTOR
+            value: "app=collector"
+          - name: CONTAINER_NAME
+            value: "collector"
+          - name: RETRY_TIMEOUT
+            value: "120"
+          - name: RETRY_SLEEP
+            value: "5"
+          - name: SEARCH_STRINGS_ENV
+            value: ($jvmProcessMemoryMetricName)
+        timeout: 2m
+        content: ../../test-e2e-apps/scripts/check_pod_logs.sh
+  - name: Check the instrumented app has sent the telemetry data successfully
+    try:
+      - command:
+          entrypoint: kubectl
+          args:
+            - get
+            - pod
+            - -n
+            - ${NAMESPACE}
+            - -l
+            - app=collector
+            - -o
+            - jsonpath={.items[0].metadata.name}
+          outputs:
+          - name: podName
+            value: ($stdout)
+      - script:
+          env:
+          - name: podName
+            value: ($podName)
+          content: |
+            #!/bin/bash
+            # set -ex
+            kubectl logs ${podName} -n ${NAMESPACE} | grep my-java
+    catch:
+      - podLogs:
+          selector: app=my-java
+          container: myapp


### PR DESCRIPTION
With this PR, we are able to deploy the mutating webhook using exclusively static configuration rather than instrumentation CRDs.

There are 3 parts to it:
* Add the instrumentation CR to the config struct, so it can be fulfilled.
* Add an option to disable looking up CRDs for instrumentations, instead relying on what the config says.
* Add an integration test showing this works end to end - this test runs outside of the current e2e tests and performs the installation step explicitly, which is not possible right now with the existing integration tests.
