### PR TITLE
[Chore] Use full image names in tests

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-apache-multicontainer/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-multicontainer/01-install-app.yaml
@@ -46,7 +46,7 @@ spec:
             capabilities:
               drop: ["ALL"]
         - name: myrabbit
-          image: rabbitmq
+          image: docker.io/library/rabbitmq:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/e2e-instrumentation/instrumentation-apache-multicontainer/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-multicontainer/02-assert.yaml
@@ -69,7 +69,7 @@ spec:
       periodSeconds: 15
       successThreshold: 1
       timeoutSeconds: 2
-  - image: rabbitmq
+  - image: docker.io/library/rabbitmq:latest
     name: myrabbit
   initContainers:
   - name: otel-agent-source-container-clone

--- a/tests/e2e-instrumentation/instrumentation-apache-multicontainer/02-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-multicontainer/02-install-app.yaml
@@ -46,7 +46,7 @@ spec:
             capabilities:
               drop: ["ALL"]
         - name: myrabbit
-          image: rabbitmq
+          image: docker.io/library/rabbitmq:latest
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/01-install-app.yaml
@@ -41,7 +41,7 @@ spec:
           timeoutSeconds: 2
           failureThreshold: 3
       - name: myrabbit
-        image: rabbitmq:3
+        image: docker.io/library/rabbitmq:3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/02-assert.yaml
@@ -74,7 +74,7 @@ spec:
           readOnly: true
         - mountPath: /otel-auto-instrumentation-dotnet
           name: opentelemetry-auto-instrumentation-dotnet
-    - image: rabbitmq:3
+    - image: docker.io/library/rabbitmq:3
       name: myrabbit
       volumeMounts:
         - mountPath: /var/run/secrets/kubernetes.io/serviceaccount

--- a/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/02-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/02-install-app.yaml
@@ -41,7 +41,7 @@ spec:
           timeoutSeconds: 2
           failureThreshold: 3
       - name: myrabbit
-        image: rabbitmq:3
+        image: docker.io/library/rabbitmq:3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/e2e-instrumentation/instrumentation-java-multicontainer/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-multicontainer/01-install-app.yaml
@@ -36,4 +36,4 @@ spec:
           timeoutSeconds: 2
           failureThreshold: 3
       - name: myrabbit
-        image: rabbitmq:3
+        image: docker.io/library/rabbitmq:3

--- a/tests/e2e-instrumentation/instrumentation-java-multicontainer/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-multicontainer/02-assert.yaml
@@ -55,7 +55,7 @@ spec:
       readOnly: true
     - mountPath: /otel-auto-instrumentation-java-myapp
       name: opentelemetry-auto-instrumentation-java
-  - image: rabbitmq:3
+  - image: docker.io/library/rabbitmq:3
     name: myrabbit
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount

--- a/tests/e2e-instrumentation/instrumentation-java-multicontainer/02-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-multicontainer/02-install-app.yaml
@@ -38,7 +38,7 @@ spec:
           timeoutSeconds: 2
           failureThreshold: 3
       - name: myrabbit
-        image: rabbitmq:3
+        image: docker.io/library/rabbitmq:3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/e2e-instrumentation/instrumentation-nginx-contnr-secctx/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-contnr-secctx/01-install-app.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: myapp
-        image: nginxinc/nginx-unprivileged:1.25.3
+        image: docker.io/nginxinc/nginx-unprivileged:1.25.3
         imagePullPolicy: Always
         securityContext:
           runAsUser: 1000

--- a/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/01-assert.yaml
@@ -103,7 +103,7 @@ spec:
     - name: OTEL_PROPAGATORS
       value: jaeger,b3
     - name: OTEL_RESOURCE_ATTRIBUTES
-    image: rabbitmq
+    image: docker.io/library/rabbitmq:latest
     name: myrabbit
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount

--- a/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/01-install-app.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 3000
       containers:
       - name: myapp
-        image: nginxinc/nginx-unprivileged:1.25.3
+        image: docker.io/nginxinc/nginx-unprivileged:1.25.3
         imagePullPolicy: Always
         securityContext:
           runAsUser: 1000
@@ -60,7 +60,7 @@ spec:
             cpu: 100m
             memory: 100Mi
       - name: myrabbit
-        image: rabbitmq
+        image: docker.io/library/rabbitmq:latest
         securityContext:
           runAsUser: 1000
           runAsGroup: 3000

