### PR TITLE
fix(webhook): check probes and scrapeconfigs RBAC only when CRDs exist

### DIFF
--- a/.chloggen/fix-4456-ta-rbac-probes-scrapeconfigs.yaml
+++ b/.chloggen/fix-4456-ta-rbac-probes-scrapeconfigs.yaml
@@ -1,0 +1,14 @@
+change_type: bug_fix
+
+component: target allocator
+
+note: "Webhook RBAC check for PrometheusCR now validates permissions for `probes` and `scrapeconfigs` in addition to `servicemonitors` and `podmonitors`, only for CRDs that are installed in the cluster."
+
+issues: [4456]
+
+subtext: |
+  Previously, the Target Allocator webhook only checked RBAC for `servicemonitors` and
+  `podmonitors`. The fix detects which `monitoring.coreos.com` CRDs are present via the
+  autodetect package at startup and stores the list in operator config. The webhook then
+  checks RBAC only for those CRDs, avoiding false warnings when prometheus-operator is
+  not installed.

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -33,7 +33,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/gatewayapi"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/opampbridge"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
-	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/targetallocator"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/controllers"
@@ -124,7 +123,7 @@ func runOperator(cfg config.Config, configFile string, opts zap.Options, feature
 		}
 	}
 
-	if result.Config.PrometheusCRAvailability == prometheus.Available {
+	if result.Config.PrometheusCRAvailability.Available() {
 		setupLog.Info("Prometheus CRDs are installed, adding to scheme.")
 		utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	} else {
@@ -248,7 +247,7 @@ func runOperator(cfg config.Config, configFile string, opts zap.Options, feature
 		}
 	}
 
-	if result.Config.PrometheusCRAvailability == prometheus.Available && result.Config.CreateServiceMonitorOperatorMetrics {
+	if result.Config.PrometheusCRAvailability.AvailableServiceMonitor() && result.Config.CreateServiceMonitorOperatorMetrics {
 		operatorMetrics, opError := operatormetrics.NewOperatorMetrics(mgr.GetConfig(), scheme, ctrl.Log.WithName("operator-metrics-sm"))
 		if opError != nil {
 			setupLog.Error(opError, "Failed to create the operator metrics SM")

--- a/cmd/webhook/webhook.go
+++ b/cmd/webhook/webhook.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
-	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	operatorsetup "github.com/open-telemetry/opentelemetry-operator/internal/operator"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
@@ -69,7 +68,7 @@ func runWebhookServer(cfg config.Config, configFile string, opts zap.Options, sc
 
 	mgr := result.Manager
 
-	if result.Config.PrometheusCRAvailability == prometheus.Available {
+	if result.Config.PrometheusCRAvailability.Available() {
 		setupLog.Info("Prometheus CRDs are installed, adding to scheme.")
 		utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	}

--- a/internal/autodetect/main.go
+++ b/internal/autodetect/main.go
@@ -34,7 +34,7 @@ var _ AutoDetect = (*autoDetect)(nil)
 // AutoDetect provides an assortment of routines that auto-detect traits based on the runtime.
 type AutoDetect interface {
 	OpenShiftRoutesAvailability() (openshift.RoutesAvailability, error)
-	PrometheusCRsAvailability() (prometheus.Availability, error)
+	PrometheusCRsAvailability() (prometheus.AvailableCRDs, error)
 	RBACPermissions(ctx context.Context) (autoRBAC.Availability, error)
 	CertManagerAvailability(ctx context.Context) (certmanager.Availability, error)
 	TargetAllocatorAvailability() (targetallocator.Availability, error)
@@ -72,41 +72,39 @@ func New(restConfig *rest.Config, reviewer *rbac.Reviewer) (AutoDetect, error) {
 	}, nil
 }
 
-// PrometheusCRsAvailability checks if Prometheus CRDs are available.
-func (a *autoDetect) PrometheusCRsAvailability() (prometheus.Availability, error) {
+var prometheusCRDNames = []string{
+	"servicemonitors",
+	"podmonitors",
+	"probes",
+	"scrapeconfigs",
+}
+
+// PrometheusCRsAvailability returns the list of monitoring.coreos.com CRD resource names
+// (e.g. "servicemonitors", "podmonitors") that are installed in the cluster.
+func (a *autoDetect) PrometheusCRsAvailability() (prometheus.AvailableCRDs, error) {
 	apiList, err := a.dcl.ServerGroups()
 	if err != nil {
-		return prometheus.NotAvailable, err
+		return nil, err
 	}
 
-	foundServiceMonitor := false
-	foundPodMonitor := false
-	apiGroups := apiList.Groups
-	for i := range apiGroups {
-		if apiGroups[i].Name == "monitoring.coreos.com" {
-			for _, version := range apiGroups[i].Versions {
-				resources, err := a.dcl.ServerResourcesForGroupVersion(version.GroupVersion)
-				if err != nil {
-					return prometheus.NotAvailable, err
-				}
-
-				for _, resource := range resources.APIResources {
-					switch resource.Kind {
-					case "ServiceMonitor":
-						foundServiceMonitor = true
-					case "PodMonitor":
-						foundPodMonitor = true
-					}
+	var available prometheus.AvailableCRDs
+	for _, group := range apiList.Groups {
+		if group.Name != "monitoring.coreos.com" {
+			continue
+		}
+		for _, v := range group.Versions {
+			resources, err := a.dcl.ServerResourcesForGroupVersion(v.GroupVersion)
+			if err != nil {
+				return nil, err
+			}
+			for _, r := range resources.APIResources {
+				if slices.Contains(prometheusCRDNames, r.Name) {
+					available = append(available, r.Name)
 				}
 			}
 		}
 	}
-
-	if foundServiceMonitor && foundPodMonitor {
-		return prometheus.Available, nil
-	}
-
-	return prometheus.NotAvailable, nil
+	return available, nil
 }
 
 // OpenShiftRoutesAvailability checks if OpenShift Route are available.

--- a/internal/autodetect/main_test.go
+++ b/internal/autodetect/main_test.go
@@ -83,12 +83,12 @@ func TestDetectPlatformBasedOnAvailableAPIGroupsPrometheus(t *testing.T) {
 	for _, tt := range []struct {
 		apiGroupList *metav1.APIGroupList
 		resources    *metav1.APIResourceList
-		expected     prometheus.Availability
+		expected     prometheus.AvailableCRDs
 	}{
 		{
 			&metav1.APIGroupList{},
 			&metav1.APIResourceList{},
-			prometheus.NotAvailable,
+			nil,
 		},
 		{
 			&metav1.APIGroupList{
@@ -100,9 +100,9 @@ func TestDetectPlatformBasedOnAvailableAPIGroupsPrometheus(t *testing.T) {
 				},
 			},
 			&metav1.APIResourceList{
-				APIResources: []metav1.APIResource{{Kind: "ServiceMonitor"}},
+				APIResources: []metav1.APIResource{{Name: "servicemonitors"}},
 			},
-			prometheus.NotAvailable,
+			prometheus.AvailableCRDs{"servicemonitors"},
 		},
 		{
 			&metav1.APIGroupList{
@@ -114,9 +114,9 @@ func TestDetectPlatformBasedOnAvailableAPIGroupsPrometheus(t *testing.T) {
 				},
 			},
 			&metav1.APIResourceList{
-				APIResources: []metav1.APIResource{{Kind: "PodMonitor"}},
+				APIResources: []metav1.APIResource{{Name: "podmonitors"}},
 			},
-			prometheus.NotAvailable,
+			prometheus.AvailableCRDs{"podmonitors"},
 		},
 		{
 			&metav1.APIGroupList{
@@ -128,9 +128,11 @@ func TestDetectPlatformBasedOnAvailableAPIGroupsPrometheus(t *testing.T) {
 				},
 			},
 			&metav1.APIResourceList{
-				APIResources: []metav1.APIResource{{Kind: "PodMonitor"}, {Kind: "ServiceMonitor"}},
+				APIResources: []metav1.APIResource{
+					{Name: "servicemonitors"}, {Name: "podmonitors"}, {Name: "probes"}, {Name: "scrapeconfigs"},
+				},
 			},
-			prometheus.Available,
+			prometheus.AvailableCRDs{"servicemonitors", "podmonitors", "probes", "scrapeconfigs"},
 		},
 	} {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -361,8 +363,8 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 		OpenShiftRoutesAvailabilityFunc: func() (openshift.RoutesAvailability, error) {
 			return openshift.RoutesAvailable, nil
 		},
-		PrometheusCRsAvailabilityFunc: func() (prometheus.Availability, error) {
-			return prometheus.Available, nil
+		PrometheusCRsAvailabilityFunc: func() (prometheus.AvailableCRDs, error) {
+			return prometheus.AvailableCRDs{"servicemonitors", "podmonitors", "probes", "scrapeconfigs"}, nil
 		},
 		RBACPermissionsFunc: func(context.Context) (autoRBAC.Availability, error) {
 			return autoRBAC.Available, nil
@@ -384,7 +386,7 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 
 	// sanity check
 	require.Equal(t, openshift.RoutesNotAvailable, cfg.OpenShiftRoutesAvailability)
-	require.Equal(t, prometheus.NotAvailable, cfg.PrometheusCRAvailability)
+	require.Empty(t, cfg.PrometheusCRAvailability)
 	require.Equal(t, autoRBAC.NotAvailable, cfg.CreateRBACPermissions)
 	require.Equal(t, certmanager.NotAvailable, cfg.CertManagerAvailability)
 	require.Equal(t, targetallocator.NotAvailable, cfg.TargetAllocatorAvailability)
@@ -397,7 +399,7 @@ func TestConfigChangesOnAutoDetect(t *testing.T) {
 
 	// verify
 	assert.Equal(t, openshift.RoutesAvailable, cfg.OpenShiftRoutesAvailability)
-	require.Equal(t, prometheus.Available, cfg.PrometheusCRAvailability)
+	require.Equal(t, prometheus.AvailableCRDs{"servicemonitors", "podmonitors", "probes", "scrapeconfigs"}, cfg.PrometheusCRAvailability)
 	require.Equal(t, autoRBAC.Available, cfg.CreateRBACPermissions)
 	require.Equal(t, certmanager.Available, cfg.CertManagerAvailability)
 	require.Equal(t, targetallocator.Available, cfg.TargetAllocatorAvailability)
@@ -409,7 +411,7 @@ var _ autodetect.AutoDetect = (*mockAutoDetect)(nil)
 
 type mockAutoDetect struct {
 	OpenShiftRoutesAvailabilityFunc func() (openshift.RoutesAvailability, error)
-	PrometheusCRsAvailabilityFunc   func() (prometheus.Availability, error)
+	PrometheusCRsAvailabilityFunc   func() (prometheus.AvailableCRDs, error)
 	RBACPermissionsFunc             func(ctx context.Context) (autoRBAC.Availability, error)
 	CertManagerAvailabilityFunc     func(ctx context.Context) (certmanager.Availability, error)
 	TargetAllocatorAvailabilityFunc func() (targetallocator.Availability, error)
@@ -444,11 +446,11 @@ func (m *mockAutoDetect) OpenShiftRoutesAvailability() (openshift.RoutesAvailabi
 	return openshift.RoutesNotAvailable, nil
 }
 
-func (m *mockAutoDetect) PrometheusCRsAvailability() (prometheus.Availability, error) {
+func (m *mockAutoDetect) PrometheusCRsAvailability() (prometheus.AvailableCRDs, error) {
 	if m.PrometheusCRsAvailabilityFunc != nil {
 		return m.PrometheusCRsAvailabilityFunc()
 	}
-	return prometheus.NotAvailable, nil
+	return nil, nil
 }
 
 func (m *mockAutoDetect) RBACPermissions(ctx context.Context) (autoRBAC.Availability, error) {

--- a/internal/autodetect/prometheus/operator.go
+++ b/internal/autodetect/prometheus/operator.go
@@ -3,17 +3,20 @@
 
 package prometheus
 
-// Availability represents what CRDs are available from the prometheus operator.
-type Availability int
+import "slices"
 
-const (
-	// NotAvailable represents the monitoring.coreos.com is not available.
-	NotAvailable Availability = iota
+// AvailableCRDs represents the list of monitoring.coreos.com CRD resource names
+// available in the cluster (e.g. "servicemonitors", "podmonitors", "probes", "scrapeconfigs").
+type AvailableCRDs []string
 
-	// Available represents the monitoring.coreos.com is available.
-	Available
-)
+func (a AvailableCRDs) Available() bool {
+	return len(a) > 0
+}
 
-func (p Availability) String() string {
-	return [...]string{"NotAvailable", "Available"}[p]
+func (a AvailableCRDs) AvailableServiceMonitor() bool {
+	return slices.Contains(a, "servicemonitors")
+}
+
+func (a AvailableCRDs) AvailablePodMonitor() bool {
+	return slices.Contains(a, "podmonitors")
 }

--- a/internal/autodetect/prometheus/operator_test.go
+++ b/internal/autodetect/prometheus/operator_test.go
@@ -1,26 +1,64 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package prometheus
+package prometheus_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 )
 
-func TestAvailabilityString(t *testing.T) {
-	tests := []struct {
-		name         string
-		availability Availability
-		want         string
+func TestAvailableCRDsMethods(t *testing.T) {
+	for _, tt := range []struct {
+		name                    string
+		crds                    prometheus.AvailableCRDs
+		available               bool
+		availableServiceMonitor bool
+		availablePodMonitor     bool
 	}{
-		{"not available", NotAvailable, "NotAvailable"},
-		{"available", Available, "Available"},
-	}
-	for _, tt := range tests {
+		{
+			name:                    "nil",
+			crds:                    nil,
+			available:               false,
+			availableServiceMonitor: false,
+			availablePodMonitor:     false,
+		},
+		{
+			name:                    "empty",
+			crds:                    prometheus.AvailableCRDs{},
+			available:               false,
+			availableServiceMonitor: false,
+			availablePodMonitor:     false,
+		},
+		{
+			name:                    "servicemonitors only",
+			crds:                    prometheus.AvailableCRDs{"servicemonitors"},
+			available:               true,
+			availableServiceMonitor: true,
+			availablePodMonitor:     false,
+		},
+		{
+			name:                    "podmonitors only",
+			crds:                    prometheus.AvailableCRDs{"podmonitors"},
+			available:               true,
+			availableServiceMonitor: false,
+			availablePodMonitor:     true,
+		},
+		{
+			name:                    "all CRDs",
+			crds:                    prometheus.AvailableCRDs{"servicemonitors", "podmonitors", "probes", "scrapeconfigs"},
+			available:               true,
+			availableServiceMonitor: true,
+			availablePodMonitor:     true,
+		},
+	} {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.availability.String())
+			assert.Equal(t, tt.available, tt.crds.Available())
+			assert.Equal(t, tt.availableServiceMonitor, tt.crds.AvailableServiceMonitor())
+			assert.Equal(t, tt.availablePodMonitor, tt.crds.AvailablePodMonitor())
 		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,8 +94,8 @@ type Config struct {
 	OpenShiftRoutesAvailability openshift.RoutesAvailability `yaml:"open-shift-routes-availability"`
 	// GatewayAPIsAvailability represents the availability of the Gateway APIs.
 	GatewayAPIsAvailability gatewayapi.ApiAvailability `yaml:"gateway-apis-availability"`
-	// PrometheusCRAvailability represents the availability of the Prometheus Operator CRDs.
-	PrometheusCRAvailability prometheus.Availability `yaml:"prometheus-cr-availability"`
+	// PrometheusCRAvailability holds the list of monitoring.coreos.com CRD resource names available in the cluster.
+	PrometheusCRAvailability prometheus.AvailableCRDs `yaml:"prometheus-cr-availability"`
 	// CertManagerAvailability represents the availability of the Cert-Manager.
 	CertManagerAvailability certmanager.Availability `yaml:"cert-manager-availability"`
 	// TargetAllocatorAvailability represents the availability of the TargetAllocator CRD.
@@ -198,7 +198,7 @@ func New() Config {
 		TargetAllocatorConfigMapEntry:       defaultTargetAllocatorConfigMapEntry,
 		OperatorOpAMPBridgeConfigMapEntry:   defaultOperatorOpAMPBridgeConfigMapEntry,
 		OpenShiftRoutesAvailability:         openshift.RoutesNotAvailable,
-		PrometheusCRAvailability:            prometheus.NotAvailable,
+		PrometheusCRAvailability:            nil,
 		CertManagerAvailability:             certmanager.NotAvailable,
 		TargetAllocatorAvailability:         targetallocator.NotAvailable,
 		CollectorAvailability:               collector.NotAvailable,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -60,7 +60,6 @@ func TestToStringMap(t *testing.T) {
 		"openshift-webhook-replicas":              "0",
 		"pprof-addr":                              "",
 		"health-probe-addr":                       "",
-		"prometheus-cr-availability":              "0",
 		"target-allocator-availability":           "0",
 		"target-allocator-configmap-entry":        "",
 		"targetallocator-image":                   "",

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -23,7 +23,6 @@ auto-instrumentation-node-js-image: ghcr.io/open-telemetry/opentelemetry-operato
 auto-instrumentation-java-image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:0.0.0
 openshift-create-dashboard: false
 open-shift-routes-availability: 1
-prometheus-cr-availability: 0
 cert-manager-availability: 0
 target-allocator-availability: 0
 collector-availability: 0

--- a/internal/controllers/opampbridge_controller_test.go
+++ b/internal/controllers/opampbridge_controller_test.go
@@ -38,8 +38,8 @@ var (
 		OpenShiftRoutesAvailabilityFunc: func() (openshift.RoutesAvailability, error) {
 			return openshift.RoutesAvailable, nil
 		},
-		PrometheusCRsAvailabilityFunc: func() (prometheus.Availability, error) {
-			return prometheus.Available, nil
+		PrometheusCRsAvailabilityFunc: func() (prometheus.AvailableCRDs, error) {
+			return prometheus.AvailableCRDs{"servicemonitors", "podmonitors"}, nil
 		},
 		RBACPermissionsFunc: func(context.Context) (rbac.Availability, error) {
 			return rbac.Available, nil

--- a/internal/controllers/opentelemetrycollector_controller.go
+++ b/internal/controllers/opentelemetrycollector_controller.go
@@ -37,7 +37,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/gatewayapi"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
-	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
@@ -408,8 +407,10 @@ func (r *OpenTelemetryCollectorReconciler) GetOwnedResourceTypes() []client.Obje
 		ownedResources = append(ownedResources, &rbacv1.ClusterRoleBinding{})
 	}
 
-	if r.config.PrometheusCRAvailability == prometheus.Available {
+	if r.config.PrometheusCRAvailability.AvailablePodMonitor() {
 		ownedResources = append(ownedResources, &monitoringv1.PodMonitor{})
+	}
+	if r.config.PrometheusCRAvailability.AvailableServiceMonitor() {
 		ownedResources = append(ownedResources, &monitoringv1.ServiceMonitor{})
 	}
 

--- a/internal/controllers/reconcile_test.go
+++ b/internal/controllers/reconcile_test.go
@@ -616,7 +616,7 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 				CollectorImage:                "default-collector",
 				TargetAllocatorImage:          "default-ta-allocator",
 				OpenShiftRoutesAvailability:   openshift.RoutesAvailable,
-				PrometheusCRAvailability:      prometheus.Available,
+				PrometheusCRAvailability:      prometheus.AvailableCRDs{"servicemonitors", "podmonitors"},
 				TargetAllocatorConfigMapEntry: "remoteconfiguration.yaml",
 				CollectorConfigMapEntry:       "collector.yaml",
 				EnableInstrumentationCRDs:     true,
@@ -794,7 +794,7 @@ func TestOpenTelemetryCollectorReconciler_RemoveDisabled(t *testing.T) {
 		TargetAllocatorImage:        "default-ta-allocator",
 		CollectorConfigMapEntry:     "collector.yaml",
 		OpenShiftRoutesAvailability: openshift.RoutesAvailable,
-		PrometheusCRAvailability:    prometheus.Available,
+		PrometheusCRAvailability:    prometheus.AvailableCRDs{"servicemonitors", "podmonitors"},
 		EnableInstrumentationCRDs:   true,
 	}
 	reconciler := createTestReconciler(t, testCtx, cfg)

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -88,7 +88,7 @@ var _ autodetect.AutoDetect = (*mockAutoDetect)(nil)
 
 type mockAutoDetect struct {
 	OpenShiftRoutesAvailabilityFunc func() (openshift.RoutesAvailability, error)
-	PrometheusCRsAvailabilityFunc   func() (prometheus.Availability, error)
+	PrometheusCRsAvailabilityFunc   func() (prometheus.AvailableCRDs, error)
 	RBACPermissionsFunc             func(ctx context.Context) (autoRBAC.Availability, error)
 	CertManagerAvailabilityFunc     func(ctx context.Context) (certmanager.Availability, error)
 	TargetAllocatorAvailabilityFunc func() (targetallocator.Availability, error)
@@ -112,11 +112,11 @@ func (m *mockAutoDetect) OpenShiftRoutesAvailability() (openshift.RoutesAvailabi
 	return openshift.RoutesNotAvailable, nil
 }
 
-func (m *mockAutoDetect) PrometheusCRsAvailability() (prometheus.Availability, error) {
+func (m *mockAutoDetect) PrometheusCRsAvailability() (prometheus.AvailableCRDs, error) {
 	if m.PrometheusCRsAvailabilityFunc != nil {
 		return m.PrometheusCRsAvailabilityFunc()
 	}
-	return prometheus.NotAvailable, nil
+	return nil, nil
 }
 
 func (m *mockAutoDetect) RBACPermissions(ctx context.Context) (autoRBAC.Availability, error) {
@@ -213,6 +213,7 @@ func TestMain(m *testing.M) {
 		fmt.Printf("failed to SetupWebhookWithManager: %v", err)
 		os.Exit(1)
 	}
+
 	if err = wh.SetupTargetAllocatorWebhook(mgr, config.New(), reviewer); err != nil {
 		fmt.Printf("failed to SetupWebhookWithManager: %v", err)
 		os.Exit(1)

--- a/internal/controllers/targetallocator_controller.go
+++ b/internal/controllers/targetallocator_controller.go
@@ -30,7 +30,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
-	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/targetallocator"
 	taStatus "github.com/open-telemetry/opentelemetry-operator/internal/status/targetallocator"
@@ -194,8 +193,10 @@ func (r *TargetAllocatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&policyV1.PodDisruptionBudget{})
 
-	if r.config.PrometheusCRAvailability == prometheus.Available {
+	if r.config.PrometheusCRAvailability.AvailableServiceMonitor() {
 		ctrlBuilder.Owns(&monitoringv1.ServiceMonitor{})
+	}
+	if r.config.PrometheusCRAvailability.AvailablePodMonitor() {
 		ctrlBuilder.Owns(&monitoringv1.PodMonitor{})
 	}
 

--- a/internal/manifests/collector/collector_test.go
+++ b/internal/manifests/collector/collector_test.go
@@ -15,8 +15,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	autoRbac "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	irbac "github.com/open-telemetry/opentelemetry-operator/internal/rbac"
@@ -209,7 +209,7 @@ func TestBuild(t *testing.T) {
 					},
 				},
 				Config: config.Config{
-					PrometheusCRAvailability: prometheus.Available,
+					PrometheusCRAvailability: prometheus.AvailableCRDs{"servicemonitors", "podmonitors"},
 				},
 			},
 			expectedObjects: 3,
@@ -260,7 +260,7 @@ func TestBuild(t *testing.T) {
 					},
 				},
 				Config: config.Config{
-					PrometheusCRAvailability: prometheus.Available,
+					PrometheusCRAvailability: prometheus.AvailableCRDs{"servicemonitors", "podmonitors"},
 				},
 			},
 			expectedObjects: 6,
@@ -297,7 +297,7 @@ func TestBuild(t *testing.T) {
 					},
 				},
 				Config: config.Config{
-					PrometheusCRAvailability: prometheus.Available,
+					PrometheusCRAvailability: prometheus.AvailableCRDs{"servicemonitors", "podmonitors"},
 				},
 			},
 			expectedObjects: 9,
@@ -336,7 +336,7 @@ func TestBuild(t *testing.T) {
 						},
 					},
 				},
-				Config: config.Config{PrometheusCRAvailability: prometheus.Available},
+				Config: config.Config{PrometheusCRAvailability: prometheus.AvailableCRDs{"servicemonitors", "podmonitors"}},
 			},
 			expectedObjects: 9,
 			wantErr:         true,

--- a/internal/manifests/collector/configmap_test.go
+++ b/internal/manifests/collector/configmap_test.go
@@ -146,7 +146,7 @@ service:
 			CollectorImage:              defaultCollectorImage,
 			TargetAllocatorImage:        defaultTaAllocationImage,
 			OpenShiftRoutesAvailability: openshift.RoutesAvailable,
-			PrometheusCRAvailability:    prometheus.Available,
+			PrometheusCRAvailability:    prometheus.AvailableCRDs{"servicemonitors", "podmonitors"},
 			CertManagerAvailability:     certmanager.Available,
 		})
 		require.NoError(t, err)
@@ -210,7 +210,7 @@ service:
 			CollectorImage:              defaultCollectorImage,
 			TargetAllocatorImage:        defaultTaAllocationImage,
 			OpenShiftRoutesAvailability: openshift.RoutesAvailable,
-			PrometheusCRAvailability:    prometheus.Available,
+			PrometheusCRAvailability:    prometheus.AvailableCRDs{"servicemonitors", "podmonitors"},
 			CertManagerAvailability:     certmanager.Available,
 		})
 		require.NoError(t, err)
@@ -257,7 +257,7 @@ service:
 			CollectorImage:              defaultCollectorImage,
 			TargetAllocatorImage:        defaultTaAllocationImage,
 			OpenShiftRoutesAvailability: openshift.RoutesAvailable,
-			PrometheusCRAvailability:    prometheus.Available,
+			PrometheusCRAvailability:    prometheus.AvailableCRDs{"servicemonitors", "podmonitors"},
 			CertManagerAvailability:     certmanager.Available,
 		})
 		require.NoError(t, err)

--- a/internal/manifests/collector/podmonitor.go
+++ b/internal/manifests/collector/podmonitor.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
@@ -84,7 +83,7 @@ func shouldCreatePodMonitor(params manifests.Params) bool {
 	case !params.OtelCol.Spec.Observability.Metrics.EnableMetrics:
 		l.V(2).Info("Metrics disabled for this OTEL Collector. PodMonitor will not ve created")
 		return false
-	case params.Config.PrometheusCRAvailability == prometheus.NotAvailable:
+	case !params.Config.PrometheusCRAvailability.AvailablePodMonitor():
 		l.V(2).Info("Cannot enable PodMonitor when prometheus CRDs are unavailable")
 		return false
 	case params.OtelCol.Spec.Mode != v1beta1.ModeSidecar:

--- a/internal/manifests/collector/podmonitor_test.go
+++ b/internal/manifests/collector/podmonitor_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
-	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 )
@@ -70,7 +69,7 @@ func TestDesiredPodMonitorsPrometheusNotAvailable(t *testing.T) {
 		CollectorImage:              defaultCollectorImage,
 		TargetAllocatorImage:        defaultTaAllocationImage,
 		OpenShiftRoutesAvailability: openshift.RoutesAvailable,
-		PrometheusCRAvailability:    prometheus.NotAvailable,
+		PrometheusCRAvailability:    nil,
 	})
 	assert.NoError(t, err)
 	params.OtelCol.Spec.Mode = v1beta1.ModeSidecar

--- a/internal/manifests/collector/servicemonitor.go
+++ b/internal/manifests/collector/servicemonitor.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
-	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
@@ -86,7 +85,7 @@ func shouldCreateServiceMonitor(params manifests.Params) bool {
 	case !params.OtelCol.Spec.Observability.Metrics.EnableMetrics:
 		l.V(2).Info("Metrics disabled for this OTEL Collector. ServiceMonitor will not ve created")
 		return false
-	case params.Config.PrometheusCRAvailability == prometheus.NotAvailable:
+	case !params.Config.PrometheusCRAvailability.AvailableServiceMonitor():
 		l.V(2).Info("Cannot enable ServiceMonitor when prometheus CRDs are unavailable")
 		return false
 	case params.OtelCol.Spec.Mode == v1beta1.ModeSidecar:

--- a/internal/manifests/collector/servicemonitor_test.go
+++ b/internal/manifests/collector/servicemonitor_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
-	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 )
 
@@ -69,7 +68,7 @@ func TestDesiredServiceMonitorsPrometheusNotAvailable(t *testing.T) {
 		CollectorImage:              defaultCollectorImage,
 		TargetAllocatorImage:        defaultTaAllocationImage,
 		OpenShiftRoutesAvailability: openshift.RoutesAvailable,
-		PrometheusCRAvailability:    prometheus.NotAvailable,
+		PrometheusCRAvailability:    nil,
 	})
 	assert.NoError(t, err)
 	params.OtelCol.Spec.Observability.Metrics.EnableMetrics = true

--- a/internal/manifests/collector/suite_test.go
+++ b/internal/manifests/collector/suite_test.go
@@ -50,7 +50,7 @@ func paramsWithMode(mode v1beta1.Mode) manifests.Params {
 	cfg2 := config.Config{
 		CollectorImage:           defaultCollectorImage,
 		TargetAllocatorImage:     defaultTaAllocationImage,
-		PrometheusCRAvailability: prometheus.Available,
+		PrometheusCRAvailability: prometheus.AvailableCRDs{"servicemonitors", "podmonitors"},
 	}
 
 	return manifests.Params{
@@ -117,7 +117,7 @@ func newParams(taContainerImage, file string, cfg *config.Config) (manifests.Par
 			CollectorImage:              defaultCollectorImage,
 			TargetAllocatorImage:        defaultTaAllocationImage,
 			OpenShiftRoutesAvailability: openshift.RoutesAvailable,
-			PrometheusCRAvailability:    prometheus.Available,
+			PrometheusCRAvailability:    prometheus.AvailableCRDs{"servicemonitors", "podmonitors"},
 		}
 	}
 

--- a/internal/webhook/collector_webhook.go
+++ b/internal/webhook/collector_webhook.go
@@ -362,7 +362,7 @@ func (c CollectorWebhook) validateTargetAllocatorConfig(ctx context.Context, r *
 			saname = naming.TargetAllocatorServiceAccount(r.Name)
 		}
 		warnings, err := checkTargetAllocatorPrometheusCRPolicyRules(
-			ctx, c.reviewer, r.GetNamespace(), saname)
+			ctx, c.reviewer, c.cfg.PrometheusCRAvailability, r.GetNamespace(), saname)
 		if err != nil || len(warnings) > 0 {
 			return warnings, err
 		}

--- a/internal/webhook/collector_webhook_test.go
+++ b/internal/webhook/collector_webhook_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
@@ -735,8 +736,10 @@ func TestOTELColValidatingWebhook(t *testing.T) {
 				},
 			},
 			expectedWarnings: []string{
-				"missing the following rules for system:serviceaccount:test-ns:adm-warning-targetallocator - monitoring.coreos.com/servicemonitors: [*]",
-				"missing the following rules for system:serviceaccount:test-ns:adm-warning-targetallocator - monitoring.coreos.com/podmonitors: [*]",
+				"missing the following rules for system:serviceaccount:test-ns:adm-warning-targetallocator - monitoring.coreos.com/servicemonitors: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:adm-warning-targetallocator - monitoring.coreos.com/podmonitors: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:adm-warning-targetallocator - monitoring.coreos.com/probes: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:adm-warning-targetallocator - monitoring.coreos.com/scrapeconfigs: [get,list,watch]",
 				"missing the following rules for system:serviceaccount:test-ns:adm-warning-targetallocator - nodes/metrics: [get,list,watch]",
 				"missing the following rules for system:serviceaccount:test-ns:adm-warning-targetallocator - services: [get,list,watch]",
 				"missing the following rules for system:serviceaccount:test-ns:adm-warning-targetallocator - endpoints: [get,list,watch]",
@@ -1438,6 +1441,9 @@ func TestOTELColValidatingWebhook(t *testing.T) {
 			cfg := config.Config{
 				CollectorImage:       "default-collector",
 				TargetAllocatorImage: "default-ta-allocator",
+				PrometheusCRAvailability: prometheus.AvailableCRDs{
+					"servicemonitors", "podmonitors", "probes", "scrapeconfigs",
+				},
 			}
 			cvw := webhook.NewCollectorWebhook(
 				logr.Discard(),

--- a/internal/webhook/targetallocator_rbac.go
+++ b/internal/webhook/targetallocator_rbac.go
@@ -9,16 +9,13 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/rbac"
 )
 
 // targetAllocatorCRPolicyRules are the policy rules required for the CR functionality.
 var targetAllocatorCRPolicyRules = []*rbacv1.PolicyRule{
 	{
-		APIGroups: []string{"monitoring.coreos.com"},
-		Resources: []string{"servicemonitors", "podmonitors"},
-		Verbs:     []string{"*"},
-	}, {
 		APIGroups: []string{""},
 		Resources: []string{"nodes", "nodes/metrics", "services", "endpoints", "pods", "namespaces"},
 		Verbs:     []string{"get", "list", "watch"},
@@ -46,14 +43,25 @@ var targetAllocatorCRPolicyRules = []*rbacv1.PolicyRule{
 func checkTargetAllocatorPrometheusCRPolicyRules(
 	ctx context.Context,
 	reviewer *rbac.Reviewer,
+	availableCRDs prometheus.AvailableCRDs,
 	namespace string,
 	serviceAccountName string,
 ) (warnings []string, err error) {
+	rules := targetAllocatorCRPolicyRules
+
+	if availableCRDs.Available() {
+		rules = append(rules, &rbacv1.PolicyRule{
+			APIGroups: []string{"monitoring.coreos.com"},
+			Resources: []string(availableCRDs),
+			Verbs:     []string{"get", "list", "watch"},
+		})
+	}
+
 	subjectAccessReviews, err := reviewer.CheckPolicyRules(
 		ctx,
 		serviceAccountName,
 		namespace,
-		targetAllocatorCRPolicyRules...,
+		rules...,
 	)
 	if err != nil {
 		return []string{}, fmt.Errorf("unable to check rbac rules %w", err)

--- a/internal/webhook/targetallocator_webhook.go
+++ b/internal/webhook/targetallocator_webhook.go
@@ -111,7 +111,7 @@ func (w TargetAllocatorWebhook) validate(ctx context.Context, ta *v1alpha1.Targe
 		if ta.Spec.ServiceAccount == "" {
 			saname = naming.TargetAllocatorServiceAccount(ta.Name)
 		}
-		warnings, err := checkTargetAllocatorPrometheusCRPolicyRules(ctx, w.reviewer, ta.GetNamespace(), saname)
+		warnings, err := checkTargetAllocatorPrometheusCRPolicyRules(ctx, w.reviewer, w.cfg.PrometheusCRAvailability, ta.GetNamespace(), saname)
 		if err != nil || len(warnings) > 0 {
 			return warnings, err
 		}

--- a/internal/webhook/targetallocator_webhook_test.go
+++ b/internal/webhook/targetallocator_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/rbac"
 )
@@ -176,6 +177,8 @@ func TestTargetAllocatorDefaultingWebhook(t *testing.T) {
 func TestTargetAllocatorValidatingWebhook(t *testing.T) {
 	three := int32(3)
 
+	allCRDs := prometheus.AvailableCRDs{"servicemonitors", "podmonitors", "probes", "scrapeconfigs"}
+
 	tests := []struct {
 		name                 string
 		targetallocator      v1alpha1.TargetAllocator
@@ -183,6 +186,7 @@ func TestTargetAllocatorValidatingWebhook(t *testing.T) {
 		expectedWarnings     []string
 		shouldFailSar        bool
 		certManagerAvailable bool
+		availableCRDs        prometheus.AvailableCRDs
 	}{
 		{
 			name:            "valid empty spec",
@@ -216,6 +220,7 @@ func TestTargetAllocatorValidatingWebhook(t *testing.T) {
 		{
 			name:          "prom CR admissions warning",
 			shouldFailSar: true, // force failure
+			availableCRDs: allCRDs,
 			targetallocator: v1alpha1.TargetAllocator{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ta",
@@ -228,8 +233,10 @@ func TestTargetAllocatorValidatingWebhook(t *testing.T) {
 				},
 			},
 			expectedWarnings: []string{
-				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - monitoring.coreos.com/servicemonitors: [*]",
-				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - monitoring.coreos.com/podmonitors: [*]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - monitoring.coreos.com/servicemonitors: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - monitoring.coreos.com/podmonitors: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - monitoring.coreos.com/probes: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - monitoring.coreos.com/scrapeconfigs: [get,list,watch]",
 				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - nodes/metrics: [get,list,watch]",
 				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - services: [get,list,watch]",
 				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - endpoints: [get,list,watch]",
@@ -249,8 +256,43 @@ func TestTargetAllocatorValidatingWebhook(t *testing.T) {
 		{
 			name:          "prom CR no admissions warning",
 			shouldFailSar: false, // force SAR okay
+			availableCRDs: allCRDs,
 			targetallocator: v1alpha1.TargetAllocator{
 				Spec: v1alpha1.TargetAllocatorSpec{},
+			},
+		},
+		{
+			name:          "prom CR admissions warning without probes and scrapeconfigs",
+			shouldFailSar: true,
+			availableCRDs: prometheus.AvailableCRDs{"servicemonitors", "podmonitors"},
+			targetallocator: v1alpha1.TargetAllocator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ta",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.TargetAllocatorSpec{
+					PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
+						Enabled: true,
+					},
+				},
+			},
+			expectedWarnings: []string{
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - monitoring.coreos.com/servicemonitors: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - monitoring.coreos.com/podmonitors: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - nodes/metrics: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - services: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - endpoints: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - namespaces: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - networking.k8s.io/ingresses: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - nodes: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - pods: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - configmaps: [get]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - discovery.k8s.io/endpointslices: [get,list,watch]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - nonResourceURL: /metrics: [get]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - nonResourceURL: /api: [get]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - nonResourceURL: /api/*: [get]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - nonResourceURL: /apis: [get]",
+				"missing the following rules for system:serviceaccount:test-ns:test-ta-targetallocator - nonResourceURL: /apis/*: [get]",
 			},
 		},
 		{
@@ -377,9 +419,10 @@ func TestTargetAllocatorValidatingWebhook(t *testing.T) {
 				cmAvailability = certmanager.Available
 			}
 			cfg := config.Config{
-				CollectorImage:          "targetallocator:v0.0.0",
-				TargetAllocatorImage:    "ta:v0.0.0",
-				CertManagerAvailability: cmAvailability,
+				CollectorImage:           "targetallocator:v0.0.0",
+				TargetAllocatorImage:     "ta:v0.0.0",
+				CertManagerAvailability:  cmAvailability,
+				PrometheusCRAvailability: test.availableCRDs,
 			}
 			cvw := &TargetAllocatorWebhook{
 				logger:   logr.Discard(),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

The webhook RBAC check for PrometheusCR only warned about `servicemonitors` and `podmonitors`,
missing `probes` and `scrapeconfigs`. 

Also, warnings were emitted even when prometheus-operator was not installed in the cluster.

This fix dynamically discovers which `monitoring.coreos.com` CRDs exist in the cluster via the
discovery API, and only includes those in the RBAC check. 

Clusters without prometheus-operator installed will no longer receive false-positive warnings.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #4456

**Testing:** <Describe what testing was performed and which tests were added.>
Updated unit tests in `targetallocator_webhook_test.go` and `collector_webhook_test.go` to cover the new dynamic CRD discovery behavior, including a case where no prometheus-operator CRDs are installed (zero warnings expected).

**Documentation:** <Describe the documentation added.>

