### PR TITLE
chore(collector): ensure additional containers are always listed after the collector

### DIFF
--- a/.chloggen/container-order.yaml
+++ b/.chloggen/container-order.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure the collector container is always listed first in the podspec
+
+# One or more tracking issues related to the change
+issues: [4548]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is so tools like kubectx logs will always default to the collector container instead of any additional containers that are configured.

--- a/internal/manifests/collector/daemonset.go
+++ b/internal/manifests/collector/daemonset.go
@@ -47,7 +47,7 @@ func DaemonSet(params manifests.Params) (*appsv1.DaemonSet, error) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            ServiceAccountName(params.OtelCol),
 					InitContainers:                params.OtelCol.Spec.InitContainers,
-					Containers:                    append(params.OtelCol.Spec.AdditionalContainers, Container(params.Config, params.Log, params.OtelCol, true)),
+					Containers:                    append([]corev1.Container{Container(params.Config, params.Log, params.OtelCol, true)}, params.OtelCol.Spec.AdditionalContainers...),
 					Volumes:                       Volumes(params.Config, params.OtelCol),
 					Tolerations:                   params.OtelCol.Spec.Tolerations,
 					NodeSelector:                  params.OtelCol.Spec.NodeSelector,

--- a/internal/manifests/collector/daemonset_test.go
+++ b/internal/manifests/collector/daemonset_test.go
@@ -511,7 +511,7 @@ func TestDaemonSetAdditionalContainer(t *testing.T) {
 	assert.Equal(t, "8888", d.Spec.Template.Annotations["prometheus.io/port"])
 	assert.Equal(t, "/metrics", d.Spec.Template.Annotations["prometheus.io/path"])
 	assert.Len(t, d.Spec.Template.Spec.Containers, 2)
-	assert.Equal(t, v1.Container{Name: "test"}, d.Spec.Template.Spec.Containers[0])
+	assert.Equal(t, v1.Container{Name: "test"}, d.Spec.Template.Spec.Containers[1])
 }
 
 func TestDaemonSetDefaultUpdateStrategy(t *testing.T) {

--- a/internal/manifests/collector/deployment.go
+++ b/internal/manifests/collector/deployment.go
@@ -48,7 +48,7 @@ func Deployment(params manifests.Params) (*appsv1.Deployment, error) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            ServiceAccountName(params.OtelCol),
 					InitContainers:                params.OtelCol.Spec.InitContainers,
-					Containers:                    append(params.OtelCol.Spec.AdditionalContainers, Container(params.Config, params.Log, params.OtelCol, true)),
+					Containers:                    append([]corev1.Container{Container(params.Config, params.Log, params.OtelCol, true)}, params.OtelCol.Spec.AdditionalContainers...),
 					Volumes:                       Volumes(params.Config, params.OtelCol),
 					DNSPolicy:                     manifestutils.GetDNSPolicy(params.OtelCol.Spec.HostNetwork, params.OtelCol.Spec.PodDNSConfig, params.OtelCol.Spec.DNSPolicy),
 					DNSConfig:                     &params.OtelCol.Spec.PodDNSConfig,

--- a/internal/manifests/collector/deployment_test.go
+++ b/internal/manifests/collector/deployment_test.go
@@ -689,7 +689,7 @@ func TestDeploymentAdditionalContainers(t *testing.T) {
 	assert.Equal(t, "8888", d.Spec.Template.Annotations["prometheus.io/port"])
 	assert.Equal(t, "/metrics", d.Spec.Template.Annotations["prometheus.io/path"])
 	assert.Len(t, d.Spec.Template.Spec.Containers, 2)
-	assert.Equal(t, v1.Container{Name: "test"}, d.Spec.Template.Spec.Containers[0])
+	assert.Equal(t, v1.Container{Name: "test"}, d.Spec.Template.Spec.Containers[1])
 }
 
 func TestDeploymentShareProcessNamespace(t *testing.T) {

--- a/internal/manifests/collector/statefulset.go
+++ b/internal/manifests/collector/statefulset.go
@@ -53,7 +53,7 @@ func StatefulSet(params manifests.Params) (*appsv1.StatefulSet, error) {
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            ServiceAccountName(params.OtelCol),
 					InitContainers:                params.OtelCol.Spec.InitContainers,
-					Containers:                    append(params.OtelCol.Spec.AdditionalContainers, Container(params.Config, params.Log, params.OtelCol, true)),
+					Containers:                    append([]corev1.Container{Container(params.Config, params.Log, params.OtelCol, true)}, params.OtelCol.Spec.AdditionalContainers...),
 					Volumes:                       Volumes(params.Config, params.OtelCol),
 					DNSPolicy:                     manifestutils.GetDNSPolicy(params.OtelCol.Spec.HostNetwork, params.OtelCol.Spec.PodDNSConfig, params.OtelCol.Spec.DNSPolicy),
 					DNSConfig:                     &params.OtelCol.Spec.PodDNSConfig,

--- a/internal/manifests/collector/statefulset_test.go
+++ b/internal/manifests/collector/statefulset_test.go
@@ -691,7 +691,7 @@ func TestStatefulSetAdditionalContainers(t *testing.T) {
 	assert.Equal(t, "8888", s.Spec.Template.Annotations["prometheus.io/port"])
 	assert.Equal(t, "/metrics", s.Spec.Template.Annotations["prometheus.io/path"])
 	assert.Len(t, s.Spec.Template.Spec.Containers, 2)
-	assert.Equal(t, corev1.Container{Name: "test"}, s.Spec.Template.Spec.Containers[0])
+	assert.Equal(t, corev1.Container{Name: "test"}, s.Spec.Template.Spec.Containers[1])
 }
 
 func TestStatefulSetShareProcessNamespace(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Sets the collector container first in the podspec so kubectl logs and exec targets that by default instead of any additional containers

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/4548

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
