### PR TITLE
[chore] update Scorecard to trigger on each PR & Enabled only SHA Pinned Actions

### DIFF
--- a/.github/workflows/ci-markdown-link.yml
+++ b/.github/workflows/ci-markdown-link.yml
@@ -17,11 +17,11 @@ jobs:
       pull-requests: write # required for posting review comments
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # equivalent cli: linkspector check
       - name: Run linkspector
-        uses: umbrelladocs/action-linkspector@v1
+        uses: umbrelladocs/action-linkspector@963b6264d7de32c904942a70b488d3407453049e # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/e2e-junit-report.yml
+++ b/.github/workflows/e2e-junit-report.yml
@@ -32,7 +32,7 @@ jobs:
           name: 'Event File'
           run_id: ${{ github.event.workflow_run.id || inputs.e2e_workflow_id }}
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: event.json

--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -181,7 +181,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Upload
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Event File
         path: ${{ github.event_path }}

--- a/.github/workflows/ensure-sha-pinned-actions.yml
+++ b/.github/workflows/ensure-sha-pinned-actions.yml
@@ -1,0 +1,25 @@
+name: Ensure SHA Pinned Actions
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ensure-sha-pinned:
+    name: Check for Tag Pinned Actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ca46236c6ce584ae24bc6283ba8dcf4b3ec8a066 # main
+        with:
+          allowlist: |
+            slsa-framework/slsa-github-generator

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "47 6 * * 0" # once a week
   workflow_dispatch:
@@ -27,7 +30,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          publish_results: ${{ github.event_name != 'pull_request' }}
 
       # Upload the results as artifacts (optional). Commenting out will disable
       # uploads of run results in SARIF format to the repository Actions tab.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,25 @@ git commit -sam "Add feature X"
 gh pr create
 ```
 
+#### Signing commits
+
+This repository enforces branch protection rules that require all commits to be signed. This protects against supply chain attacks by ensuring that the code pushed to the repository was authored by a verified contributor.
+
+To set up commit signing, you can use either SSH or GPG keys:
+
+**Using SSH (Recommended):**
+1. Ensure you have an SSH key added to your GitHub account.
+2. Tell Git to use SSH for signing: `git config --global gpg.format ssh`
+3. Set your signing key: `git config --global user.signingkey /path/to/your/ssh/key.pub`
+4. Enable automatic signing: `git config --global commit.gpgsign true`
+
+**Using GPG:**
+1. Generate a GPG key and add it to your GitHub account.
+2. Tell Git to use your GPG key: `git config --global user.signingkey <your-gpg-key-id>`
+3. Enable automatic signing: `git config --global commit.gpgsign true`
+
+For detailed instructions, refer to GitHub's official documentation on [commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
+
 #### Make changes to the project manifests
 
 The following command should be run to make sure the project manifests are up-to-date:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Continuous Integration][github-workflow-img]][github-workflow] [![Go Report Card][goreport-img]][goreport] [![GoDoc][godoc-img]][godoc]
+[![Continuous Integration][github-workflow-img]][github-workflow] [![Go Report Card][goreport-img]][goreport] [![GoDoc][godoc-img]][godoc] [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/open-telemetry/opentelemetry-operator/badge)](https://securityscorecards.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-operator)
 
 # OpenTelemetry Operator for Kubernetes
 


### PR DESCRIPTION
**Description:**
Pin GitHub Actions to full commit SHAs and update OpenSSF Scorecard workflow to trigger on pull requests. .

**Link to tracking Issue(s):**

* Resolves: #5019

**Testing:**

**Documentation:**
Added commit signing instructions (SSH & GPG) to CONTRIBUTING.md and included OpenSSF Scorecard badge in README.
