### PR TITLE
Add finalizer only for cluster scope objects

### DIFF
--- a/.chloggen/fix-finalizer-addition.yaml
+++ b/.chloggen/fix-finalizer-addition.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add finalizers to OpenTelemetryCollector CR only when cluster roles and bindings for SA are created by Operator.
+
+# One or more tracking issues related to the change
+issues: [4367]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Finalizer usage was restricted to cluster scoped resources only. Namespaced resources no longer receive finalizers,
+  preventing blocked namespace deletion if the operator is removed first. The change aligns finalizer behavior with
+  cluster-level RBAC availability, ensuring finalizers are applied only when the operator has the required
+  cluster scoped permissions.


### PR DESCRIPTION
**Description:**

- Add finalizers to CR only when cluster roles and bindings for SA are created by Operator
- Caused by #2938

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #4367
