### PR TITLE
[chore] Clean up the naming convention to make it simpler to use a retriever

### DIFF
--- a/apis/v1beta1/config.go
+++ b/apis/v1beta1/config.go
@@ -155,20 +155,20 @@ func (c *Config) getRbacRulesForComponentKinds(logger logr.Logger, componentKind
 		var cfg AnyConfig
 		switch componentKind {
 		case KindReceiver:
-			retriever = receivers.ReceiverFor
+			retriever = receivers.GetParser
 			cfg = c.Receivers
 		case KindExporter:
-			retriever = exporters.ParserFor
+			retriever = exporters.GetParser
 			cfg = c.Exporters
 		case KindProcessor:
-			retriever = processors.ProcessorFor
+			retriever = processors.GetParser
 			if c.Processors == nil {
 				cfg = AnyConfig{}
 			} else {
 				cfg = *c.Processors
 			}
 		case KindExtension:
-			retriever = extensions.ParserFor
+			retriever = extensions.GetParser
 			if c.Extensions == nil {
 				cfg = AnyConfig{}
 			} else {
@@ -179,7 +179,6 @@ func (c *Config) getRbacRulesForComponentKinds(logger logr.Logger, componentKind
 			continue
 		}
 		for componentName := range enabledComponents[componentKind] {
-			// TODO: Clean up the naming here and make it simpler to use a retriever.
 			parser := retriever(componentName)
 			if parsedRules, err := parser.GetRBACRules(logger, cfg.Object[componentName]); err != nil {
 				return nil, err
@@ -200,15 +199,15 @@ func (c *Config) getPortsForComponentKinds(logger logr.Logger, componentKinds ..
 		var cfg AnyConfig
 		switch componentKind {
 		case KindReceiver:
-			retriever = receivers.ReceiverFor
+			retriever = receivers.GetParser
 			cfg = c.Receivers
 		case KindExporter:
-			retriever = exporters.ParserFor
+			retriever = exporters.GetParser
 			cfg = c.Exporters
 		case KindProcessor:
 			continue
 		case KindExtension:
-			retriever = extensions.ParserFor
+			retriever = extensions.GetParser
 			if c.Extensions == nil {
 				cfg = AnyConfig{}
 			} else {
@@ -216,7 +215,6 @@ func (c *Config) getPortsForComponentKinds(logger logr.Logger, componentKinds ..
 			}
 		}
 		for componentName := range enabledComponents[componentKind] {
-			// TODO: Clean up the naming here and make it simpler to use a retriever.
 			parser := retriever(componentName)
 			if parsedPorts, err := parser.Ports(logger, componentName, cfg.Object[componentName]); err != nil {
 				return nil, err
@@ -243,7 +241,7 @@ func (c *Config) getEnvironmentVariablesForComponentKinds(logger logr.Logger, co
 
 		switch componentKind {
 		case KindReceiver:
-			retriever = receivers.ReceiverFor
+			retriever = receivers.GetParser
 			cfg = c.Receivers
 		case KindExporter:
 			continue
@@ -282,7 +280,7 @@ func (c *Config) applyDefaultForComponentKinds(logger logr.Logger, componentKind
 		var cfg AnyConfig
 		switch componentKind {
 		case KindReceiver:
-			retriever = receivers.ReceiverFor
+			retriever = receivers.GetParser
 			cfg = c.Receivers
 		case KindExporter:
 			continue
@@ -292,7 +290,7 @@ func (c *Config) applyDefaultForComponentKinds(logger logr.Logger, componentKind
 			if c.Extensions == nil {
 				continue
 			}
-			retriever = extensions.ParserFor
+			retriever = extensions.GetParser
 			cfg = *c.Extensions
 		}
 		for componentName := range enabledComponents[componentKind] {
@@ -367,8 +365,7 @@ func (c *Config) GetLivenessProbe(logger logr.Logger) (*corev1.Probe, error) {
 
 	enabledComponents := c.GetEnabledComponents()
 	for componentName := range enabledComponents[KindExtension] {
-		// TODO: Clean up the naming here and make it simpler to use a retriever.
-		parser := extensions.ParserFor(componentName)
+		parser := extensions.GetParser(componentName)
 		if probe, err := parser.GetLivenessProbe(logger, c.Extensions.Object[componentName]); err != nil {
 			return nil, err
 		} else if probe != nil {
@@ -387,8 +384,7 @@ func (c *Config) GetReadinessProbe(logger logr.Logger) (*corev1.Probe, error) {
 
 	enabledComponents := c.GetEnabledComponents()
 	for componentName := range enabledComponents[KindExtension] {
-		// TODO: Clean up the naming here and make it simpler to use a retriever.
-		parser := extensions.ParserFor(componentName)
+		parser := extensions.GetParser(componentName)
 		if probe, err := parser.GetReadinessProbe(logger, c.Extensions.Object[componentName]); err != nil {
 			return nil, err
 		} else if probe != nil {
@@ -407,8 +403,7 @@ func (c *Config) GetStartupProbe(logger logr.Logger) (*corev1.Probe, error) {
 
 	enabledComponents := c.GetEnabledComponents()
 	for componentName := range enabledComponents[KindExtension] {
-		// TODO: Clean up the naming here and make it simpler to use a retriever.
-		parser := extensions.ParserFor(componentName)
+		parser := extensions.GetParser(componentName)
 		if probe, err := parser.GetStartupProbe(logger, c.Extensions.Object[componentName]); err != nil {
 			return nil, err
 		} else if probe != nil {

--- a/internal/components/component.go
+++ b/internal/components/component.go
@@ -81,7 +81,26 @@ func PortFromEndpoint(endpoint string) (int32, error) {
 	return int32(port), err //nolint: gosec // disable G115, this is guaranteed to not overflow due to the bitSize in the ParseInt call
 }
 
-type ParserRetriever func(string) Parser
+// GetParserWithSinglePortParserBuilder returns a parser from the registry or creates a default silent single port parser.
+// This is used for receivers which need single port parser builders.
+func GetParserWithSinglePortParserBuilder(name string, registry map[string]Parser) Parser {
+	if parser, ok := registry[ComponentType(name)]; ok {
+		return parser
+	}
+	return NewSilentSinglePortParserBuilder(ComponentType(name), UnsetPort).MustBuild()
+}
+
+// GetParser returns a parser from the registry or creates a default nop parser.
+// This is used for exporters, processors, and extensions.
+func GetParser(name string, registry map[string]Parser) Parser {
+	if parser, ok := registry[ComponentType(name)]; ok {
+		return parser
+	}
+	// We want the default for exporters/processors/extensions to fail silently.
+	return NewBuilder[any]().WithName(name).MustBuild()
+}
+
+type ParserRetriever func(string, registry map[string]Parser) Parser
 
 type Parser interface {
 	// GetDefaultConfig returns a config with set default values.

--- a/internal/components/exporters/helpers.go
+++ b/internal/components/exporters/helpers.go
@@ -12,8 +12,8 @@ var registry = map[string]components.Parser{
 	"prometheus": components.NewSinglePortParserBuilder("prometheus", 8888).MustBuild(),
 }
 
-// ParserFor returns a parser builder for the given exporter name.
-func ParserFor(name string) components.Parser {
+// GetParser returns a parser builder for the given exporter name.
+func GetParser(name string) components.Parser {
 	if parser, ok := registry[components.ComponentType(name)]; ok {
 		return parser
 	}

--- a/internal/components/exporters/helpers.go
+++ b/internal/components/exporters/helpers.go
@@ -7,16 +7,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/components"
 )
 
-// registry holds a record of all known receiver parsers.
-var registry = map[string]components.Parser{
+// Registry holds a record of all known exporter parsers.
+var Registry = map[string]components.Parser{
 	"prometheus": components.NewSinglePortParserBuilder("prometheus", 8888).MustBuild(),
 }
 
 // GetParser returns a parser builder for the given exporter name.
 func GetParser(name string) components.Parser {
-	if parser, ok := registry[components.ComponentType(name)]; ok {
-		return parser
-	}
-	// We want the default for exporters to fail silently.
-	return components.NewBuilder[any]().WithName(name).MustBuild()
+	return components.GetParser(name, Registry)
 }

--- a/internal/components/exporters/helpers_test.go
+++ b/internal/components/exporters/helpers_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestParserForReturns(t *testing.T) {
 	const testComponentName = "test"
-	parser := GetParser(testComponentName)
+	parser := components.GetParser(testComponentName, Registry)
 	assert.Equal(t, "test", parser.ParserType())
 	assert.Equal(t, "__test", parser.ParserName())
 	ports, err := parser.Ports(logr.Discard(), testComponentName, map[string]interface{}{
@@ -27,7 +27,7 @@ func TestParserForReturns(t *testing.T) {
 
 func TestCanRegister(t *testing.T) {
 	const testComponentName = "test"
-	registry[testComponentName] = components.NewSinglePortParserBuilder(testComponentName, 9000).MustBuild()
+	Registry[testComponentName] = components.NewSinglePortParserBuilder(testComponentName, 9000).MustBuild()
 	parser := GetParser(testComponentName)
 	assert.Equal(t, "test", parser.ParserType())
 	assert.Equal(t, "__test", parser.ParserName())
@@ -47,7 +47,7 @@ func TestExporterComponentParsers(t *testing.T) {
 	} {
 		t.Run(tt.exporterName, func(t *testing.T) {
 			t.Run("is registered", func(t *testing.T) {
-				_, ok := registry[tt.exporterName]
+				_, ok := Registry[tt.exporterName]
 				assert.True(t, ok)
 			})
 			t.Run("bad config errors", func(t *testing.T) {

--- a/internal/components/exporters/helpers_test.go
+++ b/internal/components/exporters/helpers_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestParserForReturns(t *testing.T) {
 	const testComponentName = "test"
-	parser := ParserFor(testComponentName)
+	parser := GetParser(testComponentName)
 	assert.Equal(t, "test", parser.ParserType())
 	assert.Equal(t, "__test", parser.ParserName())
 	ports, err := parser.Ports(logr.Discard(), testComponentName, map[string]interface{}{
@@ -28,7 +28,7 @@ func TestParserForReturns(t *testing.T) {
 func TestCanRegister(t *testing.T) {
 	const testComponentName = "test"
 	registry[testComponentName] = components.NewSinglePortParserBuilder(testComponentName, 9000).MustBuild()
-	parser := ParserFor(testComponentName)
+	parser := GetParser(testComponentName)
 	assert.Equal(t, "test", parser.ParserType())
 	assert.Equal(t, "__test", parser.ParserName())
 	ports, err := parser.Ports(logr.Discard(), testComponentName, map[string]interface{}{})
@@ -52,7 +52,7 @@ func TestExporterComponentParsers(t *testing.T) {
 			})
 			t.Run("bad config errors", func(t *testing.T) {
 				// prepare
-				parser := ParserFor(tt.exporterName)
+				parser := GetParser(tt.exporterName)
 
 				// test throwing in pure junk
 				_, err := parser.Ports(logr.Discard(), tt.exporterName, func() {})
@@ -63,7 +63,7 @@ func TestExporterComponentParsers(t *testing.T) {
 
 			t.Run("assigns the expected port", func(t *testing.T) {
 				// prepare
-				parser := ParserFor(tt.exporterName)
+				parser := GetParser(tt.exporterName)
 
 				// test
 				ports, err := parser.Ports(logr.Discard(), tt.exporterName, map[string]interface{}{})
@@ -81,7 +81,7 @@ func TestExporterComponentParsers(t *testing.T) {
 
 			t.Run("allows port to be overridden", func(t *testing.T) {
 				// prepare
-				parser := ParserFor(tt.exporterName)
+				parser := GetParser(tt.exporterName)
 
 				// test
 				ports, err := parser.Ports(logr.Discard(), tt.exporterName, map[string]interface{}{

--- a/internal/components/extensions/healthcheckv1_test.go
+++ b/internal/components/extensions/healthcheckv1_test.go
@@ -164,7 +164,7 @@ func TestHealthCheckV1Probe(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := ParserFor("health_check")
+			parser := GetParser("health_check")
 			got, err := parser.GetLivenessProbe(logr.Discard(), tt.args.config)
 			if !tt.wantErr(t, err, fmt.Sprintf("GetLivenessProbe(%v)", tt.args.config)) {
 				return
@@ -274,7 +274,7 @@ func TestHealthCheckV1AddressDefaulter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := ParserFor("health_check")
+			parser := GetParser("health_check")
 			got, err := parser.GetDefaultConfig(logr.Discard(), tt.args.config)
 			if !tt.wantErr(t, err, fmt.Sprintf("GetDefaultConfig(%v)", tt.args.config)) {
 				return

--- a/internal/components/extensions/helpers.go
+++ b/internal/components/extensions/helpers.go
@@ -32,8 +32,8 @@ var registry = map[string]components.Parser{
 		MustBuild(),
 }
 
-// ParserFor returns a parser builder for the given exporter name.
-func ParserFor(name string) components.Parser {
+// GetParser returns a parser builder for the given exporter name.
+func GetParser(name string) components.Parser {
 	if parser, ok := registry[components.ComponentType(name)]; ok {
 		return parser
 	}

--- a/internal/components/extensions/helpers.go
+++ b/internal/components/extensions/helpers.go
@@ -10,8 +10,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/components"
 )
 
-// registry holds a record of all known receiver parsers.
-var registry = map[string]components.Parser{
+// Registry holds a record of all known extension parsers.
+var Registry = map[string]components.Parser{
 	"health_check": components.NewBuilder[healthcheckV1Config]().
 		WithName("health_check").
 		WithPort(defaultHealthcheckV1Port).
@@ -32,11 +32,7 @@ var registry = map[string]components.Parser{
 		MustBuild(),
 }
 
-// GetParser returns a parser builder for the given exporter name.
+// GetParser returns a parser builder for the given extension name.
 func GetParser(name string) components.Parser {
-	if parser, ok := registry[components.ComponentType(name)]; ok {
-		return parser
-	}
-	// We want the default for exporters to fail silently.
-	return components.NewBuilder[any]().WithName(name).MustBuild()
+	return components.GetParser(name, Registry)
 }

--- a/internal/components/extensions/helpers_test.go
+++ b/internal/components/extensions/helpers_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestParserForReturns(t *testing.T) {
 	const testComponentName = "test"
-	parser := ParserFor(testComponentName)
+	parser := GetParser(testComponentName)
 	assert.Equal(t, "test", parser.ParserType())
 	assert.Equal(t, "__test", parser.ParserName())
 	ports, err := parser.Ports(logr.Discard(), testComponentName, map[string]interface{}{
@@ -28,7 +28,7 @@ func TestParserForReturns(t *testing.T) {
 func TestCanRegister(t *testing.T) {
 	const testComponentName = "test"
 	registry[testComponentName] = components.NewSinglePortParserBuilder(testComponentName, 9000).MustBuild()
-	parser := ParserFor(testComponentName)
+	parser := GetParser(testComponentName)
 	assert.Equal(t, "test", parser.ParserType())
 	assert.Equal(t, "__test", parser.ParserName())
 	ports, err := parser.Ports(logr.Discard(), testComponentName, map[string]interface{}{})
@@ -52,7 +52,7 @@ func TestExtensionsComponentParsers(t *testing.T) {
 			})
 			t.Run("bad config errors", func(t *testing.T) {
 				// prepare
-				parser := ParserFor(tt.exporterName)
+				parser := GetParser(tt.exporterName)
 
 				// test throwing in pure junk
 				_, err := parser.Ports(logr.Discard(), tt.exporterName, func() {})
@@ -63,7 +63,7 @@ func TestExtensionsComponentParsers(t *testing.T) {
 
 			t.Run("assigns the expected port", func(t *testing.T) {
 				// prepare
-				parser := ParserFor(tt.exporterName)
+				parser := GetParser(tt.exporterName)
 
 				// test
 				ports, err := parser.Ports(logr.Discard(), tt.exporterName, map[string]interface{}{})
@@ -81,7 +81,7 @@ func TestExtensionsComponentParsers(t *testing.T) {
 
 			t.Run("allows port to be overridden", func(t *testing.T) {
 				// prepare
-				parser := ParserFor(tt.exporterName)
+				parser := GetParser(tt.exporterName)
 
 				// test
 				ports, err := parser.Ports(logr.Discard(), tt.exporterName, map[string]interface{}{

--- a/internal/components/extensions/helpers_test.go
+++ b/internal/components/extensions/helpers_test.go
@@ -27,7 +27,7 @@ func TestParserForReturns(t *testing.T) {
 
 func TestCanRegister(t *testing.T) {
 	const testComponentName = "test"
-	registry[testComponentName] = components.NewSinglePortParserBuilder(testComponentName, 9000).MustBuild()
+	Registry[testComponentName] = components.NewSinglePortParserBuilder(testComponentName, 9000).MustBuild()
 	parser := GetParser(testComponentName)
 	assert.Equal(t, "test", parser.ParserType())
 	assert.Equal(t, "__test", parser.ParserName())
@@ -47,7 +47,7 @@ func TestExtensionsComponentParsers(t *testing.T) {
 	} {
 		t.Run(tt.exporterName, func(t *testing.T) {
 			t.Run("is registered", func(t *testing.T) {
-				_, ok := registry[tt.exporterName]
+				_, ok := Registry[tt.exporterName]
 				assert.True(t, ok)
 			})
 			t.Run("bad config errors", func(t *testing.T) {

--- a/internal/components/processors/helpers.go
+++ b/internal/components/processors/helpers.go
@@ -19,8 +19,8 @@ func IsRegistered(name string) bool {
 	return ok
 }
 
-// ProcessorFor returns a parser builder for the given exporter name.
-func ProcessorFor(name string) components.Parser {
+// GetParser returns a parser builder for the given exporter name.
+func GetParser(name string) components.Parser {
 	if parser, ok := registry[components.ComponentType(name)]; ok {
 		return parser
 	}

--- a/internal/components/processors/helpers.go
+++ b/internal/components/processors/helpers.go
@@ -5,26 +5,23 @@ package processors
 
 import "github.com/open-telemetry/opentelemetry-operator/internal/components"
 
-// registry holds a record of all known receiver parsers.
-var registry = make(map[string]components.Parser)
+// Registry holds a record of all known processor parsers.
+var Registry = make(map[string]components.Parser)
 
 // Register adds a new parser builder to the list of known builders.
 func Register(name string, p components.Parser) {
-	registry[name] = p
+	Registry[name] = p
 }
 
 // IsRegistered checks whether a parser is registered with the given name.
 func IsRegistered(name string) bool {
-	_, ok := registry[components.ComponentType(name)]
+	_, ok := Registry[components.ComponentType(name)]
 	return ok
 }
 
-// GetParser returns a parser builder for the given exporter name.
+// GetParser returns a parser builder for the given processor name.
 func GetParser(name string) components.Parser {
-	if parser, ok := registry[components.ComponentType(name)]; ok {
-		return parser
-	}
-	return components.NewBuilder[any]().WithName(name).MustBuild()
+	return components.GetParser(name, Registry)
 }
 
 var componentParsers = []components.Parser{

--- a/internal/components/processors/helpers_test.go
+++ b/internal/components/processors/helpers_test.go
@@ -18,7 +18,7 @@ var logger = logf.Log.WithName("unit-tests")
 
 func TestParserForReturns(t *testing.T) {
 	const testComponentName = "test"
-	parser := processors.ProcessorFor(testComponentName)
+	parser := processors.GetParser(testComponentName)
 	assert.Equal(t, "test", parser.ParserType())
 	assert.Equal(t, "__test", parser.ParserName())
 	ports, err := parser.Ports(logr.Discard(), testComponentName, map[string]interface{}{
@@ -32,7 +32,7 @@ func TestCanRegister(t *testing.T) {
 	const testComponentName = "test"
 	processors.Register(testComponentName, components.NewSinglePortParserBuilder(testComponentName, 9000).MustBuild())
 	assert.True(t, processors.IsRegistered(testComponentName))
-	parser := processors.ProcessorFor(testComponentName)
+	parser := processors.GetParser(testComponentName)
 	assert.Equal(t, "test", parser.ParserType())
 	assert.Equal(t, "__test", parser.ParserName())
 	ports, err := parser.Ports(logr.Discard(), testComponentName, map[string]interface{}{})
@@ -53,14 +53,14 @@ func TestDownstreamParsers(t *testing.T) {
 		t.Run(tt.processorName, func(t *testing.T) {
 			t.Run("builds successfully", func(t *testing.T) {
 				// test
-				parser := processors.ProcessorFor(tt.processorName)
+				parser := processors.GetParser(tt.processorName)
 
 				// verify
 				assert.Equal(t, tt.parserName, parser.ParserName())
 			})
 			t.Run("bad config errors", func(t *testing.T) {
 				// prepare
-				parser := processors.ProcessorFor(tt.processorName)
+				parser := processors.GetParser(tt.processorName)
 
 				// test throwing in pure junk
 				_, err := parser.Ports(logger, tt.processorName, func() {})

--- a/internal/components/processors/k8sattribute_test.go
+++ b/internal/components/processors/k8sattribute_test.go
@@ -154,7 +154,7 @@ func TestGenerateK8SAttrRbacRules(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := processors.ProcessorFor("k8sattributes")
+			parser := processors.GetParser("k8sattributes")
 			got, err := parser.GetRBACRules(logger, tt.args.config)
 			if !tt.wantErr(t, err, fmt.Sprintf("GetRBACRules(%v)", tt.args.config)) {
 				return

--- a/internal/components/processors/resourcedetection_test.go
+++ b/internal/components/processors/resourcedetection_test.go
@@ -99,7 +99,7 @@ func TestGenerateResourceDetectionRbacRules(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parser := processors.ProcessorFor("resourcedetection")
+			parser := processors.GetParser("resourcedetection")
 			got, err := parser.GetRBACRules(logger, tt.args.config)
 			if !tt.wantErr(t, err, fmt.Sprintf("GetRBACRules(%v)", tt.args.config)) {
 				return

--- a/internal/components/receivers/helpers.go
+++ b/internal/components/receivers/helpers.go
@@ -9,26 +9,23 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/components"
 )
 
-// registry holds a record of all known receiver parsers.
-var registry = make(map[string]components.Parser)
+// Registry holds a record of all known receiver parsers.
+var Registry = make(map[string]components.Parser)
 
 // Register adds a new parser builder to the list of known builders.
 func Register(name string, p components.Parser) {
-	registry[name] = p
+	Registry[name] = p
 }
 
 // IsRegistered checks whether a parser is registered with the given name.
 func IsRegistered(name string) bool {
-	_, ok := registry[components.ComponentType(name)]
+	_, ok := Registry[components.ComponentType(name)]
 	return ok
 }
 
-// GetParser returns a parser builder for the given exporter name.
+// GetParser returns a parser builder for the given receiver name.
 func GetParser(name string) components.Parser {
-	if parser, ok := registry[components.ComponentType(name)]; ok {
-		return parser
-	}
-	return components.NewSilentSinglePortParserBuilder(components.ComponentType(name), components.UnsetPort).MustBuild()
+	return components.GetParserWithSinglePortParserBuilder(name, Registry)
 }
 
 // NewScraperParser is an instance of a generic parser that returns nothing when called and never fails.

--- a/internal/components/receivers/helpers.go
+++ b/internal/components/receivers/helpers.go
@@ -23,8 +23,8 @@ func IsRegistered(name string) bool {
 	return ok
 }
 
-// ReceiverFor returns a parser builder for the given exporter name.
-func ReceiverFor(name string) components.Parser {
+// GetParser returns a parser builder for the given exporter name.
+func GetParser(name string) components.Parser {
 	if parser, ok := registry[components.ComponentType(name)]; ok {
 		return parser
 	}

--- a/internal/components/receivers/multi_endpoint_receiver_test.go
+++ b/internal/components/receivers/multi_endpoint_receiver_test.go
@@ -387,13 +387,13 @@ func TestMultiEndpointReceiverParsers(t *testing.T) {
 			})
 
 			t.Run("is found by name", func(t *testing.T) {
-				p := receivers.ReceiverFor(tt.receiverName)
+				p := receivers.GetParser(tt.receiverName)
 				assert.Equal(t, tt.parserName, p.ParserName())
 			})
 
 			t.Run("bad config errors", func(t *testing.T) {
 				// prepare
-				parser := receivers.ReceiverFor(tt.receiverName)
+				parser := receivers.GetParser(tt.receiverName)
 
 				// test
 				_, err := parser.Ports(logger, tt.receiverName, []interface{}{"junk"})
@@ -403,7 +403,7 @@ func TestMultiEndpointReceiverParsers(t *testing.T) {
 			})
 			t.Run("good config, unknown protocol", func(t *testing.T) {
 				// prepare
-				parser := receivers.ReceiverFor(tt.receiverName)
+				parser := receivers.GetParser(tt.receiverName)
 
 				// test
 				_, err := parser.Ports(logger, tt.receiverName, map[string]interface{}{
@@ -418,7 +418,7 @@ func TestMultiEndpointReceiverParsers(t *testing.T) {
 			for _, kase := range tt.cases {
 				t.Run(kase.name, func(t *testing.T) {
 					// prepare
-					parser := receivers.ReceiverFor(tt.receiverName)
+					parser := receivers.GetParser(tt.receiverName)
 
 					// test
 					ports, err := parser.Ports(logger, tt.receiverName, kase.config)

--- a/internal/components/receivers/scraper_test.go
+++ b/internal/components/receivers/scraper_test.go
@@ -51,7 +51,7 @@ func TestScraperParsers(t *testing.T) {
 		t.Run(tt.receiverName, func(t *testing.T) {
 			t.Run("builds successfully", func(t *testing.T) {
 				// test
-				parser := receivers.ReceiverFor(tt.receiverName)
+				parser := receivers.GetParser(tt.receiverName)
 
 				// verify
 				assert.Equal(t, tt.parserName, parser.ParserName())
@@ -59,7 +59,7 @@ func TestScraperParsers(t *testing.T) {
 
 			t.Run("default is nothing", func(t *testing.T) {
 				// prepare
-				parser := receivers.ReceiverFor(tt.receiverName)
+				parser := receivers.GetParser(tt.receiverName)
 
 				// test
 				ports, err := parser.Ports(logger, tt.receiverName, map[string]interface{}{})
@@ -71,7 +71,7 @@ func TestScraperParsers(t *testing.T) {
 
 			t.Run("always returns nothing", func(t *testing.T) {
 				// prepare
-				parser := receivers.ReceiverFor(tt.receiverName)
+				parser := receivers.GetParser(tt.receiverName)
 
 				// test
 				ports, err := parser.Ports(logger, tt.receiverName, map[string]interface{}{

--- a/internal/components/receivers/single_endpoint_receiver_test.go
+++ b/internal/components/receivers/single_endpoint_receiver_test.go
@@ -20,7 +20,7 @@ var logger = logf.Log.WithName("unit-tests")
 func TestParseEndpoint(t *testing.T) {
 	// prepare
 	// there's no parser registered to handle "myreceiver", so, it falls back to the generic parser
-	parser := receivers.ReceiverFor("myreceiver")
+	parser := receivers.GetParser("myreceiver")
 
 	// test
 	ports, err := parser.Ports(logger, "myreceiver", map[string]interface{}{
@@ -36,7 +36,7 @@ func TestParseEndpoint(t *testing.T) {
 func TestFailedToParseEndpoint(t *testing.T) {
 	// prepare
 	// there's no parser registered to handle "myreceiver", so, it falls back to the generic parser
-	parser := receivers.ReceiverFor("myreceiver")
+	parser := receivers.GetParser("myreceiver")
 
 	// test
 	ports, err := parser.Ports(logger, "myreceiver", map[string]interface{}{
@@ -75,14 +75,14 @@ func TestDownstreamParsers(t *testing.T) {
 		t.Run(tt.receiverName, func(t *testing.T) {
 			t.Run("builds successfully", func(t *testing.T) {
 				// test
-				parser := receivers.ReceiverFor(tt.receiverName)
+				parser := receivers.GetParser(tt.receiverName)
 
 				// verify
 				assert.Equal(t, tt.parserName, parser.ParserName())
 			})
 			t.Run("bad config errors", func(t *testing.T) {
 				// prepare
-				parser := receivers.ReceiverFor(tt.receiverName)
+				parser := receivers.GetParser(tt.receiverName)
 
 				// test throwing in pure junk
 				_, err := parser.Ports(logger, tt.receiverName, func() {})
@@ -93,7 +93,7 @@ func TestDownstreamParsers(t *testing.T) {
 
 			t.Run("assigns the expected port", func(t *testing.T) {
 				// prepare
-				parser := receivers.ReceiverFor(tt.receiverName)
+				parser := receivers.GetParser(tt.receiverName)
 
 				// test
 				ports, err := parser.Ports(logger, tt.receiverName, map[string]interface{}{})
@@ -111,7 +111,7 @@ func TestDownstreamParsers(t *testing.T) {
 
 			t.Run("allows port to be overridden", func(t *testing.T) {
 				// prepare
-				parser := receivers.ReceiverFor(tt.receiverName)
+				parser := receivers.GetParser(tt.receiverName)
 
 				// test
 				var ports []corev1.ServicePort
@@ -135,7 +135,7 @@ func TestDownstreamParsers(t *testing.T) {
 
 			t.Run("returns a default config", func(t *testing.T) {
 				// prepare
-				parser := receivers.ReceiverFor(tt.receiverName)
+				parser := receivers.GetParser(tt.receiverName)
 
 				// test
 				config, err := parser.GetDefaultConfig(logger, map[string]interface{}{})


### PR DESCRIPTION
**Description:**
All instances of functions like `ReceiverFor`, `ExporterFor`, `ProcessorFor`, and `ParserFor` have been  following similar naming convention.

**Link to tracking Issue(s):**

* Resolves: #4492

**Testing:**
ran unit and e2e tests locally 

**Documentation:**