### PR TITLE
Make dotnet instrumentation approvers codeowners of the dotnet image

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,4 @@
 * @open-telemetry/operator-approvers
 
 # AutoInstrumentation owners
-/autoinstrumentation/dotnet/ @open-telemetry/dotnet-instrumentation-approvers
+/autoinstrumentation/dotnet/ @open-telemetry/dotnet-instrumentation-approvers @open-telemetry/operator-approvers


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/4812. 

@open-telemetry/dotnet-instrumentation-approvers have agreed to own the instrumentation Dockerfile. The operator approvers continue to own the injection mechanism and the e2e tests.

Generally speaking, changes to this directory mostly come from version updates. The last other significant update was when we added musl support.

If the new instrumentation version makes significant breaking changes, the PR review process would be a good place to bring it up. Operator maintainers can then make a decision on how to proceed.