### PR TITLE
docs: fix README app.kubernetes.io/instance issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ spec:
 You can also use common labels to set resource attributes (first entry wins).
 
 The following labels are supported:
-- `app.kubernetes.io/instance` becomes `service.instance`
+- `app.kubernetes.io/instance` becomes `service.name`
 - `app.kubernetes.io/name` becomes `service.name`
 - `app.kubernetes.io/version` becomes `service.version`
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>

In `### Configure resource attributes with labels` section,
labels `app.kubernetes.io/instance` will indeed become `service.name` as in #3797 

This logic is still valid if we go deep into the code

```go
// pkg/constants/env.go
LabelAppName = []string{
  "app.kubernetes.io/instance",
  "app.kubernetes.io/name",
}

// internal/instrumentation/sdk.go # chooseServiceName
if name := chooseLabelOrAnnotation(pod, useLabelsForResourceAttributes, semconv.ServiceNameKey, constants.LabelAppName); name != "" {
  return name
}
```

---

However, #4081 misunderstood and "fix the typo", which is not correct.

This PR is to re-fix this issue in `README.md`
