### PR TITLE
fix(target-allocator): Stop pretending to be Prometheus 2.55.1

### DIFF
--- a/cmd/otel-allocator/internal/watcher/promOperator.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator.go
@@ -82,7 +82,6 @@ func NewPrometheusCRWatcher(
 				ProbeSelector:                   cfg.PrometheusCR.ProbeSelector,
 				ProbeNamespaceSelector:          cfg.PrometheusCR.ProbeNamespaceSelector,
 				ServiceDiscoveryRole:            &serviceDiscoveryRole,
-				Version:                         "2.55.1", // fix Prometheus version 2 to avoid generating incompatible config
 				ScrapeProtocols:                 cfg.PrometheusCR.ScrapeProtocols,
 			},
 			EvaluationInterval: monitoringv1.Duration("30s"),

--- a/cmd/otel-allocator/internal/watcher/promOperator_test.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator_test.go
@@ -1245,7 +1245,6 @@ func getTestPrometheusCRWatcher(
 				ScrapeConfigSelector:            cfg.PrometheusCR.ScrapeConfigSelector,
 				ScrapeConfigNamespaceSelector:   cfg.PrometheusCR.ScrapeConfigNamespaceSelector,
 				ServiceDiscoveryRole:            &serviceDiscoveryRole,
-				Version:                         "2.55.1",
 			},
 			EvaluationInterval: monitoringv1.Duration("30s"),
 		},


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Stop pretending to be Prometheus 2.55.1 when generating the Scrape-Configs using PrometheusCRs.

I mentioned in https://github.com/open-telemetry/opentelemetry-operator/pull/4000#issuecomment-3107764602 that this hardcoded version number results in some ugly warnings. I don't know if there are any worse consequences than just the warnings.

Anyway, @swiatekm agreed that this hardcoded version should be removed in https://github.com/open-telemetry/opentelemetry-operator/pull/4000#issuecomment-3107912757.



**Link to tracking Issue(s):** https://github.com/open-telemetry/opentelemetry-operator/pull/4000#issuecomment-3107912757.

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/pull/4000#issuecomment-3107764602

**Testing:** <Describe what testing was performed and which tests were added.>

No testing has been performed. I don't know why the version has been set to 2.55.1 to begin with, and I don't know what happens when we stop doing this. That's why this PR is a draft.

**Documentation:** <Describe the documentation added.>
