### PR TITLE
Promote the operator.collector.targetallocatorcr feature flag to Stable

### DIFF
--- a/.chloggen/feat_targetallocator-cr-stable.yaml
+++ b/.chloggen/feat_targetallocator-cr-stable.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote the operator.collector.targetallocatorcr feature flag to Stable
+
+# One or more tracking issues related to the change
+issues: [2422]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The flag can no longer be disabled. It will be completely removed in 0.138.0.

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -18,9 +18,10 @@ var (
 	// TargetAllocator CRs instead of generating the manifests for its resources directly.
 	CollectorUsesTargetAllocatorCR = featuregate.GlobalRegistry().MustRegister(
 		"operator.collector.targetallocatorcr",
-		featuregate.StageBeta,
+		featuregate.StageStable,
 		featuregate.WithRegisterDescription("causes collector reconciliation to create a target allocator CR instead of creating resources directly"),
 		featuregate.WithRegisterFromVersion("v0.112.0"),
+		featuregate.WithRegisterToVersion("v0.138.0"),
 	)
 	// EnableNativeSidecarContainers is the feature gate that controls whether a
 	// sidecar should be injected as a native sidecar or the classic way.


### PR DESCRIPTION
**Description:**

Promote the `operator.collector.targetallocatorcr` feature flag to Stable. The plan is to remove it in 0.138.0.

**Link to tracking Issue(s):**

- Relates to #4025
