### PR TITLE
operator no longer overwrites ingress annoations on change

### DIFF
--- a/.chloggen/fix_ingress_annoation_overwrites.yaml
+++ b/.chloggen/fix_ingress_annoation_overwrites.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Operator no longer overwrites ingress annoations on change
+
+# One or more tracking issues related to the change
+issues: [4322]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The operator now respects external manipulations of the Ingress object — instead of
+  overwriting annotations it respects existing to prevent annotation-overwrite issues
+  that caused reconciliation loops with external controllers (e.g., Rancher).

--- a/internal/manifests/mutate.go
+++ b/internal/manifests/mutate.go
@@ -250,8 +250,8 @@ func mutatePolicyV1PDB(existing, desired *policyV1.PodDisruptionBudget) {
 }
 
 func mutateIngress(existing, desired *networkingv1.Ingress) {
-	existing.Labels = desired.Labels
-	existing.Annotations = desired.Annotations
+	// NOTE: Do not overwrite labels and annotations:
+	// https://github.com/open-telemetry/opentelemetry-operator/issues/4322
 	existing.Spec.DefaultBackend = desired.Spec.DefaultBackend
 	existing.Spec.Rules = desired.Spec.Rules
 	existing.Spec.TLS = desired.Spec.TLS


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The operator now respects external manipulations of the Ingress object — instead of
overwriting annotations it respects existing to prevent annotation-overwrite issues
that caused reconciliation loops with external controllers (e.g., Rancher).

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #4322

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
