### PR TITLE
[Chore] Update OTEL Kafka test.

### DIFF
--- a/tests/e2e-openshift/kafka/00-assert.yaml
+++ b/tests/e2e-openshift/kafka/00-assert.yaml
@@ -27,7 +27,7 @@ status:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: my-cluster-kafka-0
+  name: my-cluster-broker-0
   namespace: chainsaw-kafka
 status:
   phase: Running
@@ -36,7 +36,7 @@ status:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: my-cluster-zookeeper-0
+  name: my-cluster-controller-1
   namespace: chainsaw-kafka
 status:
   phase: Running
@@ -119,62 +119,3 @@ spec:
     strimzi.io/kind: Kafka
     strimzi.io/name: my-cluster-kafka
 
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/instance: my-cluster
-    app.kubernetes.io/managed-by: strimzi-cluster-operator
-    app.kubernetes.io/name: zookeeper
-    app.kubernetes.io/part-of: strimzi-my-cluster
-    strimzi.io/cluster: my-cluster
-    strimzi.io/component-type: zookeeper
-    strimzi.io/kind: Kafka
-    strimzi.io/name: my-cluster-zookeeper
-  name: my-cluster-zookeeper-client
-  namespace: chainsaw-kafka
-spec:
-  ports:
-  - name: tcp-clients
-    port: 2181
-    protocol: TCP
-    targetPort: 2181
-  selector:
-    strimzi.io/cluster: my-cluster
-    strimzi.io/kind: Kafka
-    strimzi.io/name: my-cluster-zookeeper
-
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/instance: my-cluster
-    app.kubernetes.io/managed-by: strimzi-cluster-operator
-    app.kubernetes.io/name: zookeeper
-    app.kubernetes.io/part-of: strimzi-my-cluster
-    strimzi.io/cluster: my-cluster
-    strimzi.io/component-type: zookeeper
-    strimzi.io/kind: Kafka
-    strimzi.io/name: my-cluster-zookeeper
-  name: my-cluster-zookeeper-nodes
-  namespace: chainsaw-kafka
-spec:
-  ports:
-  - name: tcp-clients
-    port: 2181
-    protocol: TCP
-    targetPort: 2181
-  - name: tcp-clustering
-    port: 2888
-    protocol: TCP
-    targetPort: 2888
-  - name: tcp-election
-    port: 3888
-    protocol: TCP
-    targetPort: 3888
-  selector:
-    strimzi.io/cluster: my-cluster
-    strimzi.io/kind: Kafka
-    strimzi.io/name: my-cluster-zookeeper

--- a/tests/e2e-openshift/kafka/00-create-kafka-instance.yaml
+++ b/tests/e2e-openshift/kafka/00-create-kafka-instance.yaml
@@ -7,16 +7,63 @@ metadata:
 
 ---
 apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: controller
+  namespace: chainsaw-kafka
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 1
+  roles:
+    - controller
+  storage:
+    type: ephemeral
+  resources:
+    limits:
+      cpu: "1"
+      memory: 4Gi
+    requests:
+      cpu: "1"
+      memory: 4Gi
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: broker
+  namespace: chainsaw-kafka
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 1
+  roles:
+    - broker
+  storage:
+    type: ephemeral
+  resources:
+    limits:
+      cpu: "1"
+      memory: 4Gi
+    requests:
+      cpu: "1"
+      memory: 4Gi
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: my-cluster
   namespace: chainsaw-kafka
+  annotations:
+    strimzi.io/node-pools: enabled
+    strimzi.io/kraft: enabled
 spec:
   entityOperator:
     topicOperator:
-      reconciliationIntervalSeconds: 90
+      reconciliationIntervalMs: 90000
     userOperator:
-      reconciliationIntervalSeconds: 120
+      reconciliationIntervalMs: 120000
   kafka:
     config:
       log.message.format.version: 3.9.0
@@ -43,18 +90,4 @@ spec:
       port: 9093
       tls: true
       type: internal
-    replicas: 1
-    resources:
-      limits:
-        cpu: "1"
-        memory: 4Gi
-      requests:
-        cpu: "1"
-        memory: 4Gi
-    storage:
-      type: ephemeral
     version: 3.9.0
-  zookeeper:
-    replicas: 1
-    storage:
-      type: ephemeral

--- a/tests/e2e-openshift/kafka/README.md
+++ b/tests/e2e-openshift/kafka/README.md
@@ -5,11 +5,12 @@ This test demonstrates how to use Apache Kafka as a messaging layer for OpenTele
 ## Test Overview
 
 This test creates:
