### PR TITLE
[chore]: enable empty-lines rule from revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -84,8 +84,6 @@ linters:
           disabled: true # FIXME
         - name: empty-block
           disabled: true
-        - name: empty-lines
-          disabled: true # FIXME
         - name: enforce-switch-style
           disabled: true # FIXME
         - name: error-naming
@@ -182,6 +180,7 @@ linters:
     - staticcheck
     - unparam
     - unused
+    - whitespace
   exclusions:
     generated: lax
     presets:

--- a/apis/v1alpha1/opampbridge_webhook_test.go
+++ b/apis/v1alpha1/opampbridge_webhook_test.go
@@ -112,7 +112,6 @@ func TestOpAMPBridgeDefaultingWebhook(t *testing.T) {
 }
 
 func TestOpAMPBridgeValidatingWebhook(t *testing.T) {
-
 	two := int32(2)
 
 	tests := []struct {

--- a/apis/v1beta1/metrics.go
+++ b/apis/v1beta1/metrics.go
@@ -137,7 +137,6 @@ func (m *Metrics) update(ctx context.Context, oldCollector *OpenTelemetryCollect
 }
 
 func (m *Metrics) updateGeneralCRMetricsComponents(ctx context.Context, collector *OpenTelemetryCollector, up bool) {
-
 	inc := 1
 	if !up {
 		inc = -1
@@ -155,7 +154,6 @@ func (m *Metrics) updateComponentCounters(ctx context.Context, collector *OpenTe
 	moveCounter(ctx, collector, components.processors, m.processorCounter, up)
 	moveCounter(ctx, collector, components.extensions, m.extensionsCounter, up)
 	moveCounter(ctx, collector, components.connectors, m.connectorsCounter, up)
-
 }
 
 func extractElements(elements map[string]any) []string {
@@ -178,7 +176,6 @@ func extractElements(elements map[string]any) []string {
 }
 
 func getComponentsFromConfig(yamlContent Config) *componentDefinitions {
-
 	info := &componentDefinitions{
 		receivers: extractElements(yamlContent.Receivers.Object),
 		exporters: extractElements(yamlContent.Exporters.Object),

--- a/apis/v1beta1/metrics_test.go
+++ b/apis/v1beta1/metrics_test.go
@@ -25,7 +25,6 @@ var wantInstrumentationScope = instrumentation.Scope{
 }
 
 func TestOTELCollectorCRDMetrics(t *testing.T) {
-
 	otelcollector1 := &OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "collector1",
@@ -527,7 +526,6 @@ func checkCreate(t *testing.T, m *Metrics, collectors []*OpenTelemetryCollector,
 }
 
 func checkUpdate(t *testing.T, m *Metrics, collectors []*OpenTelemetryCollector, reader metric.Reader) {
-
 	m.update(context.Background(), collectors[0], collectors[2])
 
 	rm := metricdata.ResourceMetrics{}

--- a/cmd/gather/cluster/cluster.go
+++ b/cmd/gather/cluster/cluster.go
@@ -77,7 +77,6 @@ func (c *Cluster) getOperatorDeployment() (appsv1.Deployment, error) {
 	}
 
 	return operatorDeployments.Items[0], nil
-
 }
 
 func (c *Cluster) GetOperatorLogs() error {
@@ -157,7 +156,6 @@ func (c *Cluster) GetOLMInfo() error {
 	}
 	for _, o := range operators.Items {
 		writeToFile(outputDir, &o)
-
 	}
 
 	// OperatorGroups
@@ -184,7 +182,6 @@ func (c *Cluster) GetOLMInfo() error {
 	}
 	for _, o := range subscriptions.Items {
 		writeToFile(outputDir, &o)
-
 	}
 
 	// InstallPlan
@@ -386,7 +383,6 @@ func (c *Cluster) getOwnerResources(objList client.ObjectList, owner any) ([]cli
 		}
 	}
 	return resources, nil
-
 }
 
 func (c *Cluster) processResourceType(list client.ObjectList, owner any, folder string) error {

--- a/cmd/gather/cluster/cluster_test.go
+++ b/cmd/gather/cluster/cluster_test.go
@@ -125,7 +125,6 @@ func TestGetOperatorNamespace(t *testing.T) {
 }
 
 func TestGetOperatorDeployment(t *testing.T) {
-
 	mockClient := new(MockClient)
 	cfg := &config.Config{
 		KubernetesClient: mockClient,
@@ -151,7 +150,6 @@ func TestGetOperatorDeployment(t *testing.T) {
 }
 
 func TestGetOperatorDeploymentNotFound(t *testing.T) {
-
 	mockClient := new(MockClient)
 	cfg := &config.Config{
 		KubernetesClient: mockClient,

--- a/cmd/operator-opamp-bridge/internal/metrics/reporter.go
+++ b/cmd/operator-opamp-bridge/internal/metrics/reporter.go
@@ -44,7 +44,6 @@ type MetricReporter struct {
 // TODO: do more validation on the endpoint, allow for gRPC.
 // TODO: set global provider and add more metrics to be reported.
 func NewMetricReporter(logger logr.Logger, dest *protobufs.TelemetryConnectionSettings, agentType string, agentVersion string, instanceId uuid.UUID) (*MetricReporter, error) {
-
 	if dest.DestinationEndpoint == "" {
 		return nil, errors.New("metric destination must specify DestinationEndpoint")
 	}

--- a/cmd/otel-allocator/benchmark_test.go
+++ b/cmd/otel-allocator/benchmark_test.go
@@ -92,7 +92,6 @@ func BenchmarkProcessTargetsWithRelabelConfig(b *testing.B) {
 			})
 		}
 	}
-
 }
 
 func prepareBenchmarkData(numTargets, targetsPerGroup, groupsPerJob int) map[string][]*targetgroup.Group {

--- a/cmd/otel-allocator/internal/allocation/allocator_test.go
+++ b/cmd/otel-allocator/internal/allocation/allocator_test.go
@@ -162,7 +162,6 @@ func TestAddingAndRemovingCollectors(t *testing.T) {
 // Tests that two targets with the same target url and job name but different label set are both added.
 func TestAllocationCollision(t *testing.T) {
 	RunForAllStrategies(t, func(t *testing.T, allocator Allocator) {
-
 		cols := MakeNCollectors(3, 0)
 		allocator.SetCollectors(cols)
 		firstLabels := labels.New(labels.Label{Name: "test", Value: "test1"})

--- a/cmd/otel-allocator/internal/allocation/consistent_hashing.go
+++ b/cmd/otel-allocator/internal/allocation/consistent_hashing.go
@@ -70,7 +70,6 @@ func (s *consistentHashingStrategy) SetCollectors(collectors map[string]*Collect
 	}
 
 	s.consistentHasher = consistent.New(members, s.config)
-
 }
 
 func (s *consistentHashingStrategy) SetFallbackStrategy(fallbackStrategy Strategy) {}

--- a/cmd/otel-allocator/internal/allocation/consistent_hashing_test.go
+++ b/cmd/otel-allocator/internal/allocation/consistent_hashing_test.go
@@ -82,7 +82,6 @@ func TestNumRemapped(t *testing.T) {
 }
 
 func TestTargetsWithNoCollectorsConsistentHashing(t *testing.T) {
-
 	c, _ := New("consistent-hashing", logger)
 
 	// Adding 10 new targets

--- a/cmd/otel-allocator/internal/allocation/least_weighted_test.go
+++ b/cmd/otel-allocator/internal/allocation/least_weighted_test.go
@@ -46,7 +46,6 @@ func TestNoCollectorReassignment(t *testing.T) {
 
 	newTargetItems := s.TargetItems()
 	assert.Equal(t, targetItems, newTargetItems)
-
 }
 
 // Tests that the newly added collector instance does not get assigned any target when the targets remain the same.
@@ -101,7 +100,6 @@ func TestNoAssignmentToNewCollector(t *testing.T) {
 
 // Tests that the delta in number of targets per collector is less than 15% of an even distribution.
 func TestCollectorBalanceWhenAddingAndRemovingAtRandom(t *testing.T) {
-
 	// prepare allocator with 3 collectors and 'random' amount of targets
 	s, _ := New("least-weighted", logger)
 

--- a/cmd/otel-allocator/internal/prehook/relabel_test.go
+++ b/cmd/otel-allocator/internal/prehook/relabel_test.go
@@ -282,7 +282,6 @@ func TestApplyHashmodAction(t *testing.T) {
 }
 
 func TestApplyEmptyRelabelCfg(t *testing.T) {
-
 	allocatorPrehook := New("relabel-config", logger)
 	assert.NotNil(t, allocatorPrehook)
 

--- a/cmd/otel-allocator/internal/target/discovery_test.go
+++ b/cmd/otel-allocator/internal/target/discovery_test.go
@@ -340,7 +340,6 @@ func TestDiscovery_ScrapeConfigHashing(t *testing.T) {
 				assert.Equal(t, lastValidHash, manager.scrapeConfigsHash)
 				assert.Equal(t, lastValidConfig, scu.mockCfg)
 			}
-
 		})
 	}
 }

--- a/cmd/otel-allocator/internal/watcher/promOperator.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator.go
@@ -187,7 +187,6 @@ func getNamespaceInformer(ctx context.Context, allowList, denyList map[string]st
 		operatorMetrics.NewInstrumentedListerWatcher(lw),
 		&v1.Namespace{}, resyncPeriod, cache.Indexers{},
 	), nil
-
 }
 
 // checkCRDAvailability checks if a specific CRD is available in the cluster.

--- a/cmd/otel-allocator/internal/watcher/promOperator_test.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator_test.go
@@ -1553,7 +1553,6 @@ func getTestPrometheusCRWatcher(
 		store:                           store,
 		prometheusCR:                    prom,
 	}, source
-
 }
 
 // Remove relable configs fields from scrape configs for testing,

--- a/internal/autodetect/main_test.go
+++ b/internal/autodetect/main_test.go
@@ -188,7 +188,6 @@ func reactorFactory(status v1.SubjectAccessReviewStatus) fakeClientGenerator {
 }
 
 func TestDetectRBACPermissionsBasedOnAvailableClusterRoles(t *testing.T) {
-
 	for _, tt := range []struct {
 		description          string
 		expectedAvailability autoRBAC.Availability

--- a/internal/components/processors/helpers_test.go
+++ b/internal/components/processors/helpers_test.go
@@ -68,7 +68,6 @@ func TestDownstreamParsers(t *testing.T) {
 				// verify
 				assert.Nil(t, err)
 			})
-
 		})
 	}
 }

--- a/internal/components/receivers/multi_endpoint_receiver_test.go
+++ b/internal/components/receivers/multi_endpoint_receiver_test.go
@@ -433,7 +433,6 @@ func TestMultiEndpointReceiverParsers(t *testing.T) {
 					assert.ElementsMatch(t, ports, kase.expectedSvc)
 				})
 			}
-
 		})
 	}
 }

--- a/internal/components/single_endpoint_test.go
+++ b/internal/components/single_endpoint_test.go
@@ -276,7 +276,6 @@ func TestSingleEndpointParser_Ports(t *testing.T) {
 }
 
 func TestNewSilentSinglePortParser_Ports(t *testing.T) {
-
 	type fields struct {
 		b components.Builder[*components.SingleEndpointConfig]
 	}

--- a/internal/config/cli.go
+++ b/internal/config/cli.go
@@ -64,7 +64,6 @@ func CreateCLIParser(cfg Config) *pflag.FlagSet {
 }
 
 func ApplyCLI(cfg *Config) error {
-
 	f := CreateCLIParser(*cfg)
 	err := f.Parse(args)
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,7 +98,6 @@ func TestApply(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-
 			if len(test.args) > 0 {
 				oldArgs := args
 				args = test.args

--- a/internal/controllers/builder_test.go
+++ b/internal/controllers/builder_test.go
@@ -1038,7 +1038,6 @@ service:
 				return
 			}
 			require.Equal(t, tt.want, got)
-
 		})
 	}
 }
@@ -1877,7 +1876,6 @@ service:
 				return
 			}
 			require.Equal(t, tt.want, got)
-
 		})
 	}
 }
