### PR TITLE
Promote Collector default config feature gate to stable

### DIFF
--- a/.chloggen/stable-feature-gate.yaml
+++ b/.chloggen/stable-feature-gate.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Promote the `operator.collector.default.config` feature gate to Stable"
+
+# One or more tracking issues related to the change
+issues: [4453]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -61,9 +61,10 @@ var (
 	// EnableConfigDefaulting is the feature gate that enables the operator to default the endpoint for known components.
 	EnableConfigDefaulting = featuregate.GlobalRegistry().MustRegister(
 		"operator.collector.default.config",
-		featuregate.StageBeta,
+		featuregate.StageStable,
 		featuregate.WithRegisterDescription("enables the operator to default the endpoint for known components"),
 		featuregate.WithRegisterFromVersion("v0.110.0"),
+		featuregate.WithRegisterToVersion("v0.139.0"),
 	)
 	// EnableOperatorNetworkPolicy is the feature gate that enables the operator to create network policies for the operator.
 	EnableOperatorNetworkPolicy = featuregate.GlobalRegistry().MustRegister(


### PR DESCRIPTION
**Description:**
Promote the `operator.collector.default.config` feature gate from Beta to Stable.

**Link to tracking Issue(s):**

* Resolves: #4453

**Testing:**
Ran e2e and unit tests locally 

**Documentation:**
