### PR TITLE
[chore] Update golangci/golangci-lint to v2.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -605,7 +605,7 @@ KUSTOMIZE_VERSION ?= v5.7.1
 # renovate: datasource=go depName=sigs.k8s.io/controller-tools/cmd/controller-gen
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.5.0
+GOLANGCI_LINT_VERSION ?= v2.6.0
 # renovate: datasource=go depName=sigs.k8s.io/kind
 KIND_VERSION ?= v0.30.0
 # renovate: datasource=go depName=github.com/kyverno/chainsaw

--- a/cmd/otel-allocator/internal/target/discovery_test.go
+++ b/cmd/otel-allocator/internal/target/discovery_test.go
@@ -501,7 +501,7 @@ func TestProcessTargetGroups_StableLabelIterationOrder(t *testing.T) {
 	require.NoError(t, err)
 	d.processTargetGroups("test", groups, results)
 
-	for i, l := range results[0].Labels {
+	for i, l := range results[0].Labels { //nolint:gosec
 		expected := string(rune('a' + i))
 		assert.Equal(t, expected, l.Name, "unexpected label key at index %d", i)
 		assert.Equal(t, expected, l.Value, "unexpected label value at index %d", i)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

It seems that when we try to update golangci-lint to the latest v2.6.0, the CI starts failing with the following error:

```bash
cmd/otel-allocator/internal/target/discovery_test.go:504:27: G602: slice index out of range (gosec)
	for i, l := range results[0].Labels {
	                         ^
1 issues:
* gosec: 1
```

The code itself looks correct, so to fix the issue, I added `//nolint:gosec` there.

- https://github.com/open-telemetry/opentelemetry-operator/pull/4463

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #issue-number

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
