### PR TITLE
Return an empty, valid configuration struct in v1alpha1 conversion webhook

### DIFF
--- a/.chloggen/api-conversion-resilience.yaml
+++ b/.chloggen/api-conversion-resilience.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Always return a valid OpenTelemetryCollector configuration during v1beta1 conversion.
+
+# One or more tracking issues related to the change
+issues: [4288]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1alpha1/convert.go
+++ b/apis/v1alpha1/convert.go
@@ -55,22 +55,24 @@ func tov1beta1(in OpenTelemetryCollector) (v1beta1.OpenTelemetryCollector, error
 	copy := in.DeepCopy()
 	cfg := &v1beta1.Config{}
 	if err := go_yaml.Unmarshal([]byte(copy.Spec.Config), cfg); err != nil {
-		// Return a valid empty config when unmarshalling fails
+		// It is critical that the conversion does not fail!
+		// See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#response
+		// Thus, if unmarshalling fails, we return a valid, empty config.
 		cfg = &v1beta1.Config{
-			Receivers: v1beta1.AnyConfig{Object: map[string]interface{}{}},
-			Exporters: v1beta1.AnyConfig{Object: map[string]interface{}{}},
+			Receivers: v1beta1.AnyConfig{Object: map[string]any{}},
+			Exporters: v1beta1.AnyConfig{Object: map[string]any{}},
 			Service: v1beta1.Service{
 				Pipelines: map[string]*v1beta1.Pipeline{},
 			},
 		}
 	}
 
-	// Ensure required fields are not nil even if unmarshalling succeeded
+	// Ensure required fields are not nil even if unmarshalling succeeded.
 	if cfg.Receivers.Object == nil {
-		cfg.Receivers.Object = map[string]interface{}{}
+		cfg.Receivers.Object = map[string]any{}
 	}
 	if cfg.Exporters.Object == nil {
-		cfg.Exporters.Object = map[string]interface{}{}
+		cfg.Exporters.Object = map[string]any{}
 	}
 	if cfg.Service.Pipelines == nil {
 		cfg.Service.Pipelines = map[string]*v1beta1.Pipeline{}

--- a/apis/v1alpha1/convert.go
+++ b/apis/v1alpha1/convert.go
@@ -21,10 +21,7 @@ func (src *OpenTelemetryCollector) ConvertTo(dstRaw conversion.Hub) error {
 	switch t := dstRaw.(type) {
 	case *v1beta1.OpenTelemetryCollector:
 		dst := dstRaw.(*v1beta1.OpenTelemetryCollector)
-		convertedSrc, err := tov1beta1(*src)
-		if err != nil {
-			return fmt.Errorf("failed to convert to v1beta1: %w", err)
-		}
+		convertedSrc := tov1beta1(*src)
 		dst.ObjectMeta = convertedSrc.ObjectMeta
 		dst.Spec = convertedSrc.Spec
 		dst.Status = convertedSrc.Status
@@ -51,7 +48,7 @@ func (dst *OpenTelemetryCollector) ConvertFrom(srcRaw conversion.Hub) error {
 	return nil
 }
 
-func tov1beta1(in OpenTelemetryCollector) (v1beta1.OpenTelemetryCollector, error) {
+func tov1beta1(in OpenTelemetryCollector) v1beta1.OpenTelemetryCollector {
 	copy := in.DeepCopy()
 	cfg := &v1beta1.Config{}
 	if err := go_yaml.Unmarshal([]byte(copy.Spec.Config), cfg); err != nil {
@@ -152,7 +149,7 @@ func tov1beta1(in OpenTelemetryCollector) (v1beta1.OpenTelemetryCollector, error
 				RollingUpdate: copy.Spec.DeploymentUpdateStrategy.RollingUpdate,
 			},
 		},
-	}, nil
+	}
 }
 
 func tov1beta1Ports(in []PortsSpec) []v1beta1.PortsSpec {

--- a/apis/v1alpha1/convert_test.go
+++ b/apis/v1alpha1/convert_test.go
@@ -68,8 +68,54 @@ func Test_tov1beta1_config(t *testing.T) {
 			},
 		}
 
-		_, err := tov1beta1(cfgV1)
-		assert.ErrorContains(t, err, "could not convert config json to v1beta1.Config")
+		cfgV2, err := tov1beta1(cfgV1)
+		assert.Nil(t, err)
+		assert.NotNil(t, cfgV2)
+		// Should return an empty valid config
+		assert.NotNil(t, cfgV2.Spec.Config.Receivers.Object)
+		assert.NotNil(t, cfgV2.Spec.Config.Exporters.Object)
+		assert.NotNil(t, cfgV2.Spec.Config.Service.Pipelines)
+		assert.Equal(t, 0, len(cfgV2.Spec.Config.Receivers.Object))
+		assert.Equal(t, 0, len(cfgV2.Spec.Config.Exporters.Object))
+		assert.Equal(t, 0, len(cfgV2.Spec.Config.Service.Pipelines))
+	})
+	t.Run("null config", func(t *testing.T) {
+		config := "null\n"
+		cfgV1 := OpenTelemetryCollector{
+			Spec: OpenTelemetryCollectorSpec{
+				Config: config,
+			},
+		}
+
+		cfgV2, err := tov1beta1(cfgV1)
+		assert.Nil(t, err)
+		assert.NotNil(t, cfgV2)
+		// Should return an empty valid config
+		assert.NotNil(t, cfgV2.Spec.Config.Receivers.Object)
+		assert.NotNil(t, cfgV2.Spec.Config.Exporters.Object)
+		assert.NotNil(t, cfgV2.Spec.Config.Service.Pipelines)
+		assert.Equal(t, 0, len(cfgV2.Spec.Config.Receivers.Object))
+		assert.Equal(t, 0, len(cfgV2.Spec.Config.Exporters.Object))
+		assert.Equal(t, 0, len(cfgV2.Spec.Config.Service.Pipelines))
+	})
+	t.Run("empty config", func(t *testing.T) {
+		config := ""
+		cfgV1 := OpenTelemetryCollector{
+			Spec: OpenTelemetryCollectorSpec{
+				Config: config,
+			},
+		}
+
+		cfgV2, err := tov1beta1(cfgV1)
+		assert.Nil(t, err)
+		assert.NotNil(t, cfgV2)
+		// Should return an empty valid config
+		assert.NotNil(t, cfgV2.Spec.Config.Receivers.Object)
+		assert.NotNil(t, cfgV2.Spec.Config.Exporters.Object)
+		assert.NotNil(t, cfgV2.Spec.Config.Service.Pipelines)
+		assert.Equal(t, 0, len(cfgV2.Spec.Config.Receivers.Object))
+		assert.Equal(t, 0, len(cfgV2.Spec.Config.Exporters.Object))
+		assert.Equal(t, 0, len(cfgV2.Spec.Config.Service.Pipelines))
 	})
 }
 
