### PR TITLE
[e2e tests] add timeout to allow update of iptables

### DIFF
--- a/tests/e2e-upgrade/upgrade-test/chainsaw-test.yaml
+++ b/tests/e2e-upgrade/upgrade-test/chainsaw-test.yaml
@@ -72,6 +72,7 @@ spec:
             sleep 1
           done
           echo "EndpointSlice settled to new pods only (retries: $ATTEMPTS)"
+          sleep 30 # give some extra time for kube-proxy to update the service NAT rules
   - name: step-02
     try:
     - apply:


### PR DESCRIPTION
Previous endpoint slice [check](#4966) hasn't removed flakiness of e2e-upgrade tests since iptable update is async of endpointslice updates.
https://github.com/open-telemetry/opentelemetry-operator/issues/4887#issuecomment-4295558292

Adding a simple timeout will be enough, as v1alpha1 will be retired after that.


**Link to tracking Issue(s):** #4887 
