### PR TITLE
Expose prometheus receiver api_server port

### DIFF
--- a/.chloggen/fix-prometheus-receiver-api-server-port.yaml
+++ b/.chloggen/fix-prometheus-receiver-api-server-port.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Expose prometheus receiver api_server port on collector Service and NetworkPolicy
+
+# One or more tracking issues related to the change
+issues: [4949]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/components/component.go
+++ b/internal/components/component.go
@@ -77,6 +77,7 @@ func ComponentType(name string) string {
 	return name
 }
 
+// PortFromEndpoint extracts the port number from a host:port endpoint string (e.g. "0.0.0.0:9090" → 9090).
 func PortFromEndpoint(endpoint string) (int32, error) {
 	var err error
 	var port int64

--- a/internal/components/receivers/helpers.go
+++ b/internal/components/receivers/helpers.go
@@ -133,7 +133,7 @@ var componentParsers = []components.Parser{
 	components.NewBuilder[k8sobjectsConfig]().WithName("k8sobjects").
 		WithRbacGen(generatek8sobjectsRbacRules).
 		MustBuild(),
-	NewScraperParser("prometheus"),
+	NewPrometheusParser(),
 	NewScraperParser("sshcheck"),
 	NewScraperParser("cloudfoundry"),
 	NewScraperParser("vcenter"),

--- a/internal/components/receivers/prometheus.go
+++ b/internal/components/receivers/prometheus.go
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receivers
+
+import (
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/open-telemetry/opentelemetry-operator/internal/components"
+	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
+)
+
+// prometheusConfig represents the Prometheus receiver config relevant for port parsing.
+// The api_server section opens an inbound HTTP listener whose port must be exposed
+// in the Kubernetes Service and NetworkPolicy.
+type prometheusConfig struct {
+	ApiServer *apiServerConfig `mapstructure:"api_server,omitempty"`
+}
+
+type apiServerConfig struct {
+	Enabled      bool          `mapstructure:"enabled,omitempty"`
+	ServerConfig *serverConfig `mapstructure:"server_config,omitempty"`
+}
+
+type serverConfig struct {
+	Endpoint string `mapstructure:"endpoint,omitempty"`
+}
+
+func (c *prometheusConfig) GetPortNum() (int32, error) {
+	if c.ApiServer == nil || !c.ApiServer.Enabled {
+		return components.UnsetPort, components.PortNotFoundErr
+	}
+	if c.ApiServer.ServerConfig != nil && c.ApiServer.ServerConfig.Endpoint != "" {
+		return components.PortFromEndpoint(c.ApiServer.ServerConfig.Endpoint)
+	}
+	return components.UnsetPort, components.PortNotFoundErr
+}
+
+func (c *prometheusConfig) GetPortNumOrDefault(logger logr.Logger, p int32) int32 {
+	num, err := c.GetPortNum()
+	if err != nil {
+		logger.V(3).Info("no port set, using default", "port", p)
+		return p
+	}
+	return num
+}
+
+func parsePrometheusPort(logger logr.Logger, name string, defaultPort *corev1.ServicePort, cfg *prometheusConfig) ([]corev1.ServicePort, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	if _, err := cfg.GetPortNum(); err != nil {
+		// No api_server port configured or not enabled — this is normal for prometheus receiver.
+		return nil, nil
+	}
+	port := cfg.GetPortNumOrDefault(logger, defaultPort.Port)
+	svcPort := defaultPort
+	svcPort.Name = naming.PortName(name, port)
+	return []corev1.ServicePort{components.ConstructServicePort(svcPort, port)}, nil
+}
+
+// NewPrometheusParser returns a parser for the prometheus receiver that extracts
+// the api_server.server_config.endpoint port for Service and NetworkPolicy exposure.
+func NewPrometheusParser() *components.GenericParser[*prometheusConfig] {
+	return components.NewBuilder[*prometheusConfig]().
+		WithName("prometheus").
+		WithPort(components.UnsetPort).
+		WithPortParser(parsePrometheusPort).
+		MustBuild()
+}

--- a/internal/components/receivers/prometheus_test.go
+++ b/internal/components/receivers/prometheus_test.go
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package receivers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-operator/internal/components/receivers"
+)
+
+func TestPrometheusParser(t *testing.T) {
+	parser := receivers.ReceiverFor("prometheus")
+	assert.Equal(t, "__prometheus", parser.ParserName())
+}
+
+func TestPrometheusParserPorts(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       map[string]any
+		expectedPort int32
+	}{
+		{
+			name:   "no config returns no ports",
+			config: map[string]any{},
+		},
+		{
+			name: "api_server disabled returns no ports",
+			config: map[string]any{
+				"api_server": map[string]any{
+					"enabled": false,
+					"server_config": map[string]any{
+						"endpoint": "0.0.0.0:9091",
+					},
+				},
+			},
+		},
+		{
+			name: "api_server enabled without server_config returns no ports",
+			config: map[string]any{
+				"api_server": map[string]any{
+					"enabled": true,
+				},
+			},
+		},
+		{
+			name: "api_server enabled with empty endpoint returns no ports",
+			config: map[string]any{
+				"api_server": map[string]any{
+					"enabled": true,
+					"server_config": map[string]any{
+						"endpoint": "",
+					},
+				},
+			},
+		},
+		{
+			name: "api_server enabled with endpoint returns port",
+			config: map[string]any{
+				"api_server": map[string]any{
+					"enabled": true,
+					"server_config": map[string]any{
+						"endpoint": "0.0.0.0:9091",
+					},
+				},
+			},
+			expectedPort: 9091,
+		},
+		{
+			name: "api_server enabled with localhost endpoint returns port",
+			config: map[string]any{
+				"api_server": map[string]any{
+					"enabled": true,
+					"server_config": map[string]any{
+						"endpoint": "localhost:9090",
+					},
+				},
+			},
+			expectedPort: 9090,
+		},
+		{
+			name: "api_server with scrape_configs still parses port",
+			config: map[string]any{
+				"api_server": map[string]any{
+					"enabled": true,
+					"server_config": map[string]any{
+						"endpoint": "0.0.0.0:9091",
+					},
+				},
+				"config": map[string]any{
+					"scrape_configs": []any{
+						map[string]any{
+							"job_name": "test",
+						},
+					},
+				},
+			},
+			expectedPort: 9091,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := receivers.ReceiverFor("prometheus")
+			ports, err := parser.Ports(logger, "prometheus", tt.config)
+			require.NoError(t, err)
+			if tt.expectedPort == 0 {
+				assert.Empty(t, ports)
+			} else {
+				require.Len(t, ports, 1)
+				assert.Equal(t, tt.expectedPort, ports[0].Port)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Rewrite prometheus receiver parser to extract port from `api_server.server_config.endpoint` using `GenericParser`, so the port is exposed on the collector Service and NetworkPolicy.
- The previous `ScraperParser`-based implementation never exposed a port for the API server.

## Test plan
- [x] Unit tests covering: disabled api_server, missing endpoint, empty endpoint, valid endpoints, coexistence with scrape_configs
- [x] Manual verification with collector CR using `api_server.enabled: true` + `operand.networkpolicy` feature gate