### PR TITLE
Fix invalid logr.Info call for Native sidecar logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -266,7 +266,7 @@ func main() {
 		}
 	}
 
-	setupLog.Info("Native sidecar", cfg.Internal.NativeSidecarSupport)
+	setupLog.Info("Native sidecar", "enabled", cfg.Internal.NativeSidecarSupport)
 
 	if cfg.AnnotationsFilter != nil {
 		for _, basePattern := range cfg.AnnotationsFilter {


### PR DESCRIPTION
This PR fixes a structured logging call in main.go that violates the logr key/value contract.

Currently, the log:

    setupLog.Info("Native sidecar", cfg.Internal.NativeSidecarSupport)

passes a value without an associated key, causing zap to emit a DPANIC in dev mode.
```
{"level":"DPANIC","timestamp":"2026-01-14T00:37:11.943980138Z","logger":"setup","message":"odd number of arguments passed as key-value pairs for logging","ignored key":true,"stacktrace":"main.main\n\t./main.go:254\nruntime.main\n\truntime/proc.go:285"}
{"level":"INFO","timestamp":"2026-01-14T00:37:11.943976638Z","logger":"setup","message":"Native sidecar"} 
```

The corrected log is:

    setupLog.Info("Native sidecar", "enabled", cfg.Internal.NativeSidecarSupport)

This preserves structured logging semantics and avoids development-time panic while keeping behavior identical in production mode.
