### PR TITLE
remove unused env from .github/workflows

### DIFF
--- a/.chloggen/remove-unused-env.yaml
+++ b/.chloggen/remove-unused-env.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: github action
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove unused VERSION and VERSION_DATE environment variables from publish workflows
+
+# One or more tracking issues related to the change
+issues: [4470]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Removed the unused "Read version" step that set VERSION and VERSION_DATE environment variables in both publish-target-allocator.yaml and publish-operator-opamp-bridge.yaml workflows. These variables were never referenced anywhere in the workflows.

--- a/.github/workflows/publish-operator-opamp-bridge.yaml
+++ b/.github/workflows/publish-operator-opamp-bridge.yaml
@@ -32,12 +32,6 @@ jobs:
         with:
           go-version: "~1.25.3"
 
-      # TODO: We're currently not using this. Should we?
-      - name: Read version
-        run: |
-          echo "VERSION=$(git describe --tags | sed 's/^v//')" >> $GITHUB_ENV
-          echo "VERSION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
-
       - name: Build the binary for each supported architecture
         run: |
           for platform in $(echo $PLATFORMS | tr "," "\n"); do

--- a/.github/workflows/publish-target-allocator.yaml
+++ b/.github/workflows/publish-target-allocator.yaml
@@ -32,12 +32,6 @@ jobs:
         with:
           go-version: "~1.25.3"
 
-      # TODO: We're currently not using this. Should we?
-      - name: Read version
-        run: |
-          echo "VERSION=$(git describe --tags | sed 's/^v//')" >> $GITHUB_ENV
-          echo "VERSION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
-
       - name: Build the binary for each supported architecture
         run: |
           for platform in $(echo $PLATFORMS | tr "," "\n"); do


### PR DESCRIPTION
**Description:**
Removed unused `VERSION` and `VERSION_DATE` environment setup from the workflows:

* `.github/workflows/publish-operator-opamp-bridge.yaml`
* `.github/workflows/publish-target-allocator.yaml`


**Link to tracking Issue(s):**
Resolves: #4470

**Testing:**

**Documentation:**
