### PR TITLE
[Chore] Add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CONTRIBUTING.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
# Add AGENTS.md for AI Coding Assistants

Enhanced `CONTRIBUTING.md` with comprehensive development guidance and created symlinks for AI tool compatibility.

## Changes

**CONTRIBUTING.md** - Enhanced with:
- Comprehensive command reference organized by category (build/test, code generation, deployment, testing)
- Project structure details (directory organization, core CRDs)
- Code style conventions with kubebuilder marker examples
- Common tasks with step-by-step guides (changing APIs, controllers, webhooks, adding instrumentation)
- Important technical details (versioning constraints, supported versions, architecture patterns)

**AGENTS.md** - Symlink to CONTRIBUTING.md (for [agents.md](https://agents.md/) standard compatibility)

**CLAUDE.md** - Symlink to AGENTS.md (for Claude Code compatibility)

## Why?

The [agents.md](https://agents.md/) standard is supported by 20+ AI coding tools (GitHub Copilot, Cursor, Claude Code, etc.). By creating a symlink, we support these tools while avoiding content duplication - all documentation lives in CONTRIBUTING.md.

This addresses SIG feedback to avoid duplication while still providing AI assistant compatibility.