-1. A Kafka cluster using AMQ Streams (Strimzi) operator
-2. Kafka topics for telemetry data
-3. An OpenTelemetry Collector that exports traces to Kafka
-4. Another OpenTelemetry Collector that receives traces from Kafka
-5. Trace generation to test the end-to-end flow
+1. A Kafka cluster using AMQ Streams (Strimzi) operator with KRaft mode
+2. KafkaNodePools for controller and broker roles
+3. Kafka topics for telemetry data
+4. An OpenTelemetry Collector that exports traces to Kafka
+5. Another OpenTelemetry Collector that receives traces from Kafka
+6. Trace generation to test the end-to-end flow
 
 ## Prerequisites
 
@@ -28,10 +29,26 @@ Deploy a Kafka cluster using AMQ Streams:
 **Configuration:** [`00-create-kafka-instance.yaml`](./00-create-kafka-instance.yaml)
 
 Creates a Kafka cluster with:
-- 1 broker and 1 zookeeper replica
+- KRaft mode enabled (no ZooKeeper required)
+- 1 controller node and 1 broker node via KafkaNodePools
 - Ephemeral storage for testing
 - Plain text (port 9092) and TLS (port 9093) listeners
 - Kafka version 3.9.0
+- Resource limits: 1 CPU and 4Gi memory per node
+
+### KafkaNodePools
+
+The configuration includes two KafkaNodePools:
+
+**Controller NodePool**: Manages Kafka metadata and cluster coordination
+- 1 replica with `controller` role
+- Ephemeral storage for testing
+- Resource allocation: 1 CPU, 4Gi memory
+
+**Broker NodePool**: Handles message storage and client connections
+- 1 replica with `broker` role  
+- Ephemeral storage for testing
+- Resource allocation: 1 CPU, 4Gi memory
 
 ### Kafka Topics
 
@@ -110,7 +127,10 @@ The test creates and verifies these resources:
 
 ### Kafka Infrastructure
 - **Namespace**: `chainsaw-kafka`
-- **Kafka Cluster**: `my-cluster` with 1 broker and 1 zookeeper
+- **Kafka Cluster**: `my-cluster` with KRaft mode enabled
+- **KafkaNodePools**: 
+  - `controller` - 1 replica with controller role
+  - `broker` - 1 replica with broker role
 - **Kafka Topic**: `otlp-spans` with 3 partitions
 - **Services**: Kafka broker services for internal communication
 
@@ -136,7 +156,10 @@ The script verifies:
 ## Verification
 
 The test verifies:
-- ✅ Kafka cluster is ready and accessible
+- ✅ Kafka cluster with KRaft mode is ready and accessible
+- ✅ KafkaNodePools (controller and broker) are deployed successfully
+- ✅ Controller pod (`my-cluster-controller-1`) is running
+- ✅ Broker pod (`my-cluster-broker-0`) is running
 - ✅ Kafka topics are created successfully
 - ✅ Kafka exporter collector is deployed and ready
 - ✅ Kafka receiver collector is deployed and ready
@@ -148,6 +171,8 @@ The test verifies:
 ## Key Features
 
 - **Kafka Integration**: Uses Apache Kafka as a messaging layer for telemetry
+- **KRaft Mode**: Uses Kafka's native metadata management (no ZooKeeper dependency)
+- **Node Pool Architecture**: Separates controller and broker roles via KafkaNodePools
 - **Decoupled Architecture**: Separates telemetry producers from consumers
 - **Scalable Processing**: Kafka enables horizontal scaling of telemetry processing
 - **Protocol Version Support**: Uses Kafka protocol version 3.5.0
@@ -156,9 +181,11 @@ The test verifies:
 
 ## Configuration Notes
 
-- The Kafka cluster uses ephemeral storage for testing purposes
+- The Kafka cluster uses KRaft mode with ephemeral storage for testing purposes
+- KafkaNodePools separate controller and broker roles for better resource management
 - Plain text communication is used between collectors and Kafka (internal cluster)
 - Kafka brokers are accessible via internal Kubernetes service DNS
 - The `otlp-spans` topic has 3 partitions for load distribution
 - Collectors use the Kafka exporter/receiver from OpenTelemetry contrib
-- Trace generation creates 50 test traces with 100ms span duration 
+- Trace generation creates 50 test traces with 100ms span duration
+- Entity operator reconciliation intervals: 90s for topics, 120s for users 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The PR updates the Kafka test to use AMQ Streams version 3.0 which uses KRaft instead of ZooKeeper. 
