### PR TITLE
[chore] migrate from go.uber.org/atomic to sync/atomic

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,10 +12,10 @@ linters:
       rules:
         main:
           deny:
-            - pkg: sync/atomic
-              desc: Use go.uber.org/atomic instead of sync/atomic
             - pkg: github.com/pkg/errors
               desc: Use 'errors' or 'fmt' instead of github.com/pkg/errors
+            - pkg: go.uber.org/atomic
+              desc: Use sync/atomic instead of go.uber.org/atomic
             - pkg: go.uber.org/multierr
               desc: Use 'errors.Join' instead of go.uber.org/multierr
     exhaustive:

--- a/cmd/otel-allocator/internal/collector/collector_test.go
+++ b/cmd/otel-allocator/internal/collector/collector_test.go
@@ -6,6 +6,7 @@ package collector
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"
-	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.40.0
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/sdk/metric v1.40.0
-	go.uber.org/atomic v1.11.0
 	go.uber.org/zap v1.27.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0
@@ -249,6 +248,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.16.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect


### PR DESCRIPTION
**Description:** 

migrate from go.uber.org/atomic to sync/atomic, this is doing the same job while diminushing the number of dependencies.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #issue-number

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