@@ -511,7 +557,7 @@ func TestConvertTo(t *testing.T) {
 	colbeta1 := v1beta1.OpenTelemetryCollector{}
 	err := col.ConvertTo(&colbeta1)
 	require.NoError(t, err)
-	assert.Equal(t, v1beta1.OpenTelemetryCollector{
+	expected := v1beta1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "otel",
 		},
@@ -525,11 +571,19 @@ func TestConvertTo(t *testing.T) {
 					ServiceMonitorSelector: &metav1.LabelSelector{},
 				},
 			},
+			Config: v1beta1.Config{
+				Receivers: v1beta1.AnyConfig{Object: map[string]interface{}{}},
+				Exporters: v1beta1.AnyConfig{Object: map[string]interface{}{}},
+				Service: v1beta1.Service{
+					Pipelines: map[string]*v1beta1.Pipeline{},
+				},
+			},
 		},
 		Status: v1beta1.OpenTelemetryCollectorStatus{
 			Image: "otel/col",
 		},
-	}, colbeta1)
+	}
+	assert.Equal(t, expected, colbeta1)
 }
 
 func TestConvertFrom(t *testing.T) {

--- a/apis/v1alpha1/convert_test.go
+++ b/apis/v1alpha1/convert_test.go
@@ -51,8 +51,7 @@ func Test_tov1beta1_config(t *testing.T) {
 			},
 		}
 
-		cfgV2, err := tov1beta1(cfgV1)
-		assert.Nil(t, err)
+		cfgV2 := tov1beta1(cfgV1)
 		assert.NotNil(t, cfgV2)
 		assert.Equal(t, cfgV1.Spec.Args, cfgV2.Spec.Args)
 
@@ -68,8 +67,7 @@ func Test_tov1beta1_config(t *testing.T) {
 			},
 		}
 
-		cfgV2, err := tov1beta1(cfgV1)
-		assert.Nil(t, err)
+		cfgV2 := tov1beta1(cfgV1)
 		assert.NotNil(t, cfgV2)
 		assert.NotNil(t, cfgV2.Spec.Config.Receivers.Object)
 		assert.NotNil(t, cfgV2.Spec.Config.Exporters.Object)
@@ -86,8 +84,7 @@ func Test_tov1beta1_config(t *testing.T) {
 			},
 		}
 
-		cfgV2, err := tov1beta1(cfgV1)
-		assert.Nil(t, err)
+		cfgV2 := tov1beta1(cfgV1)
 		assert.NotNil(t, cfgV2)
 		assert.NotNil(t, cfgV2.Spec.Config.Receivers.Object)
 		assert.NotNil(t, cfgV2.Spec.Config.Exporters.Object)