--- a/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/02-assert.yaml
@@ -78,7 +78,7 @@ spec:
       name: otel-nginx-agent
     - mountPath: /etc/nginx
       name: otel-nginx-conf-dir
-  - image: rabbitmq
+  - image: docker.io/library/rabbitmq:latest
     name: myrabbit
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount

--- a/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/02-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/02-install-app.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 3000
       containers:
       - name: myapp
-        image: nginxinc/nginx-unprivileged:1.25.3
+        image: docker.io/nginxinc/nginx-unprivileged:1.25.3
         imagePullPolicy: Always
         securityContext:
           runAsUser: 1000
@@ -60,7 +60,7 @@ spec:
             cpu: 100m
             memory: 100Mi
       - name: myrabbit
-        image: rabbitmq
+        image: docker.io/library/rabbitmq:latest
         securityContext:
           runAsUser: 1000
           runAsGroup: 3000

--- a/tests/e2e-instrumentation/instrumentation-nginx/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx/01-install-app.yaml
@@ -20,7 +20,7 @@ spec:
         fsGroup: 3000
       containers:
       - name: myapp
-        image: nginxinc/nginx-unprivileged:1.25.3
+        image: docker.io/nginxinc/nginx-unprivileged:1.25.3
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false

--- a/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/01-install-app.yaml
@@ -41,7 +41,7 @@ spec:
           timeoutSeconds: 2
           failureThreshold: 3
       - name: myrabbit
-        image: rabbitmq:3
+        image: docker.io/library/rabbitmq:3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/02-assert.yaml
@@ -70,7 +70,7 @@ spec:
       readOnly: true
     - mountPath: /otel-auto-instrumentation-nodejs
       name: opentelemetry-auto-instrumentation-nodejs
-  - image: rabbitmq:3
+  - image: docker.io/library/rabbitmq:3
     name: myrabbit
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount

--- a/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/02-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/02-install-app.yaml
@@ -41,7 +41,7 @@ spec:
           timeoutSeconds: 2
           failureThreshold: 3
       - name: myrabbit
-        image: rabbitmq:3
+        image: docker.io/library/rabbitmq:3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/e2e-instrumentation/instrumentation-python-multicontainer/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-multicontainer/01-install-app.yaml
@@ -39,7 +39,7 @@ spec:
           timeoutSeconds: 2
           failureThreshold: 3
       - name: myrabbit
-        image: rabbitmq:3
+        image: docker.io/library/rabbitmq:3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/e2e-instrumentation/instrumentation-python-multicontainer/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-multicontainer/02-assert.yaml
@@ -75,7 +75,7 @@ spec:
       readOnly: true
     - mountPath: /otel-auto-instrumentation-python
       name: opentelemetry-auto-instrumentation-python
-  - image: rabbitmq:3
+  - image: docker.io/library/rabbitmq:3
     name: myrabbit
     volumeMounts:
     - mountPath: /var/run/secrets/kubernetes.io/serviceaccount

--- a/tests/e2e-instrumentation/instrumentation-python-multicontainer/02-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-multicontainer/02-install-app.yaml
@@ -39,7 +39,7 @@ spec:
           timeoutSeconds: 2
           failureThreshold: 3
       - name: myrabbit
-        image: rabbitmq:3
+        image: docker.io/library/rabbitmq:3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/tests/e2e-instrumentation/instrumentation-python-specenv/00-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-specenv/00-install-app.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
   containers:
   - name: myapp
-    image: python:3.8-slim
+    image: docker.io/library/python:3.8-slim
     command: ["python", "-c", "import time; time.sleep(3600)"]

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/01-install-app.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/01-install-app.yaml
@@ -144,7 +144,7 @@ spec:
           ports:
           - containerPort: 8080
         - name: nginxapp
-          image: nginxinc/nginx-unprivileged:1.26.2
+          image: docker.io/nginxinc/nginx-unprivileged:1.26.2
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/tests/e2e-openshift/Dockerfile
+++ b/tests/e2e-openshift/Dockerfile
@@ -1,6 +1,6 @@
 # The Dockerfile's resulting image is purpose-built for executing OpenTelemetry Operator e2e tests within the OpenShift release (https://github.com/openshift/release) using Prow CI.
 
