### PR TITLE
Support grpc endpoint for jaeger_query_extension

### DIFF
--- a/.chloggen/jaeger-query-grpc.yaml
+++ b/.chloggen/jaeger-query-grpc.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: collector
+note: "Support gRPC endpoint for jaeger_query extension and expose it when configured."
+issues: [4358]
+subtext: |
+  - HTTP remains defaulted to 16686; gRPC has no default and is exposed only when `jaeger_query.grpc.endpoint` is set.

--- a/internal/components/extensions/jaeger_query_extension_test.go
+++ b/internal/components/extensions/jaeger_query_extension_test.go
@@ -24,16 +24,51 @@ func TestJaegerQueryExtensionParser(t *testing.T) {
 	defaultCfg, err := genericBuilder.GetDefaultConfig(logr.Discard(), nil)
 	require.NoError(t, err)
 
-	ports, err := genericBuilder.Ports(logr.Discard(), "jaeger_query", defaultCfg)
-	require.NoError(t, err)
-	assert.Equal(t, []corev1.ServicePort{{
-		Name:       "jaeger-query",
-		Port:       16686,
-		TargetPort: intstr.FromInt32(16686),
-	}}, ports)
+	tests := []struct {
+		name     string
+		config   interface{}
+		expected []corev1.ServicePort
+	}{
+		{
+			name:   "default http only",
+			config: defaultCfg,
+			expected: []corev1.ServicePort{{
+				Name: "jaeger-query", Port: 16686, TargetPort: intstr.FromInt32(16686),
+			}},
+		},
+		{
+			name:   "grpc only configured",
+			config: map[string]interface{}{"grpc": map[string]interface{}{"endpoint": "0.0.0.0:16685"}},
+			expected: []corev1.ServicePort{
+				{Name: "jaeger-query", Port: 16686, TargetPort: intstr.FromInt32(16686)},
+				{Name: "jq-grpc", Port: 16685, TargetPort: intstr.FromInt32(16685)},
+			},
+		},
+		{
+			name: "http and grpc configured (non-default ports)",
+			config: map[string]interface{}{
+				"http": map[string]interface{}{"endpoint": "0.0.0.0:17686"},
+				"grpc": map[string]interface{}{"endpoint": "0.0.0.0:17685"},
+			},
+			expected: []corev1.ServicePort{
+				{Name: "jaeger-query", Port: 17686, TargetPort: intstr.FromInt32(17686)},
+				{Name: "jq-grpc", Port: 17685, TargetPort: intstr.FromInt32(17685)},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			var cfg = tc.config
+			ports, err := genericBuilder.Ports(logr.Discard(), "jaeger_query", cfg)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tc.expected, ports)
+		})
+	}
 }
 