@@ -3359,7 +3357,6 @@ prometheus_cr:
 			require.Equal(t, tt.want[0], got[0])
 			require.Equal(t, tt.want[1], got[1])
 			require.Equal(t, tt.want, got)
-
 		})
 	}
 }

--- a/internal/controllers/clusterobservability_controller.go
+++ b/internal/controllers/clusterobservability_controller.go
@@ -507,7 +507,6 @@ func (r *ClusterObservabilityReconciler) cleanupManagedResources(ctx context.Con
 
 // cleanupClusterScopedResources removes cluster-scoped resources that can't use owner references.
 func (r *ClusterObservabilityReconciler) cleanupClusterScopedResources(ctx context.Context, log logr.Logger, instance *v1alpha1.ClusterObservability) error {
-
 	if r.config.OpenShiftRoutesAvailability == openshift.RoutesAvailable {
 		agentCollectorName := fmt.Sprintf("%s-%s", instance.Name, clusterobservability.AgentCollectorSuffix)
 		sccName := fmt.Sprintf("%s-hostaccess", agentCollectorName)

--- a/internal/controllers/reconcile_test.go
+++ b/internal/controllers/reconcile_test.go
@@ -542,7 +542,6 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 							assert.Equal(t, expected.Spec.AllocationStrategy, actual.Spec.AllocationStrategy)
 							assert.Equal(t, expected.Spec.FilterStrategy, actual.Spec.FilterStrategy)
 							assert.Equal(t, expected.Spec.ScrapeConfigs, actual.Spec.ScrapeConfigs)
-
 						},
 					},
 					wantErr:     assert.NoError,

--- a/internal/instrumentation/apachehttpd.go
+++ b/internal/instrumentation/apachehttpd.go
@@ -205,7 +205,6 @@ LoadModule otel_apache_module %[1]s/WebServerModule/Apache/libmod_apache_otel%[2
 		if len(serviceNamespace) == 0 {
 			serviceNamespace = "apache-httpd"
 		}
-
 	}
 	// Namespace name override TBD
 

--- a/internal/instrumentation/nginx.go
+++ b/internal/instrumentation/nginx.go
@@ -257,7 +257,6 @@ func isNginxInitContainerMissing(pod corev1.Pod, containerName string) bool {
 // Calculate Nginx agent configuration file based on attributes provided by the injection rules
 // and by the pod values.
 func getNginxOtelConfig(pod corev1.Pod, useLabelsForResourceAttributes bool, nginxSpec v1alpha1.Nginx, container *corev1.Container, otelEndpoint string, resourceMap map[string]string) string {
-
 	if otelEndpoint == "" {
 		otelEndpoint = "http://localhost:4317/"
 	}

--- a/internal/instrumentation/nginx_test.go
+++ b/internal/instrumentation/nginx_test.go
@@ -20,7 +20,6 @@ var nginxSdkInitContainerTestCommandCustomFile = "echo -e $OTEL_NGINX_I13N_SCRIP
 var nginxSdkInitContainerI13nScript = "\nNGINX_AGENT_DIR_FULL=$1\t\\n\nNGINX_AGENT_CONF_DIR_FULL=$2 \\n\nNGINX_CONFIG_FILE=$3 \\n\nNGINX_SID_PLACEHOLDER=$4 \\n\nNGINX_SID_VALUE=$5 \\n\necho \"Input Parameters: $@\" \\n\nset -x \\n\n\\n\ncp -r /opt/opentelemetry/* ${NGINX_AGENT_DIR_FULL} \\n\n\\n\nNGINX_VERSION=$(cat ${NGINX_AGENT_CONF_DIR_FULL}/version.txt) \\n\nNGINX_AGENT_LOG_DIR=$(echo \"${NGINX_AGENT_DIR_FULL}/logs\" | sed 's,/,\\\\/,g') \\n\n\\n\ncat ${NGINX_AGENT_DIR_FULL}/conf/opentelemetry_sdk_log4cxx.xml.template | sed 's,__agent_log_dir__,'${NGINX_AGENT_LOG_DIR}',g'  > ${NGINX_AGENT_DIR_FULL}/conf/opentelemetry_sdk_log4cxx.xml \\n\necho -e $OTEL_NGINX_AGENT_CONF > ${NGINX_AGENT_CONF_DIR_FULL}/opentelemetry_agent.conf \\n\nsed -i \"s,${NGINX_SID_PLACEHOLDER},${OTEL_NGINX_SERVICE_INSTANCE_ID},g\" ${NGINX_AGENT_CONF_DIR_FULL}/opentelemetry_agent.conf \\n\nsed -i \"1s,^,load_module ${NGINX_AGENT_DIR_FULL}/WebServerModule/Nginx/${NGINX_VERSION}/ngx_http_opentelemetry_module.so;\\\\n,g\" ${NGINX_AGENT_CONF_DIR_FULL}/${NGINX_CONFIG_FILE} \\n\nsed -i \"1s,^,env OTEL_RESOURCE_ATTRIBUTES;\\\\n,g\" ${NGINX_AGENT_CONF_DIR_FULL}/${NGINX_CONFIG_FILE} \\n\nmv ${NGINX_AGENT_CONF_DIR_FULL}/opentelemetry_agent.conf  ${NGINX_AGENT_CONF_DIR_FULL}/conf.d \\n\n\t\t"
 
 func TestInjectNginxSDK(t *testing.T) {
-
 	tests := []struct {
 		name string
 		v1alpha1.Nginx
@@ -481,7 +480,6 @@ func TestInjectNginxSDK(t *testing.T) {
 }
 
 func TestInjectNginxUnknownNamespace(t *testing.T) {
-
 	tests := []struct {
 		name string
 		v1alpha1.Nginx

--- a/internal/instrumentation/podmutator_test.go
+++ b/internal/instrumentation/podmutator_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestMutatePod(t *testing.T) {
-
 	true := true
 	zero := int64(0)
 

--- a/internal/instrumentation/sdk_test.go
+++ b/internal/instrumentation/sdk_test.go
@@ -1875,7 +1875,6 @@ func TestInjectGo(t *testing.T) {
 }
 
 func TestInjectApacheHttpd(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		insts    languageInstrumentations
@@ -2049,7 +2048,6 @@ func TestInjectApacheHttpd(t *testing.T) {
 }
 
 func TestInjectNginx(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		insts    languageInstrumentations

--- a/internal/instrumentation/upgrade/upgrade.go
+++ b/internal/instrumentation/upgrade/upgrade.go
@@ -60,7 +60,6 @@ func NewInstrumentationUpgrade(client client.Client, logger logr.Logger, recorde
 		Recorder:                   recorder,
 		defaultAnnotationToConfig:  defaultAnnotationToConfig,
 	}
-
 }
 
 // +kubebuilder:rbac:groups=opentelemetry.io,resources=instrumentations,verbs=get;list;watch;update;patch
@@ -134,7 +133,6 @@ func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instru
 						upgraded.Annotations[annotation] = u.DefaultAutoInstJava
 					}
 				}
-
 			} else {
 				u.Logger.V(4).Info("autoinstrumentation not enabled for this language", "flag", instCfg.id)
 			}

--- a/internal/manifests/collector/collector_test.go
+++ b/internal/manifests/collector/collector_test.go
@@ -324,7 +324,6 @@ func TestBuild(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			objects, err := Build(tt.params)
 			if tt.wantErr {
 				require.Error(t, err)

--- a/internal/manifests/collector/config_replace_test.go
+++ b/internal/manifests/collector/config_replace_test.go
@@ -98,7 +98,6 @@ func TestPrometheusParser(t *testing.T) {
 		}
 		assert.True(t, cfg.TargetAllocConfig == nil)
 	})
-
 }
 
 func TestReplaceConfig(t *testing.T) {
@@ -117,7 +116,6 @@ func TestReplaceConfig(t *testing.T) {
 	})
 
 	t.Run("should remove scrape configs if TargetAllocator is enabled", func(t *testing.T) {
-
 		expectedConfigBytes, err := os.ReadFile("testdata/config_expected_targetallocator.yaml")
 		assert.NoError(t, err)
 		expectedConfig := string(expectedConfigBytes)

--- a/internal/manifests/collector/configmap_test.go
+++ b/internal/manifests/collector/configmap_test.go
@@ -28,7 +28,6 @@ func TestDesiredConfigMap(t *testing.T) {
 	}
 
 	t.Run("should return expected collector config map", func(t *testing.T) {
-
 		expectedData := map[string]string{
 			"collector.yaml": `receivers:
   jaeger:
@@ -116,7 +115,6 @@ service:
 		// Reset the value
 		expectedLables["app.kubernetes.io/version"] = "0.47.0"
 		assert.NoError(t, err)
-
 	})
 
 	t.Run("should return expected escaped collector config map with target_allocator and https config block", func(t *testing.T) {
@@ -177,7 +175,6 @@ service:
 		// Reset the value
 		expectedLables["app.kubernetes.io/version"] = "0.47.0"
 		assert.NoError(t, err)
-
 	})
 
 	t.Run("Should return expected collector config map without mTLS config", func(t *testing.T) {

--- a/internal/manifests/collector/container_test.go
+++ b/internal/manifests/collector/container_test.go
@@ -1261,7 +1261,6 @@ service:
 
 			envVars := getContainerEnvVars(test.otelcol, testLogger)
 			assert.ElementsMatch(t, test.expectedEnvVars, envVars)
-
 		})
 	}
 }

--- a/internal/manifests/collector/daemonset_test.go
+++ b/internal/manifests/collector/daemonset_test.go
@@ -763,7 +763,6 @@ func TestDaemonSetTerminationGracePeriodSeconds(t *testing.T) {
 }
 
 func TestDaemonSetHostPIDCanBeSet(t *testing.T) {
-
 	// Test the case where hostPID is not set, should default to false
 	otelcol1 := v1beta1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/manifests/collector/deployment_test.go
+++ b/internal/manifests/collector/deployment_test.go
@@ -935,7 +935,6 @@ func int32Ptr(i int32) *int32 {
 }
 
 func TestDeploymentHostPIDCanBeSet(t *testing.T) {
-
 	// Test default
 	otelcol1 := v1beta1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/manifests/collector/horizontalpodautoscaler_test.go
+++ b/internal/manifests/collector/horizontalpodautoscaler_test.go
@@ -97,5 +97,4 @@ func TestHPA(t *testing.T) {
 			})
 		}
 	}
-
 }

--- a/internal/manifests/collector/rbac_test.go
+++ b/internal/manifests/collector/rbac_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestDesiredClusterRoles(t *testing.T) {
-
 	// No Cluster Roles
 	params, err := newParams("", "testdata/prometheus-exporter.yaml", nil)
 	assert.NoError(t, err, "No")
@@ -109,7 +108,6 @@ func TestDesiredClusterRoles(t *testing.T) {
 }
 
 func TestDesiredClusterRolBinding(t *testing.T) {
-
 	// No ClusterRoleBinding
 	params, err := newParams("", "testdata/prometheus-exporter.yaml", nil)
 	assert.NoError(t, err)

--- a/internal/manifests/collector/route_test.go
+++ b/internal/manifests/collector/route_test.go
@@ -175,5 +175,4 @@ func TestRoutes(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Nil(t, routes)
 	})
-
 }

--- a/internal/manifests/collector/service.go
+++ b/internal/manifests/collector/service.go
@@ -176,7 +176,6 @@ func Service(params manifests.Params) (*corev1.Service, error) {
 
 	// if we have no ports, we don't need a service
 	if len(ports) == 0 {
-
 		params.Log.V(1).Info("the instance's configuration didn't yield any ports to open, skipping service", "instance.name", params.OtelCol.Name, "instance.namespace", params.OtelCol.Namespace)
 		return nil, err
 	}

--- a/internal/manifests/collector/service_test.go
+++ b/internal/manifests/collector/service_test.go
@@ -37,12 +37,10 @@ func TestExtractPortNumbersAndNames(t *testing.T) {
 		actualPortNumbers, actualPortNames := extractPortNumbersAndNames(ports)
 		assert.Equal(t, expectedPortNames, actualPortNames)
 		assert.Equal(t, expectedPortNumbers, actualPortNumbers)
-
 	})
 }
 
 func TestFilterPort(t *testing.T) {
-
 	tests := []struct {
 		name        string
 		candidate   v1.ServicePort
@@ -135,9 +133,7 @@ func TestFilterPort(t *testing.T) {
 				return
 			}
 			assert.Nil(t, actual)
-
 		})
-
 	}
 }
 
@@ -156,7 +152,6 @@ func TestDesiredService(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("should return service with port mentioned in OtelCol.Spec.Ports and inferred ports", func(t *testing.T) {
-
 		grpc := "grpc"
 		jaegerPorts := v1beta1.PortsSpec{
 			ServicePort: v1.ServicePort{
@@ -172,7 +167,6 @@ func TestDesiredService(t *testing.T) {
 		actual, err := Service(params)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, *actual)
-
 	})
 
 	t.Run("on OpenShift gRPC appProtocol should be h2c", func(t *testing.T) {
@@ -194,11 +188,9 @@ func TestDesiredService(t *testing.T) {
 		expected := service("test-collector", ports)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, *actual)
-
 	})
 
 	t.Run("should return service with local internal traffic policy", func(t *testing.T) {
-
 		grpc := "grpc"
 		jaegerPorts := v1beta1.PortsSpec{
 			ServicePort: v1.ServicePort{
@@ -257,7 +249,6 @@ func TestDesiredService(t *testing.T) {
 		assert.Len(t, actual.Spec.Ports, 2)
 		assert.NoError(t, err)
 	})
-
 }
 
 func TestHeadlessService(t *testing.T) {

--- a/internal/manifests/collector/servicemonitor_test.go
+++ b/internal/manifests/collector/servicemonitor_test.go
@@ -41,7 +41,6 @@ func TestDesiredServiceMonitors(t *testing.T) {
 		"operator.opentelemetry.io/collector-service-type": "monitoring",
 	}
 	assert.Equal(t, expectedSelectorLabelsMonitor, actual.Spec.Selector.MatchLabels)
-
 }
 
 func TestDesiredServiceMonitorsWithPrometheus(t *testing.T) {

--- a/internal/manifests/collector/statefulset_test.go
+++ b/internal/manifests/collector/statefulset_test.go
@@ -201,7 +201,6 @@ func TestStatefulSetPeristentVolumeRetentionPolicy(t *testing.T) {
 
 	// assert correct WhenScaled value
 	assert.Equal(t, ss.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled, appsv1.DeletePersistentVolumeClaimRetentionPolicyType)
-
 }
 
 func TestStatefulSetPodAnnotations(t *testing.T) {
@@ -940,7 +939,6 @@ func TestStatefulSetServiceName(t *testing.T) {
 }
 
 func TestStatefulSetHostPIDCanBeSet(t *testing.T) {
-
 	// Test default
 	otelcol1 := v1beta1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/manifests/mutate.go
+++ b/internal/manifests/mutate.go
@@ -399,7 +399,6 @@ func mutatePodTemplate(existing, desired *corev1.PodTemplateSpec) error {
 	existing.Spec = desired.Spec
 
 	return nil
-
 }
 
 func hasImmutableLabelChange(existingSelectorLabels, desiredLabels map[string]string) error {

--- a/internal/manifests/targetallocator/adapters/config_to_prom_config.go
+++ b/internal/manifests/targetallocator/adapters/config_to_prom_config.go
@@ -125,7 +125,6 @@ func UnescapeDollarSignsInPromConfig(cfg string) (map[any]any, error) {
 	}
 
 	for i, scrapeConfig := range scrapeConfigs {
-
 		relabelConfigsProperty, found := scrapeConfig["relabel_configs"]
 		if found {
 			relabelConfigs, ok := relabelConfigsProperty.([]any)
@@ -342,7 +341,6 @@ func ValidatePromConfig(config map[any]any, targetAllocatorEnabled bool) error {
 //   - at least one scrape config has to be defined in Prometheus receiver configuration
 //   - PrometheusCR has to be enabled in target allocator settings
 func ValidateTargetAllocatorConfig(targetAllocatorPrometheusCR bool, promReceiverConfig map[any]any) error {
-
 	if targetAllocatorPrometheusCR {
 		return nil
 	}

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -62,7 +62,6 @@ filter_strategy: relabel-config
 		assert.Equal(t, "my-instance-targetallocator", actual.Name)
 		assert.Equal(t, expectedLabels, actual.Labels)
 		assert.Equal(t, expectedData[targetAllocatorFilename], actual.Data[targetAllocatorFilename])
-
 	})
 	t.Run("should return target allocator config map without collector", func(t *testing.T) {
 		expectedData := map[string]string{
@@ -83,7 +82,6 @@ filter_strategy: relabel-config
 		assert.Equal(t, "my-instance-targetallocator", actual.Name)
 		assert.Equal(t, expectedLabels, actual.Labels)
 		assert.Equal(t, expectedData[targetAllocatorFilename], actual.Data[targetAllocatorFilename])
-
 	})
 	t.Run("should return target allocator config map without scrape configs", func(t *testing.T) {
 		expectedData := map[string]string{
@@ -116,7 +114,6 @@ filter_strategy: relabel-config
 		assert.Equal(t, "my-instance-targetallocator", actual.Name)
 		assert.Equal(t, expectedLabels, actual.Labels)
 		assert.Equal(t, expectedData[targetAllocatorFilename], actual.Data[targetAllocatorFilename])
-
 	})
 	t.Run("should return expected target allocator config map with label selectors", func(t *testing.T) {
 		expectedData := map[string]string{
@@ -198,7 +195,6 @@ prometheus_cr:
 		assert.Equal(t, "my-instance-targetallocator", actual.Name)
 		assert.Equal(t, expectedLabels, actual.Labels)
 		assert.Equal(t, expectedData, actual.Data)
-
 	})
 	t.Run("should return expected target allocator config map with scrape interval set", func(t *testing.T) {
 		expectedData := map[string]string{
@@ -242,7 +238,6 @@ prometheus_cr:
 		assert.Equal(t, "my-instance-targetallocator", actual.Name)
 		assert.Equal(t, expectedLabels, actual.Labels)
 		assert.Equal(t, expectedData, actual.Data)
-
 	})
 
 	t.Run("should return expected target allocator config map with scrape classes set", func(t *testing.T) {

--- a/internal/manifests/targetallocator/servicemonitor_test.go
+++ b/internal/manifests/targetallocator/servicemonitor_test.go
@@ -40,7 +40,6 @@ func TestDesiredServiceMonitors(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s-targetallocator", params.TargetAllocator.Name), actual.Name)
 	assert.Equal(t, params.TargetAllocator.Namespace, actual.Namespace)
 	assert.Equal(t, "targetallocation", actual.Spec.Endpoints[0].Port)
-
 }
 
 func TestDesiredServiceMonitorsWithEmptyExtraLabels(t *testing.T) {

--- a/internal/rbac/format_test.go
+++ b/internal/rbac/format_test.go
@@ -61,5 +61,4 @@ func TestWarningsGroupedByResource(t *testing.T) {
 			assert.Equal(t, tt.expected, w)
 		})
 	}
-
 }

--- a/pkg/collector/upgrade/suite_test.go
+++ b/pkg/collector/upgrade/suite_test.go
@@ -139,7 +139,6 @@ func TestMain(m *testing.M) {
 			fmt.Printf("failed to wait for webhook server to be ready: %v", err)
 			os.Exit(1)
 		}
-
 	}(wg)
 	wg.Wait()
 

--- a/pkg/collector/upgrade/upgrade.go
+++ b/pkg/collector/upgrade/upgrade.go
@@ -141,7 +141,6 @@ func (u VersionUpgrade) ManagedInstance(_ context.Context, otelcol v1beta1.OpenT
 				}
 				u.Log.V(1).Info("step upgrade", "name", updated.Name, "namespace", updated.Namespace, "version", available.String())
 			} else {
-
 				upgraded, err := available.upgradeV1beta1(u, &updated) //available.upgrade(params., &updated)
 				if err != nil {
 					u.Log.Error(err, "failed to upgrade managed otelcol instance", "name", updated.Name, "namespace", updated.Namespace)

--- a/pkg/collector/upgrade/v0_111_0.go
+++ b/pkg/collector/upgrade/v0_111_0.go
@@ -13,7 +13,6 @@ import (
 )
 
 func upgrade0_111_0(u VersionUpgrade, otelcol *v1beta1.OpenTelemetryCollector) (*v1beta1.OpenTelemetryCollector, error) {
-
 	return otelcol, applyDefaults(otelcol, u.Log)
 }
 

--- a/pkg/collector/upgrade/v0_111_0_test.go
+++ b/pkg/collector/upgrade/v0_111_0_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func Test0_111_0Upgrade(t *testing.T) {
-
 	defaultCollector := v1beta1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "otel-my-instance",

--- a/pkg/collector/upgrade/v0_43_0_test.go
+++ b/pkg/collector/upgrade/v0_43_0_test.go
@@ -131,5 +131,4 @@ service:
 		"--test-upgrade43": "true",
 		"--test-arg1":      "otel",
 	}, res.Spec.Args)
-
 }

--- a/pkg/collector/upgrade/v0_57_2.go
+++ b/pkg/collector/upgrade/v0_57_2.go
@@ -14,7 +14,6 @@ import (
 )
 
 func upgrade0_57_2(u VersionUpgrade, otelcol *v1alpha1.OpenTelemetryCollector) (*v1alpha1.OpenTelemetryCollector, error) {
-
 	if len(otelcol.Spec.Config) == 0 {
 		return otelcol, nil
 	}

--- a/pkg/collector/upgrade/v0_61_0_test.go
+++ b/pkg/collector/upgrade/v0_61_0_test.go
@@ -23,7 +23,6 @@ var (
 )
 
 func Test0_61_0Upgrade(t *testing.T) {
-
 	collectorInstance := v1alpha1.OpenTelemetryCollector{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "OpenTelemetryCollector",

--- a/pkg/sidecar/attributes.go
+++ b/pkg/sidecar/attributes.go
@@ -27,7 +27,6 @@ type podReferences struct {
 // getResourceAttributesEnv returns a list of environment variables. The list contains OTEL_RESOURCE_ATTRIBUTES and additional environment variables that use Kubernetes downward API to read pod specification.
 // see: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
 func getResourceAttributesEnv(ns corev1.Namespace, podReferences podReferences) []corev1.EnvVar {
-
 	var envvars []corev1.EnvVar
 
 	attributes := map[attribute.Key]string{

--- a/pkg/sidecar/pod_test.go
+++ b/pkg/sidecar/pod_test.go
@@ -394,5 +394,4 @@ func TestAddSidecarWithAditionalEnv(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, changed.Spec.Containers, 2)
 	assert.Contains(t, changed.Spec.Containers[1].Env, extraEnv)
-
 }


### PR DESCRIPTION
**Description:** 

enable [empty-lines](https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#increment-decrement) rule from revive with the help of [whitespace](https://golangci-lint.run/docs/linters/configuration/#whitespace) linter

