### PR TITLE
Keep support for OCP 4.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ MANIFESTS_DIR = config/manifests/$(BUNDLE_VARIANT)
 BUNDLE_BUILD_GEN_FLAGS ?= $(BUNDLE_GEN_FLAGS) --output-dir . --kustomize-dir ../../$(MANIFESTS_DIR)
 
 MIN_KUBERNETES_VERSION ?= 1.25.0
-MIN_OPENSHIFT_VERSION ?= 4.14
+MIN_OPENSHIFT_VERSION ?= 4.12
 
 ## On MacOS, use gsed instead of sed, to make sed behavior
 ## consistent with Linux.

--- a/bundle/community/bundle.Dockerfile
+++ b/bundle/community/bundle.Dockerfile
@@ -19,4 +19,4 @@ COPY ./manifests /manifests/
 COPY ./metadata /metadata/
 COPY ./tests/scorecard /tests/scorecard/
 
-LABEL com.redhat.openshift.versions=v4.14
+LABEL com.redhat.openshift.versions=v4.12

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-02-25T08:17:14Z"
+    createdAt: "2026-03-04T09:54:20Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/community/metadata/annotations.yaml
+++ b/bundle/community/metadata/annotations.yaml
@@ -13,4 +13,4 @@ annotations:
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
-  com.redhat.openshift.versions: v4.14
+  com.redhat.openshift.versions: v4.12

--- a/bundle/openshift/bundle.Dockerfile
+++ b/bundle/openshift/bundle.Dockerfile
@@ -19,4 +19,4 @@ COPY ./manifests /manifests/
 COPY ./metadata /metadata/
 COPY ./tests/scorecard /tests/scorecard/
 
-LABEL com.redhat.openshift.versions=v4.14
+LABEL com.redhat.openshift.versions=v4.12

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-02-25T08:17:14Z"
+    createdAt: "2026-03-04T09:54:21Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/openshift/metadata/annotations.yaml
+++ b/bundle/openshift/metadata/annotations.yaml
@@ -13,4 +13,4 @@ annotations:
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
-  com.redhat.openshift.versions: v4.14
+  com.redhat.openshift.versions: v4.12


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

I am reverting https://github.com/open-telemetry/opentelemetry-operator/pull/4693. It was a mistake and we have to support OCP 4.12 until the `Extended Update Support Add-On - Term 3`  https://access.redhat.com/support/policy/updates/openshift 

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #issue-number

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
