### PR TITLE
[chore]: /bin/bash->/usr/bin/env bash

### DIFF
--- a/.ci/create-release-github.sh
+++ b/.ci/create-release-github.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NOTES_FILE=/tmp/notes.md
 # Note: We expect the versions to not have the `v` prefix here

--- a/hack/ignore-createdAt-bundle.sh
+++ b/hack/ignore-createdAt-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle
 # even if it is patched:
 #   https://github.com/operator-framework/operator-sdk/pull/6136

--- a/hack/install-metrics-server.sh
+++ b/hack/install-metrics-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Install metrics-server on kind clusters for autoscale tests.
 # Note: This is not needed for minikube,

--- a/hack/install-prometheus-operator.sh
+++ b/hack/install-prometheus-operator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$(kubectl api-resources --api-group=monitoring.coreos.com -o name)" ]]; then
     echo "Prometheus CRDs are there"

--- a/hack/install-targetallocator-prometheus-crds.sh
+++ b/hack/install-targetallocator-prometheus-crds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$(kubectl api-resources --api-group=monitoring.coreos.com -o name)" ]]; then
     echo "Prometheus CRDs are there"

--- a/scripts/update-golden-files.sh
+++ b/scripts/update-golden-files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script updates the golden files for unit tests that import the 'gotest.tools/v3/golden' dependency in a Go project.
 # It lists all packages in the project, checks for the dependency in test imports, and runs unit tests with '-update' to update golden files.
 
@@ -11,7 +11,7 @@ packages=$(go list ./...)
 for pkg in $packages; do
     # Use 'go list' with 'XTestImports' template to get the imports from test binaries
     imports=$(go list -f '{{join .TestImports "\n"}}{{"\n"}}{{join .XTestImports "\n"}}' "$pkg")
-    
+
     # Check if the dependency is in the imports
     if echo "$imports" | grep -q "$dependency"; then
         # If the dependency is found, run the unit tests updating the golden files

--- a/tests/e2e-instrumentation/instrumentation-go/add-scc.sh
+++ b/tests/e2e-instrumentation/instrumentation-go/add-scc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$(kubectl api-resources --api-group=operator.openshift.io -o name)" ]]; then
     kubectl apply -f scc.yaml

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer-go/add-scc.sh
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer-go/add-scc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ "$(kubectl api-resources --api-group=operator.openshift.io -o name)" ]]; then
     kubectl apply -f scc.yaml

--- a/tests/e2e-openshift-upgrade/upgrade/check_metrics.sh
+++ b/tests/e2e-openshift-upgrade/upgrade/check_metrics.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 oc create serviceaccount e2e-test-metrics-reader -n $NAMESPACE
 oc adm policy add-cluster-role-to-user cluster-monitoring-view system:serviceaccount:$NAMESPACE:e2e-test-metrics-reader

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/check_logs.sh
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/check_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TOKEN=$(oc -n openshift-logging create token otel-collector-deployment)
 LOKI_URL=$(oc -n openshift-logging get route logging-loki -o json | jq '.spec.host' -r)
@@ -20,7 +20,7 @@ while true; do
     echo "$COMMON_LABELS" | grep -q 'k8s_container_name="telemetrygen"' && \
     echo "$COMMON_LABELS" | grep -q 'k8s_namespace_name="chainsaw-incllogs"' && \
     echo "$COMMON_LABELS" | grep -q 'kubernetes_container_name="telemetrygen"' && \
-    echo "$COMMON_LABELS" | grep -q 'kubernetes_namespace_name="chainsaw-incllogs"' && \ 
+    echo "$COMMON_LABELS" | grep -q 'kubernetes_namespace_name="chainsaw-incllogs"' && \
     echo "$LOG_OUTPUT" | grep -q "the message"; then
     echo "Logs found:"
     echo "$COMMON_LABELS"
@@ -30,4 +30,3 @@ while true; do
     sleep 5
   fi
 done
-

--- a/tests/e2e-openshift/kafka/check_traces.sh
+++ b/tests/e2e-openshift/kafka/check_traces.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Define the label selector
 LABEL_SELECTOR="app.kubernetes.io/instance=chainsaw-kafka.kafka-receiver"

--- a/tests/e2e-openshift/monitoring/check_metrics.sh
+++ b/tests/e2e-openshift/monitoring/check_metrics.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 oc create serviceaccount e2e-test-metrics-reader -n $NAMESPACE
 oc adm policy add-cluster-role-to-user cluster-monitoring-view system:serviceaccount:$NAMESPACE:e2e-test-metrics-reader

--- a/tests/e2e-openshift/multi-cluster/create_otlp_sender.sh
+++ b/tests/e2e-openshift/multi-cluster/create_otlp_sender.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Get the HTTP and GRPC routes from OpenTelemetry receiver collector.
 otlp_route_http=$(oc -n chainsaw-multi-cluster-receive get route otlp-http-otlp-receiver-route -o json | jq '.spec.host' -r)
