### PR TITLE
[chore] Separately upgrade to new Go minors using renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -83,6 +83,7 @@
       "matchDatasources": ["golang-version"],
       "matchManagers": ["regex"],
       "matchFileNames": [".github/workflows/*.yaml", ".github/workflows/*.yml"],
+      "separateMinorPatch": true,
       "commitMessageTopic": "go version in CI"
     },
     {


### PR DESCRIPTION
We usually don't want to upgrade to a new Go major version immediately, and are sometimes prevented by dependency conflicts as well. In the meantime, we'd like to upgrade to new minor releases of the current major. Enable this [option](https://docs.renovatebot.com/configuration-options/#separateminorpatch) in renovate.

For example, right now we can't easily upgrade to 1.26.2 because it's impossible to build chainsaw with Go 1.26, but we'd still like to go to 1.25.9.