### PR TITLE
[chore] Set shell to bash for chainsaw script blocks

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-python/check-telemetry-data.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/check-telemetry-data.yaml
@@ -25,9 +25,9 @@ spec:
         env:
           - name: podName
             value: ($podName)
+        shell: /bin/bash
         timeout: 60s
         content: |
-          #!/bin/bash
           # Add retry logic for metrics collection to handle timing issues
           for i in {1..12}; do
             echo "Attempt $i: Fetching metrics from pod ${podName}..." >&2

--- a/tests/e2e-openshift/route/chainsaw-test.yaml
+++ b/tests/e2e-openshift/route/chainsaw-test.yaml
@@ -15,9 +15,9 @@ spec:
   - name: step-01
     try:
     - script:
+        shell: /bin/bash
         timeout: 3m
         content: |
-          #!/bin/bash
           set -ex
           # Export empty payload and check of collector accepted it with 2xx status code
           otlp_http_host=$(kubectl get route otlp-http-simplest-route -n $NAMESPACE -o jsonpath='{.spec.host}')

--- a/tests/e2e/filelog-receiver/chainsaw-test.yaml
+++ b/tests/e2e/filelog-receiver/chainsaw-test.yaml
@@ -39,9 +39,9 @@ spec:
         env:
           - name: podName
             value: ($podName)
+        shell: /bin/bash
         timeout: 90s
         content: |
-          #!/bin/bash
           # Add retry logic for metrics collection to handle timing issues
           # This is especially important on older K8s versions where sidecars are not native
           for i in {1..18}; do

--- a/tests/e2e/ingress-subdomains/chainsaw-test.yaml
+++ b/tests/e2e/ingress-subdomains/chainsaw-test.yaml
@@ -15,9 +15,9 @@ spec:
   - name: step-01
     try:
     - script:
+        shell: /bin/bash
         timeout: 1m
         content: |
-          #!/bin/bash
           set -ex
           # Export empty payload and check of collector accepted it with 2xx status code
           for i in {1..40}; do curl --fail -ivX POST --resolve 'otlp-http.test.otel:80:127.0.0.1' http://otlp-http.test.otel:80/v1/traces -H "Content-Type: application/json" -d '{}' && break || sleep 1; done


### PR DESCRIPTION
Chainsaw executes script blocks using `sh -c` by default. The `#!/bin/bash` shebangs in content fields are ignored because the content is passed as an argument to sh, not executed as a file.

This means `for i in {1..18}` does not expand — POSIX sh treats it as the literal string "{1..18}", so the loop runs exactly once instead of 18 times. This is the root cause of the filelog-receiver test failing on K8s 1.25 in ~40% of CI runs: the single metrics poll misses the brief window before the sidecar collector is ready, and there is no actual retry.