@@ -16,7 +16,7 @@ spec:
   serviceAccount: chainsaw-multi-cluster
   volumes:
     - name: chainsaw-certs
-      configMap: 
+      configMap:
         name: chainsaw-certs
   volumeMounts:
     - name: chainsaw-certs
@@ -50,7 +50,7 @@ spec:
           ca_file: /certs/ca.crt
     service:
       pipelines:
-        traces:    
+        traces:
           receivers: [otlp]
           processors: [memory_limiter, batch]
           exporters: [otlphttp, otlp]

--- a/tests/e2e-openshift/multi-cluster/generate_certs.sh
+++ b/tests/e2e-openshift/multi-cluster/generate_certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Create a directory to store certificates
 CERT_DIR="/tmp/chainsaw-certs"
@@ -70,4 +70,3 @@ kubectl create configmap chainsaw-certs -n chainsaw-multi-cluster-receive \
   --from-file=server.crt="$CERT_DIR/server.crt" \
   --from-file=server.key="$CERT_DIR/server.key" \
   --from-file=ca.crt="$CERT_DIR/ca.crt"
-

--- a/tests/e2e-openshift/must-gather/check_must_gather.sh
+++ b/tests/e2e-openshift/must-gather/check_must_gather.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Create a temporary directory to store must-gather
 MUST_GATHER_DIR=$(mktemp -d)

--- a/tests/e2e-openshift/otlp-metrics-traces/check_metrics.sh
+++ b/tests/e2e-openshift/otlp-metrics-traces/check_metrics.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 oc create serviceaccount e2e-test-metrics-reader -n $NAMESPACE
 oc adm policy add-cluster-role-to-user cluster-monitoring-view system:serviceaccount:$NAMESPACE:e2e-test-metrics-reader

--- a/tests/e2e-openshift/otlp-metrics-traces/check_must_gather.sh
+++ b/tests/e2e-openshift/otlp-metrics-traces/check_must_gather.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Create the directory to store must-gather
 MUST_GATHER_DIR=/tmp/otlp-metrics-traces

--- a/tests/e2e-openshift/scrape-in-cluster-monitoring/check_logs.sh
+++ b/tests/e2e-openshift/scrape-in-cluster-monitoring/check_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script checks the OpenTelemetry collector pod for the presence of Metrics.
 
 # Define the label selector
@@ -23,7 +23,7 @@ FOUND5=false
 while ! $FOUND1 || ! $FOUND2 || ! $FOUND3 || ! $FOUND4 || ! $FOUND5; do
     # Get the list of pods with the specified label
     PODS=($(kubectl -n $NAMESPACE get pods -l $LABEL_SELECTOR -o jsonpath='{.items[*].metadata.name}'))
-    
+
     # Loop through each pod and search for the strings in the logs
     for POD in "${PODS[@]}"; do
         # Search for the first string

--- a/tests/e2e/daemonset-features/add-sa-collector.sh
+++ b/tests/e2e/daemonset-features/add-sa-collector.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$(kubectl api-resources --api-group=operator.openshift.io -o name)" ]]; then
     echo "Adding service account to the OpenTelemetry Collector"
     kubectl patch otelcol daemonset --type=merge -p '{"spec":{"serviceAccount":"otel-collector-daemonset"}}' -n $NAMESPACE

--- a/tests/e2e/daemonset-features/add-scc-openshift.sh
+++ b/tests/e2e/daemonset-features/add-scc-openshift.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ "$(kubectl api-resources --api-group=operator.openshift.io -o name)" ]]; then
     echo "Running the test against an OpenShift Cluster"
     echo "Creating an Service Account"

--- a/tests/test-e2e-apps/scripts/check_pod_logs.sh
+++ b/tests/test-e2e-apps/scripts/check_pod_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script repeatedly checks pod logs from a specific container until all specified strings are found
 # simultaneously or a timeout occurs.
 


### PR DESCRIPTION
**Description:**

Use `/usr/bin/env bash` instead of `/bin/bash` for portability

Whilst running the e2e tests locally they wouldn't work on nixos, because `bash` doesn't live in `/bin`. This is more portable as discussed https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability, and is a common update to scripts. I've had no fallout from other repositories where I've made this change, so I think it's reliable across platforms.

I didn't change /bin/bash where it is run inside containers in the tests.

I'm happy to reduce the number of files this change is applied to (e.g. create-release-github.sh is probably not run locally) but I went for consistency.

**Link to tracking Issue(s):**

None

**Testing:**

Ran the `e2e-instrumentation` tests after this change and it worked.

**Documentation:**

None needed.