### PR TITLE
[core] Fix Prometheus label handling in prep for 0.307.0 upgrade

### DIFF
--- a/cmd/otel-allocator/internal/allocation/allocator_test.go
+++ b/cmd/otel-allocator/internal/allocation/allocator_test.go
@@ -165,12 +165,8 @@ func TestAllocationCollision(t *testing.T) {
 
 		cols := MakeNCollectors(3, 0)
 		allocator.SetCollectors(cols)
-		firstLabels := labels.Labels{
-			{Name: "test", Value: "test1"},
-		}
-		secondLabels := labels.Labels{
-			{Name: "test", Value: "test2"},
-		}
+		firstLabels := labels.New(labels.Label{Name: "test", Value: "test1"})
+		secondLabels := labels.New(labels.Label{Name: "test", Value: "test2"})
 		firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstLabels, "")
 		secondTarget := target.NewItem("sample-name", "0.0.0.0:8000", secondLabels, "")
 

--- a/cmd/otel-allocator/internal/allocation/per_node_test.go
+++ b/cmd/otel-allocator/internal/allocation/per_node_test.go
@@ -32,24 +32,22 @@ func TestAllocationPerNode(t *testing.T) {
 
 	cols := MakeNCollectors(4, 0)
 	s.SetCollectors(cols)
-	firstLabels := labels.Labels{
-		{Name: "test", Value: "test1"},
-		{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
-	}
-	secondLabels := labels.Labels{
-		{Name: "test", Value: "test2"},
-		{Name: "__meta_kubernetes_node_name", Value: "node-1"},
-	}
+	firstLabels := labels.New(
+		labels.Label{Name: "test", Value: "test1"},
+		labels.Label{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
+	)
+	secondLabels := labels.New(
+		labels.Label{Name: "test", Value: "test2"},
+		labels.Label{Name: "__meta_kubernetes_node_name", Value: "node-1"},
+	)
 	// no label, should be skipped
-	thirdLabels := labels.Labels{
-		{Name: "test", Value: "test3"},
-	}
+	thirdLabels := labels.New(labels.Label{Name: "test", Value: "test3"})
 	// endpointslice target kind and name
-	fourthLabels := labels.Labels{
-		{Name: "test", Value: "test4"},
-		{Name: "__meta_kubernetes_endpointslice_address_target_kind", Value: "Node"},
-		{Name: "__meta_kubernetes_endpointslice_address_target_name", Value: "node-3"},
-	}
+	fourthLabels := labels.New(
+		labels.Label{Name: "test", Value: "test4"},
+		labels.Label{Name: "__meta_kubernetes_endpointslice_address_target_kind", Value: "Node"},
+		labels.Label{Name: "__meta_kubernetes_endpointslice_address_target_name", Value: "node-3"},
+	)
 
 	firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstLabels, "")
 	secondTarget := target.NewItem("sample-name", "0.0.0.0:8000", secondLabels, "")
@@ -99,24 +97,22 @@ func TestAllocationPerNodeUsingFallback(t *testing.T) {
 
 	cols := MakeNCollectors(4, 0)
 	s.SetCollectors(cols)
-	firstLabels := labels.Labels{
-		{Name: "test", Value: "test1"},
-		{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
-	}
-	secondLabels := labels.Labels{
-		{Name: "test", Value: "test2"},
-		{Name: "__meta_kubernetes_node_name", Value: "node-1"},
-	}
+	firstLabels := labels.New(
+		labels.Label{Name: "test", Value: "test1"},
+		labels.Label{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
+	)
+	secondLabels := labels.New(
+		labels.Label{Name: "test", Value: "test2"},
+		labels.Label{Name: "__meta_kubernetes_node_name", Value: "node-1"},
+	)
 	// no label, should be allocated by the fallback strategy
-	thirdLabels := labels.Labels{
-		{Name: "test", Value: "test3"},
-	}
+	thirdLabels := labels.New(labels.Label{Name: "test", Value: "test3"})
 	// endpointslice target kind and name
-	fourthLabels := labels.Labels{
-		{Name: "test", Value: "test4"},
-		{Name: "__meta_kubernetes_endpointslice_address_target_kind", Value: "Node"},
-		{Name: "__meta_kubernetes_endpointslice_address_target_name", Value: "node-3"},
-	}
+	fourthLabels := labels.New(
+		labels.Label{Name: "test", Value: "test4"},
+		labels.Label{Name: "__meta_kubernetes_endpointslice_address_target_kind", Value: "Node"},
+		labels.Label{Name: "__meta_kubernetes_endpointslice_address_target_name", Value: "node-3"},
+	)
 
 	firstTarget := target.NewItem("sample-name", "0.0.0.0:8000", firstLabels, "")
 	secondTarget := target.NewItem("sample-name", "0.0.0.0:8000", secondLabels, "")

--- a/cmd/otel-allocator/internal/allocation/testutils.go
+++ b/cmd/otel-allocator/internal/allocation/testutils.go
@@ -28,10 +28,10 @@ func MakeNNewTargets(n int, numCollectors int, startingIndex int) []*target.Item
 	toReturn := []*target.Item{}
 	for i := startingIndex; i < n+startingIndex; i++ {
 		collector := fmt.Sprintf("collector-%d", colIndex(i, numCollectors))
-		label := labels.Labels{
-			{Name: "i", Value: strconv.Itoa(i)},
-			{Name: "total", Value: strconv.Itoa(n + startingIndex)},
-		}
+		label := labels.New(
+			labels.Label{Name: "i", Value: strconv.Itoa(i)},
+			labels.Label{Name: "total", Value: strconv.Itoa(n + startingIndex)},
+		)
 		newTarget := target.NewItem(fmt.Sprintf("test-job-%d", i), fmt.Sprintf("test-url-%d", i), label, collector)
 		toReturn = append(toReturn, newTarget)
 	}
@@ -54,11 +54,11 @@ func MakeNCollectors(n int, startingIndex int) map[string]*Collector {
 func MakeNNewTargetsWithEmptyCollectors(n int, startingIndex int) []*target.Item {
 	toReturn := []*target.Item{}
 	for i := startingIndex; i < n+startingIndex; i++ {
-		label := labels.Labels{
-			{Name: "i", Value: strconv.Itoa(i)},
-			{Name: "total", Value: strconv.Itoa(n + startingIndex)},
-			{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
-		}
+		label := labels.New(
+			labels.Label{Name: "i", Value: strconv.Itoa(i)},
+			labels.Label{Name: "total", Value: strconv.Itoa(n + startingIndex)},
+			labels.Label{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
+		)
 		newTarget := target.NewItem(fmt.Sprintf("test-job-%d", i), fmt.Sprintf("test-url-%d", i), label, "")
 		toReturn = append(toReturn, newTarget)
 	}

--- a/cmd/otel-allocator/internal/server/server.go
+++ b/cmd/otel-allocator/internal/server/server.go
@@ -426,9 +426,9 @@ func (s *Server) TargetHTMLHandler(c *gin.Context) {
 		Headers: []string{"Label", "Value"},
 		Rows: func() [][]Cell {
 			var rows [][]Cell
-			for _, l := range target.Labels {
+			target.Labels.Range(func(l labels.Label) {
 				rows = append(rows, []Cell{NewCell(l.Name), NewCell(l.Value)})
-			}
+			})
 			return rows
 		}(),
 	})

--- a/cmd/otel-allocator/internal/server/server_test.go
+++ b/cmd/otel-allocator/internal/server/server_test.go
@@ -31,13 +31,9 @@ import (
 )
 
 var (
-	logger       = logf.Log.WithName("server-unit-tests")
-	baseLabelSet = labels.Labels{
-		{Name: "test_label", Value: "test-value"},
-	}
-	testJobLabelSetTwo = labels.Labels{
-		{Name: "test_label", Value: "test-value2"},
-	}
+	logger                  = logf.Log.WithName("server-unit-tests")
+	baseLabelSet            = labels.New(labels.Label{Name: "test_label", Value: "test-value"})
+	testJobLabelSetTwo      = labels.New(labels.Label{Name: "test_label", Value: "test-value2"})
 	baseTargetItem          = target.NewItem("test-job", "test-url", baseLabelSet, "test-collector")
 	secondTargetItem        = target.NewItem("test-job", "test-url", baseLabelSet, "test-collector")
 	testJobTargetItemTwo    = target.NewItem("test-job", "test-url2", testJobLabelSetTwo, "test-collector2")
@@ -101,9 +97,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 				items: []*targetJSON{
 					{
 						TargetURL: []string{"test-url"},
-						Labels: labels.Labels{
-							{Name: "test_label", Value: "test-value"},
-						},
+						Labels:    labels.New(labels.Label{Name: "test_label", Value: "test-value"}),
 					},
 				},
 			},
@@ -123,9 +117,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 				items: []*targetJSON{
 					{
 						TargetURL: []string{"test-url"},
-						Labels: labels.Labels{
-							{Name: "test_label", Value: "test-value"},
-						},
+						Labels:    labels.New(labels.Label{Name: "test_label", Value: "test-value"}),
 					},
 				},
 			},
@@ -145,15 +137,11 @@ func TestServer_TargetsHandler(t *testing.T) {
 				items: []*targetJSON{
 					{
 						TargetURL: []string{"test-url"},
-						Labels: labels.Labels{
-							{Name: "test_label", Value: "test-value"},
-						},
+						Labels:    labels.New(labels.Label{Name: "test_label", Value: "test-value"}),
 					},
 					{
 						TargetURL: []string{"test-url2"},
-						Labels: labels.Labels{
-							{Name: "test_label", Value: "test-value2"},
-						},
+						Labels:    labels.New(labels.Label{Name: "test_label", Value: "test-value2"}),
 					},
 				},
 			},
@@ -568,7 +556,7 @@ func TestServer_JobHandler(t *testing.T) {
 		{
 			description: "one job",
 			targetItems: map[target.ItemHash]*target.Item{
-				0: target.NewItem("job1", "", labels.Labels{}, ""),
+				0: target.NewItem("job1", "", labels.New(), ""),
 			},
 			expectedCode: http.StatusOK,
 			expectedJobs: map[string]linkJSON{
@@ -578,11 +566,11 @@ func TestServer_JobHandler(t *testing.T) {
 		{
 			description: "multiple jobs",
 			targetItems: map[target.ItemHash]*target.Item{
-				0: target.NewItem("job1", "", labels.Labels{}, ""),
-				1: target.NewItem("job2", "", labels.Labels{}, ""),
-				2: target.NewItem("job3", "", labels.Labels{}, ""),
-				3: target.NewItem("job3", "", labels.Labels{}, ""),
-				4: target.NewItem("job3", "", labels.Labels{}, "")},
+				0: target.NewItem("job1", "", labels.New(), ""),
+				1: target.NewItem("job2", "", labels.New(), ""),
+				2: target.NewItem("job3", "", labels.New(), ""),
+				3: target.NewItem("job3", "", labels.New(), ""),
+				4: target.NewItem("job3", "", labels.New(), "")},
 			expectedCode: http.StatusOK,
 			expectedJobs: map[string]linkJSON{
 				"job1": newLink("job1"),
@@ -635,7 +623,7 @@ func TestServer_JobsHandler_HTML(t *testing.T) {
 		{
 			description: "one job",
 			targetItems: map[target.ItemHash]*target.Item{
-				0: target.NewItem("job1", "", labels.Labels{}, ""),
+				0: target.NewItem("job1", "", labels.New(), ""),
 			},
 			expectedCode: http.StatusOK,
 			Golden:       "jobs_one.html",
@@ -643,11 +631,11 @@ func TestServer_JobsHandler_HTML(t *testing.T) {
 		{
 			description: "multiple jobs",
 			targetItems: map[target.ItemHash]*target.Item{
-				0: target.NewItem("job1", "1.1.1.1:8080", labels.Labels{}, ""),
-				1: target.NewItem("job2", "1.1.1.2:8080", labels.Labels{}, ""),
-				2: target.NewItem("job3", "1.1.1.3:8080", labels.Labels{}, ""),
-				3: target.NewItem("job3", "1.1.1.4:8080", labels.Labels{}, ""),
-				4: target.NewItem("job3", "1.1.1.5:8080", labels.Labels{}, "")},
+				0: target.NewItem("job1", "1.1.1.1:8080", labels.New(), ""),
+				1: target.NewItem("job2", "1.1.1.2:8080", labels.New(), ""),
+				2: target.NewItem("job3", "1.1.1.3:8080", labels.New(), ""),
+				3: target.NewItem("job3", "1.1.1.4:8080", labels.New(), ""),
+				4: target.NewItem("job3", "1.1.1.5:8080", labels.New(), "")},
 			expectedCode: http.StatusOK,
 			Golden:       "jobs_multiple.html",
 		},

--- a/cmd/otel-allocator/internal/server/testdata/collector_multiple.html
+++ b/cmd/otel-allocator/internal/server/testdata/collector_multiple.html
@@ -31,7 +31,7 @@
             <a href="/debug/job?job_id=test-job">test-job</a>
         </td>
         <td style="vertical-align: top;">
-            <a href="/debug/target?target_hash=6737493032997278979">test-url</a>
+            <a href="/debug/target?target_hash=5512283283146621186">test-url</a>
         </td>
         <td style="vertical-align: top;">
             

--- a/cmd/otel-allocator/internal/server/testdata/collector_single.html
+++ b/cmd/otel-allocator/internal/server/testdata/collector_single.html
@@ -31,7 +31,7 @@
             <a href="/debug/job?job_id=test-job">test-job</a>
         </td>
         <td style="vertical-align: top;">
-            <a href="/debug/target?target_hash=6737493032997278979">test-url</a>
+            <a href="/debug/target?target_hash=5512283283146621186">test-url</a>
         </td>
         <td style="vertical-align: top;">
             

--- a/cmd/otel-allocator/internal/server/testdata/targets_multiple.html
+++ b/cmd/otel-allocator/internal/server/testdata/targets_multiple.html
@@ -31,10 +31,10 @@
     </thead>
     <tr style="background: #eee">
         <td style="vertical-align: top;">
-            <a href="/debug/job?job_id=test-job2">test-job2</a>
+            <a href="/debug/job?job_id=test-job">test-job</a>
         </td>
         <td style="vertical-align: top;">
-            <a href="/debug/target?target_hash=3238214178413060520">test-url3</a>
+            <a href="/debug/target?target_hash=5512283283146621186">test-url</a>
         </td>
         <td style="vertical-align: top;">
             <a href="/debug/collector?collector_id=test-collector1">test-collector1</a>
@@ -48,10 +48,10 @@
             <a href="/debug/job?job_id=test-job">test-job</a>
         </td>
         <td style="vertical-align: top;">
-            <a href="/debug/target?target_hash=6737493032997278979">test-url</a>
+            <a href="/debug/target?target_hash=7939255050499047193">test-url2</a>
         </td>
         <td style="vertical-align: top;">
-            <a href="/debug/collector?collector_id=test-collector1">test-collector1</a>
+            <a href="/debug/collector?collector_id=test-collector2">test-collector2</a>
         </td>
         <td style="vertical-align: top;">
             
@@ -59,13 +59,13 @@
     </tr>
     <tr style="background: #eee">
         <td style="vertical-align: top;">
-            <a href="/debug/job?job_id=test-job">test-job</a>
+            <a href="/debug/job?job_id=test-job2">test-job2</a>
         </td>
         <td style="vertical-align: top;">
-            <a href="/debug/target?target_hash=12162887098722716261">test-url2</a>
+            <a href="/debug/target?target_hash=13712592240399323632">test-url3</a>
         </td>
         <td style="vertical-align: top;">
-            <a href="/debug/collector?collector_id=test-collector2">test-collector2</a>
+            <a href="/debug/collector?collector_id=test-collector1">test-collector1</a>
         </td>
         <td style="vertical-align: top;">
             

--- a/cmd/otel-allocator/internal/server/testdata/targets_single.html
+++ b/cmd/otel-allocator/internal/server/testdata/targets_single.html
@@ -34,7 +34,7 @@
             <a href="/debug/job?job_id=test-job">test-job</a>
         </td>
         <td style="vertical-align: top;">
-            <a href="/debug/target?target_hash=6737493032997278979">test-url</a>
+            <a href="/debug/target?target_hash=5512283283146621186">test-url</a>
         </td>
         <td style="vertical-align: top;">
             <a href="/debug/collector?collector_id=test-collector1">test-collector1</a>


### PR DESCRIPTION
Changing how we use labels.Labels in target allocator in preparation for bumping the Prometheus dependency to 0.307.0. 

Part of https://github.com/open-telemetry/opentelemetry-operator/issues/4196.
