### PR TITLE
Fix manager logger initialization

### DIFF
--- a/.chloggen/fix-manager-logger-initialization.yaml
+++ b/.chloggen/fix-manager-logger-initialization.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: config
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix manager logger initialization
+
+# One or more tracking issues related to the change
+issues: [4584]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Apply config before setting up logger to configure it properly.

--- a/main.go
+++ b/main.go
@@ -98,6 +98,12 @@ func main() {
 		panic(err)
 	}
 
+	err := cfg.Apply(configFile)
+	if err != nil {
+		fmt.Printf("configuration error: %v\n", err)
+		os.Exit(1)
+	}
+
 	opts.EncoderConfigOptions = append(opts.EncoderConfigOptions, func(ec *zapcore.EncoderConfig) {
 		ec.MessageKey = cfg.Zap.MessageKey
 		ec.LevelKey = cfg.Zap.LevelKey
@@ -113,12 +119,6 @@ func main() {
 	ctrl.SetLogger(logger)
 
 	configLog := ctrl.Log.WithName("config")
-
-	err := cfg.Apply(configFile)
-	if err != nil {
-		configLog.Error(err, "configuration error")
-		os.Exit(1)
-	}
 
 	v := version.Get()
 


### PR DESCRIPTION
**Description:**

- Apply config file before setting up logger to ensure
- Caused by #4054

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #4584

**Before:**
`
$ .bob/gopath/bin/manager --zap-encoder=json --zap-message-key="msg" --zap-level-key="severity" --zap-time-key="ts" --zap-level-format="lowercase"
`

`
{"level":"INFO","timestamp":"2025-12-23T12:39:04+01:00","message":"Zap Config","cfg.Zap.MessageKey":"message","cfg.Zap.LevelKey":"level","cfg.Zap.TimeKey":"timestamp","cfg.Zap.LevelFormat":"uppercase"}
`


**Now:**
`
$ .bob/gopath/bin/manager --zap-encoder=json --zap-message-key="msg" --zap-level-key="severity" --zap-time-key="ts" --zap-level-format="lowercase"
`

`
{"severity":"info","ts":"2025-12-23T12:56:24+01:00","msg":"Zap Config","cfg.Zap.MessageKey":"msg","cfg.Zap.LevelKey":"severity","cfg.Zap.TimeKey":"ts","cfg.Zap.LevelFormat":"lowercase"}
`
