### PR TITLE
[chore] Use fake sources instead of fake client in prom watcher tests

### DIFF
--- a/cmd/otel-allocator/internal/watcher/promOperator_test.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator_test.go
@@ -27,7 +27,6 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	promv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
-	fakemonitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/fake"
 	"github.com/prometheus-operator/prometheus-operator/pkg/informers"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
 	"github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
@@ -42,6 +41,9 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	metadatafake "k8s.io/client-go/metadata/fake"
@@ -56,6 +58,53 @@ import (
 // let all informer caches sync. Watch() syncs ~6 informers sequentially, each
 // requiring at least one 100ms poll tick, so 1s gives comfortable headroom.
 const watchSyncDuration = time.Second
+
+// fakeInformLister wraps a SharedIndexInformer to satisfy the informers.InformLister interface.
+type fakeInformLister struct {
+	informer cache.SharedIndexInformer
+	gr       schema.GroupResource
+}
+
+func (f *fakeInformLister) Informer() cache.SharedIndexInformer { return f.informer }
+func (f *fakeInformLister) Lister() cache.GenericLister {
+	return cache.NewGenericLister(f.informer.GetIndexer(), f.gr)
+}
+
+// fakeFactoriesForNamespaces implements informers.FactoriesForNamespaces using FakeControllerSource.
+type fakeFactoriesForNamespaces struct {
+	sources    map[schema.GroupVersionResource]*fcache.FakeControllerSource
+	exemplars  map[schema.GroupVersionResource]runtime.Object
+	namespaces sets.Set[string]
+}
+
+func (f *fakeFactoriesForNamespaces) Namespaces() sets.Set[string] { return f.namespaces }
+
+func (f *fakeFactoriesForNamespaces) ForResource(_ string, resource schema.GroupVersionResource) (informers.InformLister, error) {
+	source, ok := f.sources[resource]
+	if !ok {
+		source = fcache.NewFakeControllerSource()
+		f.sources[resource] = source
+	}
+	exemplar := f.exemplars[resource]
+	inf := cache.NewSharedIndexInformer(source, exemplar, 1*time.Second,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	return &fakeInformLister{
+		informer: inf,
+		gr:       resource.GroupResource(),
+	}, nil
+}
+
+// testWatcher bundles a PrometheusCRWatcher with fake sources for use in tests.
+// Tests access only the fields they need.
+type testWatcher struct {
+	*PrometheusCRWatcher
+	NamespaceSource      *fcache.FakeControllerSource
+	ServiceMonitorSource *fcache.FakeControllerSource
+	PodMonitorSource     *fcache.FakeControllerSource
+	ProbeSource          *fcache.FakeControllerSource
+	ScrapeConfigSource   *fcache.FakeControllerSource
+	MetadataClient       *metadatafake.FakeMetadataClient
+}
 
 func TestLoadConfig(t *testing.T) {
 	namespace := "test"
@@ -1093,25 +1142,37 @@ func TestLoadConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
-				w, _, _ := getTestPrometheusCRWatcher(t, namespace, tt.serviceMonitors, tt.podMonitors, tt.probes, tt.scrapeConfigs, tt.cfg)
+				tw := newTestWatcher(t, tt.cfg)
+				for _, sm := range tt.serviceMonitors {
+					tw.ServiceMonitorSource.Add(sm)
+				}
+				for _, pm := range tt.podMonitors {
+					tw.PodMonitorSource.Add(pm)
+				}
+				for _, prb := range tt.probes {
+					tw.ProbeSource.Add(prb)
+				}
+				for _, sc := range tt.scrapeConfigs {
+					tw.ScrapeConfigSource.Add(sc)
+				}
 
 				// Start namespace informers in order to populate cache.
-				go w.nsInformer.Run(w.stopChannel)
+				go tw.nsInformer.Run(tw.stopChannel)
 				synctest.Wait()
 
-				for _, informer := range w.informers {
+				for _, informer := range tw.informers {
 					// Start informers in order to populate cache.
-					informer.Start(w.stopChannel)
+					informer.Start(tw.stopChannel)
 				}
 				synctest.Wait()
 
-				got, err := w.LoadConfig(context.Background())
+				got, err := tw.LoadConfig(context.Background())
 				assert.NoError(t, err)
 
 				sanitizeScrapeConfigsForTest(got.ScrapeConfigs)
 				assert.Equal(t, tt.want.ScrapeConfigs, got.ScrapeConfigs)
 
-				close(w.stopChannel)
+				close(tw.stopChannel)
 				synctest.Wait()
 			})
 		})
