### PR TITLE
Propagate annotations of the OTelCol and TA custom resources to the TA deployment resource

### DIFF
--- a/.chloggen/targetallocator-deployment-annotations.yaml
+++ b/.chloggen/targetallocator-deployment-annotations.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Annotations of the `OpenTelemetryCollector` and `TargetAllocator` resources are now propagated to the target allocator deployment resource.
+
+# One or more tracking issues related to the change
+issues: [4393]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: ""

--- a/hack/check-operator-ready.go
+++ b/hack/check-operator-ready.go
@@ -35,7 +35,10 @@ func main() {
 	var timeout int
 	var kubeconfigPath string
 
-	defaultKubeconfigPath := filepath.Join(homedir.HomeDir(), ".kube", "config")
+	defaultKubeconfigPath := os.Getenv("KUBECONFIG")
+	if defaultKubeconfigPath == "" {
+		defaultKubeconfigPath = filepath.Join(homedir.HomeDir(), ".kube", "config")
+	}
 
 	pflag.IntVar(&timeout, "timeout", 300, "The timeout for the check.")
 	pflag.StringVar(&kubeconfigPath, "kubeconfig-path", defaultKubeconfigPath, "Absolute path to the KubeconfigPath file")

--- a/internal/controllers/builder_test.go
+++ b/internal/controllers/builder_test.go
@@ -1839,6 +1839,9 @@ func TestBuildTargetAllocator(t *testing.T) {
 						Name:      "test",
 						Namespace: "test",
 						Labels:    nil,
+						Annotations: map[string]string{
+							"test": "test",
+						},
 					},
 					Spec: v1alpha1.TargetAllocatorSpec{
 						FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
@@ -1885,7 +1888,9 @@ func TestBuildTargetAllocator(t *testing.T) {
 							"app.kubernetes.io/part-of":    "opentelemetry",
 							"app.kubernetes.io/version":    "latest",
 						},
-						Annotations: nil,
+						Annotations: map[string]string{
+							"test": "test",
+						},
 					},
 					Data: map[string]string{
 						"targetallocator.yaml": `allocation_strategy: consistent-hashing
@@ -1929,7 +1934,10 @@ prometheus_cr:
 							"app.kubernetes.io/part-of":    "opentelemetry",
 							"app.kubernetes.io/version":    "latest",
 						},
-						Annotations: nil,
+						Annotations: map[string]string{
+							"opentelemetry-targetallocator-config/hash": "f80c054419fe2f9030368557da143e200c70772d1d5f1be50ed55ae960b4b17d",
+							"test": "test",
+						},
 					},
 					Spec: appsv1.DeploymentSpec{
 						Selector: &metav1.LabelSelector{
@@ -1947,6 +1955,7 @@ prometheus_cr:
 								},
 								Annotations: map[string]string{
 									"opentelemetry-targetallocator-config/hash": "f80c054419fe2f9030368557da143e200c70772d1d5f1be50ed55ae960b4b17d",
+									"test": "test",
 								},
 							},
 							Spec: corev1.PodSpec{
@@ -2034,6 +2043,9 @@ prometheus_cr:
 							"app.kubernetes.io/part-of":    "opentelemetry",
 							"app.kubernetes.io/version":    "latest",
 						},
+						Annotations: map[string]string{
+							"test": "test",
+						},
 					},
 				},
 				&corev1.Service{
@@ -2079,6 +2091,7 @@ prometheus_cr:
 						},
 						Annotations: map[string]string{
 							"opentelemetry-targetallocator-config/hash": "f80c054419fe2f9030368557da143e200c70772d1d5f1be50ed55ae960b4b17d",
+							"test": "test",
 						},
 					},
 					Spec: policyV1.PodDisruptionBudgetSpec{
@@ -2210,7 +2223,9 @@ prometheus_cr:
 							"app.kubernetes.io/part-of":    "opentelemetry",
 							"app.kubernetes.io/version":    "latest",
 						},
-						Annotations: nil,
+						Annotations: map[string]string{
+							"opentelemetry-targetallocator-config/hash": "f80c054419fe2f9030368557da143e200c70772d1d5f1be50ed55ae960b4b17d",
+						},
 					},
 					Spec: appsv1.DeploymentSpec{
 						Selector: &metav1.LabelSelector{
@@ -2541,7 +2556,9 @@ prometheus_cr:
 							"app.kubernetes.io/part-of":    "opentelemetry",
 							"app.kubernetes.io/version":    "latest",
 						},
-						Annotations: nil,
+						Annotations: map[string]string{
+							"opentelemetry-targetallocator-config/hash": "286a5a4e7ec6d2ce652a4ce23e135c10053b4c87fd080242daa5bf21dcd5a337",
+						},
 					},
 					Spec: appsv1.DeploymentSpec{
 						Selector: &metav1.LabelSelector{
@@ -2846,7 +2863,9 @@ prometheus_cr:
 							"app.kubernetes.io/part-of":    "opentelemetry",
 							"app.kubernetes.io/version":    "latest",
 						},
-						Annotations: nil,
+						Annotations: map[string]string{
+							"opentelemetry-targetallocator-config/hash": "3e2818ab54d866289de7837779e86e9c95803c43c0c4b58b25123e809ae9b771",
+						},
 					},
 					Spec: appsv1.DeploymentSpec{
 						Selector: &metav1.LabelSelector{

--- a/internal/manifests/targetallocator/annotations.go
+++ b/internal/manifests/targetallocator/annotations.go
@@ -15,8 +15,8 @@ import (
 
 const configMapHashAnnotationKey = "opentelemetry-targetallocator-config/hash"
 
-// Annotations returns the annotations for the TargetAllocator Pod.
-func Annotations(instance v1alpha1.TargetAllocator, configMap *v1.ConfigMap, filterAnnotations []string) map[string]string {
+// PodAnnotations returns the annotations for the TargetAllocator Pod.
+func PodAnnotations(instance v1alpha1.TargetAllocator, configMap *v1.ConfigMap, filterAnnotations []string) map[string]string {
 	// Make a copy of PodAnnotations to be safe
 	annotations := make(map[string]string, len(instance.Spec.PodAnnotations))
 	for key, value := range instance.Spec.PodAnnotations {

--- a/internal/manifests/targetallocator/annotations.go
+++ b/internal/manifests/targetallocator/annotations.go
@@ -15,6 +15,26 @@ import (
 
 const configMapHashAnnotationKey = "opentelemetry-targetallocator-config/hash"
 
+// Annotations returns the annotations for the TargetAllocator resources.
+func Annotations(instance v1alpha1.TargetAllocator, configMap *v1.ConfigMap, filterAnnotations []string) map[string]string {
+	annotations := make(map[string]string, len(instance.ObjectMeta.Annotations))
+	if instance.ObjectMeta.Annotations != nil {
+		for k, v := range instance.ObjectMeta.Annotations {
+			if !manifestutils.IsFilteredSet(k, filterAnnotations) {
+				annotations[k] = v
+			}
+		}
+	}
+	if configMap != nil {
+		cmHash := getConfigMapSHA(configMap)
+		if cmHash != "" {
+			annotations[configMapHashAnnotationKey] = getConfigMapSHA(configMap)
+		}
+	}
+
+	return annotations
+}
+
 // PodAnnotations returns the annotations for the TargetAllocator Pod.
 func PodAnnotations(instance v1alpha1.TargetAllocator, configMap *v1.ConfigMap, filterAnnotations []string) map[string]string {
 	// Make a copy of PodAnnotations to be safe

--- a/internal/manifests/targetallocator/annotations_test.go
+++ b/internal/manifests/targetallocator/annotations_test.go
@@ -20,8 +20,8 @@ func TestPodAnnotations(t *testing.T) {
 	instance.Spec.PodAnnotations = map[string]string{
 		"key": "value",
 	}
-	annotations := Annotations(instance, nil, []string{".*\\.bar\\.io"})
-	assert.Subset(t, annotations, instance.Spec.PodAnnotations)
+	podAnnotations := PodAnnotations(instance, nil, []string{".*\\.bar\\.io"})
+	assert.Subset(t, podAnnotations, instance.Spec.PodAnnotations)
 }
 
 func TestConfigMapHash(t *testing.T) {
@@ -39,14 +39,14 @@ func TestConfigMapHash(t *testing.T) {
 	expectedConfig := expectedConfigMap.Data[targetAllocatorFilename]
 	require.NotEmpty(t, expectedConfig)
 	expectedHash := sha256.Sum256([]byte(expectedConfig))
-	annotations := Annotations(targetAllocator, expectedConfigMap, []string{".*\\.bar\\.io"})
-	require.Contains(t, annotations, configMapHashAnnotationKey)
-	cmHash := annotations[configMapHashAnnotationKey]
+	podAnnotations := PodAnnotations(targetAllocator, expectedConfigMap, []string{".*\\.bar\\.io"})
+	require.Contains(t, podAnnotations, configMapHashAnnotationKey)
+	cmHash := podAnnotations[configMapHashAnnotationKey]
 	assert.Equal(t, fmt.Sprintf("%x", expectedHash), cmHash)
 }
 
 func TestInvalidConfigNoHash(t *testing.T) {
 	instance := targetAllocatorInstance()
-	annotations := Annotations(instance, nil, []string{".*\\.bar\\.io"})
-	require.NotContains(t, annotations, configMapHashAnnotationKey)
+	podAnnotations := PodAnnotations(instance, nil, []string{".*\\.bar\\.io"})
+	require.NotContains(t, podAnnotations, configMapHashAnnotationKey)
 }

--- a/internal/manifests/targetallocator/deployment.go
+++ b/internal/manifests/targetallocator/deployment.go
@@ -22,13 +22,15 @@ func Deployment(params Params) (*appsv1.Deployment, error) {
 		params.Log.Info("failed to construct target allocator config map for annotations")
 		configMap = nil
 	}
+	annotations := Annotations(params.TargetAllocator, configMap, params.Config.AnnotationsFilter)
 	podAnnotations := PodAnnotations(params.TargetAllocator, configMap, params.Config.AnnotationsFilter)
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: params.TargetAllocator.Namespace,
-			Labels:    labels,
+			Name:        name,
+			Namespace:   params.TargetAllocator.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: params.TargetAllocator.Spec.Replicas,

--- a/internal/manifests/targetallocator/deployment.go
+++ b/internal/manifests/targetallocator/deployment.go
@@ -22,7 +22,7 @@ func Deployment(params Params) (*appsv1.Deployment, error) {
 		params.Log.Info("failed to construct target allocator config map for annotations")
 		configMap = nil
 	}
-	annotations := Annotations(params.TargetAllocator, configMap, params.Config.AnnotationsFilter)
+	podAnnotations := PodAnnotations(params.TargetAllocator, configMap, params.Config.AnnotationsFilter)
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -38,7 +38,7 @@ func Deployment(params Params) (*appsv1.Deployment, error) {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: annotations,
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            ServiceAccountName(params.TargetAllocator),

--- a/internal/manifests/targetallocator/deployment_test.go
+++ b/internal/manifests/targetallocator/deployment_test.go
@@ -145,8 +145,35 @@ func TestDeploymentNewDefault(t *testing.T) {
 	assert.Contains(t, d.Spec.Template.Annotations, configMapHashAnnotationKey)
 	assert.Len(t, d.Spec.Template.Annotations, 1)
 
+	// should only have the ConfigMap hash annotation
+	assert.Contains(t, d.ObjectMeta.Annotations, configMapHashAnnotationKey)
+	assert.Len(t, d.ObjectMeta.Annotations, 1)
+
 	// the pod selector should match the pod spec's labels
 	assert.Subset(t, d.Spec.Template.Labels, d.Spec.Selector.MatchLabels)
+}
+
+func TestDeploymentAnnotations(t *testing.T) {
+	// prepare
+	testAnnotationValues := map[string]string{"annotation-key": "annotation-value"}
+	otelcol := collectorInstance()
+	targetAllocator := targetAllocatorInstance()
+	targetAllocator.ObjectMeta.Annotations = testAnnotationValues
+	cfg := config.New()
+
+	params := Params{
+		Collector:       otelcol,
+		TargetAllocator: targetAllocator,
+		Config:          cfg,
+		Log:             logger,
+	}
+
+	// test
+	ds, err := Deployment(params)
+	assert.NoError(t, err)
+	// verify
+	assert.Equal(t, "my-instance-targetallocator", ds.Name)
+	assert.Subset(t, ds.ObjectMeta.Annotations, testAnnotationValues)
 }
 
 func TestDeploymentPodAnnotations(t *testing.T) {

--- a/internal/manifests/targetallocator/networkpolicy.go
+++ b/internal/manifests/targetallocator/networkpolicy.go
@@ -29,7 +29,7 @@ func NetworkPolicy(params Params) (*networkingv1.NetworkPolicy, error) {
 
 	name := naming.TargetAllocatorNetworkPolicy(params.TargetAllocator.Name)
 	labels := manifestutils.Labels(params.TargetAllocator.ObjectMeta, name, params.TargetAllocator.Status.Image, ComponentOpenTelemetryTargetAllocator, params.Config.LabelsFilter)
-	annotations := Annotations(params.TargetAllocator, nil, params.Config.AnnotationsFilter)
+	podAnnotations := PodAnnotations(params.TargetAllocator, nil, params.Config.AnnotationsFilter)
 
 	tcp := corev1.ProtocolTCP
 	apiServerPort := intstr.FromInt32(defaultAPIServerPort)
@@ -37,7 +37,7 @@ func NetworkPolicy(params Params) (*networkingv1.NetworkPolicy, error) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   params.TargetAllocator.Namespace,
-			Annotations: annotations,
+			Annotations: podAnnotations,
 			Labels:      labels,
 		},
 		Spec: networkingv1.NetworkPolicySpec{

--- a/internal/manifests/targetallocator/poddisruptionbudget.go
+++ b/internal/manifests/targetallocator/poddisruptionbudget.go
@@ -49,13 +49,13 @@ func PodDisruptionBudget(params Params) (*policyV1.PodDisruptionBudget, error) {
 		params.Log.Info("failed to construct target allocator config map for annotations")
 		configMap = nil
 	}
-	annotations := Annotations(params.TargetAllocator, configMap, params.Config.AnnotationsFilter)
+	podAnnotations := PodAnnotations(params.TargetAllocator, configMap, params.Config.AnnotationsFilter)
 
 	objectMeta := metav1.ObjectMeta{
 		Name:        name,
 		Namespace:   params.TargetAllocator.Namespace,
 		Labels:      labels,
-		Annotations: annotations,
+		Annotations: podAnnotations,
 	}
 
 	return &policyV1.PodDisruptionBudget{

--- a/tests/e2e-targetallocator-cr/targetallocator-label/00-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/00-assert.yaml
@@ -43,3 +43,10 @@ data:
 kind: ConfigMap
 metadata:
   name: ta-targetallocator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ta-targetallocator
+  annotations:
+    e2e-test-annotation: "true"

--- a/tests/e2e-targetallocator-cr/targetallocator-label/00-install.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/00-install.yaml
@@ -3,6 +3,8 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: TargetAllocator
 metadata:
   name: ta
+  annotations:
+    e2e-test-annotation: "true"
 spec:
 ---
 apiVersion: opentelemetry.io/v1beta1

--- a/tests/e2e-targetallocator/targetallocator-features/02-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-features/02-assert.yaml
@@ -4,6 +4,8 @@ metadata:
   name: stateful-targetallocator
   labels:
     app.kubernetes.io/name: test
+  annotations:
+    e2e-test-annotation: "true"
 spec:
   selector:
     matchLabels:

--- a/tests/e2e-targetallocator/targetallocator-features/02-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-features/02-install.yaml
@@ -4,4 +4,6 @@ metadata:
   name: stateful
   labels:
     app.kubernetes.io/name: test
+  annotations:
+    e2e-test-annotation: "true"
   


### PR DESCRIPTION
**Description:**
- Propagate annotations of the OTelCol and TA custom resources to the TA deployment resource. Note: This is not about pod annotations.
- Refactor: Rename the annotation function so it's similar to the ones for the OTelCol. To me it was quite confusing to see that the TA func is called `Annotations` but means `PodAnnotations`. I just renamed it without any further change for backwards compatibility. Yet it would be debatable if it's the pod annotation which should be put on the pdb and netpol. That's a different topic though.

Resolves: #4393

**Testing:**
- I didn't manage to get the tests running on my machine (envsetup failed). `go test ./internal/manifests/...` succeeds. As the changes are limited to that package, I guessed it's enough to raise the PR and see the checks in the CI pipelines.
- Tested the functionality manually in a `kind` cluster

**Documentation:** None
