### PR TITLE
[Chore] Added Help option in Makefile

### DIFF
--- a/main.go
+++ b/main.go
@@ -266,7 +266,7 @@ func main() {
 		}
 	}
 
-	setupLog.Info("Native sidecar", cfg.Internal.NativeSidecarSupport)
+	setupLog.Info("Native sidecar", "enabled", cfg.Internal.NativeSidecarSupport)
 
 	if cfg.AnnotationsFilter != nil {
 		for _, basePattern := range cfg.AnnotationsFilter {

--- a/tests/test-e2e-apps/metrics-basic-auth/requirements.txt
+++ b/tests/test-e2e-apps/metrics-basic-auth/requirements.txt
@@ -1,2 +1,2 @@
 Flask==3.1.2
-prometheus_client==0.24.0
+prometheus_client==0.24.1


### PR DESCRIPTION
**Description:**
This PR adds a Make Help option that requires users to follow a predefined format. The goal is to standardize help requests, making them clearer, more structured, and easier to understand for new comers.
Format for each Make rule - 
```bash
##@ PR   <----- SECTION
# Verify generated code, manifests, bundles, and API docs are up to date   <---- Description
.PHONY: ensure-update-is-noop    <---- Command
ensure-update-is-noop: VERSION=$(OPERATOR_VERSION)
```

**Result**
<img width="2629" height="1641" alt="image" src="https://github.com/user-attachments/assets/1e25ee45-d3ca-4ee6-8d08-f960794b4f39" />

