### PR TITLE
[chore] Rbac for config.extensions.k8s observer

### DIFF
--- a/.chloggen/rbac_for_config.extensions.k8s_observer.yaml
+++ b/.chloggen/rbac_for_config.extensions.k8s_observer.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: rbac
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Added RBAC permissions for config.extensions.k8s_observer."
+
+# One or more tracking issues related to the change
+issues:
+  - 4113
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Generating RBAC rules for the k8s_observer extension in the OpenTelemetry Collector when used in the operator.
+  The change addresses the issue where the collector lacked necessary permissions to list and watch Kubernetes resources.

--- a/apis/v1beta1/config.go
+++ b/apis/v1beta1/config.go
@@ -159,6 +159,14 @@ func (c *Config) getRbacRulesForComponentKinds(logger logr.Logger, componentKind
 				cfg = *c.Processors
 			}
 		case KindExtension:
+			retriever = extensions.ParserFor
+			if c.Extensions == nil {
+				cfg = AnyConfig{}
+			} else {
+				cfg = *c.Extensions
+			}
+		default:
+			logger.V(1).Info("unknown component kind", "kind", componentKind)
 			continue
 		}
 		for componentName := range enabledComponents[componentKind] {
@@ -332,7 +340,7 @@ func (c *Config) GetEnvironmentVariables(logger logr.Logger) ([]corev1.EnvVar, e
 }
 
 func (c *Config) GetAllRbacRules(logger logr.Logger) ([]rbacv1.PolicyRule, error) {
-	return c.getRbacRulesForComponentKinds(logger, KindReceiver, KindExporter, KindProcessor)
+	return c.getRbacRulesForComponentKinds(logger, KindReceiver, KindExporter, KindProcessor, KindExtension)
 }
 
 func (c *Config) ApplyDefaults(logger logr.Logger) error {

--- a/internal/components/extensions/helpers.go
+++ b/internal/components/extensions/helpers.go
@@ -25,6 +25,10 @@ var registry = map[string]components.Parser{
 		MustBuild(),
 	"jaeger_query": NewJaegerQueryExtensionParserBuilder().
 		MustBuild(),
+	"k8s_observer": components.NewBuilder[k8sobserverConfig]().
+		WithName("k8s_observer").
+		WithRbacGen(generatek8sobserverRbacRules).
+		MustBuild(),
 }
 
 // ParserFor returns a parser builder for the given exporter name.

--- a/internal/components/extensions/k8sobserver.go
+++ b/internal/components/extensions/k8sobserver.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package extensions
+
+import (
+	"github.com/go-logr/logr"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+type k8sobserverConfig struct {
+	ObservePods     bool `mapstructure:"observe_pods"`
+	ObserveServices bool `mapstructure:"observe_services"`
+	ObserveNodes    bool `mapstructure:"observe_nodes"`
+}
+
+func generatek8sobserverRbacRules(_ logr.Logger, config k8sobserverConfig) ([]rbacv1.PolicyRule, error) {
+	prs := []rbacv1.PolicyRule{}
+
+	if config.ObservePods {
+		prs = append(prs, rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+			Verbs:     []string{"list", "watch"},
+		})
+	}
+
+	if config.ObserveServices {
+		prs = append(prs, rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"services"},
+			Verbs:     []string{"list", "watch"},
+		})
+	}
+
+	if config.ObserveNodes {
+		prs = append(prs, rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"nodes"},
+			Verbs:     []string{"list", "watch"},
+		})
+	}
+
+	return prs, nil
+}

--- a/internal/components/extensions/k8sobserver_test.go
+++ b/internal/components/extensions/k8sobserver_test.go
@@ -1,0 +1,104 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package extensions
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestGeneratek8sobserverRbacRules(t *testing.T) {
+	tests := []struct {
+		name   string
+		config k8sobserverConfig
+		want   []rbacv1.PolicyRule
+	}{
+		{
+			name:   "none enabled",
+			config: k8sobserverConfig{},
+			want:   []rbacv1.PolicyRule{},
+		},
+		{
+			name:   "pods only",
+			config: k8sobserverConfig{ObservePods: true},
+			want: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			name:   "services only",
+			config: k8sobserverConfig{ObserveServices: true},
+			want: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"services"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			name:   "nodes only",
+			config: k8sobserverConfig{ObserveNodes: true},
+			want: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			name:   "pods and services",
+			config: k8sobserverConfig{ObservePods: true, ObserveServices: true},
+			want: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"services"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			name:   "all enabled",
+			config: k8sobserverConfig{ObservePods: true, ObserveServices: true, ObserveNodes: true},
+			want: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"services"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := generatek8sobserverRbacRules(logr.Logger{}, tt.config)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/manifests/collector/rbac_test.go
+++ b/internal/manifests/collector/rbac_test.go
@@ -48,6 +48,38 @@ func TestDesiredClusterRoles(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:       "k8s_observer extension - all resources enabled",
+			configPath: "testdata/rbac_k8sobserver_extension.yaml",
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"services"},
+					Verbs:     []string{"list", "watch"},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
+		{
+			desc:       "k8s_observer extension - only pods enabled",
+			configPath: "testdata/rbac_k8sobserver_partial.yaml",
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"list", "watch"},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/manifests/collector/testdata/rbac_k8sobserver_extension.yaml
+++ b/internal/manifests/collector/testdata/rbac_k8sobserver_extension.yaml
@@ -1,0 +1,20 @@
+extensions:
+  k8s_observer:
+    observe_pods: true
+    observe_services: true
+    observe_nodes: true
+receivers:
+  receiver_creator/logs:
+    watch_observers: [k8s_observer]
+    discovery:
+      enabled: true
+processors: {}
+exporters:
+  debug:
+    verbosity: basic
+service:
+  pipelines:
+    logs:
+      receivers: [receiver_creator/logs]
+      exporters: [debug]
+  extensions: [k8s_observer]

--- a/internal/manifests/collector/testdata/rbac_k8sobserver_partial.yaml
+++ b/internal/manifests/collector/testdata/rbac_k8sobserver_partial.yaml
@@ -1,0 +1,20 @@
+extensions:
+  k8s_observer:
+    observe_pods: true
+    observe_services: false
+    observe_nodes: false
+receivers:
+  receiver_creator/logs:
+    watch_observers: [k8s_observer]
+    discovery:
+      enabled: true
+processors: {}
+exporters:
+  debug:
+    verbosity: basic
+service:
+  pipelines:
+    logs:
+      receivers: [receiver_creator/logs]
+      exporters: [debug]
+  extensions: [k8s_observer]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This pull request adds support for generating RBAC rules for the k8s_observer extension in the OpenTelemetry Collector when used in the operator. The change addresses the issue where the collector lacked necessary permissions to list and watch Kubernetes resources 

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #4113

**Testing:** <Describe what testing was performed and which tests were added.>

Added  tests in `internal/components/extensions/k8sobserver_test` & `internal/manifests/collector/rbac_test.go`

**Documentation:** <Describe the documentation added.>
