### PR TITLE
[chore] Update kind node images using renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,6 +69,7 @@
       "description": "Update kind node images in kind config files",
       "datasourceTemplate": "docker",
       "depNameTemplate": "kindest/node",
+      "versioningTemplate": "regex:^v?(?<compatibility>\\d+\\.\\d+)\\.(?<major>\\d+)$",
       "fileMatch": [
         "(^|/)kind-[\\d\\.]+\\.ya?ml$"
       ],
@@ -119,12 +120,6 @@
         "commitMessageTopic": "OpenTelemetry python agent version to {{ upgrades.0.newVersion }}"
       },
       "ignoreUnstable": false
-    },
-    {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["kindest/node"],
-      "matchUpdateTypes": ["major", "minor"],
-      "enabled": false
     },
     {
       "matchDatasources": ["docker"],


### PR DESCRIPTION
Use renovate to update kind images for e2e tests. Here's an example of a PR this generates: https://github.com/swiatekm/opentelemetry-operator/pull/109.
