### PR TITLE
updated chloggen

### DIFF
--- a/.chloggen/rbac_for_config.extensions.k8s_observer.yaml
+++ b/.chloggen/rbac_for_config.extensions.k8s_observer.yaml
@@ -2,7 +2,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
-component: rbac
+component: collector
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Added RBAC permissions for config.extensions.k8s_observer."


### PR DESCRIPTION
**Description:**
This PR adds a missing changelog entry for the previously merged work on generating RBAC rules for the `config.extensions.k8s_observer` extension in the OpenTelemetry Collector.

**Link to tracking Issue(s):**
*None* – this is a follow-up to a previously merged PR without a corresponding issue.

* Related to: #4232 (Original PR)

**Testing:**


**Documentation:**

