### PR TITLE
allow duplicate container names validation across different instrumentation

### DIFF
--- a/.chloggen/duplicated_container_names.yaml
+++ b/.chloggen/duplicated_container_names.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix duplicated container names validation to allow the same container name across different language instrumentations.
+
+# One or more tracking issues related to the change
+issues: [4357]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/instrumentation/podmutator.go
+++ b/internal/instrumentation/podmutator.go
@@ -79,25 +79,26 @@ func (langInsts *languageInstrumentations) hasAnyInstrumentation() bool {
 func (langInsts languageInstrumentations) areInstrumentedContainersCorrect() (bool, error) {
 	var instrWithoutContainers int
 	var instrWithContainers int
-	var allContainers []string
 	var instrumentationWithNoContainers bool
-
-	// Check for instrumentations with and without containers.
+	// Validate each enabled instrumentation independently.
+	// The same target container name is allowed across different languages
+	// (e.g., Java + Go on the same app container), but duplicates within a
+	// single instrumentation list are still invalid.
 	for _, inst := range instrumentationsList(&langInsts) {
-		if inst.Instrumentation != nil {
-			instrWithContainers += isInstrWithContainers(*inst)
-			instrWithoutContainers += isInstrWithoutContainers(*inst)
-			allContainers = append(allContainers, inst.Containers...)
-			if len(inst.Containers) == 0 {
-				instrumentationWithNoContainers = true
-			}
+		if inst.Instrumentation == nil {
+			continue
 		}
-	}
 
-	// Look for duplicated containers.
-	containerDuplicates := findDuplicatedContainers(allContainers)
-	if containerDuplicates != nil {
-		return false, containerDuplicates
+		instrWithContainers += isInstrWithContainers(*inst)
+		instrWithoutContainers += isInstrWithoutContainers(*inst)
+
+		if len(inst.Containers) == 0 {
+			instrumentationWithNoContainers = true
+		}
+
+		if containerDuplicates := findDuplicatedContainers(inst.Containers); containerDuplicates != nil {
+			return false, containerDuplicates
+		}
 	}
 
 	// Look for mixed multiple instrumentations with and without container names.

--- a/internal/instrumentation/podmutator_test.go
+++ b/internal/instrumentation/podmutator_test.go
@@ -5055,8 +5055,8 @@ func TestContainerNamesConfiguredForMultipleInstrumentations(t *testing.T) {
 				Java:   instrumentationWithContainers{Instrumentation: &v1alpha1.Instrumentation{}, Containers: []string{"app", "app1", "java"}},
 				NodeJS: instrumentationWithContainers{Instrumentation: &v1alpha1.Instrumentation{}, Containers: []string{"app1", "app", "nodejs"}},
 			},
-			expectedStatus: false,
-			expectedMsg:    errors.New("duplicated container names detected: [app app1]"),
+			expectedStatus: true,
+			expectedMsg:    nil,
 		},
 		{
 			name: "Multiple instrumentations enabled with duplicated containers for single instrumentation",
@@ -5127,6 +5127,95 @@ func TestInstrumentationLanguageContainersSet(t *testing.T) {
 			assert.Equal(t, test.expectedInstrumentations, test.instrumentations)
 		})
 	}
+}
+
+func TestGoContainerAnnotationsDuplicateDetection(t *testing.T) {
+	tests := []struct {
+		name               string
+		annotations        map[string]string
+		expectedContainers []string
+		expectedErr        string
+	}{
+		{
+			name: "go with common container-names only",
+			annotations: map[string]string{
+				annotationInjectGo:            "true",
+				annotationInjectContainerName: "initContainer",
+			},
+			expectedContainers: []string{"initContainer"},
+		},
+		{
+			name: "go with both common container names",
+			annotations: map[string]string{
+				annotationInjectGo:               "true",
+				annotationInjectContainerName:    "initContainer",
+				annotationInjectGoContainersName: "initContainer",
+			},
+			expectedContainers: []string{"initContainer", "initContainer"},
+			expectedErr:        "duplicated container names detected: [initContainer]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			insts := languageInstrumentations{
+				Go: instrumentationWithContainers{Instrumentation: &v1alpha1.Instrumentation{}},
+			}
+
+			ns := corev1.Namespace{}
+			pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: test.annotations}}
+
+			err := insts.setCommonInstrumentedContainers(ns, pod)
+			require.NoError(t, err)
+
+			err = insts.setLanguageSpecificContainers(ns.ObjectMeta, pod.ObjectMeta)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedContainers, insts.Go.Containers)
+
+			ok, validateErr := insts.areInstrumentedContainersCorrect()
+			if test.expectedErr == "" {
+				assert.True(t, ok)
+				assert.NoError(t, validateErr)
+				return
+			}
+
+			assert.False(t, ok)
+			require.Error(t, validateErr)
+			assert.Equal(t, test.expectedErr, validateErr.Error())
+		})
+	}
+}
+
+func TestMultiLanguageCommonContainerNamesDuplicateDetection(t *testing.T) {
+	insts := languageInstrumentations{
+		Java: instrumentationWithContainers{Instrumentation: &v1alpha1.Instrumentation{}},
+		Go:   instrumentationWithContainers{Instrumentation: &v1alpha1.Instrumentation{}},
+	}
+
+	ns := corev1.Namespace{}
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotationInjectJava:          "true",
+				annotationInjectGo:            "true",
+				annotationInjectContainerName: "initContainer",
+			},
+		},
+	}
+
+	err := insts.setCommonInstrumentedContainers(ns, pod)
+	require.NoError(t, err)
+
+	err = insts.setLanguageSpecificContainers(ns.ObjectMeta, pod.ObjectMeta)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"initContainer"}, insts.Java.Containers)
+	assert.Equal(t, []string{"initContainer"}, insts.Go.Containers)
+
+	ok, validateErr := insts.areInstrumentedContainersCorrect()
+	assert.True(t, ok)
+	assert.NoError(t, validateErr)
 }
 
 // TestInitContainerInstrumentation tests that init containers can be instrumented


### PR DESCRIPTION
**Description:**
Fixes incorrect validation that rejected duplicate container names across different language instrumentation's (eg, Go + Java). Now allows same container names across languages while still preventing duplicates within a single instrumentation.

**Link to tracking Issue(s):**
* Resolves: #4357

**Testing:**

* Updated existing tests
* Added cases for ,multi language instrumentation's

**Documentation:**

* Added changelog entry 