### PR TITLE
Only check if status.image is set in E2E tests

### DIFF
--- a/tests/e2e/smoke-daemonset/00-assert.yaml
+++ b/tests/e2e/smoke-daemonset/00-assert.yaml
@@ -32,7 +32,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: daemonset-test
 status:
-  (starts_with(image, 'ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector')): true
+  (image != ''): true
   scale:
     (replicas >= `1`): true
     (statusReplicas != ''): true

--- a/tests/e2e/smoke-simplest-v1beta1/00-assert.yaml
+++ b/tests/e2e/smoke-simplest-v1beta1/00-assert.yaml
@@ -58,7 +58,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: simplest
 status:
-  (starts_with(image, 'ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector')): true
+  (image != ''): true
   (version != ''): true
   scale:
     replicas: 1

--- a/tests/e2e/smoke-statefulset/00-assert.yaml
+++ b/tests/e2e/smoke-statefulset/00-assert.yaml
@@ -13,7 +13,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: stateful
 status:
-  (starts_with(image, 'ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector')): true
+  (image != ''): true
   (version != ''): true
   scale:
     replicas: 1


### PR DESCRIPTION
**Description:**

Make the E2E tests just check if `status.image` is set, rather than asserting on the actual value. This makes the tests pass on the contrib image, and was originally supposed to be part of https://github.com/open-telemetry/opentelemetry-operator/pull/4206/.

I'd like to improve this test later to take the value from the environment, but for now this is a quick fix.

**Link to tracking Issue(s):**

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/4432