-func TestJaegerQueryExtensionParser_config(t *testing.T) {
+func TestJaegerQueryExtensionParser_GetDefaultConfig(t *testing.T) {
 	jaegerBuilder := NewJaegerQueryExtensionParserBuilder()
 	genericBuilder, err := jaegerBuilder.Build()
 	require.NoError(t, err)
@@ -44,13 +79,52 @@ func TestJaegerQueryExtensionParser_config(t *testing.T) {
 		want   interface{}
 	}{
 		{
-			name:   "valid config",
-			config: map[string]interface{}{"http": map[string]interface{}{"endpoint": "127.0.0.0:16686"}},
-			want:   map[string]interface{}{"http": map[string]interface{}{"endpoint": "127.0.0.0:16686"}},
+			name:   "http: preserves provided endpoint",
+			config: map[string]interface{}{"http": map[string]interface{}{"endpoint": "127.0.0.0:17686"}},
+			want:   map[string]interface{}{"http": map[string]interface{}{"endpoint": "127.0.0.0:17686"}},
 		},
 		{
-			name: "missing config",
+			name:   "http: defaults host when missing",
+			config: map[string]interface{}{"http": map[string]interface{}{"endpoint": ":17686"}},
+			want: map[string]interface{}{
+				"http": map[string]interface{}{"endpoint": "0.0.0.0:17686"},
+			},
+		},
+		{
+			name: "http: defaults when missing",
 			want: map[string]interface{}{"http": map[string]interface{}{"endpoint": "0.0.0.0:16686"}},
+		},
+		{
+			name:   "grpc: preserves provided endpoint; http defaults",
+			config: map[string]interface{}{"grpc": map[string]interface{}{"endpoint": "127.0.0.0:17685"}},
+			want: map[string]interface{}{
+				"http": map[string]interface{}{"endpoint": "0.0.0.0:16686"},
+				"grpc": map[string]interface{}{"endpoint": "127.0.0.0:17685"},
+			},
+		},
+		{
+			name:   "grpc: defaults host when missing",
+			config: map[string]interface{}{"grpc": map[string]interface{}{"endpoint": ":17685"}},
+			want: map[string]interface{}{
+				"http": map[string]interface{}{"endpoint": "0.0.0.0:16686"},
+				"grpc": map[string]interface{}{"endpoint": "0.0.0.0:17685"},
+			},
+		},
+		{
+			name:   "grpc: empty section removed",
+			config: map[string]interface{}{"grpc": map[string]interface{}{}},
+			want:   map[string]interface{}{"http": map[string]interface{}{"endpoint": "0.0.0.0:16686"}},
+		},
+		{
+			name: "http+grpc: preserves provided endpoints",
+			config: map[string]interface{}{
+				"http": map[string]interface{}{"endpoint": "127.0.0.1:17686"},
+				"grpc": map[string]interface{}{"endpoint": "127.0.0.1:17685"},
+			},
+			want: map[string]interface{}{
+				"http": map[string]interface{}{"endpoint": "127.0.0.1:17686"},
+				"grpc": map[string]interface{}{"endpoint": "127.0.0.1:17685"},
+			},
 		},
 	}
 

--- a/internal/manifests/collector/service_test.go
+++ b/internal/manifests/collector/service_test.go
@@ -371,8 +371,8 @@ func TestExtensionService(t *testing.T) {
 							Extensions: &v1beta1.AnyConfig{
 								Object: map[string]interface{}{
 									"jaeger_query": map[string]interface{}{
-										"http": map[string]interface{}{
-											"endpoint": "0.0.0.0:16686",
+										"grpc": map[string]interface{}{
+											"endpoint": "0.0.0.0:17685",
 										},
 									},
 								},
@@ -382,13 +382,8 @@ func TestExtensionService(t *testing.T) {
 				},
 			},
 			expectedPorts: []v1.ServicePort{
-				{
-					Name: "jaeger-query",
-					Port: 16686,
-					TargetPort: intstr.IntOrString{
-						IntVal: 16686,
-					},
-				},
+				{Name: "jaeger-query", Port: 16686, TargetPort: intstr.IntOrString{IntVal: 16686}},
+				{Name: "jq-grpc", Port: 17685, TargetPort: intstr.IntOrString{IntVal: 17685}},
 			},
 		},
 		{
@@ -409,10 +404,10 @@ func TestExtensionService(t *testing.T) {
 								Object: map[string]interface{}{
 									"jaeger_query": map[string]interface{}{
 										"http": map[string]interface{}{
-											"endpoint": "0.0.0.0:16686",
+											"endpoint": "0.0.0.0:17686",
 										},
 										"grpc": map[string]interface{}{
-											"endpoint": "0.0.0.0:16686",
+											"endpoint": "0.0.0.0:17685",
 										},
 									},
 								},
@@ -422,13 +417,8 @@ func TestExtensionService(t *testing.T) {
 				},
 			},
 			expectedPorts: []v1.ServicePort{
-				{
-					Name: "jaeger-query",
-					Port: 16686,
-					TargetPort: intstr.IntOrString{
-						IntVal: 16686,
-					},
-				},
+				{Name: "jaeger-query", Port: 17686, TargetPort: intstr.IntOrString{IntVal: 17686}},
+				{Name: "jq-grpc", Port: 17685, TargetPort: intstr.IntOrString{IntVal: 17685}},
 			},
 		},
 		{


### PR DESCRIPTION
**Description:** <Describe what has changed.>
I've added support for the gRPC endpoint in jaeger_query_extension. I made it as backward-compatible as possible and decided not to expose the gRPC endpoint by default. However, if exposing it by default is acceptable, I’m happy to make those changes. Thanks for the review!

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves https://github.com/open-telemetry/opentelemetry-operator/issues/4358

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
