### PR TITLE
chore(rbac): split kubebuilder RBAC markers and remove unused delete permissions

### DIFF
--- a/.chloggen/split-rbac-markers.yaml
+++ b/.chloggen/split-rbac-markers.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Split kubebuilder RBAC markers and restrict pod permissions to get/list/watch only
+
+# One or more tracking issues related to the change
+issues: [3156]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The operator does not create, update, patch, or delete Pod objects directly;
+  pods are managed by Deployment, DaemonSet, and StatefulSet controllers.
+  Also reduced targetallocators/finalizers to only the `update` verb.

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-04-27T14:53:29Z"
+    createdAt: "2026-05-02T06:43:25Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -304,7 +304,6 @@ spec:
           - ""
           resources:
           - configmaps
-          - pods
           - serviceaccounts
           - services
           verbs:
@@ -319,6 +318,7 @@ spec:
           - ""
           resources:
           - namespaces
+          - pods
           - secrets
           verbs:
           - get
@@ -455,7 +455,6 @@ spec:
           - opampbridges
           - opentelemetrycollectors
           - targetallocators
-          - targetallocators/finalizers
           verbs:
           - create
           - delete
@@ -469,6 +468,7 @@ spec:
           resources:
           - clusterobservabilities/finalizers
           - opampbridges/finalizers
+          - targetallocators/finalizers
           verbs:
           - update
         - apiGroups:

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-04-27T14:53:29Z"
+    createdAt: "2026-05-02T06:43:25Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -304,7 +304,6 @@ spec:
           - ""
           resources:
           - configmaps
-          - pods
           - serviceaccounts
           - services
           verbs:
@@ -319,6 +318,7 @@ spec:
           - ""
           resources:
           - namespaces
+          - pods
           - secrets
           verbs:
           - get
@@ -455,7 +455,6 @@ spec:
           - opampbridges
           - opentelemetrycollectors
           - targetallocators
-          - targetallocators/finalizers
           verbs:
           - create
           - delete
@@ -469,6 +468,7 @@ spec:
           resources:
           - clusterobservabilities/finalizers
           - opampbridges/finalizers
+          - targetallocators/finalizers
           verbs:
           - update
         - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,7 +12,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   - serviceaccounts
   - services
   verbs:
@@ -27,6 +26,7 @@ rules:
   - ""
   resources:
   - namespaces
+  - pods
   - secrets
   verbs:
   - get
@@ -163,7 +163,6 @@ rules:
   - opampbridges
   - opentelemetrycollectors
   - targetallocators
-  - targetallocators/finalizers
   verbs:
   - create
   - delete
@@ -177,6 +176,7 @@ rules:
   resources:
   - clusterobservabilities/finalizers
   - opampbridges/finalizers
+  - targetallocators/finalizers
   verbs:
   - update
 - apiGroups:

--- a/internal/controllers/opentelemetrycollector_controller.go
+++ b/internal/controllers/opentelemetrycollector_controller.go
@@ -209,7 +209,8 @@ func NewReconciler(p Params) *OpenTelemetryCollectorReconciler {
 	return r
 }
 
-// +kubebuilder:rbac:groups="",resources=pods;configmaps;services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps;serviceaccounts;services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets;deployments;statefulsets,verbs=get;list;watch;create;update;patch;delete
@@ -228,7 +229,7 @@ func NewReconciler(p Params) *OpenTelemetryCollectorReconciler {
 // +kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors/finalizers,verbs=get;update;patch
 // +kubebuilder:rbac:groups=opentelemetry.io,resources=targetallocators,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=opentelemetry.io,resources=targetallocators/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=opentelemetry.io,resources=targetallocators/finalizers,verbs=update
 // +kubebuilder:rbac:urls=/version,verbs=get
 
 // Reconcile the current state of an OpenTelemetry collector resource with the desired state.

--- a/internal/controllers/targetallocator_controller.go
+++ b/internal/controllers/targetallocator_controller.go
@@ -135,7 +135,8 @@ func NewTargetAllocatorReconciler(
 	}
 }
 
-// +kubebuilder:rbac:groups="",resources=pods;configmaps;services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps;serviceaccounts;services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
## Summary

Closes #3156.

The operator's ClusterRole granted broad `create;update;patch;delete` permissions on `pods`, but the operator never directly manages Pod objects — pods are created and owned by `Deployment`, `DaemonSet`, and `StatefulSet` controllers. This PR splits the grouped RBAC markers so each resource has only the verbs it actually needs.

**Changes:**

- Split `pods;configmaps;services;serviceaccounts` (which had full write permissions) into two separate annotations:
  - `pods`: `get;list;watch` only (no create/update/patch/delete)
  - `configmaps;serviceaccounts;services`: unchanged full write permissions (these are directly managed and pruned by the operator)
- Reduced `targetallocators/finalizers` from `get;list;watch;create;update;patch;delete` down to `update` — finalizer subresources only need `update` to add/remove the finalizer field
- Regenerated `config/rbac/role.yaml` via `make manifests`

**Rationale:**

The `reconcileDesiredObjects` and `deleteObjects` functions in `internal/controllers/common.go` call `client.Delete` to prune owned objects, so `delete` is legitimately needed for `configmaps`, `services`, `serviceaccounts`, and other directly-managed resources. However, `pods` never appear in `GetOwnedResourceTypes()` and are never passed to `CreateOrUpdate` or `Delete` — the pod mutation webhook operates on admission request objects, not via a direct API client call with write permissions.

## Test plan

- [ ] `make manifests` produces the updated `config/rbac/role.yaml` with reduced pod permissions
- [ ] Existing unit tests pass (`go test ./internal/controllers/...`)
- [ ] Manual verification: operator reconciles collectors in all modes (Deployment, DaemonSet, StatefulSet) without permission errors