### PR TITLE
Fix flaky TestNamespaceLabelUpdate test

### DIFF
--- a/cmd/otel-allocator/internal/watcher/promOperator_test.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator_test.go
@@ -952,7 +952,6 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestNamespaceLabelUpdate(t *testing.T) {
-	t.Skip("Flaky test, see https://github.com/open-telemetry/opentelemetry-operator/issues/4417")
 	var err error
 	namespace := "test"
 	portName := "web"
@@ -1066,10 +1065,10 @@ func TestNamespaceLabelUpdate(t *testing.T) {
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		got, err = w.LoadConfig(context.Background())
-		assert.NoError(t, err)
+		assert.NoError(collect, err)
 
 		sanitizeScrapeConfigsForTest(got.ScrapeConfigs)
-		assert.Equal(t, want_after.ScrapeConfigs, got.ScrapeConfigs)
+		assert.Equal(collect, want_after.ScrapeConfigs, got.ScrapeConfigs)
 	}, time.Second*60, time.Millisecond*100)
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The current test uses EventuallyWithT and during assertion, it passes in the parent test object `t *testing.T` instead of `collect *assert.CollectT`. When `assert.Equal(t, want_after.ScrapeConfigs, got.ScrapeConfigs)` is called, the entire test fail immediately if config were not updated yet, causing the flakiness.

Pass in `collect *assert.CollectT` instead, to collect any errors and allow the test to poll for the entire duration of 60s.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #4417

**Testing:** <Describe what testing was performed and which tests were added.>
Tested unit-tests locally

**Documentation:** <Describe the documentation added.>
