### PR TITLE
Overwrite artifacts in e2e test workflow

### DIFF
--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -153,6 +153,7 @@ jobs:
         path: .testresults/e2e/*.xml
         name: e2e-junit-${{ matrix.group }}-${{ matrix.kube-version }}
         retention-days: 7
+        overwrite: true
 
   e2e-tests-check:
     runs-on: ubuntu-latest
@@ -183,3 +184,4 @@ jobs:
       with:
         name: Event File
         path: ${{ github.event_path }}
+        overwrite: true


### PR DESCRIPTION
**Description:** 

We automatically retry this workflow in the nightly contrib tests, and the uploads fail without allowing overwrites.

**Link to tracking Issue(s):**

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/4716
