### PR TITLE
Rbac for service.name

### DIFF
--- a/.chloggen/rbac-for-service.name.yaml
+++ b/.chloggen/rbac-for-service.name.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if you need to start with a backtick (`).
+note: "k8sattributes: Add automatic RBAC for new service.name resource attribute generator"
+
+# One or more tracking issues related to the change
+issues: [4131]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The k8sattributes processor recently added support for automatic service.name resource attribute generation.
+  This change ensures that when service.name is configured in the k8sattributes processor, the operator
+  automatically adds the necessary RBAC rules for replicasets access, which is required for extracting
+  k8s.deployment.name.

--- a/internal/components/processors/k8sattribute.go
+++ b/internal/components/processors/k8sattribute.go
@@ -53,7 +53,7 @@ func GenerateK8SAttrRbacRules(_ logr.Logger, config K8sAttributeConfig) ([]rbacv
 	addedReplicasetPolicy := false
 	for _, m := range config.Extract.Metadata {
 		metadataField := fmt.Sprint(m)
-		if (metadataField == "k8s.deployment.uid" || metadataField == "k8s.deployment.name") && !addedReplicasetPolicy {
+		if (metadataField == "k8s.deployment.uid" || metadataField == "k8s.deployment.name" || metadataField == "service.name") && !addedReplicasetPolicy {
 			prs = append(prs, replicasetPolicy)
 			addedReplicasetPolicy = true
 		} else if strings.Contains(metadataField, "k8s.node") {

--- a/internal/components/processors/k8sattribute_test.go
+++ b/internal/components/processors/k8sattribute_test.go
@@ -126,6 +126,31 @@ func TestGenerateK8SAttrRbacRules(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 		},
+		{
+			name: "config with service.name metadata",
+			args: args{
+				config: map[string]interface{}{
+					"extract": map[string]interface{}{
+						"metadata":    []string{"service.name"},
+						"labels":      []interface{}{},
+						"annotations": []interface{}{},
+					},
+				},
+			},
+			want: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods", "namespaces"},
+					Verbs:     []string{"get", "watch", "list"},
+				},
+				{
+					APIGroups: []string{"apps"},
+					Resources: []string{"replicasets"},
+					Verbs:     []string{"get", "watch", "list"},
+				},
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/manifests/collector/rbac_test.go
+++ b/internal/manifests/collector/rbac_test.go
@@ -80,6 +80,22 @@ func TestDesiredClusterRoles(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:       "k8sattributes processor - service.name metadata",
+			configPath: "testdata/rbac_k8sattributes_service_name.yaml",
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods", "namespaces"},
+					Verbs:     []string{"get", "watch", "list"},
+				},
+				{
+					APIGroups: []string{"apps"},
+					Resources: []string{"replicasets"},
+					Verbs:     []string{"get", "watch", "list"},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/manifests/collector/testdata/rbac_k8sattributes_service_name.yaml
+++ b/internal/manifests/collector/testdata/rbac_k8sattributes_service_name.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+processors:
+  k8sattributes:
+    extract:
+      metadata:
+        - service.name
+exporters:
+  otlp:
+    endpoint: "otlp:4317"
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [k8sattributes]
+      exporters: [otlp] 


### PR DESCRIPTION
**Description:**
This PR adds automatic RBAC rule generation for the `service.name` resource attribute in the `k8sattributes` processor. When `service.name` is configured, the operator now includes the necessary RBAC permissions for accessing ReplicaSets, which are required for retrieving the `k8s.deployment.name`.

**Link to tracking Issue(s):**

* Resolves: #4131

**Testing:**

Added  test in

*  `internal/components/processors/k8sattribute_test.go` 
* `internal/manifests/collector/rbac_test.go` 

**Documentation:**
