### PR TITLE
Remove unnecessary cert-manager CA annotation from CRDs

### DIFF
--- a/.chloggen/remove-cert-manager-annotations.yaml
+++ b/.chloggen/remove-cert-manager-annotations.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector, target allocator, opamp
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove unnecessary cert-manager CA annotation from CRDs
+
+# One or more tracking issues related to the change
+issues: [4321]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Remove annotation `cert-manager.io/inject-ca-from` from all OpenShift CRD manifests. The CRDs on OpenShift are installed via OLM which handles the CA injection.
+  The annotation is also not needed for non-OpenShift installations on CRDs that do not have a conversion webhook.

--- a/apis/v1alpha1/instrumentation_webhook.go
+++ b/apis/v1alpha1/instrumentation_webhook.go
@@ -81,6 +81,7 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 	if r.Labels == nil {
 		r.Labels = map[string]string{}
 	}
+	fmt.Println("---> Setting default labels")
 	if r.Spec.Java.Image == "" {
 		r.Spec.Java.Image = w.cfg.AutoInstrumentationJavaImage
 	}

--- a/apis/v1alpha1/instrumentation_webhook.go
+++ b/apis/v1alpha1/instrumentation_webhook.go
@@ -81,7 +81,6 @@ func (w InstrumentationWebhook) defaulter(r *Instrumentation) error {
 	if r.Labels == nil {
 		r.Labels = map[string]string{}
 	}
-	fmt.Println("---> Setting default labels")
 	if r.Spec.Java.Image == "" {
 		r.Spec.Java.Image = w.cfg.AutoInstrumentationJavaImage
 	}

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2025-08-15T13:11:29Z"
+    createdAt: "2025-08-28T15:18:33Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/community/manifests/opentelemetry.io_opampbridges.yaml
+++ b/bundle/community/manifests/opentelemetry.io_opampbridges.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: opentelemetry-operator-system/opentelemetry-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   labels:

--- a/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: opentelemetry-operator-system/opentelemetry-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   labels:

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2025-08-15T13:11:30Z"
+    createdAt: "2025-08-28T15:18:33Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/openshift/manifests/opentelemetry.io_opampbridges.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opampbridges.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: opentelemetry-operator-system/opentelemetry-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   labels:

--- a/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: opentelemetry-operator-system/opentelemetry-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   labels:

--- a/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: opentelemetry-operator-system/opentelemetry-operator-serving-cert
     controller-gen.kubebuilder.io/version: v0.18.0
   creationTimestamp: null
   labels:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -23,6 +23,6 @@ kind: Kustomization
 # - patches/webhook_in_opampbridges.yaml
 patches:
 - path: patches/cainjection_in_opentelemetrycollectors.yaml
-- path: patches/cainjection_in_opampbridges.yaml
+#- path: patches/cainjection_in_opampbridges.yaml
 - path: patches/webhook_in_opentelemetrycollectors.yaml
-- path: patches/cainjection_in_targetallocators.yaml
+#- path: patches/cainjection_in_targetallocators.yaml

--- a/config/overlays/openshift/kustomization.yaml
+++ b/config/overlays/openshift/kustomization.yaml
@@ -10,6 +10,7 @@ patches:
     version: v1
 - path: metrics_service_tls_patch.yaml
 - path: manager_auth_proxy_tls_patch.yaml
+- path: remove-cert-manager-annotations.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/overlays/openshift/remove-cert-manager-annotations.yaml
+++ b/config/overlays/openshift/remove-cert-manager-annotations.yaml
@@ -1,0 +1,27 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: opentelemetrycollectors.opentelemetry.io
+  annotations:
+    cert-manager.io/inject-ca-from: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: opampbridges.opentelemetry.io
+  annotations:
+    cert-manager.io/inject-ca-from: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: targetallocators.opentelemetry.io
+  annotations:
+    cert-manager.io/inject-ca-from: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: instrumentations.opentelemetry.io
+  annotations:
+    cert-manager.io/inject-ca-from: null


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

It fixes error messages in the cert-manager

```
E0704 15:55:03.868022 1 sources.go:106] "unable to fetch associated certificate" err="Certificate.cert-manager.io \"opentelemetry-operator-serving-cert\" not found" logger="cert-manager" kind="customresourcedefinition" kind="customresourcedefinition" name="opampbridges.opentelemetry.io" certificate="opentelemetry-operator-system/opentelemetry-operator-serving-cert"
E0704 15:55:03.870725 1 sources.go:106] "unable to fetch associated certificate" err="Certificate.cert-manager.io \"opentelemetry-operator-serving-cert\" not found" logger="cert-manager" kind="customresourcedefinition" kind="customresourcedefinition" name="opentelemetrycollectors.opentelemetry.io" certificate="opentelemetry-operator-system/opentelemetry-operator-serving-cert"
E0704 15:55:03.871748 1 sources.go:106] "unable to fetch associated certificate" err="Certificate.cert-manager.io \"opentelemetry-operator-serving-cert\" not found" logger="cert-manager" kind="customresourcedefinition" kind="customresourcedefinition" name="targetallocators.opentelemetry.io" certificate="opentelemetry-operator-system/opentelemetry-operator-serving-cert"
E0704 15:55:03.896481 1 sources.go:106] "unable to fetch associated certificate" err="Certificate.cert-manager.io \"jaeger-operator-serving-cert\" not found" logger="cert-manager" kind="customresourcedefinition" kind="customresourcedefinition" name="jaegers.jaegertracing.io" certificate="observability/jaeger-operator-serving-cert" 
```

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #issue-number

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
