### PR TITLE
replace controller-runtime scheme.Builder with runtime.SchemeBuilder

### DIFF
--- a/apis/v1alpha1/clusterobservability_types.go
+++ b/apis/v1alpha1/clusterobservability_types.go
@@ -270,7 +270,3 @@ type ClusterObservabilityList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ClusterObservability `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&ClusterObservability{}, &ClusterObservabilityList{})
-}

--- a/apis/v1alpha1/groupversion_info.go
+++ b/apis/v1alpha1/groupversion_info.go
@@ -7,8 +7,9 @@
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -16,8 +17,26 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "opentelemetry.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+// addKnownTypes registers the API types with the given scheme.
+func addKnownTypes(s *runtime.Scheme) error {
+	s.AddKnownTypes(GroupVersion,
+		&OpenTelemetryCollector{},
+		&OpenTelemetryCollectorList{},
+		&Instrumentation{},
+		&InstrumentationList{},
+		&OpAMPBridge{},
+		&OpAMPBridgeList{},
+		&TargetAllocator{},
+		&TargetAllocatorList{},
+		&ClusterObservability{},
+		&ClusterObservabilityList{},
+	)
+	metav1.AddToGroupVersion(s, GroupVersion)
+	return nil
+}

--- a/apis/v1alpha1/instrumentation_types.go
+++ b/apis/v1alpha1/instrumentation_types.go
@@ -400,7 +400,3 @@ type InstrumentationList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Instrumentation `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Instrumentation{}, &InstrumentationList{})
-}

--- a/apis/v1alpha1/opampbridge_types.go
+++ b/apis/v1alpha1/opampbridge_types.go
@@ -145,7 +145,3 @@ type OpAMPBridgeList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []OpAMPBridge `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&OpAMPBridge{}, &OpAMPBridgeList{})
-}

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -609,7 +609,3 @@ type ConfigMapsSpec struct {
 	Name      string `json:"name"`
 	MountPath string `json:"mountpath"`
 }
-
-func init() {
-	SchemeBuilder.Register(&OpenTelemetryCollector{}, &OpenTelemetryCollectorList{})
-}

--- a/apis/v1alpha1/targetallocator_types.go
+++ b/apis/v1alpha1/targetallocator_types.go
@@ -10,10 +10,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 )
 
-func init() {
-	SchemeBuilder.Register(&TargetAllocator{}, &TargetAllocatorList{})
-}
-
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/apis/v1beta1/groupversion_info.go
+++ b/apis/v1beta1/groupversion_info.go
@@ -7,8 +7,9 @@
 package v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -16,8 +17,18 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "opentelemetry.io", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+// addKnownTypes registers the API types with the given scheme.
+func addKnownTypes(s *runtime.Scheme) error {
+	s.AddKnownTypes(GroupVersion,
+		&OpenTelemetryCollector{},
+		&OpenTelemetryCollectorList{},
+	)
+	metav1.AddToGroupVersion(s, GroupVersion)
+	return nil
+}

--- a/apis/v1beta1/opentelemetrycollector_types.go
+++ b/apis/v1beta1/opentelemetrycollector_types.go
@@ -9,10 +9,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func init() {
-	SchemeBuilder.Register(&OpenTelemetryCollector{}, &OpenTelemetryCollectorList{})
-}
-
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=otelcol;otelcols
 // +kubebuilder:storageversion


### PR DESCRIPTION
**Description:** 
- Replace `sigs.k8s.io/controller-runtime/pkg/scheme.Builder` with `k8s.io/apimachinery/pkg/runtime.SchemeBuilder` in both `groupversion_info.go` files.
- This removes the controller-runtime dependency from the apis packages, preparing them for extraction into a standalone Go sub-module.

**Link to tracking Issue(s):**

- Part of: #4362

**Testing:** 

- `make test` — all 1947 tests pass, 0 failures.

**Documentation:** 

- No documentation changes needed, it is a pure internal refactor with no user-facing API changes.