### PR TITLE
fix(collector): respect HPA scale; don't cap replicas at minReplicas

### DIFF
--- a/.chloggen/bugfix-autoscaler-replicas-respect-spec.yaml
+++ b/.chloggen/bugfix-autoscaler-replicas-respect-spec.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: collector
+note: "Fix autoscaler not scaling above minReplicas; replicas now respect the scale subresource and never fall below autoscaler.minReplicas."
+issues: [4400]
+subtext: |
+  Also rename helper `GetInitialReplicas` to `GetDesiredReplicas` to reflect reconcile-time behavior.

--- a/internal/manifests/collector/deployment.go
+++ b/internal/manifests/collector/deployment.go
@@ -35,7 +35,7 @@ func Deployment(params manifests.Params) (*appsv1.Deployment, error) {
 			Annotations: annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: manifestutils.GetInitialReplicas(params.OtelCol),
+			Replicas: manifestutils.GetDesiredReplicas(params.OtelCol),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, ComponentOpenTelemetryCollector),
 			},

--- a/internal/manifests/collector/deployment_test.go
+++ b/internal/manifests/collector/deployment_test.go
@@ -728,7 +728,7 @@ func TestDeploymentDNSConfig(t *testing.T) {
 	assert.Equal(t, d.Spec.Template.Spec.DNSConfig.Nameservers, []string{"8.8.8.8"})
 }
 
-func TestGetInitialReplicas(t *testing.T) {
+func TestGetDesiredReplicas(t *testing.T) {
 	tests := []struct {
 		name     string
 		otelCol  v1beta1.OpenTelemetryCollector
@@ -790,11 +790,26 @@ func TestGetInitialReplicas(t *testing.T) {
 			},
 			expected: int32Ptr(6),
 		},
+		{
+			name: "autoscaler-with-minReplicas-spec-replicas-greater",
+			otelCol: v1beta1.OpenTelemetryCollector{
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+						Replicas: int32Ptr(5),
+					},
+					Autoscaler: &v1beta1.AutoscalerSpec{
+						MinReplicas: int32Ptr(3),
+						MaxReplicas: int32Ptr(10),
+					},
+				},
+			},
+			expected: int32Ptr(5),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := manifestutils.GetInitialReplicas(tt.otelCol)
+			result := manifestutils.GetDesiredReplicas(tt.otelCol)
 			if tt.expected == nil {
 				assert.Nil(t, result)
 			} else {

--- a/internal/manifests/collector/statefulset.go
+++ b/internal/manifests/collector/statefulset.go
@@ -68,7 +68,7 @@ func StatefulSet(params manifests.Params) (*appsv1.StatefulSet, error) {
 					TerminationGracePeriodSeconds: params.OtelCol.Spec.TerminationGracePeriodSeconds,
 				},
 			},
-			Replicas:                             manifestutils.GetInitialReplicas(params.OtelCol),
+			Replicas:                             manifestutils.GetDesiredReplicas(params.OtelCol),
 			PodManagementPolicy:                  "Parallel",
 			VolumeClaimTemplates:                 VolumeClaimTemplates(params.OtelCol),
 			PersistentVolumeClaimRetentionPolicy: params.OtelCol.Spec.PersistentVolumeClaimRetentionPolicy,

--- a/internal/manifests/manifestutils/replicas.go
+++ b/internal/manifests/manifestutils/replicas.go
@@ -7,8 +7,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 )
 
-func GetInitialReplicas(otelCol v1beta1.OpenTelemetryCollector) *int32 {
+func GetDesiredReplicas(otelCol v1beta1.OpenTelemetryCollector) *int32 {
+	// If autoscaling is configured, ensure we never set replicas below MinReplicas,
+	// but still respect Spec.Replicas which may be updated via the scale subresource (e.g., by HPA).
 	if otelCol.Spec.Autoscaler != nil && otelCol.Spec.Autoscaler.MinReplicas != nil {
+		if otelCol.Spec.Replicas != nil {
+			replicas := max(*otelCol.Spec.Autoscaler.MinReplicas, *otelCol.Spec.Replicas)
+			return &replicas
+		}
 		return otelCol.Spec.Autoscaler.MinReplicas
 	}
 	return otelCol.Spec.Replicas


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The issue was already well described in the original report. However, the operator currently always returns the values defined in spec, and autoscaler.minValues never scales up. I’ve fixed this problem. I also renamed the function to GetDesiredReplicas, since it’s not only called during initialization but also on every reconciliation.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/4400

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
