### PR TITLE
fix: preserve string values in YAML encoding to prevent type conversion errors

### DIFF
--- a/.chloggen/fix_yaml-string-preservation.yaml
+++ b/.chloggen/fix_yaml-string-preservation.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix string value preservation in YAML encoding to prevent automatic conversion of numeric-looking strings like \"0e12\" to float64"
+
+# One or more tracking issues related to the change
+issues: [4314]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Removed the go_yaml.AutoInt() option from YAML encoder that was causing string values
+  containing scientific notation patterns to be automatically converted to numeric types,
+  which resulted in type validation errors during collector creation.

--- a/apis/v1beta1/config.go
+++ b/apis/v1beta1/config.go
@@ -390,7 +390,7 @@ func (c *Config) GetReadinessProbe(logger logr.Logger) (*corev1.Probe, error) {
 // Yaml encodes the current object and returns it as a string.
 func (c *Config) Yaml() (string, error) {
 	var buf bytes.Buffer
-	yamlEncoder := go_yaml.NewEncoder(&buf, go_yaml.IndentSequence(true), go_yaml.AutoInt())
+	yamlEncoder := go_yaml.NewEncoder(&buf, go_yaml.IndentSequence(true), go_yaml.UseSingleQuote(false))
 	if err := yamlEncoder.Encode(&c); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Remove go_yaml.AutoInt() option from YAML encoder to prevent automatic conversion of string values that look like numbers (e.g., "0e12") to float64 types. This fixes collector creation failures when processor configurations contain string values in scientific notation format.

**Link to tracking Issue(s):** 

- Resolves: #4314

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>

Generated with [Claude Code](https://claude.ai/code) :horse: :horse: :horse: 
