### PR TITLE
[chore] Add obj to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 bin
+obj/
 vendor
 .DS_Store
 


### PR DESCRIPTION
**Description:**

Ignore files in `obj` directories for .NET.

Otherwise you get things in your Git tree if you open the repo in Visual Studio Code from the C# DevKit trying to compile the end-to-end test applications:

<img width="1181" height="302" alt="image" src="https://github.com/user-attachments/assets/131d6276-6611-4967-8a2b-1f68f570ee11" />

**Link to tracking Issue(s):**

N/A

**Testing:**

N/A

**Documentation:**

N/A
