### PR TITLE
[chore] Fix the upgrade e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ add-rbac-permissions-to-operator: manifests kustomize
 .PHONY: deploy
 deploy: set-image-controller
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
-	kubectl wait --for=condition=available deployment/opentelemetry-operator-controller-manager -n opentelemetry-operator-system --timeout=300s
+	kubectl rollout status deployment/opentelemetry-operator-controller-manager -n opentelemetry-operator-system --timeout=300s
 
 # Undeploy controller in the current Kubernetes context, configured in ~/.kube/config
 .PHONY: undeploy

--- a/tests/e2e-upgrade/upgrade-test/chainsaw-test.yaml
+++ b/tests/e2e-upgrade/upgrade-test/chainsaw-test.yaml
@@ -16,7 +16,8 @@ spec:
     try:
     - script:
         timeout: 5m
-        content: cd ../../../ && make deploy VERSION=e2e
+        content: |
+          make -C ../../../ deploy
   - name: step-02
     try:
     - apply:


### PR DESCRIPTION
Fix the command to wait for the operator deployment to be ready. What we want is for the rollout to be complete. I also fixed an issue with the upgrade test steps.