### PR TITLE
Fix ta dualstack

### DIFF
--- a/.chloggen/fix-ta-dualstack.yaml
+++ b/.chloggen/fix-ta-dualstack.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix target allocator generating duplicated targets when DualStack is enabled
+
+# One or more tracking issues related to the change
+issues: [4494]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Added logic to prevent duplicate targets from being created when dual-stack EndpointSlices 
+  are present. The fix uses service-pod combinations to identify 
+  and skip duplicate targets while preserving targets from different pods or services.

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2025-11-12T12:20:26Z"
+    createdAt: "2025-11-14T13:25:48Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -531,12 +531,6 @@ spec:
                 - --zap-log-level=info
                 - --zap-time-encoding=rfc3339nano
                 - --enable-nginx-instrumentation=true
-                - --target-allocator-image=ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.138.0-6-g6935b981
-                - --operator-opamp-bridge-image=ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:v0.138.0-6-g6935b981
-                - --target-allocator-image=ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.138.0-19-gaa012eb5
-                - --operator-opamp-bridge-image=ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:v0.138.0-19-gaa012eb5
-                - --target-allocator-image=ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.138.0-21-g5c71d40c
-                - --operator-opamp-bridge-image=ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:v0.138.0-21-g5c71d40c
                 env:
                 - name: SERVICE_ACCOUNT_NAME
                   valueFrom:
@@ -546,7 +540,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0-21-g5c71d40c
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.139.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2025-11-04T20:46:50Z"
+    createdAt: "2025-11-12T12:20:26Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -531,6 +531,12 @@ spec:
                 - --zap-log-level=info
                 - --zap-time-encoding=rfc3339nano
                 - --enable-nginx-instrumentation=true
+                - --target-allocator-image=ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.138.0-6-g6935b981
+                - --operator-opamp-bridge-image=ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:v0.138.0-6-g6935b981
+                - --target-allocator-image=ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.138.0-19-gaa012eb5
+                - --operator-opamp-bridge-image=ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:v0.138.0-19-gaa012eb5
+                - --target-allocator-image=ghcr.io/open-telemetry/opentelemetry-operator/target-allocator:v0.138.0-21-g5c71d40c
+                - --operator-opamp-bridge-image=ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge:v0.138.0-21-g5c71d40c
                 env:
                 - name: SERVICE_ACCOUNT_NAME
                   valueFrom:
@@ -540,7 +546,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.139.0
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0-21-g5c71d40c
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2025-11-12T12:20:32Z"
+    createdAt: "2025-11-14T13:25:49Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -545,7 +545,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0-21-g5c71d40c
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.139.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2025-11-04T20:46:50Z"
+    createdAt: "2025-11-12T12:20:32Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -545,7 +545,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.139.0
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.138.0-21-g5c71d40c
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/cmd/otel-allocator/internal/target/discovery.go
+++ b/cmd/otel-allocator/internal/target/discovery.go
@@ -194,6 +194,19 @@ func (m *Discoverer) Reload() {
 	}
 	m.mtxScrape.Unlock()
 	wg.Wait()
+
+	// Compact the slice by removing nil entries left by deduplication
+	writeIdx := 0
+	for readIdx := 0; readIdx < targetCount; readIdx++ {
+		if targets[readIdx] != nil {
+			if writeIdx != readIdx {
+				targets[writeIdx] = targets[readIdx]
+			}
+			writeIdx++
+		}
+	}
+	targets = targets[:writeIdx]
+
 	m.processTargetsCallBack(targets)
 }
 
@@ -228,8 +241,6 @@ func (m *Discoverer) processTargetGroups(jobName string, groups []*targetgroup.G
 				if key := item.GetDualStackKey(); key != "" {
 					seenServicePods[key] = true
 				}
-			} else {
-				item = nil
 			}
 		}
 	}

