### PR TITLE
[chore] Temporarily disable the flaky e2e-upgrade test

### DIFF
--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -77,7 +77,8 @@ jobs:
         - e2e-sidecar
         - e2e-targetallocator
         - e2e-targetallocator-cr
-        - e2e-upgrade
+        # https://github.com/open-telemetry/opentelemetry-operator/issues/4887
+        # - e2e-upgrade
         - e2e-multi-instrumentation-default
         - e2e-multi-instrumentation
         - e2e-metadata-filters


### PR DESCRIPTION
Skip the test until we figure out why it's flaky. It's very unlikely we'll break the upgrade with any change in the meantime. I'm tracking the fix in https://github.com/open-telemetry/opentelemetry-operator/issues/4887.
