### PR TITLE
Fix TestOpenTelemetryCollectorReconciler_Reconcile

### DIFF
--- a/internal/controllers/reconcile_test.go
+++ b/internal/controllers/reconcile_test.go
@@ -647,7 +647,7 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 					actual := &v1beta1.OpenTelemetryCollector{}
 					err := reconciler.Get(testContext, nsn, actual)
 					assert.NoError(collect, err)
-					assert.NotNil(t, actual.GetDeletionTimestamp())
+					assert.NotNil(collect, actual.GetDeletionTimestamp())
 				}, time.Second*30, time.Millisecond*100)
 			}
 			req := k8sreconcile.Request{


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Pass the correct test context `collect` during assert.EventuallyWithT, for the test to run fully and not fail. 

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #4436 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
