### PR TITLE
[chore] Re-enable govulncheck in a separate job

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -99,8 +99,19 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v3.29.5
 
+  govulncheck:
+    name: Govulncheck
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version: "~1.25.7"
+
     - name: Govulncheck
       uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
-      if: ${{ false }} # temporarily disabled to unblock CI, see https://github.com/open-telemetry/opentelemetry-operator/issues/4935
       with:
         repo-checkout: false


### PR DESCRIPTION
This is so it doesn't block merging PRs, but still shows up in PR checks.

Resolves https://github.com/open-telemetry/opentelemetry-operator/issues/4935