### PR TITLE
Bump default otel collector version to 0.136.0

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -2,7 +2,7 @@
 # by default with the OpenTelemetry Operator. This would usually be the latest
 # stable OpenTelemetry version. When you update this file, make sure to update the
 # the docs as well.
-opentelemetry-collector=0.135.0
+opentelemetry-collector=0.136.0
 
 # Represents the current release of the OpenTelemetry Operator.
 operator=0.135.0


### PR DESCRIPTION
Bump the otel collector to 0.136.0. This is in preparation for the next release, bumping it earlier to see if the e2e tests pass.