-FROM golang:1.23
+FROM docker.io/library/golang:1.23
 
 # Copy the repository files
 COPY . /tmp/opentelemetry-operator

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-minio.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/install-minio.yaml
@@ -41,7 +41,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: docker.io/minio/minio:latest
           name: minio
           ports:
             - containerPort: 9000

--- a/tests/e2e-prometheuscr/create-sm-prometheus-exporters/08-install.yaml
+++ b/tests/e2e-prometheuscr/create-sm-prometheus-exporters/08-install.yaml
@@ -122,6 +122,6 @@ spec:
         - /bin/sh
         - -c
         - curl -s http://simplest-targetallocator/jobs | grep "targetallocator"
-        image: curlimages/curl
+        image: docker.io/curlimages/curl:latest
         name: check-metrics
       restartPolicy: OnFailure

--- a/tests/e2e-ta-collector-mtls/ta-collector-mtls-scrapeconfig-node/01-install.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-collector-mtls-scrapeconfig-node/01-install.yaml
@@ -11,7 +11,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c
@@ -30,7 +30,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c

--- a/tests/e2e-ta-collector-mtls/ta-collector-mtls/00-install.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-collector-mtls/00-install.yaml
@@ -89,7 +89,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-ta
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           volumeMounts:
             - name: tls-secret
               mountPath: /etc/tls

--- a/tests/e2e-ta-collector-mtls/ta-collector-mtls/02-install.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-collector-mtls/02-install.yaml
@@ -19,7 +19,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c
@@ -40,7 +40,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c
@@ -56,7 +56,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c

--- a/tests/e2e-ta-collector-mtls/ta-collector-mtls/03-install.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-collector-mtls/03-install.yaml
@@ -8,7 +8,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-ta
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           volumeMounts:
             - name: tls-secret
               mountPath: /etc/tls

--- a/tests/e2e-targetallocator/targetallocator-kubernetessd/01-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-kubernetessd/01-install.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c
@@ -30,7 +30,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c
@@ -46,7 +46,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c

--- a/tests/e2e-targetallocator/targetallocator-namespace/resources/job-check-metrics.yaml
+++ b/tests/e2e-targetallocator/targetallocator-namespace/resources/job-check-metrics.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           env:
             - name: endpoint
               value: ($endpoint)

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/01-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/01-install.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c
@@ -41,7 +41,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c
@@ -57,7 +57,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/02-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/02-install.yaml
@@ -69,7 +69,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c
@@ -88,7 +88,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c
@@ -107,7 +107,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c
@@ -126,7 +126,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: curlimages/curl
+          image: docker.io/curlimages/curl:latest
           args:
             - /bin/sh
             - -c

--- a/tests/e2e/additional-containers-collector/00-assert-daemonset-without-additional-containers.yaml
+++ b/tests/e2e/additional-containers-collector/00-assert-daemonset-without-additional-containers.yaml
@@ -10,5 +10,5 @@ metadata:
 spec:
   template:
     spec:
