### PR TITLE
Make renovate update beta Python instrumentation packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -105,8 +105,8 @@
       "groupName": "OpenTelemetry Python packages",
       "group": {
         "commitMessageTopic": "OpenTelemetry python agent version to {{ upgrades.0.newVersion }}"
-      }
-
+      },
+      "ignoreUnstable": false
     }
   ]
 }


### PR DESCRIPTION
Renovate doesn't update prerelease Python packages unless explicitly instructed. This is why renovate PRs like https://github.com/open-telemetry/opentelemetry-operator/pull/4229 only update the stable packages. Fix this.
