### PR TITLE
a unit test to demonstrate uneven distribution of target samples

### DIFF
--- a/cmd/otel-allocator/internal/allocation/allocator.go
+++ b/cmd/otel-allocator/internal/allocation/allocator.go
@@ -261,6 +261,7 @@ func (a *allocator) addTargetToTargetItems(tg *target.Item) error {
 	tg.CollectorName = colOwner.Name
 	a.addCollectorTargetItemMapping(tg)
 	a.collectors[colOwner.Name].NumTargets++
+	a.collectors[colOwner.Name].NumSamples += tg.SampleCount
 	a.targetsPerCollector.Record(context.Background(), int64(a.collectors[colOwner.String()].NumTargets), metric.WithAttributes(attribute.String("collector_name", colOwner.String()), attribute.String("strategy", a.strategy.GetName())))
 	return nil
 }
@@ -276,6 +277,7 @@ func (a *allocator) unassignTargetItem(item *target.Item) {
 		return
 	}
 	c.NumTargets--
+	c.NumSamples -= item.SampleCount
 	a.targetsPerCollector.Record(context.Background(), int64(c.NumTargets), metric.WithAttributes(attribute.String("collector_name", item.CollectorName), attribute.String("strategy", a.strategy.GetName())))
 	delete(a.targetItemsPerJobPerCollector[item.CollectorName][item.JobName], item.Hash())
 	if len(a.targetItemsPerJobPerCollector[item.CollectorName][item.JobName]) == 0 {

--- a/cmd/otel-allocator/internal/allocation/strategy.go
+++ b/cmd/otel-allocator/internal/allocation/strategy.go
@@ -12,7 +12,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/target"
 )
 
-type AllocatorProvider func(log logr.Logger, opts ...Option) Allocator
 
 var (
 	strategies = map[string]Strategy{
@@ -70,6 +69,7 @@ type Allocator interface {
 }
 
 type Strategy interface {
+	// 关键方法
 	GetCollectorForTarget(map[string]*Collector, *target.Item) (*Collector, error)
 	// SetCollectors exists for strategies where changing the collector set is potentially an expensive operation.
 	// The caller must guarantee that the collectors map passed in GetCollectorForTarget is consistent with the latest
@@ -89,6 +89,8 @@ type Collector struct {
 	Name       string
 	NodeName   string
 	NumTargets int
+
+	NumSamples int
 }
 
 func (c Collector) Hash() string {

--- a/cmd/otel-allocator/internal/allocation/testutils.go
+++ b/cmd/otel-allocator/internal/allocation/testutils.go
@@ -38,6 +38,44 @@ func MakeNNewTargets(n int, numCollectors int, startingIndex int) []*target.Item
 	return toReturn
 }
 
+func MakeNNewUnevenTargets(n int, numCollectors int, startingIndex int, max, min, maxCnt int) []*target.Item {
+	toReturn := []*target.Item{}
+	sampleCnts := generateInts(n, max, min, maxCnt)
+	for i := startingIndex; i < n+startingIndex; i++ {
+		collector := fmt.Sprintf("collector-%d", colIndex(i, numCollectors))
+		label := labels.Labels{
+			{Name: "i", Value: strconv.Itoa(i)},
+			{Name: "total", Value: strconv.Itoa(n + startingIndex)},
+		}
+		newTarget := target.NewItem(fmt.Sprintf("test-job-%d", i), fmt.Sprintf("test-url-%d", i), label, collector)
+		newTarget.SampleCount = sampleCnts[i-startingIndex]
+		toReturn = append(toReturn, newTarget)
+	}
+	return toReturn
+}
+
+func generateInts(n, max, min, maxCnt int) []int {
+	if n <= 0 {
+		return []int{}
+	}
+
+	if n == 1 {
+		return []int{max}
+	}
+
+	toReturn := make([]int, n)
+
+	for i := range toReturn {
+		if i < maxCnt {
+			toReturn[i] = max
+		} else {
+			toReturn[i] = min
+		}
+	}
+
+	return toReturn
+}
+
 func MakeNCollectors(n int, startingIndex int) map[string]*Collector {
 	toReturn := map[string]*Collector{}
 	for i := startingIndex; i < n+startingIndex; i++ {

--- a/cmd/otel-allocator/internal/target/target.go
+++ b/cmd/otel-allocator/internal/target/target.go
@@ -38,7 +38,10 @@ type Item struct {
 	Labels        labels.Labels
 	CollectorName string
 	hash          ItemHash
+
+	SampleCount int
 }
+
 
 func (t *Item) Hash() ItemHash {
 	if t.hash == 0 {


### PR DESCRIPTION
```
Running tool: /opt/homebrew/bin/go test -timeout 90s -run ^TestUnevenDistribution$ github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/allocation -count=1 -v

=== RUN   TestUnevenDistribution
expectedPerCollector 666
col.NumTargets 715 col.NumSamples 27130
col.NumTargets 802 col.NumSamples 8020
col.NumTargets 629 col.NumSamples 6290
col.NumTargets 706 col.NumSamples 37030
col.NumTargets 488 col.NumSamples 4880
col.NumTargets 705 col.NumSamples 27030
col.NumTargets 727 col.NumSamples 7270
col.NumTargets 716 col.NumSamples 7160
col.NumTargets 695 col.NumSamples 16940
col.NumTargets 627 col.NumSamples 6270
col.NumTargets 364 col.NumSamples 3640
col.NumTargets 675 col.NumSamples 6750
col.NumTargets 702 col.NumSamples 7020
col.NumTargets 738 col.NumSamples 17370
col.NumTargets 711 col.NumSamples 17100
maxSamples 37030 minSamples 3640 max/min 10
--- PASS: TestUnevenDistribution (0.01s)
PASS
ok  	github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/allocation	1.207s
```