@@ -104,8 +101,7 @@ func Test_tov1beta1_config(t *testing.T) {
 			},
 		}
 
-		cfgV2, err := tov1beta1(cfgV1)
-		assert.Nil(t, err)
+		cfgV2 := tov1beta1(cfgV1)
 		assert.NotNil(t, cfgV2)
 		assert.NotNil(t, cfgV2.Spec.Config.Receivers.Object)
 		assert.NotNil(t, cfgV2.Spec.Config.Exporters.Object)
@@ -343,8 +339,7 @@ func Test_tov1beta1AndBack(t *testing.T) {
 		},
 	}
 
-	colbeta1, err := tov1beta1(*colalpha1)
-	require.NoError(t, err)
+	colbeta1 := tov1beta1(*colalpha1)
 	colalpha1Converted, err := tov1alpha1(colbeta1)
 	require.NoError(t, err)
 

--- a/apis/v1alpha1/convert_test.go
+++ b/apis/v1alpha1/convert_test.go
@@ -71,7 +71,6 @@ func Test_tov1beta1_config(t *testing.T) {
 		cfgV2, err := tov1beta1(cfgV1)
 		assert.Nil(t, err)
 		assert.NotNil(t, cfgV2)
-		// Should return an empty valid config
 		assert.NotNil(t, cfgV2.Spec.Config.Receivers.Object)
 		assert.NotNil(t, cfgV2.Spec.Config.Exporters.Object)
 		assert.NotNil(t, cfgV2.Spec.Config.Service.Pipelines)
@@ -90,7 +89,6 @@ func Test_tov1beta1_config(t *testing.T) {
 		cfgV2, err := tov1beta1(cfgV1)
 		assert.Nil(t, err)
 		assert.NotNil(t, cfgV2)
-		// Should return an empty valid config
 		assert.NotNil(t, cfgV2.Spec.Config.Receivers.Object)
 		assert.NotNil(t, cfgV2.Spec.Config.Exporters.Object)
 		assert.NotNil(t, cfgV2.Spec.Config.Service.Pipelines)
@@ -109,7 +107,6 @@ func Test_tov1beta1_config(t *testing.T) {
 		cfgV2, err := tov1beta1(cfgV1)
 		assert.Nil(t, err)
 		assert.NotNil(t, cfgV2)
-		// Should return an empty valid config
 		assert.NotNil(t, cfgV2.Spec.Config.Receivers.Object)
 		assert.NotNil(t, cfgV2.Spec.Config.Exporters.Object)
 		assert.NotNil(t, cfgV2.Spec.Config.Service.Pipelines)

--- a/tests/e2e/conversion-webhook-invalid-config/00-assert-created.yaml
+++ b/tests/e2e/conversion-webhook-invalid-config/00-assert-created.yaml
@@ -1,0 +1,19 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: invalid-config-collector
+spec:
+  mode: deployment
+  config: |
+    receivers: {}
+    exporters: {}
+    service:
+      telemetry:
+        metrics:
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: 0.0.0.0
+                    port: 8888
+      pipelines: {}

--- a/tests/e2e/conversion-webhook-invalid-config/00-create-invalid-config.yaml
+++ b/tests/e2e/conversion-webhook-invalid-config/00-create-invalid-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: invalid-config-collector
+spec:
+  mode: deployment
+  config: "null"

--- a/tests/e2e/conversion-webhook-invalid-config/01-assert-deployment-created.yaml
+++ b/tests/e2e/conversion-webhook-invalid-config/01-assert-deployment-created.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: invalid-config-collector-collector
+spec:
+  template:
+    spec:
+      containers:
+      - name: otc-container

--- a/tests/e2e/conversion-webhook-invalid-config/chainsaw-test.yaml
+++ b/tests/e2e/conversion-webhook-invalid-config/chainsaw-test.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: conversion-webhook-invalid-config
+spec:
+  steps:
+    - name: step-00
+      description: create v1alpha1 opentelemetrycollector with invalid config and verify conversion webhook handles it gracefully
+      try:
+        - apply:
+            file: 00-create-invalid-config.yaml
+        - assert:
+            file: 00-assert-created.yaml
+
+    - name: step-01
+      description: verify collector deployment is created with valid empty config (conversion webhook successful)
+      try:
+        - assert:
+            file: 01-assert-deployment-created.yaml


### PR DESCRIPTION
**Description:** Returns a valid, empty configuration struct in the v1alpha1 conversion webhook rather than returning a failure.

**Link to tracking Issue(s):** #4288

- Resolves: #4288 

**Testing:** Added a few tests with invalid YAML configuration strings to ensure that a valid configuration, and no error, is returned from the webhook.

**Documentation:** None