### PR TITLE
bugfix: validate maxReplica when minReplica is set for autoscaler

### DIFF
--- a/.chloggen/autoscaler-maxreplica-check.yaml
+++ b/.chloggen/autoscaler-maxreplica-check.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: added check for maxReplica when minReplica is set in autoscaler 
+
+# One or more tracking issues related to the change
+issues: [4160]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: When using the AutoScaler, maxReplica must be set when minReplica is set.
+
+

--- a/apis/v1beta1/collector_webhook.go
+++ b/apis/v1beta1/collector_webhook.go
@@ -230,6 +230,11 @@ func (c CollectorWebhook) Validate(ctx context.Context, r *OpenTelemetryCollecto
 	if r.Spec.Autoscaler != nil && r.Spec.Autoscaler.MinReplicas != nil {
 		minReplicas = r.Spec.Autoscaler.MinReplicas
 	}
+
+	if r.Spec.Autoscaler != nil && r.Spec.Autoscaler.MinReplicas != nil && r.Spec.Autoscaler.MaxReplicas == nil {
+		return warnings, fmt.Errorf("spec.maxReplica must be set when spec.minReplica is set")
+	}
+	
 	// check deprecated .Spec.MinReplicas if minReplicas is not set
 	if minReplicas == nil {
 		minReplicas = r.Spec.Replicas

--- a/apis/v1beta1/collector_webhook.go
+++ b/apis/v1beta1/collector_webhook.go
@@ -234,7 +234,7 @@ func (c CollectorWebhook) Validate(ctx context.Context, r *OpenTelemetryCollecto
 	if r.Spec.Autoscaler != nil && r.Spec.Autoscaler.MinReplicas != nil && r.Spec.Autoscaler.MaxReplicas == nil {
 		return warnings, fmt.Errorf("spec.maxReplica must be set when spec.minReplica is set")
 	}
-	
+
 	// check deprecated .Spec.MinReplicas if minReplicas is not set
 	if minReplicas == nil {
 		minReplicas = r.Spec.Replicas

--- a/apis/v1beta1/collector_webhook_test.go
+++ b/apis/v1beta1/collector_webhook_test.go
@@ -920,6 +920,17 @@ func TestOTELColValidatingWebhook(t *testing.T) {
 			expectedErr: "maxReplicas should be defined and one or more",
 		},
 		{
+			name: "it should return error when minReplica is set but maxReplica is not set",
+			otelcol: v1beta1.OpenTelemetryCollector{
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					Autoscaler: &v1beta1.AutoscalerSpec{
+						MinReplicas: &three,
+					},
+				},
+			},
+			expectedErr: "spec.maxReplica must be set when spec.minReplica is set",
+		},
+		{
 			name: "invalid replicas, greater than max",
 			otelcol: v1beta1.OpenTelemetryCollector{
 				Spec: v1beta1.OpenTelemetryCollectorSpec{


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
bugfix - added a validation check when minReplica is set but maxReplica is not. This returns an error and does not allow the number of replicas to be updated.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #4160

**Testing:** 
- added unit test for this change
- also tested the fix locally, by trying to update autoscaler without maxReplica when minReplica is set:

```
error: opentelemetrycollectors.opentelemetry.io "simplest" could not be patched: admission webhook "vopentelemetrycollectorcreateupdatebeta.kb.io" denied the request: spec.maxReplica must be set when spec.minReplica is set
```

**Documentation:** <Describe the documentation added.>
