### PR TITLE
feat: added env only injection logic via annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,12 @@ OpenTelemetry SDK environment variables only:
 instrumentation.opentelemetry.io/inject-sdk: "true"
 ```
 
+OpenTelemetry environment variables only (alternative annotation name):
+
+```bash
+instrumentation.opentelemetry.io/inject-env: "true"
+```
+
 The possible values for the annotation can be
 
 - `"true"` - inject and `Instrumentation` resource from the namespace.

--- a/internal/instrumentation/annotation.go
+++ b/internal/instrumentation/annotation.go
@@ -28,6 +28,8 @@ const (
 	annotationGoExecPath                      = "instrumentation.opentelemetry.io/otel-go-auto-target-exe"
 	annotationInjectSdk                       = "instrumentation.opentelemetry.io/inject-sdk"
 	annotationInjectSdkContainersName         = "instrumentation.opentelemetry.io/sdk-container-names"
+	annotationInjectEnv                       = "instrumentation.opentelemetry.io/inject-env"
+	annotationInjectEnvContainersName         = "instrumentation.opentelemetry.io/env-container-names"
 	annotationInjectApacheHttpd               = "instrumentation.opentelemetry.io/inject-apache-httpd"
 	annotationInjectApacheHttpdContainersName = "instrumentation.opentelemetry.io/apache-httpd-container-names"
 	annotationInjectNginx                     = "instrumentation.opentelemetry.io/inject-nginx"

--- a/internal/instrumentation/sdk.go
+++ b/internal/instrumentation/sdk.go
@@ -215,6 +215,21 @@ func (i *sdkInjector) inject(ctx context.Context, insts languageInstrumentations
 		}
 	}
 
+	if insts.Env.Instrumentation != nil {
+		otelinst := *insts.Env.Instrumentation
+		i.logger.V(1).Info("injecting env-only instrumentation into pod", "otelinst-namespace", otelinst.Namespace, "otelinst-name", otelinst.Name)
+
+		if len(insts.Env.Containers) == 0 {
+			insts.Env.Containers = []string{pod.Spec.Containers[0].Name}
+		}
+
+		for _, container := range insts.Env.Containers {
+			index := getContainerIndex(container, pod)
+			pod = i.injectCommonEnvVar(otelinst, pod, index)
+			pod = i.injectCommonSDKConfig(ctx, otelinst, ns, pod, index, index)
+		}
+	}
+
 	return pod
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
- Renamed annotation `inject-sdk` to `inject-env` and corresponding logics to reduce confusion.
- For backward compatibility, added new logic alongside only (not deprecated `inject-sdk` logic immediately).

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #4382 

**Testing:** <Describe what testing was performed and which tests were added.>
- Added unit testing logic at `internal/instrumentation/annotation_test.go`

**Documentation:** <Describe the documentation added.>
- Updated documentation at `README.md`
