### PR TITLE
Calculate hash & send info to gateway

### DIFF
--- a/.chloggen/calculate-hash-.yaml
+++ b/.chloggen/calculate-hash-.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: opamp
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Calculate hash from connection settings and auto-send own telemetry settings to gateway for leaf nodes
+
+# One or more tracking issues related to the change
+issues: [4506]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The OpAMP bridge now calculates SHA-256 hash from connection settings and automatically
+  sends own metrics, traces, and logs settings to the OpAMP gateway for leaf collector nodes.

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2025-11-20T10:03:26Z"
+    createdAt: "2025-11-23T10:52:03Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2025-11-20T10:03:26Z"
+    createdAt: "2025-11-23T10:52:07Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/cmd/operator-opamp-bridge/internal/agent/agent.go
+++ b/cmd/operator-opamp-bridge/internal/agent/agent.go
@@ -510,22 +510,22 @@ func (agent *Agent) onMessage(ctx context.Context, msg *types.MessageData) {
 	}
 }
 
-// GetOwnMetricsSettings returns the telemetry connection settings for metrics
+// GetOwnMetricsSettings returns the telemetry connection settings for metrics.
 func (agent *Agent) GetOwnMetricsSettings() *protobufs.TelemetryConnectionSettings {
 	return agent.ownMetricsSettings
 }
 
-// GetOwnTracesSettings returns the telemetry connection settings for traces
+// GetOwnTracesSettings returns the telemetry connection settings for traces.
 func (agent *Agent) GetOwnTracesSettings() *protobufs.TelemetryConnectionSettings {
 	return agent.ownTracesSettings
 }
 
-// GetOwnLogsSettings returns the telemetry connection settings for logs
+// GetOwnLogsSettings returns the telemetry connection settings for logs.
 func (agent *Agent) GetOwnLogsSettings() *protobufs.TelemetryConnectionSettings {
 	return agent.ownLogsSettings
 }
 
-// GetOtherConnectionSettings returns the telemetry connection settings for other connections
+// GetOtherConnectionSettings returns the telemetry connection settings for other connections.
 func (agent *Agent) GetOtherConnectionSettings() map[string]*protobufs.OtherConnectionSettings {
 	return agent.otherSettings
 }

--- a/cmd/operator-opamp-bridge/internal/agent/agent.go
+++ b/cmd/operator-opamp-bridge/internal/agent/agent.go
@@ -46,6 +46,11 @@ type Agent struct {
 	applier             operator.ConfigApplier
 	remoteConfigEnabled bool
 
+	ownMetricsSettings *protobufs.TelemetryConnectionSettings
+	ownTracesSettings  *protobufs.TelemetryConnectionSettings
+	ownLogsSettings    *protobufs.TelemetryConnectionSettings
+	otherSettings      map[string]*protobufs.OtherConnectionSettings
+
 	done   chan struct{}
 	ticker *time.Ticker
 }
@@ -490,7 +495,39 @@ func (agent *Agent) onMessage(ctx context.Context, msg *types.MessageData) {
 
 	if msg.OwnMetricsConnSettings != nil {
 		agent.initMeter(msg.OwnMetricsConnSettings)
+		agent.ownMetricsSettings = msg.OwnMetricsConnSettings
 	}
+
+	if msg.OwnTracesConnSettings != nil {
+		agent.ownTracesSettings = msg.OwnTracesConnSettings
+	}
+
+	if msg.OwnLogsConnSettings != nil {
+		agent.ownLogsSettings = msg.OwnLogsConnSettings
+	}
+	if msg.OtherConnSettings != nil {
+		agent.otherSettings = msg.OtherConnSettings
+	}
+}
+
+// GetOwnMetricsSettings returns the telemetry connection settings for metrics
+func (agent *Agent) GetOwnMetricsSettings() *protobufs.TelemetryConnectionSettings {
+	return agent.ownMetricsSettings
+}
+
+// GetOwnTracesSettings returns the telemetry connection settings for traces
+func (agent *Agent) GetOwnTracesSettings() *protobufs.TelemetryConnectionSettings {
+	return agent.ownTracesSettings
+}
+
+// GetOwnLogsSettings returns the telemetry connection settings for logs
+func (agent *Agent) GetOwnLogsSettings() *protobufs.TelemetryConnectionSettings {
+	return agent.ownLogsSettings
+}
+
+// GetOtherConnectionSettings returns the telemetry connection settings for other connections
+func (agent *Agent) GetOtherConnectionSettings() map[string]*protobufs.OtherConnectionSettings {
+	return agent.otherSettings
 }
 
 // getCurrentTimeUnixNano returns the current time as a uint64, which the protocol expects.

