### PR TITLE
[chore] use `errors.Join` instead of `go.uber.org/multierr`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,8 @@ linters:
               desc: Use go.uber.org/atomic instead of sync/atomic
             - pkg: github.com/pkg/errors
               desc: Use 'errors' or 'fmt' instead of github.com/pkg/errors
+            - pkg: go.uber.org/multierr
+              desc: Use 'errors.Join' instead of go.uber.org/multierr
     exhaustive:
       default-signifies-exhaustive: true
     goheader:

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/sdk/metric v1.40.0
 	go.uber.org/atomic v1.11.0
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
@@ -250,6 +249,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.16.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.8.0 // indirect


### PR DESCRIPTION
**Description:** 

use `errors.Join` instead of `go.uber.org/multierr`.

Also clean up go.mod

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #issue-number

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
