### PR TITLE
Ensure CRs are always serialized correctly in opamp bridge

### DIFF
--- a/cmd/operator-opamp-bridge/internal/operator/client_test.go
+++ b/cmd/operator-opamp-bridge/internal/operator/client_test.go
@@ -159,13 +159,13 @@ func TestClient_ApplyUpdate(t *testing.T) {
 	err = yaml.Unmarshal(reportingColConfig, &reportingCol)
 	require.NoError(t, err, "Should be no error on unmarshal")
 
-	reportingCol.TypeMeta.Kind = CollectorResource
-	reportingCol.TypeMeta.APIVersion = v1beta1.GroupVersion.String()
+	setTypedMeta(&reportingCol)
 	reportingCol.ObjectMeta.Name = "simplest"
 	reportingCol.ObjectMeta.Namespace = namespace
 
 	err = fakeClient.Create(context.Background(), &reportingCol)
 	require.NoError(t, err, "Should be able to make reporting col")
+	setTypedMeta(&reportingCol) // calling client.Create() can unset this
 
 	allInstances, err := c.ListInstances()
 	require.NoError(t, err, "Should be able to list all collectors")


### PR DESCRIPTION
**Description:**

When trying to upgrade to controller-runtime 0.22.1 as part of #4196, I found these unit tests for opamp bridge failing. The root cause was the fact that the OpenTelemetryCollector CR instances created by the controller-runtime client didn't have `TypeMeta` set, and therefore didn't serialize to yaml correctly. I fixed this in the simplest way I could think of, but we should probably use a more foolproof serialization method here.

**Link to tracking Issue(s):**

- Relates: #4196 
