### PR TITLE
[chore] Update autoinstrumentation-dotnet to 1.13.0

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -27,7 +27,7 @@ autoinstrumentation-python=0.59b0
 
 # Represents the current release of DotNet instrumentation.
 # Should match autoinstrumentation/dotnet/version.txt
-autoinstrumentation-dotnet=1.2.0
+autoinstrumentation-dotnet=1.13.0
 
 # Represents the current release of Go instrumentation.
 autoinstrumentation-go=v0.22.1


### PR DESCRIPTION
**Description:**

Update the version to match `autoinstrumentation/dotnet/version.txt` as the comment says it should.

https://github.com/open-telemetry/opentelemetry-operator/blob/4d14dcf7f7653cf480bb2b9c90d000811979da83/versions.txt#L28-L30

https://github.com/open-telemetry/opentelemetry-operator/blob/4d14dcf7f7653cf480bb2b9c90d000811979da83/autoinstrumentation/dotnet/version.txt#L1

I found this after I looked in [the release notes](https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.140.0), and it says .NET was 1.2.0 not 1.12.0 that I'd expected.

> [.NET auto-instrumentation - v1.2.0](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.2.0)

/cc @Kielek as I assume this should have been part of #4527 (and other previous PRs?)

**Link to tracking Issue(s):** N/A

- Resolves: N/A

**Testing:** None - I assume Ci will pick up anything.

**Documentation:** None
