### PR TITLE
Remove operator.collector.default.config feature gate

### DIFF
--- a/.chloggen/stable-feature-gate.yaml
+++ b/.chloggen/stable-feature-gate.yaml
@@ -5,13 +5,12 @@ change_type: enhancement
 component: collector
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Promote the `operator.collector.default.config` feature gate to Stable"
+note: "Remove the `operator.collector.default.config` feature gate as it has graduated to stable and is now always enabled"
 
 # One or more tracking issues related to the change
-issues: [4453]
+issues: [4453,4473]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-

--- a/apis/v1beta1/collector_webhook.go
+++ b/apis/v1beta1/collector_webhook.go
@@ -97,9 +97,6 @@ func (c CollectorWebhook) Default(_ context.Context, obj runtime.Object) error {
 	if len(otelcol.Spec.ManagementState) == 0 {
 		otelcol.Spec.ManagementState = ManagementStateManaged
 	}
-	if !featuregate.EnableConfigDefaulting.IsEnabled() {
-		return nil
-	}
 	if featuregate.EnableOperandNetworkPolicy.IsEnabled() && otelcol.Spec.NetworkPolicy.Enabled == nil {
 		trueVal := true
 		otelcol.Spec.NetworkPolicy.Enabled = &trueVal

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -50,14 +50,6 @@ var (
 		featuregate.WithRegisterDescription("enables fallback allocation strategy for the target allocator"),
 		featuregate.WithRegisterFromVersion("v0.114.0"),
 	)
-	// EnableConfigDefaulting is the feature gate that enables the operator to default the endpoint for known components.
-	EnableConfigDefaulting = featuregate.GlobalRegistry().MustRegister(
-		"operator.collector.default.config",
-		featuregate.StageStable,
-		featuregate.WithRegisterDescription("enables the operator to default the endpoint for known components"),
-		featuregate.WithRegisterFromVersion("v0.110.0"),
-		featuregate.WithRegisterToVersion("v0.139.0"),
-	)
 	// EnableOperatorNetworkPolicy is the feature gate that enables the operator to create network policies for the operator.
 	EnableOperatorNetworkPolicy = featuregate.GlobalRegistry().MustRegister(
 		"operator.networkpolicy",


### PR DESCRIPTION
**Description:**
Removes the stable feature gate `operator.collector.default.config`, https://github.com/open-telemetry/opentelemetry-operator/issues/4453. 

**Link to tracking Issue(s):**

* Resolves: #4473

**Testing:**
Verified by running e2e and unit tests locally.

**Documentation:**