### PR TITLE
fix(opamp-bridge): guard nil processors in validateComponents

### DIFF
--- a/.chloggen/fix-bridge-nil-processors-check.yaml
+++ b/.chloggen/fix-bridge-nil-processors-check.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: opamp
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix nil pointer dereference in OpAMP Bridge when validating a remote collector config that omits the `processors` section
+
+# One or more tracking issues related to the change
+issues: [4970]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `v1beta1.Config.Processors` is an optional `*AnyConfig`, but `validateComponents` dereferenced it unconditionally.
+  When a remote config without a `processors` section is applied through a bridge that had `componentsAllowed`
+  configured, it panicked and pod restarted. The nil case is now skipped during validation.

--- a/cmd/operator-opamp-bridge/internal/operator/client.go
+++ b/cmd/operator-opamp-bridge/internal/operator/client.go
@@ -111,9 +111,11 @@ func (c Client) validateComponents(collectorConfig *v1beta1.Config) error {
 	}
 
 	configuredComponents := map[string]map[string]any{
-		"receivers":  collectorConfig.Receivers.Object,
-		"processors": collectorConfig.Processors.Object,
-		"exporters":  collectorConfig.Exporters.Object,
+		"receivers": collectorConfig.Receivers.Object,
+		"exporters": collectorConfig.Exporters.Object,
+	}
+	if collectorConfig.Processors != nil {
+		configuredComponents["processors"] = collectorConfig.Processors.Object
 	}
 
 	var invalidComponents []string

--- a/cmd/operator-opamp-bridge/internal/operator/client_test.go
+++ b/cmd/operator-opamp-bridge/internal/operator/client_test.go
@@ -46,6 +46,19 @@ func getFakeClient(t *testing.T, lists ...client.ObjectList) client.WithWatch {
 }
 
 func TestClient_Apply(t *testing.T) {
+	componentsAllowed := map[string]map[string]bool{
+		"receivers": {
+			"otlp": true,
+		},
+		"processors": {
+			"memory_limiter": true,
+			"batch":          true,
+		},
+		"exporters": {
+			"debug": true,
+		},
+	}
+
 	type args struct {
 		name      string
 		namespace string
@@ -64,6 +77,15 @@ func TestClient_Apply(t *testing.T) {
 				name:      "test",
 				namespace: "opentelemetry",
 				file:      "testdata/collector.yaml",
+			},
+			wantErr: false,
+		},
+		{
+			name: "no processors case",
+			args: args{
+				name:      "test",
+				namespace: "opentelemetry",
+				file:      "testdata/no-processors-collector.yaml",
 			},
 			wantErr: false,
 		},
@@ -121,7 +143,7 @@ func TestClient_Apply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := getFakeClient(t)
-			c := NewClient(bridgeName, clientLogger, fakeClient, nil)
+			c := NewClient(bridgeName, clientLogger, fakeClient, componentsAllowed)
 			var colConfig []byte
 			var err error
 			if tt.args.file != "" {

--- a/cmd/operator-opamp-bridge/internal/operator/testdata/no-processors-collector.yaml
+++ b/cmd/operator-opamp-bridge/internal/operator/testdata/no-processors-collector.yaml
@@ -1,0 +1,22 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: simplest
+  labels:
+    opentelemetry.io/opamp-managed: "true"
+spec:
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+
+    exporters:
+      debug:
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

The opamp-bridge panics with a nil pointer dereference in validateComponents when a remote config omits the `processors` field. `v1beta1.Config.Processors` is *AnyConfig with omitempty tag, so nil is a valid case, but dereferencing it unconditionally.

**Testing:** <Describe what testing was performed and which tests were added.>

- Added testdata/no-processors-collector.yaml (minimal config without processors)
- Added a no processors case to `TestClient_Apply`
- Updated `TestClient_Apply` to pass a non-empty componentsAllowed map