### PR TITLE
Switch from nodes/proxy to nodes/pods subresource

### DIFF
--- a/.chloggen/noproxy_subresource.yaml
+++ b/.chloggen/noproxy_subresource.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use the nodes/pods subresource instead of the nodes/proxy subresource in the ClusterRole for the kubeletstats receiver.
+
+# One or more tracking issues related to the change
+issues: [4712]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/autodetect/main.go
+++ b/internal/autodetect/main.go
@@ -41,6 +41,7 @@ type AutoDetect interface {
 	OpAmpBridgeAvailablity() (opampbridge.Availability, error)
 	FIPSEnabled(ctx context.Context) bool
 	NativeSidecarSupport() (bool, error)
+	KubeletFineGrainedAuthzSupport() (bool, error)
 }
 
 type k8sVersionDiscovery interface {
@@ -278,6 +279,17 @@ func (a *autoDetect) NativeSidecarSupport() (bool, error) {
 	return currentVersion.AtLeast(minimumVersion), nil
 }
 
+// KubeletFineGrainedAuthzSupport checks if nodes/pods subresource is supported for kubeletstats receiver (k8s >= 1.33.0).
+func (a *autoDetect) KubeletFineGrainedAuthzSupport() (bool, error) {
+	currentVersion, err := a.k8sDetector.GetKubernetesVersion()
+	if err != nil {
+		return false, err
+	}
+
+	minimumVersion := version.MustParseGeneric("1.33.0")
+	return currentVersion.AtLeast(minimumVersion), nil
+}
+
 // ApplyAutoDetect attempts to automatically detect relevant information for this operator.
 func ApplyAutoDetect(autoDetect AutoDetect, c *config.Config, logger logr.Logger) error {
 	logger.V(2).Info("auto-detecting the configuration based on the environment")
@@ -338,6 +350,14 @@ func ApplyAutoDetect(autoDetect AutoDetect, c *config.Config, logger logr.Logger
 	}
 	c.Internal.NativeSidecarSupport = nativeSidecarSupport
 	logger.V(2).Info("determined native sidecar support", "availability", c.Internal.NativeSidecarSupport)
+
+	kubeletFineGrainedAuthzSupport, err := autoDetect.KubeletFineGrainedAuthzSupport()
+	if err != nil {
+		logger.V(2).Info("failed to detect kubelet fine grained authz support", "reason", err)
+	} else {
+		c.Internal.KubeletFineGrainedAuthzSupport = kubeletFineGrainedAuthzSupport
+		logger.V(2).Info("determined kubelet fine grained authz support", "availability", c.Internal.KubeletFineGrainedAuthzSupport)
+	}
 
 	return nil
 }

--- a/internal/autodetect/main_test.go
+++ b/internal/autodetect/main_test.go
@@ -378,6 +378,9 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 		NativeSidecarSupportFunc: func() (bool, error) {
 			return true, nil
 		},
+		KubeletFineGrainedAuthzSupportFunc: func() (bool, error) {
+			return true, nil
+		},
 	}
 	cfg := config.New()
 
@@ -402,19 +405,21 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 	require.Equal(t, targetallocator.Available, cfg.TargetAllocatorAvailability)
 	require.Equal(t, opampbridge.Available, cfg.OpAmpBridgeAvailability)
 	require.Equal(t, true, cfg.Internal.NativeSidecarSupport)