--- a/cmd/operator-opamp-bridge/internal/proxy/agent_test.go
+++ b/cmd/operator-opamp-bridge/internal/proxy/agent_test.go
@@ -18,7 +18,7 @@ func TestNewAgent(t *testing.T) {
 	instanceId := uuid.New()
 	conn := &mockConnection{}
 
-	agent := NewAgent(logger, instanceId, conn)
+	agent := NewAgent(logger, instanceId, conn, nil)
 	require.NotNil(t, agent, "agent should not be nil")
 	assert.Equal(t, instanceId, agent.InstanceId, "instance ID should match")
 	assert.Equal(t, conn, agent.conn, "connection should match")
@@ -28,7 +28,7 @@ func TestAgent_hasCapability(t *testing.T) {
 	logger := logr.Discard()
 	instanceId := uuid.New()
 	conn := &mockConnection{}
-	agent := NewAgent(logger, instanceId, conn)
+	agent := NewAgent(logger, instanceId, conn, nil)
 
 	agent.Status = &protobufs.AgentToServer{
 		Capabilities: uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig),
@@ -42,7 +42,7 @@ func TestAgent_UpdateStatus(t *testing.T) {
 	logger := logr.Discard()
 	instanceId := uuid.New()
 	conn := &mockConnection{}
-	agent := NewAgent(logger, instanceId, conn)
+	agent := NewAgent(logger, instanceId, conn, nil)
 
 	newStatus := &protobufs.AgentToServer{
 		SequenceNum: 1,
@@ -66,7 +66,7 @@ func TestAgent_GetHealth(t *testing.T) {
 	logger := logr.Discard()
 	instanceId := uuid.New()
 	conn := &mockConnection{}
-	agent := NewAgent(logger, instanceId, conn)
+	agent := NewAgent(logger, instanceId, conn, nil)
 
 	health := &protobufs.ComponentHealth{
 		Healthy: true,
@@ -80,7 +80,7 @@ func TestAgent_GetConfiguration(t *testing.T) {
 	logger := logr.Discard()
 	instanceId := uuid.New()
 	conn := &mockConnection{}
-	agent := NewAgent(logger, instanceId, conn)
+	agent := NewAgent(logger, instanceId, conn, nil)
 
 	config := &protobufs.EffectiveConfig{
 		ConfigMap: &protobufs.AgentConfigMap{
@@ -92,4 +92,147 @@ func TestAgent_GetConfiguration(t *testing.T) {
 	agent.effectiveConfig = config
 
 	assert.Equal(t, config, agent.GetConfiguration(), "configuration should match")
+}
+
+func Test_CalcConnectionSettings(t *testing.T) {
+	tests := []struct {
+		name        string
+		expectedErr bool
+		expected    *protobufs.ServerToAgent
+		setSettings *mockBridgeAgent
+	}{
+		{
+			name: "all settings present",
+			expected: &protobufs.ServerToAgent{
+				ConnectionSettings: &protobufs.ConnectionSettingsOffers{
+					OwnMetrics: &protobufs.TelemetryConnectionSettings{
+						DestinationEndpoint: "metrics-endpoint",
+					},
+					OwnTraces: &protobufs.TelemetryConnectionSettings{
+						DestinationEndpoint: "traces-endpoint",
+					},
+					OwnLogs: &protobufs.TelemetryConnectionSettings{
+						DestinationEndpoint: "logs-endpoint",
+					},
+					OtherConnections: map[string]*protobufs.OtherConnectionSettings{
+						"custom-connection": {
+							DestinationEndpoint: "custom-endpoint",
+							OtherSettings: map[string]string{
+								"setting1": "value1",
+								"setting2": "value2",
+							},
+						},
+					},
+				},
+			},
+			setSettings: &mockBridgeAgent{
+				ownMetrics: &protobufs.TelemetryConnectionSettings{
+					DestinationEndpoint: "metrics-endpoint",
+				},
+				ownTraces: &protobufs.TelemetryConnectionSettings{
+					DestinationEndpoint: "traces-endpoint",
+				},
+				ownLogs: &protobufs.TelemetryConnectionSettings{
+					DestinationEndpoint: "logs-endpoint",
+				},
+				otherConnections: map[string]*protobufs.OtherConnectionSettings{
+					"custom-connection": {
+						DestinationEndpoint: "custom-endpoint",
+						OtherSettings: map[string]string{
+							"setting1": "value1",
+							"setting2": "value2",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "no settings present",
+			expected: &protobufs.ServerToAgent{
+				ConnectionSettings: &protobufs.ConnectionSettingsOffers{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := logr.Discard()
+			instanceId := uuid.New()
+			conn := &mockConnection{}
+			bridge := tt.setSettings
+			if bridge == nil {
+				bridge = &mockBridgeAgent{}
+			}
+			agent := NewAgent(logger, instanceId, conn, bridge)
+			response := &protobufs.ServerToAgent{}
+			agent.calcConnectionSettings(response)
+
+			if tt.expectedErr {
+				assert.Nil(t, response.ConnectionSettings, "expected nil ConnectionSettings due to error")
+			} else {
+				assert.NotNil(t, response.ConnectionSettings, "expected non-nil ConnectionSettings")
+				assert.Equal(t, tt.expected.ConnectionSettings.OwnMetrics, response.ConnectionSettings.OwnMetrics, "OwnMetrics should match")
+				assert.Equal(t, tt.expected.ConnectionSettings.OwnTraces, response.ConnectionSettings.OwnTraces, "OwnTraces should match")
+				assert.Equal(t, tt.expected.ConnectionSettings.OwnLogs, response.ConnectionSettings.OwnLogs, "OwnLogs should match")
+				assert.Equal(t, tt.expected.ConnectionSettings.OtherConnections, response.ConnectionSettings.OtherConnections, "OtherConnections should match")
+				assert.NotEmpty(t, response.ConnectionSettings.Hash, "Hash should not be empty")
+			}
+		})
+	}
+}
+
+type mockBridgeAgent struct {
+	ownMetrics       *protobufs.TelemetryConnectionSettings
+	ownTraces        *protobufs.TelemetryConnectionSettings
+	ownLogs          *protobufs.TelemetryConnectionSettings
+	otherConnections map[string]*protobufs.OtherConnectionSettings
+}
+
+func (m *mockBridgeAgent) GetOwnMetricsSettings() *protobufs.TelemetryConnectionSettings {
+	return m.ownMetrics
+}
+
+func (m *mockBridgeAgent) GetOwnTracesSettings() *protobufs.TelemetryConnectionSettings {
+	return m.ownTraces
+}
+
+func (m *mockBridgeAgent) GetOwnLogsSettings() *protobufs.TelemetryConnectionSettings {
+	return m.ownLogs
+}
+
+func (m *mockBridgeAgent) GetOtherConnectionSettings() map[string]*protobufs.OtherConnectionSettings {
+	return m.otherConnections
+}
+
+func Test_CalcConnectionSettings_HashUniqueness(t *testing.T) {
+	logger := logr.Discard()
+	instanceId := uuid.New()
+	conn := &mockConnection{}
+
+	bridge1 := &mockBridgeAgent{
+		ownMetrics: &protobufs.TelemetryConnectionSettings{
+			DestinationEndpoint: "metrics-endpoint",
+		},
+	}
+	agent1 := NewAgent(logger, instanceId, conn, bridge1)
+	response1 := &protobufs.ServerToAgent{}
+	agent1.calcConnectionSettings(response1)
+
+	bridge2 := &mockBridgeAgent{
+		ownTraces: &protobufs.TelemetryConnectionSettings{
+			DestinationEndpoint: "traces-endpoint",
+		},
+	}
+	agent2 := NewAgent(logger, instanceId, conn, bridge2)
+	response2 := &protobufs.ServerToAgent{}
+	agent2.calcConnectionSettings(response2)
+
+	bridge3 := &mockBridgeAgent{}
+	agent3 := NewAgent(logger, instanceId, conn, bridge3)
+	response3 := &protobufs.ServerToAgent{}
+	agent3.calcConnectionSettings(response3)
+
+	assert.NotEqual(t, response1.ConnectionSettings.Hash, response2.ConnectionSettings.Hash)
+	assert.NotEqual(t, response1.ConnectionSettings.Hash, response3.ConnectionSettings.Hash)
+	assert.NotEqual(t, response2.ConnectionSettings.Hash, response3.ConnectionSettings.Hash)
 }

--- a/cmd/operator-opamp-bridge/internal/proxy/server_test.go
+++ b/cmd/operator-opamp-bridge/internal/proxy/server_test.go
@@ -49,7 +49,7 @@ func TestOpAMPProxy_OnDisconnect(t *testing.T) {
 
 	instanceId := uuid.New()
 	conn := &mockConnection{}
-	proxyServer.agentsById[instanceId] = NewAgent(logger, instanceId, conn)
+	proxyServer.agentsById[instanceId] = NewAgent(logger, instanceId, conn, nil)
 	proxyServer.connections[conn] = map[uuid.UUID]bool{instanceId: true}
 
 	proxyServer.onDisconnect(conn)
@@ -66,7 +66,7 @@ func TestOpAMPProxy_GetConfigurations(t *testing.T) {
 
 	instanceId := uuid.New()
 	conn := &mockConnection{}
-	agent := NewAgent(logger, instanceId, conn)
+	agent := NewAgent(logger, instanceId, conn, nil)
 	proxyServer.agentsById[instanceId] = agent
 
 	configs := proxyServer.GetConfigurations()
@@ -81,7 +81,7 @@ func TestOpAMPProxy_GetHealth(t *testing.T) {
 
 	instanceId := uuid.New()
 	conn := &mockConnection{}
-	agent := NewAgent(logger, instanceId, conn)
+	agent := NewAgent(logger, instanceId, conn, nil)
 	proxyServer.agentsById[instanceId] = agent
 
 	healths := proxyServer.GetHealth()

--- a/cmd/operator-opamp-bridge/main.go
+++ b/cmd/operator-opamp-bridge/main.go
@@ -34,6 +34,7 @@ func main() {
 	opampClient := cfg.CreateClient()
 	opampProxy := proxy.NewOpAMPProxy(l.WithName("server"), cfg.ListenAddr)
 	opampAgent := agent.NewAgent(l.WithName("agent"), operatorClient, cfg, opampClient, opampProxy)
+	opampProxy.SetBridgeAgent(opampAgent)
 
 	if err := opampAgent.Start(); err != nil {
 		l.Error(err, "Cannot start OpAMP client")


### PR DESCRIPTION
**Description:**

1. **Compute settings hash:**
   Previously, the connection `SettingsHash` field was always `nil`.
   This change introduces proper hash generation based on the current settings. The hash is now computed whenever settings are updated .

2. **Auto-send leaf node settings :**
   Leaf nodes now automatically send their `OwnMetrics`, `OwnTraces`, and `OwnLogs` settings.
   This ensures the updated metadata and   doesn't make assumptions that leaf node settings remain unchanged.


**Link to tracking Issue(s):**

* Resolves: #4506

**Testing:**

* added unit tests 


**Documentation:**