--- a/cmd/otel-allocator/internal/target/target_test.go
+++ b/cmd/otel-allocator/internal/target/target_test.go
@@ -6,6 +6,9 @@ package target
 import (
 	"testing"
 
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,6 +32,115 @@ func TestItemHash_String(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.want, tt.h.String(), "String()")
+		})
+	}
+}
+
+func TestDuplicatedTargetMetricsWhenDualStackEnabled(t *testing.T) {
+	tests := []struct {
+		name                string
+		tg                  targetgroup.Group
+		expectedTargetCount int
+	}{
+		{
+			name: "should ignore duplicate target allocation when dualStack is enabled",
+			tg: targetgroup.Group{
+				Labels: model.LabelSet{
+					"job": "serviceMonitor/opentelemetry-operator-system/kube-state-metrics/0",
+				},
+				Targets: []model.LabelSet{
+					{
+						model.AddressLabel:                     "[2600:1234:5678:b307:48::8a7b]:8080",
+						"__meta_kubernetes_service_name":       "opentelemetry-kube-stack-kube-state-metrics",
+						"__meta_kubernetes_pod_name":           "kube-state-metrics-pod-1",
+						"__meta_kubernetes_namespace":          "opentelemetry-operator-system",
+						"__meta_kubernetes_endpointslice_name": "opentelemetry-kube-stack-kube-state-metrics-tl2q7",
+					},
+					{
+						model.AddressLabel:                     "10.233.12.197:8080",
+						"__meta_kubernetes_service_name":       "opentelemetry-kube-stack-kube-state-metrics",
+						"__meta_kubernetes_pod_name":           "kube-state-metrics-pod-1",
+						"__meta_kubernetes_namespace":          "opentelemetry-operator-system",
+						"__meta_kubernetes_endpointslice_name": "opentelemetry-kube-stack-kube-state-metrics-tzk4w",
+					},
+				},
+			},
+			expectedTargetCount: 1,
+		},
+		{
+			name: "should keep targets from different pods",
+			tg: targetgroup.Group{
+				Labels: model.LabelSet{
+					"job": "serviceMonitor/default/my-service/0",
+				},
+				Targets: []model.LabelSet{
+					{
+						model.AddressLabel:               "10.233.12.198:8080",
+						"__meta_kubernetes_service_name": "my-service",
+						"__meta_kubernetes_pod_name":     "my-service-pod-1",
+						"__meta_kubernetes_namespace":    "default",
+					},
+					{
+						model.AddressLabel:               "10.233.12.199:8080",
+						"__meta_kubernetes_service_name": "my-service",
+						"__meta_kubernetes_pod_name":     "my-service-pod-2",
+						"__meta_kubernetes_namespace":    "default",
+					},
+				},
+			},
+			expectedTargetCount: 2,
+		},
+		{
+			name: "should keep targets without service name",
+			tg: targetgroup.Group{
+				Labels: model.LabelSet{
+					"job": "erviceMonitor/default/my-service/0",
+				},
+				Targets: []model.LabelSet{
+					{
+						model.AddressLabel:            "10.233.12.200:8080",
+						"__meta_kubernetes_namespace": "default",
+					},
+					{
+						model.AddressLabel:            "10.233.12.201:8080",
+						"__meta_kubernetes_namespace": "default",
+					},
+				},
+			},
+			expectedTargetCount: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			builder := labels.NewBuilder(labels.Labels{})
+			var seenServicePods = make(map[string]bool)
+			index := 0
+			tg := test.tg
+			builder.Reset(labels.EmptyLabels())
+
+			intoTargets := make([]*Item, len(tg.Targets))
+
+			for ln, lv := range tg.Labels {
+				builder.Set(string(ln), string(lv))
+			}
+			groupLabels := builder.Labels()
+			for _, t := range tg.Targets {
+				builder.Reset(groupLabels)
+				for ln, lv := range t {
+					builder.Set(string(ln), string(lv))
+				}
+				item := NewItem(test.name, string(t[model.AddressLabel]), builder.Labels(), "")
+				if !item.IsDualStackDuplicate(seenServicePods) {
+					intoTargets[index] = item
+					index++
+					if key := item.GetDualStackKey(); key != "" {
+						seenServicePods[key] = true
+					}
+				}
+			}
+			intoTargets = intoTargets[:index]
+			assert.Equal(t, test.expectedTargetCount, len(intoTargets), "unexpected targets after deduplication")
 		})
 	}
 }


### PR DESCRIPTION
**Description:**
This Pr fixes the Target Allocator generated duplicated targets when DualStack (IPv4 and IPv6) EndpointSlices referencing for the same service.
This update added a  logic to detect and skip duplicates based on a  service & pod combination key, ensuring that each target is discovered only once per pod while preserving distinct targets across different pods or services.

**Link to tracking Issue(s):**

* Resolves: #4494

**Testing:**

* Added unit tests , all existing e2e  passes locally.

**Documentation:**
