### PR TITLE
Move openshift namespace annotation setup into a step template

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-apache-httpd/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-httpd/chainsaw-test.yaml
@@ -5,25 +5,11 @@ metadata:
   name: instrumentation-apache-httpd
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-apache-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-multicontainer/chainsaw-test.yaml
@@ -6,25 +6,9 @@ metadata:
   name: instrumentation-apache-multicontainer
 spec:
   steps:
-  - name: step-00
-    try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-01
     try:
       - apply:

--- a/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/chainsaw-test.yaml
@@ -6,25 +6,9 @@ metadata:
   name: instrumentation-dotnet-multicontainer
 spec:
   steps:
-  - name: step-00
-    try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-dotnet-musl/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-musl/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: instrumentation-dotnet-musl
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-dotnet/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: instrumentation-dotnet
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-go/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-go/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: instrumentation-go
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations-root.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=0/0
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-java-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-multicontainer/chainsaw-test.yaml
@@ -6,25 +6,9 @@ metadata:
   name: instrumentation-java-multicontainer
 spec:
   steps:
-  - name: step-00
-    try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-java-other-ns/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-other-ns/chainsaw-test.yaml
@@ -5,25 +5,11 @@ metadata:
   name: instrumentation-java-other-ns
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-01
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - delete:
         ref:
           apiVersion: v1

--- a/tests/e2e-instrumentation/instrumentation-java-tls/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-tls/chainsaw-test.yaml
@@ -5,25 +5,11 @@ metadata:
   name: instrumentation-java-tls
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: ca.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-java/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java/chainsaw-test.yaml
@@ -5,25 +5,11 @@ metadata:
   name: instrumentation-java
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nginx-contnr-secctx/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-contnr-secctx/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: instrumentation-nginx-contnr-secctx
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: instrumentation-nginx-multicontainer
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nginx/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: instrumentation-nginx
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/chainsaw-test.yaml
@@ -6,25 +6,9 @@ metadata:
   name: instrumentation-nodejs-multicontainer
 spec:
   steps:
-  - name: step-00
-    try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nodejs-volume/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-volume/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: instrumentation-nodejs-volume
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nodejs/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: instrumentation-nodejs
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-python-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-multicontainer/chainsaw-test.yaml
@@ -6,25 +6,9 @@ metadata:
   name: instrumentation-python-multicontainer
 spec:
   steps:
-  - name: step-00
-    try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-python-musl/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-musl/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: instrumentation-python-musl
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-sdk/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-sdk/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: instrumentation-sdk
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer-go/chainsaw-test.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer-go/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: instrumentation-multi-multicontainer-go
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations-root.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=0/0
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: 00-install-collector.yaml
     - apply:

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/chainsaw-test.yaml
@@ -6,25 +6,9 @@ metadata:
   name: instrumentation-multi-multicontainer
 spec:
   steps:
-  - name: step-00
-    try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
     - apply:

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-no-containers/chainsaw-test.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-no-containers/chainsaw-test.yaml
@@ -6,25 +6,9 @@ metadata:
   name: instrumentation-multi-no-containers
 spec:
   steps:
-  - name: step-00
-    try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
     - apply:

--- a/tests/e2e-multi-instrumentation/instrumentation-single-instr-first-container/chainsaw-test.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-single-instr-first-container/chainsaw-test.yaml
@@ -6,25 +6,9 @@ metadata:
   name: instrumentation-single-instr-first-container
 spec:
   steps:
-  - name: step-00
-    try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
     - apply:

--- a/tests/e2e-openshift/must-gather/chainsaw-test.yaml
+++ b/tests/e2e-openshift/must-gather/chainsaw-test.yaml
@@ -15,25 +15,11 @@ spec:
     catch:
     - podLogs:
         selector: app.kubernetes.io/component=opentelemetry-targetallocator
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: Create instrumentation CR and gather collector instance
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/3000
-        - --overwrite
     - apply:
         file: install-collector-gather.yaml
     - assert:

--- a/tests/e2e-targetallocator-cr/chainsaw-test.yaml
+++ b/tests/e2e-targetallocator-cr/chainsaw-test.yaml
@@ -5,25 +5,11 @@ metadata:
   name: targetallocator-cr
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/1000
-        - --overwrite
     - apply:
         template: true
         file: 00-install.yaml

--- a/tests/e2e-targetallocator/targetallocator-features/chainsaw-test.yaml
+++ b/tests/e2e-targetallocator/targetallocator-features/chainsaw-test.yaml
@@ -6,25 +6,11 @@ metadata:
   name: targetallocator-features
 spec:
   steps:
+  - name: Add OpenShift namespace annotations
+    use:
+      template: ../../step-templates/openshift-namespace-annotations.yaml
   - name: step-00
     try:
-    # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added. However, if a namespace is created using a resource file with only selected SCCs, the other auto-added SCCs are not included. Therefore, the UID-range and supplemental groups SCC annotations must be set after the namespace is created.
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.uid-range=1000/1000
-        - --overwrite
-    - command:
-        entrypoint: kubectl
-        args:
-        - annotate
-        - namespace
-        - ${NAMESPACE}
-        - openshift.io/sa.scc.supplemental-groups=3000/1000
-        - --overwrite
     - apply:
         template: true
         file: 00-install.yaml

--- a/tests/step-templates/openshift-namespace-annotations-root.yaml
+++ b/tests/step-templates/openshift-namespace-annotations-root.yaml
@@ -1,7 +1,7 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: StepTemplate
 metadata:
-  name: openshift-namespace-annotations
+  name: openshift-namespace-annotations-root
 spec:
   try:
     # In OpenShift, when a namespace is created, all necessary SCC annotations are automatically added.
@@ -14,7 +14,7 @@ spec:
           - annotate
           - namespace
           - ${NAMESPACE}
-          - openshift.io/sa.scc.uid-range=1000/1000
+          - openshift.io/sa.scc.uid-range=0/0
           - --overwrite
     - command:
         entrypoint: kubectl


### PR DESCRIPTION
Move adding openshift namespace annotations in e2e tests to a step template. This removes a lot of unnecessary duplication.

Some tests require the annotation to permit root users. Passing arguments into the template steps was a bit annoying, so I just created two separate steps. We can optimize this further later if we want.