### PR TITLE
Update Python auto-instrumentation envvar injection to use appendOrReplace to be consistent with other langugages

### DIFF
--- a/internal/instrumentation/sdk.go
+++ b/internal/instrumentation/sdk.go
@@ -299,7 +299,7 @@ func (i *sdkInjector) injectDefaultNodeJSEnvVars(pod corev1.Pod, index int) core
 // injectDefaultPythonEnvVars injects default environment variables for Python.
 func (i *sdkInjector) injectDefaultPythonEnvVars(pod corev1.Pod, index int) corev1.Pod {
 	container := &pod.Spec.Containers[index]
-	container.Env = appendIfNotSet(container.Env, getDefaultPythonEnvVars()...)
+	container.Env = appendOrReplace(container.Env, getDefaultPythonEnvVars()...)
 	return pod
 }
 


### PR DESCRIPTION
Signed-off-by: Braden Chapman <braden.chapman@chicagotrading.com>

**Description:** Updated Python environment variable injection for autoinstrumentation to use appendOrReplace() instead of appendIfNotSet(). Other languages use appendOrReplace().

Users at my company deploy their applications into kubernetes using Helm. In the Helm chart, we have the following set:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
            value: "http://$(NODE_IP):4317"
          - name: OTEL_EXPORTER_OTLP_PROTOCOL
            value: "grpc"
But Python cannot use grpc. When attempting to override the variables in the helm chart by setting them in the Instrumentation object to be used by the autoinstrumentation injection, the helm chart variables take precedent because the Python injection in the operator currently uses appendIfNotSet, whereas other languages use appendOrReplace.
