### PR TITLE
Upgrade to Dotnet 1.15.0 by default

### DIFF
--- a/.chloggen/feat_upgrade-default-dotnet-instrumentation.yaml
+++ b/.chloggen/feat_upgrade-default-dotnet-instrumentation.yaml
@@ -1,0 +1,21 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update default .NET auto-instrumentation version from 1.2.0 to 1.15.0
+
+# One or more tracking issues related to the change
+issues: [4996]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This update addresses security vulnerabilities in versions older than 1.15.0 (CVE-2026-40894, GHSA-g94r-2vxg-569j).
+  This is a breaking change due to HTTP semantic convention changes between versions.
+  Existing Instrumentation CRs using version 1.2.0 will NOT be automatically upgraded.
+  To upgrade, manually update the image in your Instrumentation CR after reviewing the migration guide.
+  See https://github.com/open-telemetry/opentelemetry-operator/issues/2542 for details.

--- a/internal/instrumentation/upgrade/upgrade_test.go
+++ b/internal/instrumentation/upgrade/upgrade_test.go
@@ -25,6 +25,9 @@ import (
 )
 
 func TestUpgrade(t *testing.T) {
+	cleanup := version.SetUnupgradableInstrumentationVersionsForTests(map[constants.InstrumentationLanguage]map[string]string{})
+	defer cleanup()
+
 	nsName := strings.ToLower(t.Name())
 	err := k8sClient.Create(context.Background(), &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -121,10 +124,11 @@ func TestUpgrade(t *testing.T) {
 }
 
 func TestUpgradeBlockedForUnupgradableVersion(t *testing.T) {
-	// Set up unupgradable version for testing
+	// Set up unupgradable version for testing. The blocked version "2" sits in
+	// (current, target] when going from "1" to "2", so the upgrade should be blocked.
 	cleanup := version.SetUnupgradableInstrumentationVersionsForTests(map[constants.InstrumentationLanguage]map[string]string{
 		constants.InstrumentationLanguageJava: {
-			"1": "Breaking changes in Java agent require manual migration.",
+			"2": "Breaking changes in Java agent require manual migration.",
 		},
 	})
 	defer cleanup()
@@ -222,10 +226,10 @@ func TestUpgradeBlockedForUnupgradableVersion(t *testing.T) {
 // TestUpgradeClearsStaleBlockedStatus verifies that a previously-blocked instrumentation has its
 // status.upgradeBlockedVersions cleared once the blocking condition no longer applies.
 func TestUpgradeClearsStaleBlockedStatus(t *testing.T) {
-	// Initially block "java:1" so the first reconcile populates status.
+	// Block "2" so the first reconcile (java:1 -> java:2) hits the blocking range and populates status.
 	cleanup := version.SetUnupgradableInstrumentationVersionsForTests(map[constants.InstrumentationLanguage]map[string]string{
 		constants.InstrumentationLanguageJava: {
-			"1": "Breaking changes in Java agent require manual migration.",
+			"2": "Breaking changes in Java agent require manual migration.",
 		},
 	})
 

--- a/internal/version/unupgradable.go
+++ b/internal/version/unupgradable.go
@@ -11,9 +11,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 )
 
+// Kubernetes admission warnings are transmitted in HTTP headers and MUST NOT contain control
+// characters like newlines, so these messages are kept on a single line.
+const (
+	dotNet130WarningMessage = ".NET instrumentation 1.3.0 contains breaking HTTP semantic convention changes. " +
+		"See https://opentelemetry.io/blog/2023/http-conventions-declared-stable/ for a general description of the changes. " +
+		"To upgrade, manually set the image on this Instrumentation resource to 1.3.0 or higher."
+)
+
 // unupgradableInstrumentationVersions contains instrumentation versions that cannot be automatically upgraded from.
 // Outer key is the language, inner key is the version tag, value is the warning message.
-var unupgradableInstrumentationVersions = map[constants.InstrumentationLanguage]map[string]string{}
+var unupgradableInstrumentationVersions = map[constants.InstrumentationLanguage]map[string]string{
+	constants.InstrumentationLanguageDotNet: {
+		"1.3.0": dotNet130WarningMessage,
+	},
+}
 
 // IsInstrumentationVersionUnupgradable checks if an instrumentation image upgrade should be blocked.
 // It first verifies the image is from the same repository as defaultImage — images from other repositories are never blocked.
@@ -59,8 +71,8 @@ func IsInstrumentationVersionUnupgradable(language constants.InstrumentationLang
 			}
 			continue
 		}
-		// Block if the blocked version is in range [current, target)
-		if !blockedVer.LessThan(currentVer) && blockedVer.LessThan(targetVer) {
+		// Block if the blocked version is in range (current, target]
+		if blockedVer.GreaterThan(currentVer) && blockedVer.LessThanEqual(targetVer) {
 			return true, msg
 		}
 	}

--- a/internal/version/unupgradable_test.go
+++ b/internal/version/unupgradable_test.go
@@ -60,11 +60,24 @@ func TestIsInstrumentationVersionUnupgradable(t *testing.T) {
 			defaultImage: "ghcr.io/org/java:v2.0.0",
 			unupgradableMap: map[constants.InstrumentationLanguage]map[string]string{
 				constants.InstrumentationLanguageJava: {
-					"v1.0.0": "Breaking changes in Java agent.",
+					"v2.0.0": "Breaking changes in Java agent.",
 				},
 			},
 			wantBlocked: true,
 			wantMessage: "Breaking changes in Java agent.",
+		},
+		{
+			name:         "unupgradable version without v prefix returns true with message",
+			language:     constants.InstrumentationLanguageDotNet,
+			image:        "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0",
+			defaultImage: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0",
+			unupgradableMap: map[constants.InstrumentationLanguage]map[string]string{
+				constants.InstrumentationLanguageDotNet: {
+					"1.3.0": "Breaking changes in dotNet agent.",
+				},
+			},
+			wantBlocked: true,
+			wantMessage: "Breaking changes in dotNet agent.",
 		},
 		{
 			name:         "different repo skips check",

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/00-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/00-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: blocked-upgrade-test
+spec:
+  dotnet:
+    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/00-install-instrumentation-blocked.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/00-install-instrumentation-blocked.yaml
@@ -1,0 +1,11 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: blocked-upgrade-test
+spec:
+  exporter:
+    endpoint: http://localhost:4317
+  sampler:
+    type: always_on
+  dotnet:
+    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/01-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: upgrade-test
+spec:
+  dotnet:
+    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/01-install-instrumentation-upgrade-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/01-install-instrumentation-upgrade-test.yaml
@@ -1,0 +1,9 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: upgrade-test
+spec:
+  exporter:
+    endpoint: http://localhost:4317
+  sampler:
+    type: always_on

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/02-assert.yaml
@@ -8,3 +8,14 @@ spec:
 status:
   upgradeBlockedVersions:
     dotnet: "Automated upgrade blocked for dotnet: .NET instrumentation 1.3.0 contains breaking HTTP semantic convention changes. See https://opentelemetry.io/blog/2023/http-conventions-declared-stable/ for a general description of the changes. To upgrade, manually set the image on this Instrumentation resource to 1.3.0 or higher."
+---
+apiVersion: events.k8s.io/v1
+kind: Event
+note: "Automated upgrade blocked for dotnet: .NET instrumentation 1.3.0 contains breaking HTTP semantic convention changes. See https://opentelemetry.io/blog/2023/http-conventions-declared-stable/ for a general description of the changes. To upgrade, manually set the image on this Instrumentation resource to 1.3.0 or higher."
+reason: "UpgradeBlocked"
+regarding:
+  apiVersion: opentelemetry.io/v1alpha1
+  kind: Instrumentation
+  name: upgrade-test
+reportingController: opentelemetry-operator
+type: Warning

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/02-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: upgrade-test
+spec:
+  dotnet:
+    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
+status:
+  upgradeBlockedVersions:
+    dotnet: "Automated upgrade blocked for dotnet: .NET instrumentation 1.3.0 contains breaking HTTP semantic convention changes. See https://opentelemetry.io/blog/2023/http-conventions-declared-stable/ for a general description of the changes. To upgrade, manually set the image on this Instrumentation resource to 1.3.0 or higher."

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/chainsaw-test.yaml
@@ -20,6 +20,7 @@ spec:
     try:
     - script:
         timeout: 5m
+        shell: /bin/bash
         content: |
           #!/bin/bash
           set -eo pipefail
@@ -46,6 +47,7 @@ spec:
     try:
     - script:
         timeout: 5m
+        shell: /bin/bash
         content: |
           #!/bin/bash
           set -eo pipefail
@@ -68,9 +70,3 @@ spec:
     # and the status should reflect the blocked upgrade
     - assert:
         file: 02-assert.yaml
-    - script:
-        timeout: 30s
-        content: |
-          kubectl get events.events.k8s.io -n $NAMESPACE --field-selector reason=UpgradeBlocked -o jsonpath='{.items[*].note}'
-        check:
-          (contains($stdout, 'Automated upgrade blocked for dotnet')): true

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/chainsaw-test.yaml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: instrumentation-blocked-upgrade
+spec:
+  # This test modifies the operator deployment to verify upgrade blocking behavior.
+  steps:
+  - name: Create instrumentation with blocked dotnet version and verify webhook warning
+    try:
+    - script:
+        timeout: 30s
+        content: |
+          kubectl apply -n $NAMESPACE -f 00-install-instrumentation-blocked.yaml 2>&1
+        check:
+          (contains($stdout, 'cannot be automatically upgraded')): true
+    - assert:
+        file: 00-assert.yaml
+  - name: Patch operator to use old dotnet version as default
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          #!/bin/bash
+          set -eo pipefail
+          NS=opentelemetry-operator-system
+          DEPLOY=opentelemetry-operator-controller-manager
+          OLD_IMG="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
+
+          # Add the dotnet image arg to override the compiled-in default
+          ARGS=$(kubectl get deploy -n $NS $DEPLOY -o json | jq -c '.spec.template.spec.containers[0].args')
+          NEW_ARGS=$(echo "$ARGS" | jq -c --arg img "$OLD_IMG" \
+            '[.[] | select(startswith("--auto-instrumentation-dotnet-image=") | not)] + ["--auto-instrumentation-dotnet-image=" + $img]')
+
+          kubectl patch deploy -n $NS $DEPLOY --type='json' \
+            -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/args\",\"value\":$NEW_ARGS}]"
+
+          kubectl rollout status deploy/$DEPLOY -n $NS --timeout=120s
+  - name: Create instrumentation that will be subject to upgrade
+    try:
+    - apply:
+        file: 01-install-instrumentation-upgrade-test.yaml
+    - assert:
+        file: 01-assert.yaml
+  - name: Restore operator to default dotnet version and trigger upgrade
+    try:
+    - script:
+        timeout: 5m
+        content: |
+          #!/bin/bash
+          set -eo pipefail
+          NS=opentelemetry-operator-system
+          DEPLOY=opentelemetry-operator-controller-manager
+
+          # Remove the override arg so the operator uses its compiled-in default (1.15.0)
+          ARGS=$(kubectl get deploy -n $NS $DEPLOY -o json | jq -c '.spec.template.spec.containers[0].args')
+          NEW_ARGS=$(echo "$ARGS" | jq -c '[.[] | select(startswith("--auto-instrumentation-dotnet-image=") | not)]')
+
+          kubectl patch deploy -n $NS $DEPLOY --type='json' \
+            -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/args\",\"value\":$NEW_ARGS}]"
+
+          kubectl rollout status deploy/$DEPLOY -n $NS --timeout=120s
+          # Give the upgrade mechanism time to process existing Instrumentation CRs
+          sleep 5
+  - name: Assert upgrade was blocked with status and event
+    try:
+    # DotNet image should still be 1.2.0 (not upgraded to 1.15.0)
+    # and the status should reflect the blocked upgrade
+    - assert:
+        file: 02-assert.yaml
+    - script:
+        timeout: 30s
+        content: |
+          kubectl get events.events.k8s.io -n $NAMESPACE --field-selector reason=UpgradeBlocked -o jsonpath='{.items[*].note}'
+        check:
+          (contains($stdout, 'Automated upgrade blocked for dotnet')): true

--- a/versions.txt
+++ b/versions.txt
@@ -26,8 +26,7 @@ autoinstrumentation-nodejs=0.73.0
 autoinstrumentation-python=0.61b0
 
 # Represents the current release of DotNet instrumentation.
-# This version should remain pinned to 1.2.0.
-autoinstrumentation-dotnet=1.2.0
+autoinstrumentation-dotnet=1.15.0
 
 # Represents the current release of Go instrumentation.
 autoinstrumentation-go=v0.23.0


### PR DESCRIPTION
**Description:**

Upgrade to dotnet 1.15.0 instrumentation by default and set 1.3.0 as a blocked version.

Also fix a minor bug in the interval check for blocked instrumentation versions.

**Link to tracking Issue(s):**

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/4996

**Testing:**
Added a unit test and integration tests.

