### PR TITLE
[manager] check the TA CRD before declaring it a dependency

### DIFF
--- a/.chloggen/check_ta_availability.yaml
+++ b/.chloggen/check_ta_availability.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: manager
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Check the TargetAllocator CRD availability as part of the collector controller setup
+
+# One or more tracking issues related to the change
+issues: [4282]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/controllers/builder_test.go
+++ b/internal/controllers/builder_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
+	autodetectta "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/targetallocator"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
@@ -1028,7 +1029,7 @@ service:
 				Config:  cfg,
 				OtelCol: tt.args.instance,
 			}
-			got, err := BuildCollector(params)
+			got, err := BuildCollector(autodetectta.Available, params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildAll() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1842,6 +1843,7 @@ service:
 				TargetAllocatorImage:          "default-ta-allocator",
 				CollectorConfigMapEntry:       "collector.yaml",
 				TargetAllocatorConfigMapEntry: "targetallocator.yaml",
+				TargetAllocatorAvailability:   autodetectta.Available,
 			}
 			params := manifests.Params{
 				Log:     logr.Discard(),
@@ -1866,7 +1868,7 @@ service:
 					require.NoError(t, setErr)
 				})
 			}
-			got, err := BuildCollector(params)
+			got, err := BuildCollector(autodetectta.Available, params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildAll() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	autodetectta "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/targetallocator"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/opampbridge"
@@ -40,7 +41,7 @@ func isNamespaceScoped(obj client.Object) bool {
 }
 
 // BuildCollector returns the generation and collected errors of all manifests for a given instance.
-func BuildCollector(params manifests.Params) ([]client.Object, error) {
+func BuildCollector(availability autodetectta.Availability, params manifests.Params) ([]client.Object, error) {
 	builders := []manifests.Builder[manifests.Params]{
 		collector.Build,
 	}
@@ -51,6 +52,27 @@ func BuildCollector(params manifests.Params) ([]client.Object, error) {
 			return nil, err
 		}
 		resources = append(resources, objs...)
+	}
+	// If we're not building a TargetAllocator CRD, then we need to separately invoke its builder
+	// to directly build the manifests. This is what used to happen before the TargetAllocator CRD
+	// was introduced.
+	if availability != autodetectta.Available {
+		if params.TargetAllocator != nil {
+			taParams := targetallocator.Params{
+				Client:          params.Client,
+				Scheme:          params.Scheme,
+				Recorder:        params.Recorder,
+				Log:             params.Log,
+				Config:          params.Config,
+				Collector:       &params.OtelCol,
+				TargetAllocator: *params.TargetAllocator,
+			}
+			taResources, err := BuildTargetAllocator(taParams)
+			if err != nil {
+				return nil, err
+			}
+			resources = append(resources, taResources...)
+		}
 	}
 	return resources, nil
 }

--- a/internal/controllers/opentelemetrycollector_controller.go
+++ b/internal/controllers/opentelemetrycollector_controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/targetallocator"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
@@ -284,7 +285,7 @@ func (r *OpenTelemetryCollectorReconciler) Reconcile(ctx context.Context, req ct
 		}
 	}
 
-	desiredObjects, buildErr := BuildCollector(params)
+	desiredObjects, buildErr := BuildCollector(r.config.TargetAllocatorAvailability, params)
 	if buildErr != nil {
 		return ctrl.Result{}, buildErr
 	}
@@ -371,6 +372,9 @@ func (r *OpenTelemetryCollectorReconciler) GetOwnedResourceTypes() []client.Obje
 
 	if r.config.GatewayAPIsAvailability == gatewayapi.ApiAvailable {
 		ownedResources = append(ownedResources, &gatewayv1.HTTPRoute{})
+	}
+	if r.config.TargetAllocatorAvailability == targetallocator.Available {
+		ownedResources = append(ownedResources, &v1alpha1.TargetAllocator{})
 	}
 
 	return ownedResources

--- a/internal/controllers/reconcile_test.go
+++ b/internal/controllers/reconcile_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
+	autodetectta "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/targetallocator"
 	"github.com/open-telemetry/opentelemetry-operator/internal/components"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/controllers"
@@ -618,6 +619,7 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 				PrometheusCRAvailability:      prometheus.Available,
 				TargetAllocatorConfigMapEntry: "remoteconfiguration.yaml",
 				CollectorConfigMapEntry:       "collector.yaml",
+				TargetAllocatorAvailability:   autodetectta.Available,
 			}
 			reconciler := createTestReconciler(t, testCtx, cfg)
 
@@ -787,6 +789,7 @@ func TestOpenTelemetryCollectorReconciler_RemoveDisabled(t *testing.T) {
 		CollectorConfigMapEntry:     "collector.yaml",
 		OpenShiftRoutesAvailability: openshift.RoutesAvailable,
 		PrometheusCRAvailability:    prometheus.Available,
+		TargetAllocatorAvailability: autodetectta.Available,
 	}
 	reconciler := createTestReconciler(t, testCtx, cfg)
 

--- a/internal/manifests/collector/collector.go
+++ b/internal/manifests/collector/collector.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/targetallocator"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
 
@@ -44,8 +45,11 @@ func Build(params manifests.Params) ([]client.Object, error) {
 		manifests.Factory(ExtensionService),
 		manifests.Factory(Ingress),
 		manifests.Factory(NetworkPolicy),
-		manifests.Factory(TargetAllocator),
 	}...)
+
+	if params.Config.TargetAllocatorAvailability == targetallocator.Available {
+		manifestFactories = append(manifestFactories, manifests.Factory(TargetAllocator))
+	}
 
 	if params.OtelCol.Spec.Observability.Metrics.EnableMetrics {
 		if params.OtelCol.Spec.Mode == v1beta1.ModeSidecar {


### PR DESCRIPTION
**Description:**
The OpenTelemetryCollector has a dependency in some cases on the TA CRD.

If the TA CRD is not present, the OpenTelemetryCollector controller should be able to continue to perform.
