### PR TITLE
fix(processors): register k8s_attributes alongside k8sattributes for RBAC

### DIFF
--- a/.chloggen/fix-k8s-attributes-rbac-snakecase.yaml
+++ b/.chloggen/fix-k8s-attributes-rbac-snakecase.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Register the `k8s_attributes` spelling alongside `k8sattributes` when generating RBAC from a Collector CR so either processor name produces the pods/replicasets/etc. permissions the processor needs.
+
+# One or more tracking issues related to the change
+issues: [4922]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The underlying processor was renamed to snake_case in
+  open-telemetry/opentelemetry-collector-contrib#45901 while keeping the
+  original spelling accepted, but the operator only parsed the camel form
+  and emitted no RBAC for configs using the new name.

--- a/.chloggen/fix-k8s-attributes-snake-case-rbac.yaml
+++ b/.chloggen/fix-k8s-attributes-snake-case-rbac.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Generate RBAC for the k8s_attributes processor under its snake_case spelling, matching the camelCase k8sattributes it was renamed from.
+
+# One or more tracking issues related to the change
+issues: [4922]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/components/processors/helpers.go
+++ b/internal/components/processors/helpers.go
@@ -29,6 +29,11 @@ func ProcessorFor(name string) components.Parser {
 
 var componentParsers = []components.Parser{
 	components.NewBuilder[K8sAttributeConfig]().WithName("k8sattributes").WithRbacGen(GenerateK8SAttrRbacRules).MustBuild(),
+	// k8s_attributes is the snake-case alias introduced in
+	// open-telemetry/opentelemetry-collector-contrib#45901. Both names
+	// resolve to the same processor in the collector, so the operator
+	// must generate the same RBAC for either spelling (#4922).
+	components.NewBuilder[K8sAttributeConfig]().WithName("k8s_attributes").WithRbacGen(GenerateK8SAttrRbacRules).MustBuild(),
 	components.NewBuilder[ResourceDetectionConfig]().WithName("resourcedetection").WithRbacGen(GenerateResourceDetectionRbacRules).MustBuild(),
 }
 

--- a/internal/manifests/collector/rbac_test.go
+++ b/internal/manifests/collector/rbac_test.go
@@ -106,6 +106,22 @@ func TestDesiredClusterRoles(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:       "k8s_attributes processor - snake_case alias",
+			configPath: "testdata/rbac_k8s_attributes_snake_case.yaml",
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods", "namespaces"},
+					Verbs:     []string{"get", "watch", "list"},
+				},
+				{
+					APIGroups: []string{"apps"},
+					Resources: []string{"replicasets"},
+					Verbs:     []string{"get", "watch", "list"},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/manifests/collector/testdata/rbac_k8s_attributes_snake_case.yaml
+++ b/internal/manifests/collector/testdata/rbac_k8s_attributes_snake_case.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+processors:
+  k8s_attributes:
+    extract:
+      metadata:
+        - service.name
+exporters:
+  otlp:
+    endpoint: "otlp:4317"
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [k8s_attributes]
+      exporters: [otlp]


### PR DESCRIPTION
## Summary

Fixes #4922.

open-telemetry/opentelemetry-collector-contrib#45901 renamed the processor to the snake-case `k8s_attributes` while keeping the original `k8sattributes` spelling accepted by the collector. The operator only registered the camel spelling, so a collector configured with `k8s_attributes` produced no RBAC and the collector logged `pods is forbidden` / `replicasets is forbidden` at runtime against the default `node-collector` service account.

## Fix

Register a second `Parser` for `k8s_attributes` under the same `K8sAttributeConfig` type and `GenerateK8SAttrRbacRules` generator. `k8sattributes` keeps its existing registration so both spellings continue to work — the collector accepts either, and now so does the operator's RBAC pass.

## Tests

- New testdata fixture `rbac_k8s_attributes_snake_case.yaml` (same content as `rbac_k8sattributes_service_name.yaml`, but using the snake-case processor name).
- New `TestDesiredClusterRoles` table entry asserting the same RBAC rules are generated for the snake-case spelling.

`go test ./internal/components/processors/... ./internal/manifests/collector/...` green; `go vet` clean.
