### PR TITLE
remove the kubebuilder default tag on the statefulset pod management policy

### DIFF
--- a/.chloggen/rm-default-mgmt-policy.yaml
+++ b/.chloggen/rm-default-mgmt-policy.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the kubebuilder default from the sts pod management policy field so it can be properly `omitempty`
+
+# One or more tracking issues related to the change
+issues: [4875]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This field should not be set on deployment or daemonset collectors.

--- a/apis/v1beta1/common.go
+++ b/apis/v1beta1/common.go
@@ -265,8 +265,8 @@ type StatefulSetCommonFields struct {
 	ServiceName string `json:"serviceName,omitempty"`
 
 	// PodManagementPolicy defines the pod creation and termination order in StatefulSet.
+	// If not specified, it will default to "Parallel"
 	// +optional
-	// +kubebuilder:default:=Parallel
 	// +kubebuilder:validation:Enum=OrderedReady;Parallel
 	PodManagementPolicy appsv1.PodManagementPolicyType `json:"podManagementPolicy,omitempty"`
 }

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-03-27T15:20:41Z"
+    createdAt: "2026-03-27T16:38:21Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -7321,7 +7321,6 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
               podManagementPolicy:
-                default: Parallel
                 enum:
                 - OrderedReady
                 - Parallel

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-03-27T15:20:42Z"
+    createdAt: "2026-03-27T16:38:22Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -7320,7 +7320,6 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
               podManagementPolicy:
-                default: Parallel
                 enum:
                 - OrderedReady
                 - Parallel

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -7307,7 +7307,6 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
               podManagementPolicy:
-                default: Parallel
                 enum:
                 - OrderedReady
                 - Parallel

--- a/docs/api/opentelemetrycollectors.md
+++ b/docs/api/opentelemetrycollectors.md
@@ -20408,10 +20408,10 @@ for the generated workload. By default, a PDB with a MaxUnavailable of one is se
         <td><b>podManagementPolicy</b></td>
         <td>enum</td>
         <td>
-          PodManagementPolicy defines the pod creation and termination order in StatefulSet.<br/>
+          PodManagementPolicy defines the pod creation and termination order in StatefulSet.
+If not specified, it will default to "Parallel"<br/>
           <br/>
             <i>Enum</i>: OrderedReady, Parallel<br/>
-            <i>Default</i>: Parallel<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
**Description:** <Describe what has changed.>
`+kubebuilder:default:=Parallel` puts `podManagementPolicy: Parallel` on all collector resources even if they are not in statefulset mode. This isn't necessarily harmful, but it is confusing. It's safe to remove the default as the reconcile handles empty strings: https://github.com/open-telemetry/opentelemetry-operator/blob/main/internal/manifests/collector/statefulset.go#L37

**Link to tracking Issue(s):** https://github.com/open-telemetry/opentelemetry-operator/issues/4875

**Testing:** N/A

**Documentation:** N/A