+	require.Equal(t, true, cfg.Internal.KubeletFineGrainedAuthzSupport)
 }
 
 var _ autodetect.AutoDetect = (*mockAutoDetect)(nil)
 
 type mockAutoDetect struct {
-	OpenShiftRoutesAvailabilityFunc func() (openshift.RoutesAvailability, error)
-	PrometheusCRsAvailabilityFunc   func() (prometheus.Availability, error)
-	RBACPermissionsFunc             func(ctx context.Context) (autoRBAC.Availability, error)
-	CertManagerAvailabilityFunc     func(ctx context.Context) (certmanager.Availability, error)
-	TargetAllocatorAvailabilityFunc func() (targetallocator.Availability, error)
-	CollectorAvailabilityFunc       func() (collector.Availability, error)
-	OpAmpBridgeAvailabilityFunc     func() (opampbridge.Availability, error)
-	NativeSidecarSupportFunc        func() (bool, error)
+	OpenShiftRoutesAvailabilityFunc    func() (openshift.RoutesAvailability, error)
+	PrometheusCRsAvailabilityFunc      func() (prometheus.Availability, error)
+	RBACPermissionsFunc                func(ctx context.Context) (autoRBAC.Availability, error)
+	CertManagerAvailabilityFunc        func(ctx context.Context) (certmanager.Availability, error)
+	TargetAllocatorAvailabilityFunc    func() (targetallocator.Availability, error)
+	CollectorAvailabilityFunc          func() (collector.Availability, error)
+	OpAmpBridgeAvailabilityFunc        func() (opampbridge.Availability, error)
+	NativeSidecarSupportFunc           func() (bool, error)
+	KubeletFineGrainedAuthzSupportFunc func() (bool, error)
 }
 
 func (m *mockAutoDetect) OpAmpBridgeAvailablity() (opampbridge.Availability, error) {
@@ -473,6 +478,13 @@ func (m *mockAutoDetect) TargetAllocatorAvailability() (targetallocator.Availabi
 func (m *mockAutoDetect) NativeSidecarSupport() (bool, error) {
 	if m.NativeSidecarSupportFunc != nil {
 		return m.NativeSidecarSupportFunc()
+	}
+	return false, nil
+}
+
+func (m *mockAutoDetect) KubeletFineGrainedAuthzSupport() (bool, error) {
+	if m.KubeletFineGrainedAuthzSupportFunc != nil {
+		return m.KubeletFineGrainedAuthzSupportFunc()
 	}
 	return false, nil
 }

--- a/internal/components/receivers/kubeletstats.go
+++ b/internal/components/receivers/kubeletstats.go
@@ -52,15 +52,15 @@ func generateKubeletStatsRbacRules(_ logr.Logger, config kubeletStatsConfig) ([]
 	}
 
 	// Additionally, when using extra_metadata_labels or any of the {request|limit}_utilization metrics
-	// the processor also needs the get permissions for nodes/proxy resources.
-	nodesProxyPr := rbacv1.PolicyRule{
+	// the processor also needs the get permissions for nodes/pods resources.
+	nodesPodsPr := rbacv1.PolicyRule{
 		APIGroups: []string{""},
-		Resources: []string{"nodes/proxy"},
+		Resources: []string{"nodes/pods"},
 		Verbs:     []string{"get"},
 	}
 
 	if len(config.ExtraMetadataLabels) > 0 {
-		prs = append(prs, nodesProxyPr)
+		prs = append(prs, nodesPodsPr)
 		return prs, nil
 	}
 
@@ -76,7 +76,7 @@ func generateKubeletStatsRbacRules(_ logr.Logger, config kubeletStatsConfig) ([]
 	}
 	for _, metric := range metrics {
 		if metric {
-			prs = append(prs, nodesProxyPr)
+			prs = append(prs, nodesPodsPr)
 			return prs, nil
 		}
 	}

--- a/internal/components/receivers/kubeletstats_test.go
+++ b/internal/components/receivers/kubeletstats_test.go
@@ -19,9 +19,9 @@ func TestGenerateKubeletStatsRbacRules(t *testing.T) {
 		Verbs:     []string{"get"},
 	}
 
-	proxyRule := rbacv1.PolicyRule{
+	podsRule := rbacv1.PolicyRule{
 		APIGroups: []string{""},
-		Resources: []string{"nodes/proxy"},
+		Resources: []string{"nodes/pods"},
 		Verbs:     []string{"get"},
 	}
 
@@ -41,7 +41,7 @@ func TestGenerateKubeletStatsRbacRules(t *testing.T) {
 			config: kubeletStatsConfig{
 				ExtraMetadataLabels: []string{"label1", "label2"},
 			},
-			expectedRules: []rbacv1.PolicyRule{baseRule, proxyRule},
+			expectedRules: []rbacv1.PolicyRule{baseRule, podsRule},
 		},
 		{
 			name: "CPU limit utilization enabled",
@@ -50,7 +50,7 @@ func TestGenerateKubeletStatsRbacRules(t *testing.T) {
 					K8sContainerCPULimitUtilization: metricConfig{Enabled: true},
 				},
 			},
-			expectedRules: []rbacv1.PolicyRule{baseRule, proxyRule},
+			expectedRules: []rbacv1.PolicyRule{baseRule, podsRule},
 		},
 		{
 			name: "Memory request utilization enabled",
@@ -59,7 +59,7 @@ func TestGenerateKubeletStatsRbacRules(t *testing.T) {
 					K8sPodMemoryRequestUtilization: metricConfig{Enabled: true},
 				},
 			},
-			expectedRules: []rbacv1.PolicyRule{baseRule, proxyRule},
+			expectedRules: []rbacv1.PolicyRule{baseRule, podsRule},
 		},
 		{
 			name: "No extra permissions needed",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,6 +139,8 @@ type Config struct {
 type Internal struct {
 	// NativeSidecarSupport is set to true if the corresponding featuregate is enabled and the minimum required k8s version is met.
 	NativeSidecarSupport bool `yaml:"native-sidecar-support"`
+	// KubeletFineGrainedAuthzSupport is set to true if the minimum required k8s version is met.
+	KubeletFineGrainedAuthzSupport bool `yaml:"kubelet-fine-grained-authz-support"`
 	// KubeAPIServerPort is the port of the Kubernetes API server discovered from EndpointSlices.
 	KubeAPIServerPort int32 `yaml:"kube-api-server-port"`
 	// KubeAPIServerIPs are the IPs of the Kubernetes API server discovered from EndpointSlices.

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -92,13 +92,14 @@ const (
 var _ autodetect.AutoDetect = (*mockAutoDetect)(nil)
 
 type mockAutoDetect struct {
-	OpenShiftRoutesAvailabilityFunc func() (openshift.RoutesAvailability, error)
-	PrometheusCRsAvailabilityFunc   func() (prometheus.Availability, error)
-	RBACPermissionsFunc             func(ctx context.Context) (autoRBAC.Availability, error)
-	CertManagerAvailabilityFunc     func(ctx context.Context) (certmanager.Availability, error)
-	TargetAllocatorAvailabilityFunc func() (targetallocator.Availability, error)
-	CollectorCRDAvailabilityFunc    func() (collector.Availability, error)
-	OpAmpBridgeAvailabilityFunc     func() (opampbridge.Availability, error)
+	OpenShiftRoutesAvailabilityFunc    func() (openshift.RoutesAvailability, error)
+	PrometheusCRsAvailabilityFunc      func() (prometheus.Availability, error)
+	RBACPermissionsFunc                func(ctx context.Context) (autoRBAC.Availability, error)
+	CertManagerAvailabilityFunc        func(ctx context.Context) (certmanager.Availability, error)
+	TargetAllocatorAvailabilityFunc    func() (targetallocator.Availability, error)
+	CollectorCRDAvailabilityFunc       func() (collector.Availability, error)
+	OpAmpBridgeAvailabilityFunc        func() (opampbridge.Availability, error)
+	KubeletFineGrainedAuthzSupportFunc func() (bool, error)
 }
 
 func (*mockAutoDetect) FIPSEnabled(context.Context) bool {
@@ -106,6 +107,13 @@ func (*mockAutoDetect) FIPSEnabled(context.Context) bool {
 }
 
 func (*mockAutoDetect) NativeSidecarSupport() (bool, error) {
+	return false, nil
+}
+
+func (m *mockAutoDetect) KubeletFineGrainedAuthzSupport() (bool, error) {
+	if m.KubeletFineGrainedAuthzSupportFunc != nil {
+		return m.KubeletFineGrainedAuthzSupportFunc()
+	}
 	return false, nil
 }
 

--- a/internal/manifests/collector/rbac.go
+++ b/internal/manifests/collector/rbac.go
@@ -20,8 +20,13 @@ func ClusterRole(params manifests.Params) (*rbacv1.ClusterRole, error) {
 	rules, err := params.OtelCol.Spec.Config.GetAllRbacRules(params.Log)
 	if err != nil {
 		return nil, err
-	} else if len(rules) == 0 {
+	}
+	if len(rules) == 0 {
 		return nil, nil
+	}
+
+	if !params.Config.Internal.KubeletFineGrainedAuthzSupport {
+		replaceNodesPodsWithNodesProxy(rules)
 	}
 
 	name := naming.ClusterRole(params.OtelCol.Name, params.OtelCol.Namespace)
@@ -46,8 +51,13 @@ func ClusterRoleBinding(params manifests.Params) (*rbacv1.ClusterRoleBinding, er
 	rules, err := params.OtelCol.Spec.Config.GetAllRbacRules(params.Log)
 	if err != nil {
 		return nil, err
-	} else if len(rules) == 0 {
+	}
+	if len(rules) == 0 {
 		return nil, nil
+	}
+
+	if !params.Config.Internal.KubeletFineGrainedAuthzSupport {
+		replaceNodesPodsWithNodesProxy(rules)
 	}
 
 	name := naming.ClusterRoleBinding(params.OtelCol.Name, params.OtelCol.Namespace)
@@ -87,6 +97,10 @@ func CheckRbacRules(params manifests.Params, saName string) ([]string, error) {
 		return nil, err
 	}
 
+	if !params.Config.Internal.KubeletFineGrainedAuthzSupport {
+		replaceNodesPodsWithNodesProxy(rules)
+	}
+
 	r := []*rbacv1.PolicyRule{}
 
 	for _, rule := range rules {
@@ -99,4 +113,19 @@ func CheckRbacRules(params manifests.Params, saName string) ([]string, error) {
 		return rbac.WarningsGroupedByResource(deniedReviews), nil
 	}
 	return nil, nil
+}
+
+func replaceNodesPodsWithNodesProxy(rules []rbacv1.PolicyRule) {
+	for i := range rules {
+		for j, resource := range rules[i].Resources {
+			if resource == "nodes/pods" {
+				// Create a new slice for Resources to avoid modifying the backing array
+				// which may be shared across multiple calls or statically allocated.
+				newResources := make([]string, len(rules[i].Resources))
+				copy(newResources, rules[i].Resources)
+				newResources[j] = "nodes/proxy"
+				rules[i].Resources = newResources
+			}
+		}
+	}
 }

--- a/tests/e2e-automatic-rbac/extra-permissions-operator/nodes-proxy.yaml
+++ b/tests/e2e-automatic-rbac/extra-permissions-operator/nodes-proxy.yaml
@@ -6,6 +6,6 @@
     - ""
     resources:
     - nodes/stats
-    - nodes/proxy
+    - nodes/pods
     verbs:
     - get

--- a/tests/e2e-automatic-rbac/extra-permissions-operator/nodes-proxy.yaml
+++ b/tests/e2e-automatic-rbac/extra-permissions-operator/nodes-proxy.yaml
@@ -7,5 +7,6 @@
     resources:
     - nodes/stats
     - nodes/pods
+    - nodes/proxy
     verbs:
     - get

--- a/tests/e2e-automatic-rbac/receiver-kubeletstats/02-assert.yaml
+++ b/tests/e2e-automatic-rbac/receiver-kubeletstats/02-assert.yaml
@@ -7,7 +7,7 @@ rules:
   resources: ["nodes/stats"]
   verbs: ["get"]
 - apiGroups: [""]
-  resources: ["nodes/proxy"]
+  resources: ["nodes/pods"]
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tests/e2e-automatic-rbac/receiver-kubeletstats/02-assert.yaml
+++ b/tests/e2e-automatic-rbac/receiver-kubeletstats/02-assert.yaml
@@ -7,7 +7,7 @@ rules:
   resources: ["nodes/stats"]
   verbs: ["get"]
 - apiGroups: [""]
-  resources: ["nodes/pods"]
+  resources: ["(nodes/proxy|nodes/pods)"]
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tests/e2e-automatic-rbac/receiver-kubeletstats/03-assert.yaml
+++ b/tests/e2e-automatic-rbac/receiver-kubeletstats/03-assert.yaml
@@ -7,7 +7,7 @@ rules:
   resources: ["nodes/stats"]
   verbs: ["get"]
 - apiGroups: [""]
-  resources: ["nodes/proxy"]
+  resources: ["nodes/pods"]
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tests/e2e-automatic-rbac/receiver-kubeletstats/03-assert.yaml
+++ b/tests/e2e-automatic-rbac/receiver-kubeletstats/03-assert.yaml
@@ -7,7 +7,7 @@ rules:
   resources: ["nodes/stats"]
   verbs: ["get"]
 - apiGroups: [""]
-  resources: ["nodes/pods"]
+  resources: ["(nodes/proxy|nodes/pods)"]
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
**Description:**

Use the nodes/pods instead of the nodes/proxy subresource for fetching extra metadata.

See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46187 for the corresponding collector documentation changes.

**Link to tracking Issue(s):**

Context: https://github.com/open-telemetry/opentelemetry-helm-charts/issues/2056

**Testing:**

**Documentation:**