@@ -1201,28 +1262,31 @@ func TestNamespaceLabelUpdate(t *testing.T) {
 	}
 
 	synctest.Test(t, func(t *testing.T) {
-		w, source, _ := getTestPrometheusCRWatcher(t, namespace, nil, podMonitors, nil, nil, cfg)
+		tw := newTestWatcher(t, cfg)
+		for _, pm := range podMonitors {
+			tw.PodMonitorSource.Add(pm)
+		}
 		events := make(chan Event, 1)
 		eventInterval := 5 * time.Millisecond
 
-		defer w.Close()
-		w.eventInterval = eventInterval
+		defer tw.Close()
+		tw.eventInterval = eventInterval
 
 		go func() {
-			watchErr := w.Watch(events, make(chan error))
+			watchErr := tw.Watch(events, make(chan error))
 			require.NoError(t, watchErr)
 		}()
 		// Advance time past the informer sync polling period to let Watch complete setup.
 		time.Sleep(watchSyncDuration)
 		synctest.Wait()
 
-		got, err := w.LoadConfig(context.Background())
+		got, err := tw.LoadConfig(context.Background())
 		assert.NoError(t, err)
 
 		sanitizeScrapeConfigsForTest(got.ScrapeConfigs)
 		assert.Equal(t, want_before.ScrapeConfigs, got.ScrapeConfigs)
 
-		source.Modify(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		tw.NamespaceSource.Modify(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{
 			Name: "labellednamespace",
 			Labels: map[string]string{
 				"label2": "label2",
@@ -1232,7 +1296,7 @@ func TestNamespaceLabelUpdate(t *testing.T) {
 		time.Sleep(eventInterval)
 		synctest.Wait()
 
-		got, err = w.LoadConfig(context.Background())
+		got, err = tw.LoadConfig(context.Background())
 		assert.NoError(t, err)
 
 		sanitizeScrapeConfigsForTest(got.ScrapeConfigs)
@@ -1290,8 +1354,9 @@ func TestSecretInformerUpdatesStore(t *testing.T) {
 	}
 
 	synctest.Test(t, func(t *testing.T) {
-		w, _, mdClient := getTestPrometheusCRWatcher(t, namespace, []*monitoringv1.ServiceMonitor{sm}, nil, nil, nil, cfg)
-		defer w.Close()
+		tw := newTestWatcher(t, cfg)
+		tw.ServiceMonitorSource.Add(sm)
+		defer tw.Close()
 
 		// Add initial secret to the metadata client's tracker so the informer can watch it
 		secretGVR := v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets))
@@ -1306,17 +1371,17 @@ func TestSecretInformerUpdatesStore(t *testing.T) {
 				ResourceVersion: "1",
 			},
 		}
-		err := mdClient.Tracker().Add(initialSecretMeta)
+		err := tw.MetadataClient.Tracker().Add(initialSecretMeta)
 		require.NoError(t, err)
 
 		events := make(chan Event, 1)
 		errors := make(chan error, 1)
 		eventInterval := 5 * time.Millisecond
-		w.eventInterval = eventInterval
+		tw.eventInterval = eventInterval
 
 		// Start Watch in a goroutine - this registers the secret informer event handlers
 		go func() {
-			watchErr := w.Watch(events, errors)
+			watchErr := tw.Watch(events, errors)
 			require.NoError(t, watchErr)
 		}()
 
@@ -1326,7 +1391,7 @@ func TestSecretInformerUpdatesStore(t *testing.T) {
 		<-events
 
 		// Initial config should reflect the original secret values.
-		got, err := w.LoadConfig(context.Background())
+		got, err := tw.LoadConfig(context.Background())
 		require.NoError(t, err)
 		require.NotEmpty(t, got.ScrapeConfigs)
 
@@ -1354,7 +1419,7 @@ func TestSecretInformerUpdatesStore(t *testing.T) {
 				"password": []byte("newpassword"),
 			},
 		}
-		_, err = w.k8sClient.CoreV1().Secrets(namespace).Update(context.Background(), updatedSecret, metav1.UpdateOptions{})
+		_, err = tw.k8sClient.CoreV1().Secrets(namespace).Update(context.Background(), updatedSecret, metav1.UpdateOptions{})
 		require.NoError(t, err)
 
 		// Update the metadata client's tracker to trigger the informer's UpdateFunc
@@ -1369,7 +1434,7 @@ func TestSecretInformerUpdatesStore(t *testing.T) {
 				ResourceVersion: "2",
 			},
 		}
-		err = mdClient.Tracker().Update(secretGVR, updatedSecretMeta, namespace)
+		err = tw.MetadataClient.Tracker().Update(secretGVR, updatedSecretMeta, namespace)
 		require.NoError(t, err)
 
 		// Wait for the informer event to be processed
@@ -1377,7 +1442,7 @@ func TestSecretInformerUpdatesStore(t *testing.T) {
 		time.Sleep(eventInterval)
 		synctest.Wait()
 
-		got, err = w.LoadConfig(context.Background())
+		got, err = tw.LoadConfig(context.Background())
 		require.NoError(t, err)
 
 		smSC = nil
@@ -1415,19 +1480,18 @@ func TestRateLimit(t *testing.T) {
 		eventInterval := 500 * time.Millisecond
 		cfg := allocatorconfig.Config{}
 
-		w, _, _ := getTestPrometheusCRWatcher(t, namespace, nil, nil, nil, nil, cfg)
-		defer w.Close()
-		w.eventInterval = eventInterval
+		tw := newTestWatcher(t, cfg)
+		defer tw.Close()
+		tw.eventInterval = eventInterval
 
 		go func() {
-			watchErr := w.Watch(events, make(chan error))
+			watchErr := tw.Watch(events, make(chan error))
 			require.NoError(t, watchErr)
 		}()
 		time.Sleep(watchSyncDuration)
 		synctest.Wait()
 
-		_, err := w.kubeMonitoringClient.MonitoringV1().ServiceMonitors("test").Create(context.Background(), serviceMonitor, metav1.CreateOptions{})
-		require.NoError(t, err)
+		tw.ServiceMonitorSource.Add(serviceMonitor)
 		synctest.Wait()
 		time.Sleep(eventInterval)
 		synctest.Wait()
@@ -1435,15 +1499,13 @@ func TestRateLimit(t *testing.T) {
 
 		// Send two updates and verify that the elapsed time is at least eventInterval
 		startTime := time.Now()
-		_, err = w.kubeMonitoringClient.MonitoringV1().ServiceMonitors("test").Update(context.Background(), serviceMonitor, metav1.UpdateOptions{})
-		require.NoError(t, err)
+		tw.ServiceMonitorSource.Modify(serviceMonitor)
 		synctest.Wait()
 		time.Sleep(eventInterval)
 		synctest.Wait()
 		<-events
 
-		_, err = w.kubeMonitoringClient.MonitoringV1().ServiceMonitors("test").Update(context.Background(), serviceMonitor, metav1.UpdateOptions{})
-		require.NoError(t, err)
+		tw.ServiceMonitorSource.Modify(serviceMonitor)
 		synctest.Wait()
 		time.Sleep(eventInterval)
 		synctest.Wait()
@@ -1523,21 +1585,24 @@ func TestDefaultDurations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
-				w, _, _ := getTestPrometheusCRWatcher(t, namespace, tt.serviceMonitors, nil, nil, nil, tt.cfg)
-				defer w.Close()
+				tw := newTestWatcher(t, tt.cfg)
+				for _, sm := range tt.serviceMonitors {
+					tw.ServiceMonitorSource.Add(sm)
+				}
+				defer tw.Close()
 
 				events := make(chan Event, 1)
 				eventInterval := 5 * time.Millisecond
-				w.eventInterval = eventInterval
+				tw.eventInterval = eventInterval
 
 				go func() {
-					watchErr := w.Watch(events, make(chan error))
+					watchErr := tw.Watch(events, make(chan error))
 					require.NoError(t, watchErr)
 				}()
 				time.Sleep(watchSyncDuration)
 				synctest.Wait()
 
-				got, err := w.LoadConfig(context.Background())
+				got, err := tw.LoadConfig(context.Background())
 				assert.NoError(t, err)
 
 				assert.NotEmpty(t, got.ScrapeConfigs)
@@ -1551,51 +1616,11 @@ func TestDefaultDurations(t *testing.T) {
 	}
 }
 
-// getTestPrometheusCRWatcher creates a test instance of PrometheusCRWatcher with fake clients
-// and test secrets. Returns the watcher, namespace source, and metadata client for secret updates.
-func getTestPrometheusCRWatcher(
-	t *testing.T,
-	namespace string,
-	svcMonitors []*monitoringv1.ServiceMonitor,
-	podMonitors []*monitoringv1.PodMonitor,
-	probes []*monitoringv1.Probe,
-	scrapeConfigs []*promv1alpha1.ScrapeConfig,
-	cfg allocatorconfig.Config,
-) (*PrometheusCRWatcher, *fcache.FakeControllerSource, *metadatafake.FakeMetadataClient) {
-	mClient := fakemonitoringclient.NewSimpleClientset()
-	for _, sm := range svcMonitors {
-		if sm != nil {
-			_, err := mClient.MonitoringV1().ServiceMonitors(sm.Namespace).Create(context.Background(), sm, metav1.CreateOptions{})
-			if err != nil {
-				t.Fatal(t, err)
-			}
-		}
-	}
-	for _, pm := range podMonitors {
-		if pm != nil {
-			_, err := mClient.MonitoringV1().PodMonitors(pm.Namespace).Create(context.Background(), pm, metav1.CreateOptions{})
-			if err != nil {
-				t.Fatal(t, err)
-			}
-		}
-	}
-	for _, prb := range probes {
-		if prb != nil {
-			_, err := mClient.MonitoringV1().Probes(prb.Namespace).Create(context.Background(), prb, metav1.CreateOptions{})
-			if err != nil {
-				t.Fatal(t, err)
-			}
-		}
-	}
-
-	for _, scc := range scrapeConfigs {
-		if scc != nil {
-			_, err := mClient.MonitoringV1alpha1().ScrapeConfigs(scc.Namespace).Create(context.Background(), scc, metav1.CreateOptions{})
-			if err != nil {
-				t.Fatal(t, err)
-			}
-		}
-	}
+// newTestWatcher creates a testWatcher with fake sources for the given config.
+// Callers add resources to the returned sources (e.g. tw.ServiceMonitorSource.Add)
+// before starting informers.
+func newTestWatcher(t *testing.T, cfg allocatorconfig.Config) *testWatcher {
+	t.Helper()
 
 	k8sClient := fake.NewSimpleClientset()
 	_, err := k8sClient.CoreV1().Secrets("test").Create(context.Background(), &v1.Secret{
@@ -1605,9 +1630,7 @@ func getTestPrometheusCRWatcher(
 		},
 		Data: map[string][]byte{"username": []byte("admin"), "password": []byte("password")},
 	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(t, err)
-	}
+	require.NoError(t, err)
 	_, err = k8sClient.CoreV1().Secrets("test").Create(context.Background(), &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bearer",
@@ -1615,28 +1638,82 @@ func getTestPrometheusCRWatcher(
 		},
 		Data: map[string][]byte{"token": []byte("bearer-token")},
 	}, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatal(t, err)
+	require.NoError(t, err)
+
+	// newSource creates a FakeControllerSource and registers cleanup.
+	newSource := func() *fcache.FakeControllerSource {
+		s := fcache.NewFakeControllerSource()
+		t.Cleanup(func() { s.Broadcaster.Shutdown() })
+		return s
 	}
 
-	factory := informers.NewMonitoringInformerFactories(map[string]struct{}{v1.NamespaceAll: {}}, map[string]struct{}{}, mClient, 1*time.Second, nil)
+	smSource := newSource()
+	pmSource := newSource()
+	probeSource := newSource()
+	scSource := newSource()
+	nsSource := newSource()
 
-	// Create fake metadata client for secret informer
-	scheme := metadatafake.NewTestScheme()
-	_ = metav1.AddMetaToScheme(scheme)
-	mdClient := metadatafake.NewSimpleMetadataClient(scheme)
+	// Build fake factories backed by the sources.
+	type gvrInfo struct {
+		gvr      schema.GroupVersionResource
+		source   *fcache.FakeControllerSource
+		exemplar runtime.Object
+	}
+	resources := []gvrInfo{
+		{monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName), smSource, &monitoringv1.ServiceMonitor{}},
+		{monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName), pmSource, &monitoringv1.PodMonitor{}},
+		{monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ProbeName), probeSource, &monitoringv1.Probe{}},
+		{promv1alpha1.SchemeGroupVersion.WithResource(promv1alpha1.ScrapeConfigName), scSource, &promv1alpha1.ScrapeConfig{}},
+	}
+
+	sources := make(map[schema.GroupVersionResource]*fcache.FakeControllerSource, len(resources))
+	exemplars := make(map[schema.GroupVersionResource]runtime.Object, len(resources))
+	for _, r := range resources {
+		sources[r.gvr] = r.source
+		exemplars[r.gvr] = r.exemplar
+	}
+
+	fakeFactory := &fakeFactoriesForNamespaces{
+		sources:    sources,
+		exemplars:  exemplars,
+		namespaces: sets.New[string](v1.NamespaceAll),
+	}
+
+	// Create fake metadata client for secret informer.
+	mdScheme := metadatafake.NewTestScheme()
+	_ = metav1.AddMetaToScheme(mdScheme)
+	mdClient := metadatafake.NewSimpleMetadataClient(mdScheme)
 	metadataFactory := informers.NewMetadataInformerFactory(map[string]struct{}{v1.NamespaceAll: {}}, map[string]struct{}{}, mdClient, 1*time.Second, nil)
 
-	informers, err := getTestInformers(factory, metadataFactory)
-	if err != nil {
-		t.Fatal(t, err)
+	// Build informers via a for-range loop over name→GVR.
+	informerDefs := map[string]schema.GroupVersionResource{
+		monitoringv1.ServiceMonitorName: monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName),
+		monitoringv1.PodMonitorName:     monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName),
+		monitoringv1.ProbeName:          monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ProbeName),
+		promv1alpha1.ScrapeConfigName:   promv1alpha1.SchemeGroupVersion.WithResource(promv1alpha1.ScrapeConfigName),
+	}
+	informersMap := make(map[string]*informers.ForResource, len(informerDefs)+1)
+	for name, gvr := range informerDefs {
+		inf, infErr := informers.NewInformersForResource(fakeFactory, gvr)
+		require.NoError(t, infErr)
+		informersMap[name] = inf
+	}
+	// Secret informer from metadata factory.
+	secretInformer, err := informers.NewInformersForResourceWithTransform(
+		metadataFactory,
+		v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
+		informers.PartialObjectMetadataStrip(operator.SecretGVK()),
+	)
+	require.NoError(t, err)
+	if secretInformer != nil {
+		informersMap[string(v1.ResourceSecrets)] = secretInformer
 	}
 
 	serviceDiscoveryRole := monitoringv1.ServiceDiscoveryRole("EndpointSlice")
 
 	prom := &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
+			Namespace: "test",
 		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
@@ -1659,19 +1736,15 @@ func getTestPrometheusCRWatcher(
 	promOperatorLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
 	generator, err := prometheus.NewConfigGenerator(promOperatorLogger, prom, prometheus.WithEndpointSliceSupport(), prometheus.WithInlineTLSConfig())
-	if err != nil {
-		t.Fatal(t, err)
-	}
+	require.NoError(t, err)
 
 	store := assets.NewStoreBuilder(k8sClient.CoreV1(), k8sClient.CoreV1())
 	promRegisterer := prometheusgoclient.NewRegistry()
 	operatorMetrics := operator.NewMetrics(promRegisterer)
 	eventRecorder := operator.NewFakeRecorder(10, prom)
 
-	source := fcache.NewFakeControllerSource()
-	t.Cleanup(func() { source.Broadcaster.Shutdown() })
-	source.Add(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}})
-	source.Add(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{
+	nsSource.Add(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}})
+	nsSource.Add(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{
 		Name: "labellednamespace",
 		Labels: map[string]string{
 			"label1": "label1",
@@ -1679,27 +1752,34 @@ func getTestPrometheusCRWatcher(
 	}})
 
 	// create the shared informer and resync every 1s
-	nsMonInf := cache.NewSharedInformer(source, &v1.Namespace{}, 1*time.Second).(cache.SharedIndexInformer)
+	nsMonInf := cache.NewSharedInformer(nsSource, &v1.Namespace{}, 1*time.Second).(cache.SharedIndexInformer)
 
 	resourceSelector, err := prometheus.NewResourceSelector(promOperatorLogger, prom, store, nsMonInf, operatorMetrics, eventRecorder)
 	require.NoError(t, err)
 
-	return &PrometheusCRWatcher{
-		logger:                          slog.Default(),
-		kubeMonitoringClient:            mClient,
-		k8sClient:                       k8sClient,
-		informers:                       informers,
-		nsInformer:                      nsMonInf,
-		stopChannel:                     make(chan struct{}),
-		configGenerator:                 generator,
-		podMonitorNamespaceSelector:     cfg.PrometheusCR.PodMonitorNamespaceSelector,
-		serviceMonitorNamespaceSelector: cfg.PrometheusCR.ServiceMonitorNamespaceSelector,
-		probeNamespaceSelector:          cfg.PrometheusCR.ProbeNamespaceSelector,
-		scrapeConfigNamespaceSelector:   cfg.PrometheusCR.ScrapeConfigNamespaceSelector,
-		resourceSelector:                resourceSelector,
-		store:                           store,
-		prometheusCR:                    prom,
-	}, source, mdClient
+	return &testWatcher{
+		PrometheusCRWatcher: &PrometheusCRWatcher{
+			logger:                          slog.Default(),
+			k8sClient:                       k8sClient,
+			informers:                       informersMap,
+			nsInformer:                      nsMonInf,
+			stopChannel:                     make(chan struct{}),
+			configGenerator:                 generator,
+			podMonitorNamespaceSelector:     cfg.PrometheusCR.PodMonitorNamespaceSelector,
+			serviceMonitorNamespaceSelector: cfg.PrometheusCR.ServiceMonitorNamespaceSelector,
+			probeNamespaceSelector:          cfg.PrometheusCR.ProbeNamespaceSelector,
+			scrapeConfigNamespaceSelector:   cfg.PrometheusCR.ScrapeConfigNamespaceSelector,
+			resourceSelector:                resourceSelector,
+			store:                           store,
+			prometheusCR:                    prom,
+		},
+		NamespaceSource:      nsSource,
+		ServiceMonitorSource: smSource,
+		PodMonitorSource:     pmSource,
+		ProbeSource:          probeSource,
+		ScrapeConfigSource:   scSource,
+		MetadataClient:       mdClient,
+	}
 }
 
 // Remove relable configs fields from scrape configs for testing,
@@ -1709,56 +1789,6 @@ func sanitizeScrapeConfigsForTest(scs []*promconfig.ScrapeConfig) {
 		sc.RelabelConfigs = nil
 		sc.MetricRelabelConfigs = nil
 	}
-}
-
-// getTestInformers creates informers for testing without CRD availability checks.
-func getTestInformers(factory, metadataFactory informers.FactoriesForNamespaces) (map[string]*informers.ForResource, error) {
-	informersMap := make(map[string]*informers.ForResource)
-
-	// Create ServiceMonitor informers
-	serviceMonitorInformers, err := informers.NewInformersForResource(factory, monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName))
-	if err != nil {
-		return nil, err
-	}
-	informersMap[monitoringv1.ServiceMonitorName] = serviceMonitorInformers
-
-	// Create PodMonitor informers
-	podMonitorInformers, err := informers.NewInformersForResource(factory, monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName))
-	if err != nil {
-		return nil, err
-	}
-	informersMap[monitoringv1.PodMonitorName] = podMonitorInformers
-
-	// Create Probe informers
-	probeInformers, err := informers.NewInformersForResource(factory, monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ProbeName))
-	if err != nil {
-		return nil, err
-	}
-	informersMap[monitoringv1.ProbeName] = probeInformers
-
-	// Create ScrapeConfig informers
-	scrapeConfigInformers, err := informers.NewInformersForResource(factory, promv1alpha1.SchemeGroupVersion.WithResource(promv1alpha1.ScrapeConfigName))
-	if err != nil {
-		return nil, err
-	}
-	informersMap[promv1alpha1.ScrapeConfigName] = scrapeConfigInformers
-
-	// Secret informer - mirrors production code in getInformers
-	if metadataFactory != nil {
-		secretInformer, err := informers.NewInformersForResourceWithTransform(
-			metadataFactory,
-			v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
-			informers.PartialObjectMetadataStrip(operator.SecretGVK()),
-		)
-		if err != nil {
-			return nil, err
-		}
-		if secretInformer != nil {
-			informersMap[string(v1.ResourceSecrets)] = secretInformer
-		}
-	}
-
-	return informersMap, nil
 }
 
 // TestCRDAvailabilityChecks tests the CRDs' availability.


### PR DESCRIPTION
In the 1.35.x release of client-go, the [watchlistclient](https://kubernetes.io/blog/2024/12/17/kube-apiserver-api-streaming/#streaming-list-requests) feature is enabled by default. This means that the fake client we use for test doesn't work. Fix the tests before we upgrade.

Unblocks https://github.com/open-telemetry/opentelemetry-operator/pull/4880.