-      (containers[?image == 'alpine' && name == 'alpine']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine']):
         (length(@)): 0

--- a/tests/e2e/additional-containers-collector/00-assert-deployment-without-additional-containers.yaml
+++ b/tests/e2e/additional-containers-collector/00-assert-deployment-without-additional-containers.yaml
@@ -10,5 +10,5 @@ metadata:
 spec:
   template:
     spec:
-      (containers[?image == 'alpine' && name == 'alpine']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine']):
         (length(@)): 0

--- a/tests/e2e/additional-containers-collector/00-assert-statefulset-without-additional-containers.yaml
+++ b/tests/e2e/additional-containers-collector/00-assert-statefulset-without-additional-containers.yaml
@@ -10,5 +10,5 @@ metadata:
 spec:
   template:
     spec:
-      (containers[?image == 'alpine' && name == 'alpine']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine']):
         (length(@)): 0

--- a/tests/e2e/additional-containers-collector/01-assert-daemonset-with-additional-containers.yaml
+++ b/tests/e2e/additional-containers-collector/01-assert-daemonset-with-additional-containers.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   template:
     spec:
-      (containers[?image == 'alpine' && name == 'alpine']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine']):
         (length(@)): 1
-      (containers[?image == 'alpine' && name == 'alpine2']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine2']):
         (length(@)): 1

--- a/tests/e2e/additional-containers-collector/01-assert-deployment-with-additional-containers.yaml
+++ b/tests/e2e/additional-containers-collector/01-assert-deployment-with-additional-containers.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   template:
     spec:
-      (containers[?image == 'alpine' && name == 'alpine']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine']):
         (length(@)): 1
-      (containers[?image == 'alpine' && name == 'alpine2']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine2']):
         (length(@)): 1

--- a/tests/e2e/additional-containers-collector/01-assert-statefulset-with-additional-containers.yaml
+++ b/tests/e2e/additional-containers-collector/01-assert-statefulset-with-additional-containers.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   template:
     spec:
-      (containers[?image == 'alpine' && name == 'alpine']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine']):
         (length(@)): 1
-      (containers[?image == 'alpine' && name == 'alpine2']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine2']):
         (length(@)): 1

--- a/tests/e2e/additional-containers-collector/01-install-collectors-with-additional-containers.yaml
+++ b/tests/e2e/additional-containers-collector/01-install-collectors-with-additional-containers.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   mode: deployment
   additionalContainers:
-  - image: alpine
+  - image: docker.io/library/alpine:latest
     name: alpine
-  - image: alpine
+  - image: docker.io/library/alpine:latest
     name: alpine2
   config:
     receivers:
@@ -37,9 +37,9 @@ metadata:
 spec:
   mode: daemonset
   additionalContainers:
-  - image: alpine
+  - image: docker.io/library/alpine:latest
     name: alpine
-  - image: alpine
+  - image: docker.io/library/alpine:latest
     name: alpine2
   config:
     receivers:
@@ -67,9 +67,9 @@ metadata:
 spec:
   mode: statefulset
   additionalContainers:
-  - image: alpine
+  - image: docker.io/library/alpine:latest
     name: alpine
-  - image: alpine
+  - image: docker.io/library/alpine:latest
     name: alpine2
   config:
     receivers:

--- a/tests/e2e/additional-containers-collector/02-assert-daemonset-with-modified-additional-containers.yaml
+++ b/tests/e2e/additional-containers-collector/02-assert-daemonset-with-modified-additional-containers.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   template:
     spec:
-      (containers[?image == 'alpine' && name == 'alpine']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine']):
         (length(@)): 0
-      (containers[?image == 'alpine' && name == 'alpine2']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine2']):
         (length(@)): 0
-      (containers[?image == 'alpine' && name == 'alpine3']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine3']):
         (length(@)): 1

--- a/tests/e2e/additional-containers-collector/02-assert-deployment-with-modified-additional-containers.yaml
+++ b/tests/e2e/additional-containers-collector/02-assert-deployment-with-modified-additional-containers.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   template:
     spec:
-      (containers[?image == 'alpine' && name == 'alpine']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine']):
         (length(@)): 0
-      (containers[?image == 'alpine' && name == 'alpine2']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine2']):
         (length(@)): 0
-      (containers[?image == 'alpine' && name == 'alpine3']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine3']):
         (length(@)): 1

--- a/tests/e2e/additional-containers-collector/02-assert-statefulset-with-modified-additional-containers.yaml
+++ b/tests/e2e/additional-containers-collector/02-assert-statefulset-with-modified-additional-containers.yaml
@@ -10,9 +10,9 @@ metadata:
 spec:
   template:
     spec:
-      (containers[?image == 'alpine' && name == 'alpine']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine']):
         (length(@)): 0
-      (containers[?image == 'alpine' && name == 'alpine2']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine2']):
         (length(@)): 0
-      (containers[?image == 'alpine' && name == 'alpine3']):
+      (containers[?image == 'docker.io/library/alpine:latest' && name == 'alpine3']):
         (length(@)): 1

--- a/tests/e2e/additional-containers-collector/02-modify-collectors-additional-containers.yaml
+++ b/tests/e2e/additional-containers-collector/02-modify-collectors-additional-containers.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   mode: deployment
   additionalContainers:
-  - image: alpine
+  - image: docker.io/library/alpine:latest
     name: alpine3
   config:
     receivers:
@@ -35,7 +35,7 @@ metadata:
 spec:
   mode: daemonset
   additionalContainers:
-  - image: alpine
+  - image: docker.io/library/alpine:latest
     name: alpine3
   config:
     receivers:
@@ -63,7 +63,7 @@ metadata:
 spec:
   mode: statefulset
   additionalContainers:
-  - image: alpine
+  - image: docker.io/library/alpine:latest
     name: alpine3
   config:
     receivers:

--- a/tests/e2e/extension/00-install-jaeger-extension.yaml
+++ b/tests/e2e/extension/00-install-jaeger-extension.yaml
@@ -3,7 +3,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: jaeger-inmemory
 spec:
-  image: jaegertracing/jaeger:latest
+  image: docker.io/jaegertracing/jaeger:latest
   config:
     service:
       extensions: [jaeger_storage, jaeger_query]

--- a/tests/e2e/filelog-receiver/01-deployment.yaml
+++ b/tests/e2e/filelog-receiver/01-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: busybox:latest
+        image: docker.io/library/busybox:latest
         command: ["/bin/sh", "/scripts/generate-logs.sh"]
         volumeMounts:
         - name: scripts

--- a/tests/e2e/smoke-init-containers/00-install.yaml
+++ b/tests/e2e/smoke-init-containers/00-install.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   initContainers:
     - name: init-test-echo
-      image: alpine
+      image: docker.io/library/alpine:latest
       command: ['sh', '-c', 'sleep 5 && echo "this is a test"']
   config: |
     receivers:

--- a/tests/test-e2e-apps/apache-httpd/Dockerfile
+++ b/tests/test-e2e-apps/apache-httpd/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM httpd:2.4
+FROM docker.io/library/httpd:2.4
 
 RUN sed -i "s#Listen 80#Listen 8080#g" /usr/local/apache2/conf/httpd.conf
 RUN chmod 777 -R /usr/local/apache2/

--- a/tests/test-e2e-apps/bridge-server/Dockerfile
+++ b/tests/test-e2e-apps/bridge-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM docker.io/library/golang:1.23-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/tests/test-e2e-apps/golang/Dockerfile
+++ b/tests/test-e2e-apps/golang/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go application
-FROM golang:1.23.0-alpine AS builder
+FROM docker.io/library/golang:1.23.0-alpine AS builder
 
 # Set the working directory inside the container for the build stage.
 WORKDIR /app

--- a/tests/test-e2e-apps/java/Dockerfile
+++ b/tests/test-e2e-apps/java/Dockerfile
@@ -17,7 +17,7 @@ COPY DemoApplication.java /app/src/main/java/com/example/app/
 COPY build.gradle .
 RUN ./gradlew bootJar --no-daemon
 
-FROM eclipse-temurin:17.0.8.1_1-jre
+FROM docker.io/library/eclipse-temurin:17.0.8.1_1-jre
 
 COPY --from=builder /app/build/libs/app-0.0.1-SNAPSHOT.jar .
 ENTRYPOINT ["java", "-jar", "app-0.0.1-SNAPSHOT.jar"]

--- a/tests/test-e2e-apps/metrics-basic-auth/Dockerfile
+++ b/tests/test-e2e-apps/metrics-basic-auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM docker.io/library/python:3.11-slim
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/tests/test-e2e-apps/nodejs/Dockerfile
+++ b/tests/test-e2e-apps/nodejs/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Use an official Node.js image as a base.
-FROM node:lts-bookworm
+FROM docker.io/library/node:lts-bookworm
 
 # Set the working directory inside the container
 WORKDIR /usr/src/app

--- a/tests/test-e2e-apps/python/Dockerfile
+++ b/tests/test-e2e-apps/python/Dockerfile
@@ -1,6 +1,6 @@
 ARG python_version=3.13
 
-FROM python:${python_version}-alpine3.22
+FROM docker.io/library/python:${python_version}-alpine3.22
 
 WORKDIR /app
 


### PR DESCRIPTION
**Description**

Replace short container image names with fully qualified image names (e.g., rabbitmq → docker.io/library/rabbitmq:latest)
 across all test manifests and Dockerfiles.

**Why**

Image pulls are failing on OpenShift due to short name enforcement. OpenShift enforces fully qualified image names as a
security measure to prevent ambiguous registry resolution and potential image spoofing attacks.

Without explicit registry paths, pods fail to start with errors related to short name resolution being blocked by the
container runtime policy.

**Changes**

- Updated all test YAML manifests with explicit docker.io registry paths
- Added explicit tags (:latest, :3, etc.) where previously omitted
- Updated Dockerfiles to use fully qualified base image names