### PR TITLE
expose grpc(default) when using otelarrow as receiver

### DIFF
--- a/.chloggen/expose_grpc_otelarrow.yaml
+++ b/.chloggen/expose_grpc_otelarrow.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Expose the default gRPC receiver port (4317) for otelarrow and automatically apply grpc protocol defaults when protocols are omitted or otelarrow is enabled."
+
+
+# One or more tracking issues related to the change
+issues: [4713]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/components/multi_endpoint.go
+++ b/internal/components/multi_endpoint.go
@@ -77,8 +77,15 @@ func (m *MultiPortReceiver) GetDefaultConfig(logger logr.Logger, config any, opt
 	if err := mapstructure.Decode(config, multiProtoEndpointCfg); err != nil {
 		return nil, err
 	}
+	protocols := multiProtoEndpointCfg.Protocols
+	if len(protocols) == 0 {
+		protocols = map[string]*SingleEndpointConfig{}
+		for protocol := range m.portMappings {
+			protocols[protocol] = nil
+		}
+	}
 	defaultedConfig := map[string]any{}
-	for protocol, ec := range multiProtoEndpointCfg.Protocols {
+	for protocol, ec := range protocols {
 		defaultSvc, ok := m.portMappings[protocol]
 		if !ok {
 			return nil, fmt.Errorf("unknown protocol set: %s", protocol)

--- a/internal/components/receivers/helpers.go
+++ b/internal/components/receivers/helpers.go
@@ -77,6 +77,11 @@ var componentParsers = []components.Parser{
 			WithTargetPort(3100).
 			WithAppProtocol(&components.HttpProtocol)).
 		MustBuild(),
+	components.NewMultiPortReceiverBuilder("otelarrow").
+		AddPortMapping(components.NewProtocolBuilder("grpc", 4317).
+			WithAppProtocol(&components.GrpcProtocol).
+			WithTargetPort(4317)).
+		MustBuild(),
 	components.NewSinglePortParserBuilder("awsxray", 2000).
 		WithTargetPort(2000).
 		WithProtocol(corev1.ProtocolUDP).

--- a/internal/otelconfig/config_test.go
+++ b/internal/otelconfig/config_test.go
@@ -800,10 +800,11 @@ func TestConfig_getEnvironmentVariablesForComponentKinds(t *testing.T) {
 
 func TestConfig_GetReceiverPorts(t *testing.T) {
 	tests := []struct {
-		name    string
-		file    string
-		want    []v1.ServicePort
-		wantErr bool
+		name          string
+		file          string
+		want          []v1.ServicePort
+		wantErr       bool
+		applyDefaults bool
 	}{
 		{
 			name: "k8sevents",
@@ -857,6 +858,33 @@ func TestConfig_GetReceiverPorts(t *testing.T) {
 			},
 		},
 		{
+			name: "otelarrow",
+			file: "testdata/otelcol-otelarrow.yaml",
+			want: []v1.ServicePort{
+				{
+					Name:        "otelarrow-grpc",
+					Protocol:    "",
+					AppProtocol: ptr.To("grpc"),
+					Port:        4317,
+					TargetPort:  intstr.FromInt32(4317),
+				},
+			},
+		},
+		{
+			name:          "otelarrow missing protocols",
+			file:          "testdata/otelcol-otelarrow-no-protocols.yaml",
+			applyDefaults: true,
+			want: []v1.ServicePort{
+				{
+					Name:        "otelarrow-grpc",
+					Protocol:    "",
+					AppProtocol: ptr.To("grpc"),
+					Port:        4317,
+					TargetPort:  intstr.FromInt32(4317),
+				},
+			},
+		},
+		{
 			name: "filelog",
 			file: "testdata/otelcol-filelog.yaml",
 			want: nil,
@@ -875,6 +903,10 @@ func TestConfig_GetReceiverPorts(t *testing.T) {
 			c := &v1beta1.Config{}
 			err = go_yaml.Unmarshal(collectorYaml, c)
 			require.NoError(t, err)
+			if tt.applyDefaults {
+				_, err = ApplyDefaults(c, logr.Discard())
+				require.NoError(t, err)
+			}
 			ports, err := GetReceiverPorts(c, logr.Discard())
 			if tt.wantErr {
 				require.Error(t, err)

--- a/internal/otelconfig/testdata/otelcol-otelarrow-no-protocols.yaml
+++ b/internal/otelconfig/testdata/otelcol-otelarrow-no-protocols.yaml
@@ -1,0 +1,11 @@
+receivers:
+  otelarrow: {}
+
+exporters:
+  debug:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otelarrow]
+      exporters: [debug]

--- a/internal/otelconfig/testdata/otelcol-otelarrow.yaml
+++ b/internal/otelconfig/testdata/otelcol-otelarrow.yaml
@@ -1,0 +1,13 @@
+receivers:
+  otelarrow:
+    protocols:
+      grpc:
+
+exporters:
+  debug:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otelarrow]
+      exporters: [debug]


### PR DESCRIPTION
**Description:**  
This PR exposes the default gRPC receiver port (`4317`) for the `otelarrow` receiver and ensures `grpc` protocol defaults are automatically applied when `protocols` are omitted or left empty.

**Link to tracking Issue(s):**  
- Resolves: #4713

**Testing:**  
Added unit tests for both normal `otelarrow` configs and cases where `protocols` are missing but defaults are applied. 

**Documentation:**  
Added changelog entry in `.chloggen/expose_grpc_otelarrow.yaml`.