### PR TITLE
Fixed note on Go auto-instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ spec:
 
 In the above case, `myapp` and `myapp2` containers will be instrumented, `myapp3` will not.
 
-> 🚨 **NOTE**: Go auto-instrumentation **does not** support multicontainer pods. When injecting Go auto-instrumentation the first pod should be the only pod you want instrumented.
+> 🚨 **NOTE**: Go auto-instrumentation **does not** support multicontainer pods. When injecting Go auto-instrumentation the first container should be the only container you want instrumented.
 
 #### Instrumenting Init Containers
 


### PR DESCRIPTION
**Description:**
Fixed note about Go auto-instrumentation not supporting multi-container pods

**Documentation:**
Fixed the README.md
