### PR TITLE
feat(api): restore CRD field descriptions for operator-owned types

### DIFF
--- a/.chloggen/restore-crd-field-descriptions.yaml
+++ b/.chloggen/restore-crd-field-descriptions.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Restore CRD field descriptions for operator-owned types by setting maxDescLen=128.
+
+# One or more tracking issues related to the change
+issues: [2737]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `make install` target now uses `kubectl apply --server-side` to support the larger
+  CRD payloads that include field descriptions. This allows `kubectl explain` and similar
+  tools to show useful documentation for operator-defined fields.

--- a/Makefile
+++ b/Makefile
@@ -149,8 +149,11 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 MANIFEST_DIR ?= config/crd/bases
 
-# kubectl apply does not work on large CRDs.
-CRD_OPTIONS ?= "crd:generateEmbeddedObjectMeta=true,maxDescLen=0"
+# Use a moderate description length to restore CRD field descriptions for operator-owned
+# types while keeping total CRD size within etcd limits. Use kubectl apply --server-side
+# when applying CRDs to accommodate the larger payload.
+# See: https://github.com/open-telemetry/opentelemetry-operator/issues/2737
+CRD_OPTIONS ?= "crd:generateEmbeddedObjectMeta=true,maxDescLen=128"
 
 # Choose which version to generate
 BUNDLE_VARIANT ?= community
@@ -242,9 +245,10 @@ run: generate fmt vet manifests
 	ENABLE_WEBHOOKS=$(ENABLE_WEBHOOKS) go run -ldflags "${OPERATOR_LDFLAGS}" ./main.go --zap-devel
 
 # Install CRDs into a cluster
+# Use --server-side to support the larger CRDs that include field descriptions.
 .PHONY: install
 install: manifests kustomize
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | kubectl apply --server-side -f -
 
 # Uninstall CRDs from a cluster
 .PHONY: uninstall

--- a/config/crd/bases/opentelemetry.io_clusterobservabilities.yaml
+++ b/config/crd/bases/opentelemetry.io_clusterobservabilities.yaml
@@ -29,87 +29,152 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: ClusterObservability is the Schema for the clusterobservabilities
+          API.
         properties:
           apiVersion:
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
             type: string
           kind:
+            description: Kind is a string value representing the REST resource this
+              object represents.
             type: string
           metadata:
             type: object
           spec:
+            description: ClusterObservabilitySpec defines the desired state of ClusterObservability.
             properties:
               exporter:
+                description: Exporter defines the OTLP HTTP exporter configuration
+                  for all signals.
                 properties:
                   compression:
+                    description: |-
+                      Compression defines the compression algorithm to use.
+                      By default gzip compression is enabled. Use "none" to disable.
                     enum:
                     - gzip
                     - none
                     - ""
                     type: string
                   encoding:
+                    description: |-
+                      Encoding defines the encoding to use for the messages.
+                      Valid options: proto, json. Default is proto.
                     enum:
                     - proto
                     - json
                     type: string
                   endpoint:
+                    description: Endpoint is the target base URL to send data to (e.g.,
+                      https://example.com:4318).
                     type: string
                   headers:
                     additionalProperties:
                       type: string
+                    description: Headers defines additional headers to be sent with
+                      each request.
                     type: object
                   logs_endpoint:
+                    description: LogsEndpoint is the target URL to send log data to
+                      (e.g., https://example.com:4318/v1/logs).
                     type: string
                   metrics_endpoint:
+                    description: MetricsEndpoint is the target URL to send metric
+                      data to (e.g., https://example.com:4318/v1/metrics).
                     type: string
                   profiles_endpoint:
+                    description: ProfilesEndpoint is the target URL to send profile
+                      data to (e.g., https://example.com:4318/v1/development/profiles).
                     type: string
                   read_buffer_size:
+                    description: ReadBufferSize for HTTP client. Default is 0.
                     minimum: 0
                     type: integer
                   retry_on_failure:
+                    description: RetryOnFailure defines retry configuration for failed
+                      requests.
                     properties:
                       enabled:
+                        description: Enabled controls whether retry is enabled. Default
+                          is true.
                         type: boolean
                       initial_interval:
+                        description: InitialInterval is the initial retry interval
+                          (e.g., "5s"). Default is 5s.
                         type: string
                       max_elapsed_time:
+                        description: MaxElapsedTime is the maximum elapsed time for
+                          retries (e.g., "5m"). Default is 5m.
                         type: string
                       max_interval:
+                        description: MaxInterval is the maximum retry interval (e.g.,
+                          "30s"). Default is 30s.
                         type: string
                       multiplier:
+                        description: Multiplier is the multiplier for retry intervals
+                          (e.g., "1.5"). Default is 1.5.
                         type: string
                       randomization_factor:
+                        description: RandomizationFactor is the randomization factor
+                          for retry intervals (e.g., "0.5"). Default is 0.5.
                         type: string
                     type: object
                   sending_queue:
+                    description: SendingQueue defines configuration for the sending
+                      queue.
                     properties:
                       enabled:
+                        description: Enabled controls whether the queue is enabled.
+                          Default is true.
                         type: boolean
                       num_consumers:
+                        description: NumConsumers is the number of consumers that
+                          dequeue batches. Default is 10.
                         minimum: 1
                         type: integer
                       queue_size:
+                        description: QueueSize is the maximum number of batches allowed
+                          in queue at a given time. Default is 1000.
                         minimum: 1
                         type: integer
                     type: object
                   timeout:
+                    description: Timeout is the HTTP request time limit (e.g., "30s",
+                      "1m"). Default is 30s.
                     type: string
                   tls:
+                    description: TLS defines TLS configuration for the exporter.
                     properties:
                       ca_file:
+                        description: CAFile is the path to the CA certificate file
+                          for server verification.
                         type: string
                       cert_file:
+                        description: CertFile is the path to the client certificate
+                          file for mutual TLS.
                         type: string
                       insecure:
+                        description: Insecure controls whether to use insecure transport.
+                          Default is false.
                         type: boolean
                       key_file:
+                        description: KeyFile is the path to the client private key
+                          file for mutual TLS.
                         type: string
                       server_name:
+                        description: ServerName for TLS handshake. If empty, uses
+                          the hostname from endpoint.
                         type: string
                     type: object
                   traces_endpoint:
+                    description: TracesEndpoint is the target URL to send trace data
+                      to (e.g., https://example.com:4318/v1/traces).
                     type: string
                   write_buffer_size:
+                    description: WriteBufferSize for HTTP client. Default is 512 *
+                      1024.
                     minimum: 0
                     type: integer
                 type: object
@@ -117,35 +182,58 @@ spec:
             - exporter
             type: object
           status:
+            description: ClusterObservabilityStatus defines the observed state of
+              ClusterObservability.
             properties:
               componentsStatus:
                 additionalProperties:
+                  description: ComponentStatus represents the status of an individual
+                    component.
                   properties:
                     lastUpdated:
+                      description: LastUpdated is the last time this status was updated.
                       format: date-time
                       type: string
                     message:
+                      description: Message provides additional information about the
+                        component status.
                       type: string
                     ready:
+                      description: Ready indicates whether the component is ready.
                       type: boolean
                   type: object
+                description: ComponentsStatus provides status information about individual
+                  observability components.
                 type: object
               conditions:
+                description: Conditions represent the latest available observations
+                  of the ClusterObservability state.
                 items:
+                  description: ClusterObservabilityCondition represents a condition
+                    of a ClusterObservability.
                   properties:
                     lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
                       format: date-time
                       type: string
                     message:
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     observedGeneration:
+                      description: ObservedGeneration represents the .metadata.generation
+                        that the condition was set based upon.
                       format: int64
                       type: integer
                     reason:
+                      description: The reason for the condition's last transition.
                       type: string
                     status:
+                      description: Status of the condition.
                       type: string
                     type:
+                      description: Type of condition.
                       type: string
                   required:
                   - status
@@ -158,13 +246,20 @@ spec:
               configVersions:
                 additionalProperties:
                   type: string
+                description: ConfigVersions tracks the version hashes of the configuration
+                  files used.
                 type: object
               message:
+                description: Message provides additional information about the current
+                  state.
                 type: string
               observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this ClusterObservability.
                 format: int64
                 type: integer
               phase:
+                description: Phase represents the current phase of the ClusterObservability.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/opentelemetry.io_instrumentations.yaml
+++ b/config/crd/bases/opentelemetry.io_instrumentations.yaml
@@ -33,59 +33,107 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: Instrumentation is the spec for OpenTelemetry instrumentation.
         properties:
           apiVersion:
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
             type: string
           kind:
+            description: Kind is a string value representing the REST resource this
+              object represents.
             type: string
           metadata:
             type: object
           spec:
+            description: InstrumentationSpec defines the desired state of OpenTelemetry
+              SDK and instrumentation.
             properties:
               apacheHttpd:
+                description: ApacheHttpd defines configuration for Apache HTTPD auto-instrumentation.
                 properties:
                   attrs:
+                    description: Attrs defines Apache HTTPD agent specific attributes.
                     items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any...
                           type: string
                         valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
+                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.'
                               properties:
                                 apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
                               properties:
                                 key:
+                                  description: The key within the env file. An invalid
+                                    key will prevent the pod from starting.
                                   type: string
                                 optional:
                                   default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
                                   type: boolean
                                 path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
                                   type: string
                                 volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
                                   type: string
                               required:
                               - key
@@ -94,29 +142,47 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.
                               properties:
                                 containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
+                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -128,49 +194,92 @@ spec:
                       type: object
                     type: array
                   configPath:
+                    description: |-
+                      Location of Apache HTTPD server configuration.
+                      Needed only if different from default "/usr/local/apache2/conf"
                     type: string
                   env:
+                    description: Env defines Apache HTTPD specific env vars.
                     items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any...
                           type: string
                         valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
+                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.'
                               properties:
                                 apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
                               properties:
                                 key:
+                                  description: The key within the env file. An invalid
+                                    key will prevent the pod from starting.
                                   type: string
                                 optional:
                                   default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
                                   type: boolean
                                 path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
                                   type: string
                                 volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
                                   type: string
                               required:
                               - key
@@ -179,29 +288,47 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.
                               properties:
                                 containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
+                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -213,15 +340,26 @@ spec:
                       type: object
                     type: array
                   image:
+                    description: Image is a container image with Apache SDK and auto-instrumentation.
                     type: string
                   resourceRequirements:
+                    description: Resources describes the compute resource requirements.
                     properties:
                       claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
                         items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used.
                               type: string
                             request:
+                              description: Request is the name chosen for a request
+                                in the referenced claim.
                               type: string
                           required:
                           - name
@@ -237,6 +375,9 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.
                         type: object
                       requests:
                         additionalProperties:
@@ -245,13 +386,22 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                   version:
+                    description: Apache HTTPD server version. One of 2.4 or 2.2. Default
+                      is 2.4
                     type: string
                   volumeClaimTemplate:
+                    description: VolumeClaimTemplate defines an ephemeral volume used
+                      for auto-instrumentation.
                     properties:
                       metadata:
+                        description: |-
+                          May contain labels and annotations that will be copied into the PVC
+                          when creating it.
                         properties:
                           annotations:
                             additionalProperties:
@@ -271,19 +421,30 @@ spec:
                             type: string
                         type: object
                       spec:
+                        description: The specification for the PersistentVolumeClaim.
                         properties:
                           accessModes:
+                            description: |-
+                              accessModes contains the desired access modes the volume should have.
+                              More info: https://kubernetes.
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           dataSource:
+                            description: |-
+                              dataSource field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -291,20 +452,32 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
+                            description: |-
+                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                              volume is desired.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
+                                description: |-
+                                  Namespace is the namespace of resource being referenced
+                                  Note that when a namespace is specified, a gateway.networking.k8s.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
+                            description: resources represents the minimum resources
+                              the volume should have.
                             properties:
                               limits:
                                 additionalProperties:
@@ -313,6 +486,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -321,18 +497,35 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           selector:
+                            description: selector is a label query over volumes to
+                              consider for binding.
                             properties:
                               matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
                                 items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
+                                      description: key is the label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty.
                                       items:
                                         type: string
                                       type: array
@@ -346,16 +539,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
+                            description: |-
+                              storageClassName is the name of the StorageClass required by the claim.
+                              More info: https://kubernetes.
                             type: string
                           volumeAttributesClassName:
+                            description: volumeAttributesClassName may be used to
+                              set the VolumeAttributesClass used by this claim.
                             type: string
                           volumeMode:
+                            description: |-
+                              volumeMode defines what type of volume is required by the claim.
+                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
+                            description: volumeName is the binding reference to the
+                              PersistentVolume backing this claim.
                             type: string
                         type: object
                     required:
@@ -365,58 +569,109 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      VolumeSizeLimit defines size limit for volume used for auto-instrumentation.
+                      The default size is 200Mi.
+
+                      Deprecated: use spec.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
               defaults:
+                description: Defaults defines default values for the instrumentation.
                 properties:
                   useLabelsForResourceAttributes:
+                    description: |-
+                      UseLabelsForResourceAttributes defines whether to use common labels for resource attributes:
+                      Note: first entry wins:
+                        - `app.
                     type: boolean
                 type: object
               dotnet:
+                description: DotNet defines configuration for DotNet auto-instrumentation.
                 properties:
                   env:
+                    description: Env defines DotNet specific env vars.
                     items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any...
                           type: string
                         valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
+                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.'
                               properties:
                                 apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
                               properties:
                                 key:
+                                  description: The key within the env file. An invalid
+                                    key will prevent the pod from starting.
                                   type: string
                                 optional:
                                   default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
                                   type: boolean
                                 path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
                                   type: string
                                 volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
                                   type: string
                               required:
                               - key
@@ -425,29 +680,47 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.
                               properties:
                                 containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
+                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -459,15 +732,26 @@ spec:
                       type: object
                     type: array
                   image:
+                    description: Image is a container image with DotNet SDK and auto-instrumentation.
                     type: string
                   resourceRequirements:
+                    description: Resources describes the compute resource requirements.
                     properties:
                       claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
                         items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used.
                               type: string
                             request:
+                              description: Request is the name chosen for a request
+                                in the referenced claim.
                               type: string
                           required:
                           - name
@@ -483,6 +767,9 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.
                         type: object
                       requests:
                         additionalProperties:
@@ -491,11 +778,18 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                   volumeClaimTemplate:
+                    description: VolumeClaimTemplate defines an ephemeral volume used
+                      for auto-instrumentation.
                     properties:
                       metadata:
+                        description: |-
+                          May contain labels and annotations that will be copied into the PVC
+                          when creating it.
                         properties:
                           annotations:
                             additionalProperties:
@@ -515,19 +809,30 @@ spec:
                             type: string
                         type: object
                       spec:
+                        description: The specification for the PersistentVolumeClaim.
                         properties:
                           accessModes:
+                            description: |-
+                              accessModes contains the desired access modes the volume should have.
+                              More info: https://kubernetes.
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           dataSource:
+                            description: |-
+                              dataSource field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -535,20 +840,32 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
+                            description: |-
+                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                              volume is desired.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
+                                description: |-
+                                  Namespace is the namespace of resource being referenced
+                                  Note that when a namespace is specified, a gateway.networking.k8s.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
+                            description: resources represents the minimum resources
+                              the volume should have.
                             properties:
                               limits:
                                 additionalProperties:
@@ -557,6 +874,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -565,18 +885,35 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           selector:
+                            description: selector is a label query over volumes to
+                              consider for binding.
                             properties:
                               matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
                                 items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
+                                      description: key is the label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty.
                                       items:
                                         type: string
                                       type: array
@@ -590,16 +927,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
+                            description: |-
+                              storageClassName is the name of the StorageClass required by the claim.
+                              More info: https://kubernetes.
                             type: string
                           volumeAttributesClassName:
+                            description: volumeAttributesClassName may be used to
+                              set the VolumeAttributesClass used by this claim.
                             type: string
                           volumeMode:
+                            description: |-
+                              volumeMode defines what type of volume is required by the claim.
+                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
+                            description: volumeName is the binding reference to the
+                              PersistentVolume backing this claim.
                             type: string
                         type: object
                     required:
@@ -609,51 +957,95 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      VolumeSizeLimit defines size limit for volume used for auto-instrumentation.
+                      The default size is 200Mi.
+
+                      Deprecated: use spec.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
               env:
+                description: Env defines common env vars.
                 items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
                   properties:
                     name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any...
                       type: string
                     valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
                           properties:
                             key:
+                              description: The key to select.
                               type: string
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.'
                           properties:
                             apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
                               type: string
                           required:
                           - fieldPath
                           type: object
                           x-kubernetes-map-type: atomic
                         fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
                           properties:
                             key:
+                              description: The key within the env file. An invalid
+                                key will prevent the pod from starting.
                               type: string
                             optional:
                               default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
                               type: boolean
                             path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
                               type: string
                             volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
                               type: string
                           required:
                           - key
@@ -662,29 +1054,46 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.
                           properties:
                             containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
+                              description: 'Required: resource to select'
                               type: string
                           required:
                           - resource
                           type: object
                           x-kubernetes-map-type: atomic
                         secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
@@ -696,67 +1105,125 @@ spec:
                   type: object
                 type: array
               exporter:
+                description: Exporter defines exporter configuration.
                 properties:
                   endpoint:
+                    description: |-
+                      Endpoint is address of the collector with OTLP endpoint.
+                      If the endpoint defines https:// scheme TLS has to be specified.
                     type: string
                   tls:
+                    description: |-
+                      TLS defines certificates for TLS.
+                      TLS needs to be enabled by specifying https:// scheme in the Endpoint.
                     properties:
                       ca_file:
+                        description: CA defines the key of certificate (e.g. ca.crt)
+                          in the configmap map, secret or absolute path to a certificate.
                         type: string
                       cert_file:
+                        description: Cert defines the key (e.g. tls.crt) of the client
+                          certificate in the secret or absolute path to a certificate.
                         type: string
                       configMapName:
+                        description: ConfigMapName defines configmap name with CA
+                          certificate.
                         type: string
                       key_file:
+                        description: Key defines a key (e.g. tls.key) of the private
+                          key in the secret or absolute path to a certificate.
                         type: string
                       secretName:
+                        description: SecretName defines secret name that will be used
+                          to configure TLS on the exporter.
                         type: string
                     type: object
                 type: object
               go:
+                description: Go defines configuration for Go auto-instrumentation.
                 properties:
                   env:
+                    description: Env defines Go specific env vars.
                     items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any...
                           type: string
                         valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
+                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.'
                               properties:
                                 apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
                               properties:
                                 key:
+                                  description: The key within the env file. An invalid
+                                    key will prevent the pod from starting.
                                   type: string
                                 optional:
                                   default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
                                   type: boolean
                                 path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
                                   type: string
                                 volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
                                   type: string
                               required:
                               - key
@@ -765,29 +1232,47 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.
                               properties:
                                 containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
+                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -799,15 +1284,26 @@ spec:
                       type: object
                     type: array
                   image:
+                    description: Image is a container image with Go SDK and auto-instrumentation.
                     type: string
                   resourceRequirements:
+                    description: Resources describes the compute resource requirements.
                     properties:
                       claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
                         items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used.
                               type: string
                             request:
+                              description: Request is the name chosen for a request
+                                in the referenced claim.
                               type: string
                           required:
                           - name
@@ -823,6 +1319,9 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.
                         type: object
                       requests:
                         additionalProperties:
@@ -831,83 +1330,153 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                   securityContext:
+                    description: SecurityContext applied to the Go auto-instrumentation
+                      sidecar.
                     properties:
                       allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process.
                         type: boolean
                       appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                          overrides the pod's appArmorProfile.
                         properties:
                           localhostProfile:
+                            description: localhostProfile indicates a profile loaded
+                              on the node that should be used.
                             type: string
                           type:
+                            description: type indicates which kind of AppArmor profile
+                              will be applied.
                             type: string
                         required:
                         - type
                         type: object
                       capabilities:
+                        description: The capabilities to add/drop when running containers.
                         properties:
                           add:
+                            description: Added capabilities
                             items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           drop:
+                            description: Removed capabilities
                             items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                         type: object
                       privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
                         type: boolean
                       procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers.
                         type: string
                       readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.
                         type: boolean
                       runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.
                         format: int64
                         type: integer
                       runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user.
                         type: boolean
                       runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
                         format: int64
                         type: integer
                       seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
                         properties:
                           level:
+                            description: Level is SELinux level label that applies
+                              to the container.
                             type: string
                           role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
                             type: string
                           type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
                             type: string
                           user:
+                            description: User is a SELinux user label that applies
+                              to the container.
                             type: string
                         type: object
                       seccompProfile:
+                        description: The seccomp options to use by this container.
                         properties:
                           localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used.
                             type: string
                           type:
+                            description: type indicates which kind of seccomp profile
+                              will be applied.
                             type: string
                         required:
                         - type
                         type: object
                       windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
                         properties:
                           gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.
                             type: string
                           gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
                           hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container.
                             type: boolean
                           runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process.
                             type: string
                         type: object
                     type: object
                   volumeClaimTemplate:
+                    description: VolumeClaimTemplate defines an ephemeral volume used
+                      for auto-instrumentation.
                     properties:
                       metadata:
+                        description: |-
+                          May contain labels and annotations that will be copied into the PVC
+                          when creating it.
                         properties:
                           annotations:
                             additionalProperties:
@@ -927,19 +1496,30 @@ spec:
                             type: string
                         type: object
                       spec:
+                        description: The specification for the PersistentVolumeClaim.
                         properties:
                           accessModes:
+                            description: |-
+                              accessModes contains the desired access modes the volume should have.
+                              More info: https://kubernetes.
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           dataSource:
+                            description: |-
+                              dataSource field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -947,20 +1527,32 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
+                            description: |-
+                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                              volume is desired.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
+                                description: |-
+                                  Namespace is the namespace of resource being referenced
+                                  Note that when a namespace is specified, a gateway.networking.k8s.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
+                            description: resources represents the minimum resources
+                              the volume should have.
                             properties:
                               limits:
                                 additionalProperties:
@@ -969,6 +1561,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -977,18 +1572,35 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           selector:
+                            description: selector is a label query over volumes to
+                              consider for binding.
                             properties:
                               matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
                                 items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
+                                      description: key is the label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty.
                                       items:
                                         type: string
                                       type: array
@@ -1002,16 +1614,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
+                            description: |-
+                              storageClassName is the name of the StorageClass required by the claim.
+                              More info: https://kubernetes.
                             type: string
                           volumeAttributesClassName:
+                            description: volumeAttributesClassName may be used to
+                              set the VolumeAttributesClass used by this claim.
                             type: string
                           volumeMode:
+                            description: |-
+                              volumeMode defines what type of volume is required by the claim.
+                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
+                            description: volumeName is the binding reference to the
+                              PersistentVolume backing this claim.
                             type: string
                         type: object
                     required:
@@ -1021,127 +1644,239 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      VolumeSizeLimit defines size limit for volume used for auto-instrumentation.
+                      The default size is 200Mi.
+
+                      Deprecated: use spec.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
               imagePullPolicy:
+                description: |-
+                  ImagePullPolicy
+                  One of Always, Never, IfNotPresent.
+                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
                 type: string
               initContainerSecurityContext:
+                description: |-
+                  InitContainerSecurityContext applied to the auto-instrumentation init
+                  containers created for Java, NodeJS, Python, DotNet,...
                 properties:
                   allowPrivilegeEscalation:
+                    description: |-
+                      AllowPrivilegeEscalation controls whether a process can gain more
+                      privileges than its parent process.
                     type: boolean
                   appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                      overrides the pod's appArmorProfile.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile loaded on
+                          the node that should be used.
                         type: string
                       type:
+                        description: type indicates which kind of AppArmor profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   capabilities:
+                    description: The capabilities to add/drop when running containers.
                     properties:
                       add:
+                        description: Added capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       drop:
+                        description: Removed capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                     type: object
                   privileged:
+                    description: |-
+                      Run container in privileged mode.
+                      Processes in privileged containers are essentially equivalent to root on the host.
                     type: boolean
                   procMount:
+                    description: procMount denotes the type of proc mount to use for
+                      the containers.
                     type: string
                   readOnlyRootFilesystem:
+                    description: |-
+                      Whether this container has a read-only root filesystem.
+                      Default is false.
+                      Note that this field cannot be set when spec.os.
                     type: boolean
                   runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in PodSecurityContext.
                     format: int64
                     type: integer
                   runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user.
                     type: boolean
                   runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
                     format: int64
                     type: integer
                   seLinuxOptions:
+                    description: The SELinux context to be applied to the container.
                     properties:
                       level:
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
+                    description: The seccomp options to use by this container.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used.
                         type: string
                       type:
+                        description: type indicates which kind of seccomp profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   windowsOptions:
+                    description: |-
+                      The Windows specific settings applied to all containers.
+                      If unspecified, the options from the PodSecurityContext will be used.
                     properties:
                       gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.
                         type: string
                       gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container.
                         type: boolean
                       runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process.
                         type: string
                     type: object
                 type: object
               java:
+                description: Java defines configuration for java auto-instrumentation.
                 properties:
                   env:
+                    description: Env defines java specific env vars.
                     items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any...
                           type: string
                         valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
+                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.'
                               properties:
                                 apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
                               properties:
                                 key:
+                                  description: The key within the env file. An invalid
+                                    key will prevent the pod from starting.
                                   type: string
                                 optional:
                                   default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
                                   type: boolean
                                 path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
                                   type: string
                                 volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
                                   type: string
                               required:
                               - key
@@ -1150,29 +1885,47 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.
                               properties:
                                 containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
+                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -1184,11 +1937,16 @@ spec:
                       type: object
                     type: array
                   extensions:
+                    description: Extensions defines java specific extensions.
                     items:
                       properties:
                         dir:
+                          description: Dir is a directory with extensions auto-instrumentation
+                            JAR.
                           type: string
                         image:
+                          description: Image is a container image with extensions
+                            auto-instrumentation JAR.
                           type: string
                       required:
                       - dir
@@ -1196,15 +1954,27 @@ spec:
                       type: object
                     type: array
                   image:
+                    description: Image is a container image with javaagent auto-instrumentation
+                      JAR.
                     type: string
                   resources:
+                    description: Resources describes the compute resource requirements.
                     properties:
                       claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
                         items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used.
                               type: string
                             request:
+                              description: Request is the name chosen for a request
+                                in the referenced claim.
                               type: string
                           required:
                           - name
@@ -1220,6 +1990,9 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.
                         type: object
                       requests:
                         additionalProperties:
@@ -1228,11 +2001,18 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                   volumeClaimTemplate:
+                    description: VolumeClaimTemplate defines an ephemeral volume used
+                      for auto-instrumentation.
                     properties:
                       metadata:
+                        description: |-
+                          May contain labels and annotations that will be copied into the PVC
+                          when creating it.
                         properties:
                           annotations:
                             additionalProperties:
@@ -1252,19 +2032,30 @@ spec:
                             type: string
                         type: object
                       spec:
+                        description: The specification for the PersistentVolumeClaim.
                         properties:
                           accessModes:
+                            description: |-
+                              accessModes contains the desired access modes the volume should have.
+                              More info: https://kubernetes.
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           dataSource:
+                            description: |-
+                              dataSource field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -1272,20 +2063,32 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
+                            description: |-
+                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                              volume is desired.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
+                                description: |-
+                                  Namespace is the namespace of resource being referenced
+                                  Note that when a namespace is specified, a gateway.networking.k8s.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
+                            description: resources represents the minimum resources
+                              the volume should have.
                             properties:
                               limits:
                                 additionalProperties:
@@ -1294,6 +2097,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1302,18 +2108,35 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           selector:
+                            description: selector is a label query over volumes to
+                              consider for binding.
                             properties:
                               matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
                                 items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
+                                      description: key is the label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty.
                                       items:
                                         type: string
                                       type: array
@@ -1327,16 +2150,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
+                            description: |-
+                              storageClassName is the name of the StorageClass required by the claim.
+                              More info: https://kubernetes.
                             type: string
                           volumeAttributesClassName:
+                            description: volumeAttributesClassName may be used to
+                              set the VolumeAttributesClass used by this claim.
                             type: string
                           volumeMode:
+                            description: |-
+                              volumeMode defines what type of volume is required by the claim.
+                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
+                            description: volumeName is the binding reference to the
+                              PersistentVolume backing this claim.
                             type: string
                         type: object
                     required:
@@ -1346,53 +2180,99 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      VolumeSizeLimit defines size limit for volume used for auto-instrumentation.
+                      The default size is 200Mi.
+
+                      Deprecated: use spec.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
               nginx:
+                description: Nginx defines configuration for Nginx auto-instrumentation.
                 properties:
                   attrs:
+                    description: Attrs defines Nginx agent specific attributes.
                     items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any...
                           type: string
                         valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
+                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.'
                               properties:
                                 apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
                               properties:
                                 key:
+                                  description: The key within the env file. An invalid
+                                    key will prevent the pod from starting.
                                   type: string
                                 optional:
                                   default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
                                   type: boolean
                                 path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
                                   type: string
                                 volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
                                   type: string
                               required:
                               - key
@@ -1401,29 +2281,47 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.
                               properties:
                                 containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
+                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -1435,49 +2333,92 @@ spec:
                       type: object
                     type: array
                   configFile:
+                    description: |-
+                      Location of Nginx configuration file.
+                      Needed only if different from default "/etx/nginx/nginx.conf"
                     type: string
                   env:
+                    description: Env defines Nginx specific env vars.
                     items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any...
                           type: string
                         valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
+                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.'
                               properties:
                                 apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
                               properties:
                                 key:
+                                  description: The key within the env file. An invalid
+                                    key will prevent the pod from starting.
                                   type: string
                                 optional:
                                   default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
                                   type: boolean
                                 path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
                                   type: string
                                 volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
                                   type: string
                               required:
                               - key
@@ -1486,29 +2427,47 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.
                               properties:
                                 containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
+                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -1520,15 +2479,26 @@ spec:
                       type: object
                     type: array
                   image:
+                    description: Image is a container image with Nginx SDK and auto-instrumentation.
                     type: string
                   resourceRequirements:
+                    description: Resources describes the compute resource requirements.
                     properties:
                       claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
                         items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used.
                               type: string
                             request:
+                              description: Request is the name chosen for a request
+                                in the referenced claim.
                               type: string
                           required:
                           - name
@@ -1544,6 +2514,9 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.
                         type: object
                       requests:
                         additionalProperties:
@@ -1552,11 +2525,18 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                   volumeClaimTemplate:
+                    description: VolumeClaimTemplate defines an ephemeral volume used
+                      for auto-instrumentation.
                     properties:
                       metadata:
+                        description: |-
+                          May contain labels and annotations that will be copied into the PVC
+                          when creating it.
                         properties:
                           annotations:
                             additionalProperties:
@@ -1576,19 +2556,30 @@ spec:
                             type: string
                         type: object
                       spec:
+                        description: The specification for the PersistentVolumeClaim.
                         properties:
                           accessModes:
+                            description: |-
+                              accessModes contains the desired access modes the volume should have.
+                              More info: https://kubernetes.
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           dataSource:
+                            description: |-
+                              dataSource field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -1596,20 +2587,32 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
+                            description: |-
+                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                              volume is desired.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
+                                description: |-
+                                  Namespace is the namespace of resource being referenced
+                                  Note that when a namespace is specified, a gateway.networking.k8s.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
+                            description: resources represents the minimum resources
+                              the volume should have.
                             properties:
                               limits:
                                 additionalProperties:
@@ -1618,6 +2621,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1626,18 +2632,35 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           selector:
+                            description: selector is a label query over volumes to
+                              consider for binding.
                             properties:
                               matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
                                 items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
+                                      description: key is the label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty.
                                       items:
                                         type: string
                                       type: array
@@ -1651,16 +2674,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
+                            description: |-
+                              storageClassName is the name of the StorageClass required by the claim.
+                              More info: https://kubernetes.
                             type: string
                           volumeAttributesClassName:
+                            description: volumeAttributesClassName may be used to
+                              set the VolumeAttributesClass used by this claim.
                             type: string
                           volumeMode:
+                            description: |-
+                              volumeMode defines what type of volume is required by the claim.
+                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
+                            description: volumeName is the binding reference to the
+                              PersistentVolume backing this claim.
                             type: string
                         type: object
                     required:
@@ -1670,53 +2704,99 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      VolumeSizeLimit defines size limit for volume used for auto-instrumentation.
+                      The default size is 200Mi.
+
+                      Deprecated: use spec.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
               nodejs:
+                description: NodeJS defines configuration for nodejs auto-instrumentation.
                 properties:
                   env:
+                    description: Env defines nodejs specific env vars.
                     items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any...
                           type: string
                         valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
+                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.'
                               properties:
                                 apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
                               properties:
                                 key:
+                                  description: The key within the env file. An invalid
+                                    key will prevent the pod from starting.
                                   type: string
                                 optional:
                                   default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
                                   type: boolean
                                 path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
                                   type: string
                                 volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
                                   type: string
                               required:
                               - key
@@ -1725,29 +2805,47 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.
                               properties:
                                 containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
+                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -1759,15 +2857,26 @@ spec:
                       type: object
                     type: array
                   image:
+                    description: Image is a container image with NodeJS SDK and auto-instrumentation.
                     type: string
                   resourceRequirements:
+                    description: Resources describes the compute resource requirements.
                     properties:
                       claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
                         items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used.
                               type: string
                             request:
+                              description: Request is the name chosen for a request
+                                in the referenced claim.
                               type: string
                           required:
                           - name
@@ -1783,6 +2892,9 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.
                         type: object
                       requests:
                         additionalProperties:
@@ -1791,11 +2903,18 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                   volumeClaimTemplate:
+                    description: VolumeClaimTemplate defines an ephemeral volume used
+                      for auto-instrumentation.
                     properties:
                       metadata:
+                        description: |-
+                          May contain labels and annotations that will be copied into the PVC
+                          when creating it.
                         properties:
                           annotations:
                             additionalProperties:
@@ -1815,19 +2934,30 @@ spec:
                             type: string
                         type: object
                       spec:
+                        description: The specification for the PersistentVolumeClaim.
                         properties:
                           accessModes:
+                            description: |-
+                              accessModes contains the desired access modes the volume should have.
+                              More info: https://kubernetes.
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           dataSource:
+                            description: |-
+                              dataSource field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -1835,20 +2965,32 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
+                            description: |-
+                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                              volume is desired.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
+                                description: |-
+                                  Namespace is the namespace of resource being referenced
+                                  Note that when a namespace is specified, a gateway.networking.k8s.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
+                            description: resources represents the minimum resources
+                              the volume should have.
                             properties:
                               limits:
                                 additionalProperties:
@@ -1857,6 +2999,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1865,18 +3010,35 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           selector:
+                            description: selector is a label query over volumes to
+                              consider for binding.
                             properties:
                               matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
                                 items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
+                                      description: key is the label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty.
                                       items:
                                         type: string
                                       type: array
@@ -1890,16 +3052,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
+                            description: |-
+                              storageClassName is the name of the StorageClass required by the claim.
+                              More info: https://kubernetes.
                             type: string
                           volumeAttributesClassName:
+                            description: volumeAttributesClassName may be used to
+                              set the VolumeAttributesClass used by this claim.
                             type: string
                           volumeMode:
+                            description: |-
+                              volumeMode defines what type of volume is required by the claim.
+                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
+                            description: volumeName is the binding reference to the
+                              PersistentVolume backing this claim.
                             type: string
                         type: object
                     required:
@@ -1909,11 +3082,19 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      VolumeSizeLimit defines size limit for volume used for auto-instrumentation.
+                      The default size is 200Mi.
+
+                      Deprecated: use spec.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
               propagators:
+                description: Propagators defines inter-process context propagation
+                  configuration.
                 items:
+                  description: Propagator represents the propagation type.
                   enum:
                   - tracecontext
                   - baggage
@@ -1926,49 +3107,90 @@ spec:
                   type: string
                 type: array
               python:
+                description: Python defines configuration for python auto-instrumentation.
                 properties:
                   env:
+                    description: Env defines python specific env vars.
                     items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any...
                           type: string
                         valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
+                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.'
                               properties:
                                 apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
                               properties:
                                 key:
+                                  description: The key within the env file. An invalid
+                                    key will prevent the pod from starting.
                                   type: string
                                 optional:
                                   default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
                                   type: boolean
                                 path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
                                   type: string
                                 volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
                                   type: string
                               required:
                               - key
@@ -1977,29 +3199,47 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.
                               properties:
                                 containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
+                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -2011,15 +3251,26 @@ spec:
                       type: object
                     type: array
                   image:
+                    description: Image is a container image with Python SDK and auto-instrumentation.
                     type: string
                   resourceRequirements:
+                    description: Resources describes the compute resource requirements.
                     properties:
                       claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
                         items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used.
                               type: string
                             request:
+                              description: Request is the name chosen for a request
+                                in the referenced claim.
                               type: string
                           required:
                           - name
@@ -2035,6 +3286,9 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.
                         type: object
                       requests:
                         additionalProperties:
@@ -2043,11 +3297,18 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                   volumeClaimTemplate:
+                    description: VolumeClaimTemplate defines an ephemeral volume used
+                      for auto-instrumentation.
                     properties:
                       metadata:
+                        description: |-
+                          May contain labels and annotations that will be copied into the PVC
+                          when creating it.
                         properties:
                           annotations:
                             additionalProperties:
@@ -2067,19 +3328,30 @@ spec:
                             type: string
                         type: object
                       spec:
+                        description: The specification for the PersistentVolumeClaim.
                         properties:
                           accessModes:
+                            description: |-
+                              accessModes contains the desired access modes the volume should have.
+                              More info: https://kubernetes.
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           dataSource:
+                            description: |-
+                              dataSource field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                             required:
                             - kind
@@ -2087,20 +3359,32 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
+                            description: |-
+                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                              volume is desired.
                             properties:
                               apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced.
                                 type: string
                               kind:
+                                description: Kind is the type of resource being referenced
                                 type: string
                               name:
+                                description: Name is the name of resource being referenced
                                 type: string
                               namespace:
+                                description: |-
+                                  Namespace is the namespace of resource being referenced
+                                  Note that when a namespace is specified, a gateway.networking.k8s.
                                 type: string
                             required:
                             - kind
                             - name
                             type: object
                           resources:
+                            description: resources represents the minimum resources
+                              the volume should have.
                             properties:
                               limits:
                                 additionalProperties:
@@ -2109,6 +3393,9 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.
                                 type: object
                               requests:
                                 additionalProperties:
@@ -2117,18 +3404,35 @@ spec:
                                   - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: Requests describes the minimum amount
+                                  of compute resources required.
                                 type: object
                             type: object
                           selector:
+                            description: selector is a label query over volumes to
+                              consider for binding.
                             properties:
                               matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
                                 items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
                                     key:
+                                      description: key is the label key that the selector
+                                        applies to.
                                       type: string
                                     operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty.
                                       items:
                                         type: string
                                       type: array
@@ -2142,16 +3446,27 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
+                                description: matchLabels is a map of {key,value} pairs.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
+                            description: |-
+                              storageClassName is the name of the StorageClass required by the claim.
+                              More info: https://kubernetes.
                             type: string
                           volumeAttributesClassName:
+                            description: volumeAttributesClassName may be used to
+                              set the VolumeAttributesClass used by this claim.
                             type: string
                           volumeMode:
+                            description: |-
+                              volumeMode defines what type of volume is required by the claim.
+                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
+                            description: volumeName is the binding reference to the
+                              PersistentVolume backing this claim.
                             type: string
                         type: object
                     required:
@@ -2161,23 +3476,42 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      VolumeSizeLimit defines size limit for volume used for auto-instrumentation.
+                      The default size is 200Mi.
+
+                      Deprecated: use spec.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
               resource:
+                description: Resource defines the configuration for the resource attributes,
+                  as defined by the OpenTelemetry specification.
                 properties:
                   addK8sUIDAttributes:
+                    description: AddK8sUIDAttributes defines whether K8s UID attributes
+                      should be collected (e.g. k8s.deployment.uid).
                     type: boolean
                   resourceAttributes:
                     additionalProperties:
                       type: string
+                    description: |-
+                      Attributes defines attributes that are added to the resource.
+                      For example environment: dev
                     type: object
                 type: object
               sampler:
+                description: Sampler defines sampling configuration.
                 properties:
                   argument:
+                    description: |-
+                      Argument defines sampler argument.
+                      The value depends on the sampler type.
                     type: string
                   type:
+                    description: |-
+                      Type defines sampler type.
+                      The value will be set in the OTEL_TRACES_SAMPLER env var.
                     enum:
                     - always_on
                     - always_off
@@ -2191,10 +3525,14 @@ spec:
                 type: object
             type: object
           status:
+            description: InstrumentationStatus defines status of the instrumentation.
             properties:
               upgradeBlockedVersions:
                 additionalProperties:
                   type: string
+                description: |-
+                  UpgradeBlockedVersions contains instrumentation language images whose
+                  versions could not be automatically upgraded, mapped to a...
                 type: object
             type: object
         type: object

--- a/config/crd/bases/opentelemetry.io_opampbridges.yaml
+++ b/config/crd/bases/opentelemetry.io_opampbridges.yaml
@@ -28,32 +28,62 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: OpAMPBridge is the Schema for the opampbridges API.
         properties:
           apiVersion:
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
             type: string
           kind:
+            description: Kind is a string value representing the REST resource this
+              object represents.
             type: string
           metadata:
             type: object
           spec:
+            description: OpAMPBridgeSpec defines the desired state of OpAMPBridge.
             properties:
               affinity:
+                description: If specified, indicates the pod's scheduling constraints
                 properties:
                   nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may...
                         items:
+                          description: |-
+                            An empty preferred scheduling term matches all objects with implicit weight 0
+                            (i.e. it's a no-op).
                           properties:
                             preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
                               properties:
                                 matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -65,13 +95,26 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -85,6 +128,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -94,18 +139,39 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the...
                         properties:
                           nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
                             items:
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
                               properties:
                                 matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -117,13 +183,26 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -144,22 +223,48 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may...
                         items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -173,29 +278,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -209,20 +338,30 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -232,18 +371,40 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the...
                         items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be...
                           properties:
                             labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -257,29 +418,52 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -293,15 +477,22 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the...
                               type: string
                           required:
                           - topologyKey
@@ -310,22 +501,49 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                   podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the anti-affinity expressions specified by this field, but it...
                         items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -339,29 +557,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -375,20 +617,30 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -398,18 +650,40 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the anti-affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto...
                         items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be...
                           properties:
                             labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -423,29 +697,52 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -459,15 +756,22 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the...
                               type: string
                           required:
                           - topologyKey
@@ -479,66 +783,114 @@ spec:
               capabilities:
                 additionalProperties:
                   type: boolean
+                description: Capabilities supported by the OpAMP Bridge
                 type: object
               componentsAllowed:
                 additionalProperties:
                   items:
                     type: string
                   type: array
+                description: ComponentsAllowed is a list of allowed OpenTelemetry
+                  components for each pipeline type (receiver, processor, etc.)
                 type: object
               description:
+                description: Description allows the customization of the non identifying
+                  attributes for the OpAMP Bridge.
                 properties:
                   non_identifying_attributes:
                     additionalProperties:
                       type: string
+                    description: |-
+                      NonIdentifyingAttributes are a map of key-value pairs that may be specified to provide
+                      extra information about the agent to the...
                     type: object
                 required:
                 - non_identifying_attributes
                 type: object
               endpoint:
+                description: OpAMP backend Server endpoint
                 type: string
               env:
+                description: ENV vars to set on the OpAMPBridge Pods.
                 items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
                   properties:
                     name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any...
                       type: string
                     valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
                           properties:
                             key:
+                              description: The key to select.
                               type: string
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.'
                           properties:
                             apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
                               type: string
                           required:
                           - fieldPath
                           type: object
                           x-kubernetes-map-type: atomic
                         fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
                           properties:
                             key:
+                              description: The key within the env file. An invalid
+                                key will prevent the pod from starting.
                               type: string
                             optional:
                               default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
                               type: boolean
                             path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
                               type: string
                             volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
                               type: string
                           required:
                           - key
@@ -547,29 +899,46 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.
                           properties:
                             containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
+                              description: 'Required: resource to select'
                               type: string
                           required:
                           - resource
                           type: object
                           x-kubernetes-map-type: atomic
                         secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
@@ -581,25 +950,44 @@ spec:
                   type: object
                 type: array
               envFrom:
+                description: List of sources to populate environment variables on
+                  the OpAMPBridge Pods.
                 items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
                   properties:
                     configMapRef:
+                      description: The ConfigMap to select from
                       properties:
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: Specify whether the ConfigMap must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     secretRef:
+                      description: The Secret to select from
                       properties:
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: Specify whether the Secret must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
@@ -608,110 +996,198 @@ spec:
               headers:
                 additionalProperties:
                   type: string
+                description: |-
+                  Headers is an optional map of headers to use when connecting to the OpAMP Server,
+                  typically used to set access tokens or other...
                 type: object
               hostNetwork:
+                description: HostNetwork indicates if the pod should run in the host
+                  networking namespace.
                 type: boolean
               image:
+                description: Image indicates the container image to use for the OpAMPBridge.
                 type: string
               imagePullPolicy:
+                description: ImagePullPolicy indicates the pull policy to be used
+                  for retrieving the container image (Always, Never, IfNotPresent)
                 type: string
               ipFamilies:
+                description: |-
+                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                  to express the family of an IP expressed by a type (e.g.
                 items:
+                  description: |-
+                    IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                    to express the family of an IP expressed by a type (e.g.
                   type: string
                 type: array
               ipFamilyPolicy:
+                description: IPFamilyPolicy represents the dual-stack-ness requested
+                  or required by a Service
                 type: string
               nodeSelector:
                 additionalProperties:
                   type: string
+                description: NodeSelector to schedule OpAMPBridge pods.
                 type: object
               podAnnotations:
                 additionalProperties:
                   type: string
+                description: |-
+                  PodAnnotations is the set of annotations that will be attached to
+                  OpAMPBridge pods.
                 type: object
               podDnsConfig:
+                description: PodDNSConfig defines the DNS parameters of a pod in addition
+                  to those generated from DNSPolicy.
                 properties:
                   nameservers:
+                    description: |-
+                      A list of DNS name server IP addresses.
+                      This will be appended to the base nameservers generated from DNSPolicy.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
                   options:
+                    description: |-
+                      A list of DNS resolver options.
+                      This will be merged with the base options generated from DNSPolicy.
                     items:
+                      description: PodDNSConfigOption defines DNS resolver options
+                        of a pod.
                       properties:
                         name:
+                          description: |-
+                            Name is this DNS resolver option's name.
+                            Required.
                           type: string
                         value:
+                          description: Value is this DNS resolver option's value.
                           type: string
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
                   searches:
+                    description: |-
+                      A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from DNSPolicy.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
               podSecurityContext:
+                description: PodSecurityContext will be set as the pod security context.
                 properties:
                   appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by the containers in this pod.
+                      Note that this field cannot be set when spec.os.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile loaded on
+                          the node that should be used.
                         type: string
                       type:
+                        description: type indicates which kind of AppArmor profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   fsGroup:
+                    description: A special supplemental group that applies to all
+                      containers in a pod.
                     format: int64
                     type: integer
                   fsGroupChangePolicy:
+                    description: |-
+                      fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                      before being exposed inside Pod.
                     type: string
                   runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in SecurityContext.
                     format: int64
                     type: integer
                   runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user.
                     type: boolean
                   runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
                     format: int64
                     type: integer
                   seLinuxChangePolicy:
+                    description: seLinuxChangePolicy defines how the container's SELinux
+                      label is applied to all volumes used by the Pod.
                     type: string
                   seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
                     properties:
                       level:
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
+                    description: |-
+                      The seccomp options to use by the containers in this pod.
+                      Note that this field cannot be set when spec.os.name is windows.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used.
                         type: string
                       type:
+                        description: type indicates which kind of seccomp profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   supplementalGroups:
+                    description: |-
+                      A list of groups applied to the first process run in each container, in
+                      addition to the container's primary GID and fsGroup (if...
                     items:
                       format: int64
                       type: integer
                     type: array
                     x-kubernetes-list-type: atomic
                   supplementalGroupsPolicy:
+                    description: |-
+                      Defines how supplemental groups of the first container processes are calculated.
+                      Valid values are "Merge" and "Strict".
                     type: string
                   sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod.
                     items:
+                      description: Sysctl defines a kernel parameter to be set
                       properties:
                         name:
+                          description: Name of a property to set
                           type: string
                         value:
+                          description: Value of a property to set
                           type: string
                       required:
                       - name
@@ -720,37 +1196,64 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   windowsOptions:
+                    description: The Windows specific settings applied to all containers.
                     properties:
                       gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.
                         type: string
                       gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container.
                         type: boolean
                       runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process.
                         type: string
                     type: object
                 type: object
               ports:
+                description: Ports allows a set of ports to be exposed by the underlying
+                  v1.Service.
                 items:
+                  description: ServicePort contains information on service's port.
                   properties:
                     appProtocol:
+                      description: The application protocol for this port.
                       type: string
                     name:
+                      description: |-
+                        The name of this port within the service. This must be a DNS_LABEL.
+                        All ports within a ServiceSpec must have unique names.
                       type: string
                     nodePort:
+                      description: |-
+                        The port on each node on which this service is exposed when type is
+                        NodePort or LoadBalancer.  Usually assigned by the system.
                       format: int32
                       type: integer
                     port:
+                      description: The port that will be exposed by this service.
                       format: int32
                       type: integer
                     protocol:
                       default: TCP
+                      description: |-
+                        The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                        Default is TCP.
                       type: string
                     targetPort:
                       anyOf:
                       - type: integer
                       - type: string
+                      description: |-
+                        Number or name of the port to access on the pods targeted by the service.
+                        Number must be in the range 1 to 65535.
                       x-kubernetes-int-or-string: true
                   required:
                   - port
@@ -758,19 +1261,34 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               priorityClassName:
+                description: |-
+                  If specified, indicates the pod's priority.
+                  If not specified, the pod priority will be default or zero if there is no
+                  default.
                 type: string
               replicas:
+                description: Replicas is the number of pod instances for the OpAMPBridge.
                 format: int32
                 maximum: 1
                 type: integer
               resources:
+                description: Resources to set on the OpAMPBridge pods.
                 properties:
                   claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
                     items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used.
                           type: string
                         request:
+                          description: Request is the name chosen for a request in
+                            the referenced claim.
                           type: string
                       required:
                       - name
@@ -786,6 +1304,9 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.
                     type: object
                   requests:
                     additionalProperties:
@@ -794,111 +1315,211 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
+                    description: Requests describes the minimum amount of compute
+                      resources required.
                     type: object
                 type: object
               securityContext:
+                description: SecurityContext will be set as the container security
+                  context.
                 properties:
                   allowPrivilegeEscalation:
+                    description: |-
+                      AllowPrivilegeEscalation controls whether a process can gain more
+                      privileges than its parent process.
                     type: boolean
                   appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                      overrides the pod's appArmorProfile.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile loaded on
+                          the node that should be used.
                         type: string
                       type:
+                        description: type indicates which kind of AppArmor profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   capabilities:
+                    description: The capabilities to add/drop when running containers.
                     properties:
                       add:
+                        description: Added capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       drop:
+                        description: Removed capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                     type: object
                   privileged:
+                    description: |-
+                      Run container in privileged mode.
+                      Processes in privileged containers are essentially equivalent to root on the host.
                     type: boolean
                   procMount:
+                    description: procMount denotes the type of proc mount to use for
+                      the containers.
                     type: string
                   readOnlyRootFilesystem:
+                    description: |-
+                      Whether this container has a read-only root filesystem.
+                      Default is false.
+                      Note that this field cannot be set when spec.os.
                     type: boolean
                   runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in PodSecurityContext.
                     format: int64
                     type: integer
                   runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user.
                     type: boolean
                   runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
                     format: int64
                     type: integer
                   seLinuxOptions:
+                    description: The SELinux context to be applied to the container.
                     properties:
                       level:
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
+                    description: The seccomp options to use by this container.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used.
                         type: string
                       type:
+                        description: type indicates which kind of seccomp profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   windowsOptions:
+                    description: |-
+                      The Windows specific settings applied to all containers.
+                      If unspecified, the options from the PodSecurityContext will be used.
                     properties:
                       gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.
                         type: string
                       gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container.
                         type: boolean
                       runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process.
                         type: string
                     type: object
                 type: object
               serviceAccount:
+                description: ServiceAccount indicates the name of an existing service
+                  account to use with this instance.
                 type: string
               tolerations:
+                description: Toleration to schedule OpAMPBridge pods.
                 items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching...
                   properties:
                     effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects.
                       type: string
                     key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys.
                       type: string
                     operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                       type: string
                     tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is...
                       format: int64
                       type: integer
                     value:
+                      description: Value is the taint value the toleration matches
+                        to.
                       type: string
                   type: object
                 type: array
               topologySpreadConstraints:
+                description: |-
+                  TopologySpreadConstraints embedded kubernetes pod configuration option,
+                  controls how pods are spread across your cluster among...
                 items:
+                  description: TopologySpreadConstraint specifies how to spread matching
+                    pods among the given topology.
                   properties:
                     labelSelector:
+                      description: LabelSelector is used to find matching pods.
                       properties:
                         matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
                           items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
+                                description: key is the label key that the selector
+                                  applies to.
                                 type: string
                               operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty.
                                 items:
                                   type: string
                                 type: array
@@ -912,27 +1533,45 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
+                          description: matchLabels is a map of {key,value} pairs.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     matchLabelKeys:
+                      description: |-
+                        MatchLabelKeys is a set of pod label keys to select the pods over which
+                        spreading will be calculated.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     maxSkew:
+                      description: MaxSkew describes the degree to which pods may
+                        be unevenly distributed.
                       format: int32
                       type: integer
                     minDomains:
+                      description: MinDomains indicates a minimum number of eligible
+                        domains.
                       format: int32
                       type: integer
                     nodeAffinityPolicy:
+                      description: |-
+                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                        when calculating pod topology spread skew.
                       type: string
                     nodeTaintsPolicy:
+                      description: |-
+                        NodeTaintsPolicy indicates how we will treat node taints when calculating
+                        pod topology spread skew.
                       type: string
                     topologyKey:
+                      description: TopologyKey is the key of node labels.
                       type: string
                     whenUnsatisfiable:
+                      description: |-
+                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                        the spread constraint.
                       type: string
                   required:
                   - maxSkew
@@ -941,26 +1580,50 @@ spec:
                   type: object
                 type: array
               upgradeStrategy:
+                description: UpgradeStrategy represents how the operator will handle
+                  upgrades to the CR when a newer version of the operator is deployed
                 enum:
                 - automatic
                 - none
                 type: string
               volumeMounts:
+                description: VolumeMounts represents the mount points to use in the
+                  underlying OpAMPBridge deployment(s)
                 items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
                   properties:
                     mountPath:
+                      description: |-
+                        Path within the container at which the volume should be mounted.  Must
+                        not contain ':'.
                       type: string
                     mountPropagation:
+                      description: |-
+                        mountPropagation determines how mounts are propagated from the host
+                        to container and the other way around.
                       type: string
                     name:
+                      description: This must match the Name of a Volume.
                       type: string
                     readOnly:
+                      description: |-
+                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                        Defaults to false.
                       type: boolean
                     recursiveReadOnly:
+                      description: |-
+                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                        recursively.
                       type: string
                     subPath:
+                      description: |-
+                        Path within the volume from which the container's volume should be mounted.
+                        Defaults to "" (volume's root).
                       type: string
                     subPathExpr:
+                      description: Expanded path within the volume from which the
+                        container's volume should be mounted.
                       type: string
                   required:
                   - mountPath
@@ -969,111 +1632,212 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               volumes:
+                description: Volumes represents which volumes to use in the underlying
+                  OpAMPBridge deployment(s).
                 items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
+                      description: |-
+                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
                           format: int32
                           type: integer
                         readOnly:
+                          description: |-
+                            readOnly value true will force the readOnly setting in VolumeMounts.
+                            More info: https://kubernetes.
                           type: boolean
                         volumeID:
+                          description: |-
+                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                            More info: https://kubernetes.
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
+                      description: |-
+                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        Deprecated: AzureDisk is deprecated.
                       properties:
                         cachingMode:
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
                           type: string
                         diskName:
+                          description: diskName is the Name of the data disk in the
+                            blob storage
                           type: string
                         diskURI:
+                          description: diskURI is the URI of data disk in the blob
+                            storage
                           type: string
                         fsType:
                           default: ext4
+                          description: |-
+                            fsType is Filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
                           type: string
                         kind:
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account ...'
                           type: string
                         readOnly:
                           default: false
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
+                      description: |-
+                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        Deprecated: AzureFile is deprecated.
                       properties:
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
                           type: string
                         shareName:
+                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
+                      description: cephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime.
                       properties:
                         monitors:
+                          description: |-
+                            monitors is Required: Monitors is a collection of Ceph monitors
+                            More info: https://examples.k8s.io/volumes/cephfs/README.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         path:
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretFile:
+                          description: 'secretFile is Optional: SecretFile is the
+                            path to key ring for User, default is /etc/ceph/user.'
                           type: string
                         secretRef:
+                          description: 'secretRef is Optional: SecretRef is reference
+                            to the authentication secret for User, default is empty.'
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
+                          description: |-
+                            user is optional: User is the rados user name, default is admin
+                            More info: https://examples.k8s.io/volumes/cephfs/README.
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
+                      description: |-
+                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        Deprecated: Cinder is deprecated.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is optional: points to a secret object containing parameters used to connect
+                            to OpenStack.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
+                          description: |-
+                            volumeID used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
+                      description: configMap represents a configMap that should populate
+                        this volume
                       properties:
                         defaultMode:
+                          description: 'defaultMode is optional: mode bits used to
+                            set permissions on created files by default.'
                           format: int32
                           type: integer
                         items:
+                          description: |-
+                            items if unspecified, each key-value pair in the Data field of the referenced
+                            ConfigMap will be projected into the volume as a...
                           items:
+                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
+                                description: key is the key to project.
                                 type: string
                               mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file.'
                                 format: int32
                                 type: integer
                               path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
                                 type: string
                             required:
                             - key
@@ -1083,67 +1847,119 @@ spec:
                           x-kubernetes-list-type: atomic
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
+                      description: csi (Container Storage Interface) represents ephemeral
+                        storage that is handled by certain external CSI drivers.
                       properties:
                         driver:
+                          description: driver is the name of the CSI driver that handles
+                            this volume.
                           type: string
                         fsType:
+                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
                           type: string
                         nodePublishSecretRef:
+                          description: |-
+                            nodePublishSecretRef is a reference to the secret object containing
+                            sensitive information to pass to the CSI driver to complete...
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
+                          description: |-
+                            readOnly specifies a read-only configuration for the volume.
+                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
+                          description: |-
+                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                            driver.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
+                      description: downwardAPI represents downward API about the pod
+                        that should populate this volume
                       properties:
                         defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default.'
                           format: int32
                           type: integer
                         items:
+                          description: Items is a list of downward API volume file
                           items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
                             properties:
                               fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name, namespace and uid
+                                  are supported.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
+                                description: |-
+                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                  between 0000 and 0777 or a decimal value...
                                 format: int32
                                 type: integer
                               path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path.'
                                 type: string
                               resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, requests.cpu and requests.
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -1156,21 +1972,35 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     emptyDir:
+                      description: |-
+                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                        More info: https://kubernetes.
                       properties:
                         medium:
+                          description: medium represents what type of storage medium
+                            should back this directory.
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
+                          description: sizeLimit is the total amount of local storage
+                            required for this EmptyDir volume.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
+                      description: ephemeral represents a volume that is handled by
+                        a cluster storage driver.
                       properties:
                         volumeClaimTemplate:
+                          description: Will be used to create a stand-alone PVC to
+                            provision the volume.
                           properties:
                             metadata:
+                              description: |-
+                                May contain labels and annotations that will be copied into the PVC
+                                when creating it.
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -1190,19 +2020,32 @@ spec:
                                   type: string
                               type: object
                             spec:
+                              description: The specification for the PersistentVolumeClaim.
                               properties:
                                 accessModes:
+                                  description: |-
+                                    accessModes contains the desired access modes the volume should have.
+                                    More info: https://kubernetes.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 dataSource:
+                                  description: |-
+                                    dataSource field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.
                                   properties:
                                     apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced.
                                       type: string
                                     kind:
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -1210,20 +2053,34 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
+                                  description: |-
+                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                    volume is desired.
                                   properties:
                                     apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced.
                                       type: string
                                     kind:
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                     namespace:
+                                      description: |-
+                                        Namespace is the namespace of resource being referenced
+                                        Note that when a namespace is specified, a gateway.networking.k8s.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
+                                  description: resources represents the minimum resources
+                                    the volume should have.
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -1232,6 +2089,9 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -1240,18 +2100,36 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
                                       type: object
                                   type: object
                                 selector:
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -1265,16 +2143,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
+                                  description: |-
+                                    storageClassName is the name of the StorageClass required by the claim.
+                                    More info: https://kubernetes.
                                   type: string
                                 volumeAttributesClassName:
+                                  description: volumeAttributesClassName may be used
+                                    to set the VolumeAttributesClass used by this
+                                    claim.
                                   type: string
                                 volumeMode:
+                                  description: |-
+                                    volumeMode defines what type of volume is required by the claim.
+                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
+                                  description: volumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -1282,41 +2173,78 @@ spec:
                           type: object
                       type: object
                     fc:
+                      description: fc represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         lun:
+                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         wwids:
+                          description: |-
+                            wwids Optional: FC volume world wide identifiers (wwids)
+                            Either wwids or combination of targetWWNs and lun must be set, but not...
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                       type: object
                     flexVolume:
+                      description: |-
+                        flexVolume represents a generic volume resource that is
+                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
+                          description: driver is the name of the driver to use for
+                            this volume.
                           type: string
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         options:
                           additionalProperties:
                             type: string
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
                           type: object
                         readOnly:
+                          description: |-
+                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is Optional: secretRef is reference to the secret object containing
+                            sensitive information to pass to the plugin...
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -1324,98 +2252,184 @@ spec:
                       - driver
                       type: object
                     flocker:
+                      description: flocker represents a Flocker volume attached to
+                        a kubelet's host machine.
                       properties:
                         datasetName:
+                          description: |-
+                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                            should be considered as deprecated
                           type: string
                         datasetUUID:
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
+                      description: |-
+                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         fsType:
+                          description: fsType is filesystem type of the volume that
+                            you want to mount.
                           type: string
                         partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
                           format: int32
                           type: integer
                         pdName:
+                          description: |-
+                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                            More info: https://kubernetes.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://kubernetes.
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
+                      description: |-
+                        gitRepo represents a git repository at a particular revision.
+                        Deprecated: GitRepo is deprecated.
                       properties:
                         directory:
+                          description: |-
+                            directory is the target directory name.
+                            Must not contain or start with '..'.  If '.
                           type: string
                         repository:
+                          description: repository is the URL
                           type: string
                         revision:
+                          description: revision is the commit hash for the specified
+                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
+                      description: glusterfs represents a Glusterfs mount on the host
+                        that shares a pod's lifetime.
                       properties:
                         endpoints:
+                          description: endpoints is the endpoint name that details
+                            Glusterfs topology.
                           type: string
                         path:
+                          description: |-
+                            path is the Glusterfs volume path.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
+                      description: |-
+                        hostPath represents a pre-existing file or directory on the host
+                        machine that is directly exposed to the container.
                       properties:
                         path:
+                          description: |-
+                            path of the directory on the host.
+                            If the path is a symlink, it will follow the link to the real path.
                           type: string
                         type:
+                          description: |-
+                            type for HostPath Volume
+                            Defaults to ""
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     image:
+                      description: image represents an OCI object (a container image
+                        or artifact) pulled and mounted on the kubelet's host machine.
                       properties:
                         pullPolicy:
+                          description: |-
+                            Policy for pulling OCI objects. Possible values are:
+                            Always: the kubelet always attempts to pull the reference.
                           type: string
                         reference:
+                          description: |-
+                            Required: Image or artifact reference to be used.
+                            Behaves in the same way as pod.spec.containers[*].image.
                           type: string
                       type: object
                     iscsi:
+                      description: |-
+                        iscsi represents an ISCSI Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         chapAuthDiscovery:
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
                           type: boolean
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         initiatorName:
+                          description: initiatorName is the custom iSCSI Initiator
+                            Name.
                           type: string
                         iqn:
+                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
                           default: default
+                          description: |-
+                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
                           type: string
                         lun:
+                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
+                          description: portals is the iSCSI Target Portal List.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
                           type: boolean
                         secretRef:
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
+                          description: targetPortal is iSCSI Target Portal.
                           type: string
                       required:
                       - iqn
@@ -1423,68 +2437,140 @@ spec:
                       - targetPortal
                       type: object
                     name:
+                      description: |-
+                        name of the volume.
+                        Must be a DNS_LABEL and unique within the pod.
+                        More info: https://kubernetes.
                       type: string
                     nfs:
+                      description: |-
+                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                        More info: https://kubernetes.
                       properties:
                         path:
+                          description: |-
+                            path that is exported by the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                         server:
+                          description: |-
+                            server is the hostname or IP address of the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
+                      description: |-
+                        persistentVolumeClaimVolumeSource represents a reference to a
+                        PersistentVolumeClaim in the same namespace.
                       properties:
                         claimName:
+                          description: claimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
+                      description: photonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         pdID:
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
+                      description: portworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
+                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
                       properties:
                         defaultMode:
+                          description: defaultMode are the mode bits used to set permissions
+                            on created files by default.
                           format: int32
                           type: integer
                         sources:
+                          description: |-
+                            sources is the list of volume projections. Each entry in this list
+                            handles one source.
                           items:
+                            description: |-
+                              Projection that may be projected along with other supported volume types.
+                              Exactly one of these fields must be set.
                             properties:
                               clusterTrustBundle:
+                                description: |-
+                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                  of ClusterTrustBundle objects in an auto-updating file.
                                 properties:
                                   labelSelector:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this label selector.  Only has
+                                      effect if signerName is set.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -1498,31 +2584,58 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
+                                    description: |-
+                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                      with signerName and labelSelector.
                                     type: string
                                   optional:
+                                    description: |-
+                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                      aren't available.
                                     type: boolean
                                   path:
+                                    description: Relative path from the volume root
+                                      to write the bundle.
                                     type: string
                                   signerName:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this signer name.
+                                      Mutually-exclusive with name.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
+                                description: configMap information about the configMap
+                                  data to project
                                 properties:
                                   items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a...
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: key is the key to project.
                                           type: string
                                         mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
                                           type: string
                                       required:
                                       - key
@@ -1532,42 +2645,80 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
                                 properties:
                                   items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
                                     items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
                                       properties:
                                         fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name, namespace and uid are supported.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value...
                                           format: int32
                                           type: integer
                                         path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path.'
                                           type: string
                                         resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to
+                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -1580,39 +2731,76 @@ spec:
                                     x-kubernetes-list-type: atomic
                                 type: object
                               podCertificate:
+                                description: |-
+                                  Projects an auto-rotating credential bundle (private key and certificate
+                                  chain) that the pod can use either as a TLS client or...
                                 properties:
                                   certificateChainPath:
+                                    description: |-
+                                      Write the certificate chain at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.
                                     type: string
                                   credentialBundlePath:
+                                    description: Write the credential bundle at this
+                                      path in the projected volume.
                                     type: string
                                   keyPath:
+                                    description: |-
+                                      Write the key at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.
                                     type: string
                                   keyType:
+                                    description: The type of keypair Kubelet will
+                                      generate for the pod.
                                     type: string
                                   maxExpirationSeconds:
+                                    description: |-
+                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                      certificate.
                                     format: int32
                                     type: integer
                                   signerName:
+                                    description: Kubelet's generated CSRs will be
+                                      addressed to this signer.
                                     type: string
                                   userAnnotations:
                                     additionalProperties:
                                       type: string
+                                    description: |-
+                                      userAnnotations allow pod authors to pass additional information to
+                                      the signer implementation.
                                     type: object
                                 required:
                                 - keyType
                                 - signerName
                                 type: object
                               secret:
+                                description: secret information about the secret data
+                                  to project
                                 properties:
                                   items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a...
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: key is the key to project.
                                           type: string
                                         mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
                                           type: string
                                       required:
                                       - key
@@ -1622,19 +2810,35 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
+                                    description: audience is the intended audience
+                                      of the token.
                                     type: string
                                   expirationSeconds:
+                                    description: |-
+                                      expirationSeconds is the requested duration of validity of the service
+                                      account token.
                                     format: int64
                                     type: integer
                                   path:
+                                    description: |-
+                                      path is the path relative to the mount point of the file to project the
+                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -1644,84 +2848,168 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     quobyte:
+                      description: quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime.
                       properties:
                         group:
+                          description: |-
+                            group to map volume access to
+                            Default is no group
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                         registry:
+                          description: |-
+                            registry represents a single or multiple Quobyte Registry services
+                            specified as a string as host:port pair (multiple entries...
                           type: string
                         tenant:
+                          description: |-
+                            tenant owning the given Quobyte volume in the Backend
+                            Used with dynamically provisioned Quobyte volumes, value is set by the...
                           type: string
                         user:
+                          description: |-
+                            user to map volume access to
+                            Defaults to serivceaccount user
                           type: string
                         volume:
+                          description: volume is a string that references an already
+                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
+                      description: rbd represents a Rados Block Device mount on the
+                        host that shares a pod's lifetime.
                       properties:
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         image:
+                          description: |-
+                            image is the rados image name.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
                           default: /etc/ceph/keyring
+                          description: |-
+                            keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring.
+                            More info: https://examples.k8s.
                           type: string
                         monitors:
+                          description: |-
+                            monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         pool:
                           default: rbd
+                          description: |-
+                            pool is the rados pool name.
+                            Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://examples.k8s.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is name of the authentication secret for RBDUser. If provided
+                            overrides keyring.
+                            Default is nil.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
                           default: admin
+                          description: |-
+                            user is the rados user name.
+                            Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
+                      description: scaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
                           default: xfs
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         gateway:
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
                           type: string
                         protectionDomain:
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef references to the secret for ScaleIO user and other
+                            sensitive information.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
                           type: boolean
                         storageMode:
                           default: ThinProvisioned
+                          description: storageMode indicates whether the storage for
+                            a volume should be ThickProvisioned or ThinProvisioned.
                           type: string
                         storagePool:
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
                           type: string
                         system:
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
                           type: string
                         volumeName:
+                          description: |-
+                            volumeName is the name of a volume already created in the ScaleIO system
+                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -1729,19 +3017,35 @@ spec:
                       - system
                       type: object
                     secret:
+                      description: |-
+                        secret represents a secret that should populate this volume.
+                        More info: https://kubernetes.
                       properties:
                         defaultMode:
+                          description: 'defaultMode is Optional: mode bits used to
+                            set permissions on created files by default.'
                           format: int32
                           type: integer
                         items:
+                          description: |-
+                            items If unspecified, each key-value pair in the Data field of the referenced
+                            Secret will be projected into the volume as a...
                           items:
+                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
+                                description: key is the key to project.
                                 type: string
                               mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file.'
                                 format: int32
                                 type: integer
                               path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
                                 type: string
                             required:
                             - key
@@ -1750,37 +3054,75 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         optional:
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
                           type: boolean
                         secretName:
+                          description: |-
+                            secretName is the name of the secret in the pod's namespace to use.
+                            More info: https://kubernetes.
                           type: string
                       type: object
                     storageos:
+                      description: storageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef specifies the secret to use for obtaining the StorageOS API
+                            credentials.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
+                          description: |-
+                            volumeName is the human-readable name of the StorageOS volume.  Volume
+                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
+                          description: volumeNamespace specifies the scope of the
+                            volume within StorageOS.
                           type: string
                       type: object
                     vsphereVolume:
+                      description: vsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
                           type: string
                         storagePolicyID:
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
                           type: string
                         volumePath:
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -1795,8 +3137,10 @@ spec:
             - endpoint
             type: object
           status:
+            description: OpAMPBridgeStatus defines the observed state of OpAMPBridge.
             properties:
               version:
+                description: Version of the managed OpAMP Bridge (operand)
                 type: string
             type: object
         type: object

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -45,70 +45,129 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: OpenTelemetryCollector is the Schema for the opentelemetrycollectors
+          API.
         properties:
           apiVersion:
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
             type: string
           kind:
+            description: Kind is a string value representing the REST resource this
+              object represents.
             type: string
           metadata:
             type: object
           spec:
+            description: OpenTelemetryCollectorSpec defines the desired state of OpenTelemetryCollector.
             properties:
               additionalContainers:
+                description: AdditionalContainers allows injecting additional containers
+                  into the Collector's pod definition.
                 items:
+                  description: A single application container that you want to run
+                    within a pod.
                   properties:
                     args:
+                      description: |-
+                        Arguments to the entrypoint.
+                        The container image's CMD is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     command:
+                      description: |-
+                        Entrypoint array. Not executed within a shell.
+                        The container image's ENTRYPOINT is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     env:
+                      description: |-
+                        List of environment variables to set in the container.
+                        Cannot be updated.
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any...
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
                                 properties:
                                   key:
+                                    description: The key within the env file. An invalid
+                                      key will prevent the pod from starting.
                                     type: string
                                   optional:
                                     default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
                                     type: boolean
                                   path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
                                     type: string
                                   volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
                                     type: string
                                 required:
                                 - key
@@ -117,29 +176,47 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -154,25 +231,45 @@ spec:
                       - name
                       x-kubernetes-list-type: map
                     envFrom:
+                      description: List of sources to populate environment variables
+                        in the container.
                       items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps or Secrets
                         properties:
                           configMapRef:
+                            description: The ConfigMap to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
+                            description: The Secret to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the Secret must be defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
@@ -180,31 +277,60 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     image:
+                      description: |-
+                        Container image name.
+                        More info: https://kubernetes.
                       type: string
                     imagePullPolicy:
+                      description: |-
+                        Image pull policy.
+                        One of Always, Never, IfNotPresent.
                       type: string
                     lifecycle:
+                      description: |-
+                        Actions that the management system should take in response to container lifecycle events.
+                        Cannot be updated.
                       properties:
                         postStart:
+                          description: PostStart is called immediately after a container
+                            is created.
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -213,58 +339,100 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
+                          description: |-
+                            PreStop is called immediately before a container is terminated due to an
+                            API request or management event such as...
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -273,75 +441,128 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         stopSignal:
+                          description: StopSignal defines which signal will be sent
+                            to a container when it is being stopped.
                           type: string
                       type: object
                     livenessProbe:
+                      description: |-
+                        Periodic probe of container liveness.
+                        Container will be restarted if the probe fails.
+                        Cannot be updated.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -350,62 +571,114 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     name:
+                      description: |-
+                        Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
                       type: string
                     ports:
+                      description: |-
+                        List of ports to expose from the container. Not specifying a port here
+                        DOES NOT prevent that port from being exposed.
                       items:
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
                           containerPort:
+                            description: |-
+                              Number of port to expose on the pod's IP address.
+                              This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
+                            description: What host IP to bind the external port to.
                             type: string
                           hostPort:
+                            description: |-
+                              Number of port to expose on the host.
+                              If specified, this must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           name:
+                            description: |-
+                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                              named port in a pod must have a unique name.
                             type: string
                           protocol:
                             default: TCP
+                            description: |-
+                              Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -416,39 +689,68 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
+                      description: |-
+                        Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe fails.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -457,51 +759,92 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     resizePolicy:
+                      description: |-
+                        Resources resize policy for the container.
+                        This field cannot be set on ephemeral containers.
                       items:
+                        description: ContainerResizePolicy represents resource resize
+                          policy for the container.
                         properties:
                           resourceName:
+                            description: |-
+                              Name of the resource to which this resource resize policy applies.
+                              Supported values: cpu, memory.
                             type: string
                           restartPolicy:
+                            description: |-
+                              Restart policy to apply when specified resource is resized.
+                              If not specified, it defaults to NotRequired.
                             type: string
                         required:
                         - resourceName
@@ -510,13 +853,26 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     resources:
+                      description: |-
+                        Compute Resources required by this container.
+                        Cannot be updated.
+                        More info: https://kubernetes.
                       properties:
                         claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
                           items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used.
                                 type: string
                               request:
+                                description: Request is the name chosen for a request
+                                  in the referenced claim.
                                 type: string
                             required:
                             - name
@@ -532,6 +888,9 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.
                           type: object
                         requests:
                           additionalProperties:
@@ -540,20 +899,41 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: Requests describes the minimum amount of compute
+                            resources required.
                           type: object
                       type: object
                     restartPolicy:
+                      description: |-
+                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                        This overrides the pod-level restart policy.
                       type: string
                     restartPolicyRules:
+                      description: |-
+                        Represents a list of rules to be checked to determine if the
+                        container should be restarted on exit.
                       items:
+                        description: ContainerRestartRule describes how a container
+                          exit is handled.
                         properties:
                           action:
+                            description: |-
+                              Specifies the action taken on a container exit if the requirements
+                              are satisfied.
                             type: string
                           exitCodes:
+                            description: Represents the exit codes to check on container
+                              exits.
                             properties:
                               operator:
+                                description: |-
+                                  Represents the relationship between the container exit code(s) and the
+                                  specified values.
                                 type: string
                               values:
+                                description: |-
+                                  Specifies the set of values to check for container exit codes.
+                                  At most 255 elements are allowed.
                                 items:
                                   format: int32
                                   type: integer
@@ -568,111 +948,202 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     securityContext:
+                      description: SecurityContext defines the security options the
+                        container should be run with.
                       properties:
                         allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process.
                           type: boolean
                         appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile loaded
+                                on the node that should be used.
                               type: string
                             type:
+                              description: type indicates which kind of AppArmor profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         capabilities:
+                          description: The capabilities to add/drop when running containers.
                           properties:
                             add:
+                              description: Added capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             drop:
+                              description: Removed capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
                           type: boolean
                         procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers.
                           type: string
                         readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.
                           type: boolean
                         runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user.
                           type: boolean
                         runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by this container.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used.
                               type: string
                             type:
+                              description: type indicates which kind of seccomp profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
                           properties:
                             gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container.
                               type: boolean
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process.
                               type: string
                           type: object
                       type: object
                     startupProbe:
+                      description: StartupProbe indicates that the Pod has successfully
+                        initialized.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -681,61 +1152,112 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime.
                       type: boolean
                     stdinOnce:
+                      description: |-
+                        Whether the container runtime should close the stdin channel after it has been opened by
+                        a single attach.
                       type: boolean
                     terminationMessagePath:
+                      description: |-
+                        Optional: Path at which the file to which the container's termination message
+                        will be written is mounted into the container's...
                       type: string
                     terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated.
                       type: string
                     tty:
+                      description: |-
+                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                        Default is false.
                       type: boolean
                     volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
                       items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
                         properties:
                           devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
                             type: string
                           name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -746,21 +1268,44 @@ spec:
                       - devicePath
                       x-kubernetes-list-type: map
                     volumeMounts:
+                      description: |-
+                        Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
                       items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
+                            description: |-
+                              Path within the container at which the volume should be mounted.  Must
+                              not contain ':'.
                             type: string
                           mountPropagation:
+                            description: |-
+                              mountPropagation determines how mounts are propagated from the host
+                              to container and the other way around.
                             type: string
                           name:
+                            description: This must match the Name of a Volume.
                             type: string
                           readOnly:
+                            description: |-
+                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                              Defaults to false.
                             type: boolean
                           recursiveReadOnly:
+                            description: |-
+                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                              recursively.
                             type: string
                           subPath:
+                            description: |-
+                              Path within the volume from which the container's volume should be mounted.
+                              Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted.
                             type: string
                         required:
                         - mountPath
@@ -771,28 +1316,53 @@ spec:
                       - mountPath
                       x-kubernetes-list-type: map
                     workingDir:
+                      description: Container's working directory.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               affinity:
+                description: If specified, indicates the pod's scheduling constraints
                 properties:
                   nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may...
                         items:
+                          description: |-
+                            An empty preferred scheduling term matches all objects with implicit weight 0
+                            (i.e. it's a no-op).
                           properties:
                             preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
                               properties:
                                 matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -804,13 +1374,26 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -824,6 +1407,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -833,18 +1418,39 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the...
                         properties:
                           nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
                             items:
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
                               properties:
                                 matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -856,13 +1462,26 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -883,22 +1502,48 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may...
                         items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -912,29 +1557,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -948,20 +1617,30 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -971,18 +1650,40 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the...
                         items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be...
                           properties:
                             labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -996,29 +1697,52 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -1032,15 +1756,22 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the...
                               type: string
                           required:
                           - topologyKey
@@ -1049,22 +1780,49 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                   podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the anti-affinity expressions specified by this field, but it...
                         items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -1078,29 +1836,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -1114,20 +1896,30 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -1137,18 +1929,40 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the anti-affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto...
                         items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be...
                           properties:
                             labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -1162,29 +1976,52 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -1198,15 +2035,22 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the...
                               type: string
                           required:
                           - topologyKey
@@ -1218,22 +2062,42 @@ spec:
               args:
                 additionalProperties:
                   type: string
+                description: Args is the set of arguments to pass to the OpenTelemetry
+                  Collector binary
                 type: object
               autoscaler:
+                description: |-
+                  Autoscaler specifies the pod autoscaling configuration to use
+                  for the OpenTelemetryCollector workload.
                 properties:
                   behavior:
+                    description: |-
+                      HorizontalPodAutoscalerBehavior configures the scaling behavior of the target
+                      in both Up and Down directions (scaleUp and...
                     properties:
                       scaleDown:
+                        description: scaleDown is scaling policy for scaling Down.
                         properties:
                           policies:
+                            description: policies is a list of potential scaling polices
+                              which can be used during scaling.
                             items:
+                              description: HPAScalingPolicy is a single policy which
+                                must hold true for a specified past interval.
                               properties:
                                 periodSeconds:
+                                  description: periodSeconds specifies the window
+                                    of time for which the policy should hold true.
                                   format: int32
                                   type: integer
                                 type:
+                                  description: type is used to specify the scaling
+                                    policy.
                                   type: string
                                 value:
+                                  description: |-
+                                    value contains the amount of change which is permitted by the policy.
+                                    It must be greater than zero
                                   format: int32
                                   type: integer
                               required:
@@ -1244,28 +2108,49 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           selectPolicy:
+                            description: |-
+                              selectPolicy is used to specify which policy should be used.
+                              If not set, the default value Max is used.
                             type: string
                           stabilizationWindowSeconds:
+                            description: |-
+                              stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                              considered while scaling up or...
                             format: int32
                             type: integer
                           tolerance:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              tolerance is the tolerance on the ratio between the current and desired
+                              metric value under which no updates are made to the...
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                         type: object
                       scaleUp:
+                        description: scaleUp is scaling policy for scaling Up.
                         properties:
                           policies:
+                            description: policies is a list of potential scaling polices
+                              which can be used during scaling.
                             items:
+                              description: HPAScalingPolicy is a single policy which
+                                must hold true for a specified past interval.
                               properties:
                                 periodSeconds:
+                                  description: periodSeconds specifies the window
+                                    of time for which the policy should hold true.
                                   format: int32
                                   type: integer
                                 type:
+                                  description: type is used to specify the scaling
+                                    policy.
                                   type: string
                                 value:
+                                  description: |-
+                                    value contains the amount of change which is permitted by the policy.
+                                    It must be greater than zero
                                   format: int32
                                   type: integer
                               required:
@@ -1276,40 +2161,79 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           selectPolicy:
+                            description: |-
+                              selectPolicy is used to specify which policy should be used.
+                              If not set, the default value Max is used.
                             type: string
                           stabilizationWindowSeconds:
+                            description: |-
+                              stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                              considered while scaling up or...
                             format: int32
                             type: integer
                           tolerance:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              tolerance is the tolerance on the ratio between the current and desired
+                              metric value under which no updates are made to the...
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                         type: object
                     type: object
                   maxReplicas:
+                    description: MaxReplicas sets an upper bound to the autoscaling
+                      feature. If MaxReplicas is set autoscaling is enabled.
                     format: int32
                     type: integer
                   metrics:
+                    description: Metrics is meant to provide a customizable way to
+                      configure HPA metrics.
                     items:
+                      description: |-
+                        MetricSpec defines a subset of metrics to be defined for the HPA's metric array
+                        more metric type can be supported as needed.
                       properties:
                         pods:
+                          description: |-
+                            PodsMetricSource indicates how to scale on a metric describing each pod in
+                            the current scale target (for example,...
                           properties:
                             metric:
+                              description: metric identifies the target metric by
+                                name and selector
                               properties:
                                 name:
+                                  description: name is the name of the given metric
                                   type: string
                                 selector:
+                                  description: |-
+                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                    When set, it is passed as an...
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -1323,6 +2247,8 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -1330,22 +2256,34 @@ spec:
                               - name
                               type: object
                             target:
+                              description: target specifies the target value for the
+                                given metric
                               properties:
                                 averageUtilization:
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a...
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
                                   type: string
                                 value:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               required:
@@ -1356,29 +2294,44 @@ spec:
                           - target
                           type: object
                         type:
+                          description: MetricSourceType indicates the type of metric.
                           type: string
                       required:
                       - type
                       type: object
                     type: array
                   minReplicas:
+                    description: MinReplicas sets a lower bound to the autoscaling
+                      feature.  Set this if you are using autoscaling. It must be
+                      at least 1
                     format: int32
                     type: integer
                   targetCPUUtilization:
+                    description: TargetCPUUtilization sets the target average CPU
+                      used across all replicas.
                     format: int32
                     type: integer
                   targetMemoryUtilization:
+                    description: TargetMemoryUtilization sets the target average memory
+                      utilization across all replicas
                     format: int32
                     type: integer
                 type: object
               config:
+                description: Config is the raw YAML to be used as the collector's
+                  configuration.
                 type: string
               configmaps:
+                description: |-
+                  ConfigMaps is a list of ConfigMaps in the same namespace as the OpenTelemetryCollector
+                  object, which shall be mounted into the...
                 items:
                   properties:
                     mountpath:
                       type: string
                     name:
+                      description: Configmap defines name and path where the configMaps
+                        should be mounted.
                       type: string
                   required:
                   - mountpath
@@ -1386,65 +2339,116 @@ spec:
                   type: object
                 type: array
               deploymentUpdateStrategy:
+                description: UpdateStrategy represents the strategy the operator will
+                  take replacing existing Deployment pods with new pods...
                 properties:
                   rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if DeploymentStrategyType =
+                      RollingUpdate.
                     properties:
                       maxSurge:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          The maximum number of pods that can be scheduled above the desired number of
+                          pods.
                         x-kubernetes-int-or-string: true
                       maxUnavailable:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: The maximum number of pods that can be unavailable
+                          during the update.
                         x-kubernetes-int-or-string: true
                     type: object
                   type:
+                    description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                      Default is RollingUpdate.
                     type: string
                 type: object
               env:
+                description: ENV vars to set on the OpenTelemetry Collector's Pods.
                 items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
                   properties:
                     name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any...
                       type: string
                     valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
                           properties:
                             key:
+                              description: The key to select.
                               type: string
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.'
                           properties:
                             apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
                               type: string
                           required:
                           - fieldPath
                           type: object
                           x-kubernetes-map-type: atomic
                         fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
                           properties:
                             key:
+                              description: The key within the env file. An invalid
+                                key will prevent the pod from starting.
                               type: string
                             optional:
                               default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
                               type: boolean
                             path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
                               type: string
                             volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
                               type: string
                           required:
                           - key
@@ -1453,29 +2457,46 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.
                           properties:
                             containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
+                              description: 'Required: resource to select'
                               type: string
                           required:
                           - resource
                           type: object
                           x-kubernetes-map-type: atomic
                         secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
@@ -1487,49 +2508,87 @@ spec:
                   type: object
                 type: array
               envFrom:
+                description: List of sources to populate environment variables on
+                  the OpenTelemetry Collector's Pods.
                 items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
                   properties:
                     configMapRef:
+                      description: The ConfigMap to select from
                       properties:
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: Specify whether the ConfigMap must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     secretRef:
+                      description: The Secret to select from
                       properties:
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: Specify whether the Secret must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
               hostNetwork:
+                description: HostNetwork indicates if the pod should run in the host
+                  networking namespace.
                 type: boolean
               image:
+                description: Image indicates the container image to use for the OpenTelemetry
+                  Collector.
                 type: string
               imagePullPolicy:
+                description: ImagePullPolicy indicates the pull policy to be used
+                  for retrieving the container image (Always, Never, IfNotPresent)
                 type: string
               ingress:
+                description: Ingress is used to specify how OpenTelemetry Collector
+                  is exposed.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
+                    description: |-
+                      Annotations to add to ingress.
+                      e.g. 'cert-manager.io/cluster-issuer: "letsencrypt"'
                     type: object
                   hostname:
+                    description: Hostname by which the ingress proxy can be reached.
                     type: string
                   ingressClassName:
+                    description: IngressClassName is the name of an IngressClass cluster
+                      resource.
                     type: string
                   route:
+                    description: |-
+                      Route is an OpenShift specific section that is only considered when
+                      type "route" is used.
                     properties:
                       termination:
+                        description: Termination indicates termination type. By default
+                          "edge" is used.
                         enum:
                         - insecure
                         - edge
@@ -1538,83 +2597,148 @@ spec:
                         type: string
                     type: object
                   ruleType:
+                    description: RuleType defines how Ingress exposes collector receivers.
                     enum:
                     - path
                     - subdomain
                     type: string
                   tls:
+                    description: TLS configuration.
                     items:
+                      description: IngressTLS describes the transport layer security
+                        associated with an ingress.
                       properties:
                         hosts:
+                          description: |-
+                            hosts is a list of hosts included in the TLS certificate. The values in
+                            this list must match the name/s used in the tlsSecret.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         secretName:
+                          description: |-
+                            secretName is the name of the secret used to terminate TLS traffic on
+                            port 443.
                           type: string
                       type: object
                     type: array
                   type:
+                    description: |-
+                      Type default value is: ""
+                      Supported types are: ingress, route
                     enum:
                     - ingress
                     - route
                     type: string
                 type: object
               initContainers:
+                description: InitContainers allows injecting initContainers to the
+                  Collector's pod definition.
                 items:
+                  description: A single application container that you want to run
+                    within a pod.
                   properties:
                     args:
+                      description: |-
+                        Arguments to the entrypoint.
+                        The container image's CMD is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     command:
+                      description: |-
+                        Entrypoint array. Not executed within a shell.
+                        The container image's ENTRYPOINT is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     env:
+                      description: |-
+                        List of environment variables to set in the container.
+                        Cannot be updated.
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any...
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
                                 properties:
                                   key:
+                                    description: The key within the env file. An invalid
+                                      key will prevent the pod from starting.
                                     type: string
                                   optional:
                                     default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
                                     type: boolean
                                   path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
                                     type: string
                                   volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
                                     type: string
                                 required:
                                 - key
@@ -1623,29 +2747,47 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -1660,25 +2802,45 @@ spec:
                       - name
                       x-kubernetes-list-type: map
                     envFrom:
+                      description: List of sources to populate environment variables
+                        in the container.
                       items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps or Secrets
                         properties:
                           configMapRef:
+                            description: The ConfigMap to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
+                            description: The Secret to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the Secret must be defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1686,31 +2848,60 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     image:
+                      description: |-
+                        Container image name.
+                        More info: https://kubernetes.
                       type: string
                     imagePullPolicy:
+                      description: |-
+                        Image pull policy.
+                        One of Always, Never, IfNotPresent.
                       type: string
                     lifecycle:
+                      description: |-
+                        Actions that the management system should take in response to container lifecycle events.
+                        Cannot be updated.
                       properties:
                         postStart:
+                          description: PostStart is called immediately after a container
+                            is created.
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -1719,58 +2910,100 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
+                          description: |-
+                            PreStop is called immediately before a container is terminated due to an
+                            API request or management event such as...
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -1779,75 +3012,128 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         stopSignal:
+                          description: StopSignal defines which signal will be sent
+                            to a container when it is being stopped.
                           type: string
                       type: object
                     livenessProbe:
+                      description: |-
+                        Periodic probe of container liveness.
+                        Container will be restarted if the probe fails.
+                        Cannot be updated.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -1856,62 +3142,114 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     name:
+                      description: |-
+                        Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
                       type: string
                     ports:
+                      description: |-
+                        List of ports to expose from the container. Not specifying a port here
+                        DOES NOT prevent that port from being exposed.
                       items:
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
                           containerPort:
+                            description: |-
+                              Number of port to expose on the pod's IP address.
+                              This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
+                            description: What host IP to bind the external port to.
                             type: string
                           hostPort:
+                            description: |-
+                              Number of port to expose on the host.
+                              If specified, this must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           name:
+                            description: |-
+                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                              named port in a pod must have a unique name.
                             type: string
                           protocol:
                             default: TCP
+                            description: |-
+                              Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -1922,39 +3260,68 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
+                      description: |-
+                        Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe fails.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -1963,51 +3330,92 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     resizePolicy:
+                      description: |-
+                        Resources resize policy for the container.
+                        This field cannot be set on ephemeral containers.
                       items:
+                        description: ContainerResizePolicy represents resource resize
+                          policy for the container.
                         properties:
                           resourceName:
+                            description: |-
+                              Name of the resource to which this resource resize policy applies.
+                              Supported values: cpu, memory.
                             type: string
                           restartPolicy:
+                            description: |-
+                              Restart policy to apply when specified resource is resized.
+                              If not specified, it defaults to NotRequired.
                             type: string
                         required:
                         - resourceName
@@ -2016,13 +3424,26 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     resources:
+                      description: |-
+                        Compute Resources required by this container.
+                        Cannot be updated.
+                        More info: https://kubernetes.
                       properties:
                         claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
                           items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used.
                                 type: string
                               request:
+                                description: Request is the name chosen for a request
+                                  in the referenced claim.
                                 type: string
                             required:
                             - name
@@ -2038,6 +3459,9 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.
                           type: object
                         requests:
                           additionalProperties:
@@ -2046,20 +3470,41 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: Requests describes the minimum amount of compute
+                            resources required.
                           type: object
                       type: object
                     restartPolicy:
+                      description: |-
+                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                        This overrides the pod-level restart policy.
                       type: string
                     restartPolicyRules:
+                      description: |-
+                        Represents a list of rules to be checked to determine if the
+                        container should be restarted on exit.
                       items:
+                        description: ContainerRestartRule describes how a container
+                          exit is handled.
                         properties:
                           action:
+                            description: |-
+                              Specifies the action taken on a container exit if the requirements
+                              are satisfied.
                             type: string
                           exitCodes:
+                            description: Represents the exit codes to check on container
+                              exits.
                             properties:
                               operator:
+                                description: |-
+                                  Represents the relationship between the container exit code(s) and the
+                                  specified values.
                                 type: string
                               values:
+                                description: |-
+                                  Specifies the set of values to check for container exit codes.
+                                  At most 255 elements are allowed.
                                 items:
                                   format: int32
                                   type: integer
@@ -2074,111 +3519,202 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     securityContext:
+                      description: SecurityContext defines the security options the
+                        container should be run with.
                       properties:
                         allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process.
                           type: boolean
                         appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile loaded
+                                on the node that should be used.
                               type: string
                             type:
+                              description: type indicates which kind of AppArmor profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         capabilities:
+                          description: The capabilities to add/drop when running containers.
                           properties:
                             add:
+                              description: Added capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             drop:
+                              description: Removed capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
                           type: boolean
                         procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers.
                           type: string
                         readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.
                           type: boolean
                         runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user.
                           type: boolean
                         runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by this container.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used.
                               type: string
                             type:
+                              description: type indicates which kind of seccomp profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
                           properties:
                             gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container.
                               type: boolean
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process.
                               type: string
                           type: object
                       type: object
                     startupProbe:
+                      description: StartupProbe indicates that the Pod has successfully
+                        initialized.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -2187,61 +3723,112 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime.
                       type: boolean
                     stdinOnce:
+                      description: |-
+                        Whether the container runtime should close the stdin channel after it has been opened by
+                        a single attach.
                       type: boolean
                     terminationMessagePath:
+                      description: |-
+                        Optional: Path at which the file to which the container's termination message
+                        will be written is mounted into the container's...
                       type: string
                     terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated.
                       type: string
                     tty:
+                      description: |-
+                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                        Default is false.
                       type: boolean
                     volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
                       items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
                         properties:
                           devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
                             type: string
                           name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -2252,21 +3839,44 @@ spec:
                       - devicePath
                       x-kubernetes-list-type: map
                     volumeMounts:
+                      description: |-
+                        Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
                       items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
+                            description: |-
+                              Path within the container at which the volume should be mounted.  Must
+                              not contain ':'.
                             type: string
                           mountPropagation:
+                            description: |-
+                              mountPropagation determines how mounts are propagated from the host
+                              to container and the other way around.
                             type: string
                           name:
+                            description: This must match the Name of a Volume.
                             type: string
                           readOnly:
+                            description: |-
+                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                              Defaults to false.
                             type: boolean
                           recursiveReadOnly:
+                            description: |-
+                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                              recursively.
                             type: string
                           subPath:
+                            description: |-
+                              Path within the volume from which the container's volume should be mounted.
+                              Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted.
                             type: string
                         required:
                         - mountPath
@@ -2277,33 +3887,54 @@ spec:
                       - mountPath
                       x-kubernetes-list-type: map
                     workingDir:
+                      description: Container's working directory.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               lifecycle:
+                description: Actions that the management system should take in response
+                  to container lifecycle events. Cannot be updated.
                 properties:
                   postStart:
+                    description: PostStart is called immediately after a container
+                      is created.
                     properties:
                       exec:
+                        description: Exec specifies a command to execute in the container.
                         properties:
                           command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the...
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                         type: object
                       httpGet:
+                        description: HTTPGet specifies an HTTP GET request to perform.
                         properties:
                           host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
                             items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
                               properties:
                                 name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
+                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -2312,58 +3943,97 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           path:
+                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       sleep:
+                        description: Sleep represents a duration that the container
+                          should sleep.
                         properties:
                           seconds:
+                            description: Seconds is the number of seconds to sleep.
                             format: int64
                             type: integer
                         required:
                         - seconds
                         type: object
                       tcpSocket:
+                        description: |-
+                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                          for backward compatibility.
                         properties:
                           host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                     type: object
                   preStop:
+                    description: |-
+                      PreStop is called immediately before a container is terminated due to an
+                      API request or management event such as...
                     properties:
                       exec:
+                        description: Exec specifies a command to execute in the container.
                         properties:
                           command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the...
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                         type: object
                       httpGet:
+                        description: HTTPGet specifies an HTTP GET request to perform.
                         properties:
                           host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
                             items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
                               properties:
                                 name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
+                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -2372,75 +4042,127 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           path:
+                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       sleep:
+                        description: Sleep represents a duration that the container
+                          should sleep.
                         properties:
                           seconds:
+                            description: Seconds is the number of seconds to sleep.
                             format: int64
                             type: integer
                         required:
                         - seconds
                         type: object
                       tcpSocket:
+                        description: |-
+                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                          for backward compatibility.
                         properties:
                           host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                     type: object
                   stopSignal:
+                    description: StopSignal defines which signal will be sent to a
+                      container when it is being stopped.
                     type: string
                 type: object
               livenessProbe:
+                description: Liveness config for the OpenTelemetry Collector except
+                  the probe handler which is auto generated from the health extension
+                  of...
                 properties:
                   failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
                     format: int32
                     type: integer
                   initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      Defaults to 0 seconds.
                     format: int32
                     type: integer
                   periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
                     format: int32
                     type: integer
                   successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1.
                     format: int32
                     type: integer
                   terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure.
                     format: int64
                     type: integer
                   timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.
                     format: int32
                     type: integer
                 type: object
               managementState:
                 default: managed
+                description: |-
+                  ManagementState defines if the CR should be managed by the operator or not.
+                  Default is managed.
                 enum:
                 - managed
                 - unmanaged
                 type: string
               maxReplicas:
+                description: MaxReplicas sets an upper bound to the autoscaling feature.
+                  If MaxReplicas is set autoscaling is enabled.
                 format: int32
                 type: integer
               minReplicas:
+                description: MinReplicas sets a lower bound to the autoscaling feature.  Set
+                  this if you are using autoscaling.
                 format: int32
                 type: integer
               mode:
+                description: Mode represents how the collector should be deployed
+                  (deployment, daemonset, statefulset or sidecar)
                 enum:
                 - daemonset
                 - deployment
@@ -2450,94 +4172,170 @@ spec:
               nodeSelector:
                 additionalProperties:
                   type: string
+                description: |-
+                  NodeSelector to schedule OpenTelemetry Collector pods.
+                  This is only relevant to daemonset, statefulset, and deployment mode
                 type: object
               observability:
+                description: ObservabilitySpec defines how telemetry data gets handled.
                 properties:
                   metrics:
+                    description: Metrics defines the metrics configuration for operands.
                     properties:
                       DisablePrometheusAnnotations:
+                        description: |-
+                          DisablePrometheusAnnotations controls the automatic addition of default Prometheus annotations
+                          ('prometheus.
                         type: boolean
                       enableMetrics:
+                        description: EnableMetrics specifies if ServiceMonitor or
+                          PodMonitor(for sidecar mode) should be created for the service
+                          managed by the...
                         type: boolean
                     type: object
                 type: object
               podAnnotations:
                 additionalProperties:
                   type: string
+                description: |-
+                  PodAnnotations is the set of annotations that will be attached to
+                  Collector and Target Allocator pods.
                 type: object
               podDisruptionBudget:
+                description: |-
+                  PodDisruptionBudget specifies the pod disruption budget configuration to use
+                  for the OpenTelemetryCollector workload.
                 properties:
                   maxUnavailable:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      An eviction is allowed if at most "maxUnavailable" pods selected by
+                      "selector" are unavailable after the eviction, i.e.
                     x-kubernetes-int-or-string: true
                   minAvailable:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      An eviction is allowed if at least "minAvailable" pods selected by
+                      "selector" will still be available after the eviction, i.e.
                     x-kubernetes-int-or-string: true
                 type: object
               podSecurityContext:
+                description: |-
+                  PodSecurityContext configures the pod security context for the
+                  opentelemetry-collector pod, when running as a deployment,...
                 properties:
                   appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by the containers in this pod.
+                      Note that this field cannot be set when spec.os.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile loaded on
+                          the node that should be used.
                         type: string
                       type:
+                        description: type indicates which kind of AppArmor profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   fsGroup:
+                    description: A special supplemental group that applies to all
+                      containers in a pod.
                     format: int64
                     type: integer
                   fsGroupChangePolicy:
+                    description: |-
+                      fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                      before being exposed inside Pod.
                     type: string
                   runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in SecurityContext.
                     format: int64
                     type: integer
                   runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user.
                     type: boolean
                   runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
                     format: int64
                     type: integer
                   seLinuxChangePolicy:
+                    description: seLinuxChangePolicy defines how the container's SELinux
+                      label is applied to all volumes used by the Pod.
                     type: string
                   seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
                     properties:
                       level:
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
+                    description: |-
+                      The seccomp options to use by the containers in this pod.
+                      Note that this field cannot be set when spec.os.name is windows.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used.
                         type: string
                       type:
+                        description: type indicates which kind of seccomp profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   supplementalGroups:
+                    description: |-
+                      A list of groups applied to the first process run in each container, in
+                      addition to the container's primary GID and fsGroup (if...
                     items:
                       format: int64
                       type: integer
                     type: array
                     x-kubernetes-list-type: atomic
                   supplementalGroupsPolicy:
+                    description: |-
+                      Defines how supplemental groups of the first container processes are calculated.
+                      Valid values are "Merge" and "Strict".
                     type: string
                   sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod.
                     items:
+                      description: Sysctl defines a kernel parameter to be set
                       properties:
                         name:
+                          description: Name of a property to set
                           type: string
                         value:
+                          description: Value of a property to set
                           type: string
                       required:
                       - name
@@ -2546,40 +4344,70 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   windowsOptions:
+                    description: The Windows specific settings applied to all containers.
                     properties:
                       gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.
                         type: string
                       gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container.
                         type: boolean
                       runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process.
                         type: string
                     type: object
                 type: object
               ports:
+                description: Ports allows a set of ports to be exposed by the underlying
+                  v1.Service.
                 items:
+                  description: PortsSpec defines the OpenTelemetryCollector's container/service
+                    ports additional specifications.
                   properties:
                     appProtocol:
+                      description: The application protocol for this port.
                       type: string
                     hostPort:
+                      description: Allows defining which port to bind to the host
+                        in the Container.
                       format: int32
                       type: integer
                     name:
+                      description: |-
+                        The name of this port within the service. This must be a DNS_LABEL.
+                        All ports within a ServiceSpec must have unique names.
                       type: string
                     nodePort:
+                      description: |-
+                        The port on each node on which this service is exposed when type is
+                        NodePort or LoadBalancer.  Usually assigned by the system.
                       format: int32
                       type: integer
                     port:
+                      description: The port that will be exposed by this service.
                       format: int32
                       type: integer
                     protocol:
                       default: TCP
+                      description: |-
+                        The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                        Default is TCP.
                       type: string
                     targetPort:
                       anyOf:
                       - type: integer
                       - type: string
+                      description: |-
+                        Number or name of the port to access on the pods targeted by the service.
+                        Number must be in the range 1 to 65535.
                       x-kubernetes-int-or-string: true
                   required:
                   - port
@@ -2587,19 +4415,35 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               priorityClassName:
+                description: |-
+                  If specified, indicates the pod's priority.
+                  If not specified, the pod priority will be default or zero if there is no
+                  default.
                 type: string
               replicas:
                 default: 1
+                description: Replicas is the number of pod instances for the underlying
+                  OpenTelemetry Collector. Set this if you are not using autoscaling
                 format: int32
                 type: integer
               resources:
+                description: Resources to set on the OpenTelemetry Collector pods.
                 properties:
                   claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
                     items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used.
                           type: string
                         request:
+                          description: Request is the name chosen for a request in
+                            the referenced claim.
                           type: string
                       required:
                       - name
@@ -2615,6 +4459,9 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.
                     type: object
                   requests:
                     additionalProperties:
@@ -2623,105 +4470,202 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
+                    description: Requests describes the minimum amount of compute
+                      resources required.
                     type: object
                 type: object
               securityContext:
+                description: |-
+                  SecurityContext configures the container security context for
+                  the opentelemetry-collector container.
                 properties:
                   allowPrivilegeEscalation:
+                    description: |-
+                      AllowPrivilegeEscalation controls whether a process can gain more
+                      privileges than its parent process.
                     type: boolean
                   appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                      overrides the pod's appArmorProfile.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile loaded on
+                          the node that should be used.
                         type: string
                       type:
+                        description: type indicates which kind of AppArmor profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   capabilities:
+                    description: The capabilities to add/drop when running containers.
                     properties:
                       add:
+                        description: Added capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       drop:
+                        description: Removed capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                     type: object
                   privileged:
+                    description: |-
+                      Run container in privileged mode.
+                      Processes in privileged containers are essentially equivalent to root on the host.
                     type: boolean
                   procMount:
+                    description: procMount denotes the type of proc mount to use for
+                      the containers.
                     type: string
                   readOnlyRootFilesystem:
+                    description: |-
+                      Whether this container has a read-only root filesystem.
+                      Default is false.
+                      Note that this field cannot be set when spec.os.
                     type: boolean
                   runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in PodSecurityContext.
                     format: int64
                     type: integer
                   runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user.
                     type: boolean
                   runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
                     format: int64
                     type: integer
                   seLinuxOptions:
+                    description: The SELinux context to be applied to the container.
                     properties:
                       level:
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
+                    description: The seccomp options to use by this container.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used.
                         type: string
                       type:
+                        description: type indicates which kind of seccomp profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   windowsOptions:
+                    description: |-
+                      The Windows specific settings applied to all containers.
+                      If unspecified, the options from the PodSecurityContext will be used.
                     properties:
                       gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.
                         type: string
                       gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container.
                         type: boolean
                       runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process.
                         type: string
                     type: object
                 type: object
               serviceAccount:
+                description: ServiceAccount indicates the name of an existing service
+                  account to use with this instance.
                 type: string
               serviceName:
+                description: |-
+                  ServiceName is the name of the Service to be used.
+                  If not specified, it will default to "<name>-headless".
                 type: string
               shareProcessNamespace:
+                description: ShareProcessNamespace indicates if the pod's containers
+                  should share process namespace.
                 type: boolean
               targetAllocator:
+                description: TargetAllocator indicates a value which determines whether
+                  to spawn a target allocation resource or not.
                 properties:
                   affinity:
+                    description: If specified, indicates the pod's scheduling constraints
                     properties:
                       nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may...
                             items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op).
                               properties:
                                 preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
                                       items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
                                         properties:
                                           key:
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2733,13 +4677,26 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
                                       items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
                                         properties:
                                           key:
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2753,6 +4710,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -2762,18 +4721,39 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the...
                             properties:
                               nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
                                 items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
                                   properties:
                                     matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
                                       items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
                                         properties:
                                           key:
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2785,13 +4765,26 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
                                       items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
                                         properties:
                                           key:
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2812,22 +4805,50 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may...
                             items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
                               properties:
                                 podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2841,29 +4862,53 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -2877,20 +4922,30 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the...
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -2900,18 +4955,41 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the...
                             items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be...
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2925,29 +5003,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -2961,15 +5063,22 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
@@ -2978,22 +5087,50 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it...
                             items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
                               properties:
                                 podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3007,29 +5144,53 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3043,20 +5204,30 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the...
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -3066,18 +5237,41 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto...
                             items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be...
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -3091,29 +5285,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -3127,15 +5345,22 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
@@ -3146,55 +5371,100 @@ spec:
                     type: object
                   allocationStrategy:
                     default: consistent-hashing
+                    description: AllocationStrategy determines which strategy the
+                      target allocator should use for allocation.
                     enum:
                     - least-weighted
                     - consistent-hashing
                     - per-node
                     type: string
                   enabled:
+                    description: Enabled indicates whether to use a target allocation
+                      mechanism for Prometheus targets or not.
                     type: boolean
                   env:
+                    description: ENV vars to set on the OpenTelemetry TargetAllocator's
+                      Pods.
                     items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any...
                           type: string
                         valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
+                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.'
                               properties:
                                 apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
                               properties:
                                 key:
+                                  description: The key within the env file. An invalid
+                                    key will prevent the pod from starting.
                                   type: string
                                 optional:
                                   default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
                                   type: boolean
                                 path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
                                   type: string
                                 volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
                                   type: string
                               required:
                               - key
@@ -3203,29 +5473,47 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.
                               properties:
                                 containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
+                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -3238,96 +5526,174 @@ spec:
                     type: array
                   filterStrategy:
                     default: relabel-config
+                    description: FilterStrategy determines how to filter targets before
+                      allocating them among the collectors.
                     type: string
                   image:
+                    description: Image indicates the container image to use for the
+                      OpenTelemetry TargetAllocator.
                     type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
+                    description: NodeSelector to schedule OpenTelemetry TargetAllocator
+                      pods.
                     type: object
                   observability:
+                    description: ObservabilitySpec defines how telemetry data gets
+                      handled.
                     properties:
                       metrics:
+                        description: Metrics defines the metrics configuration for
+                          operands.
                         properties:
                           DisablePrometheusAnnotations:
+                            description: |-
+                              DisablePrometheusAnnotations controls the automatic addition of default Prometheus annotations
+                              ('prometheus.
                             type: boolean
                           enableMetrics:
+                            description: EnableMetrics specifies if ServiceMonitor
+                              or PodMonitor(for sidecar mode) should be created for
+                              the service managed by the...
                             type: boolean
                         type: object
                     type: object
                   podDisruptionBudget:
+                    description: |-
+                      PodDisruptionBudget specifies the pod disruption budget configuration to use
+                      for the target allocator workload.
                     properties:
                       maxUnavailable:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          An eviction is allowed if at most "maxUnavailable" pods selected by
+                          "selector" are unavailable after the eviction, i.e.
                         x-kubernetes-int-or-string: true
                       minAvailable:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          An eviction is allowed if at least "minAvailable" pods selected by
+                          "selector" will still be available after the eviction, i.e.
                         x-kubernetes-int-or-string: true
                     type: object
                   podSecurityContext:
+                    description: |-
+                      PodSecurityContext configures the pod security context for the
+                      targetallocator.
                     properties:
                       appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.
                         properties:
                           localhostProfile:
+                            description: localhostProfile indicates a profile loaded
+                              on the node that should be used.
                             type: string
                           type:
+                            description: type indicates which kind of AppArmor profile
+                              will be applied.
                             type: string
                         required:
                         - type
                         type: object
                       fsGroup:
+                        description: A special supplemental group that applies to
+                          all containers in a pod.
                         format: int64
                         type: integer
                       fsGroupChangePolicy:
+                        description: |-
+                          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being exposed inside Pod.
                         type: string
                       runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in SecurityContext.
                         format: int64
                         type: integer
                       runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user.
                         type: boolean
                       runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
                         format: int64
                         type: integer
                       seLinuxChangePolicy:
+                        description: seLinuxChangePolicy defines how the container's
+                          SELinux label is applied to all volumes used by the Pod.
                         type: string
                       seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
                         properties:
                           level:
+                            description: Level is SELinux level label that applies
+                              to the container.
                             type: string
                           role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
                             type: string
                           type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
                             type: string
                           user:
+                            description: User is a SELinux user label that applies
+                              to the container.
                             type: string
                         type: object
                       seccompProfile:
+                        description: |-
+                          The seccomp options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
                         properties:
                           localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used.
                             type: string
                           type:
+                            description: type indicates which kind of seccomp profile
+                              will be applied.
                             type: string
                         required:
                         - type
                         type: object
                       supplementalGroups:
+                        description: |-
+                          A list of groups applied to the first process run in each container, in
+                          addition to the container's primary GID and fsGroup (if...
                         items:
                           format: int64
                           type: integer
                         type: array
                         x-kubernetes-list-type: atomic
                       supplementalGroupsPolicy:
+                        description: |-
+                          Defines how supplemental groups of the first container processes are calculated.
+                          Valid values are "Merge" and "Strict".
                         type: string
                       sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod.
                         items:
+                          description: Sysctl defines a kernel parameter to be set
                           properties:
                             name:
+                              description: Name of a property to set
                               type: string
                             value:
+                              description: Value of a property to set
                               type: string
                           required:
                           - name
@@ -3336,51 +5702,92 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers.
                         properties:
                           gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.
                             type: string
                           gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
                           hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container.
                             type: boolean
                           runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process.
                             type: string
                         type: object
                     type: object
                   prometheusCR:
+                    description: PrometheusCR defines the configuration for the retrieval
+                      of PrometheusOperator CRDs ( servicemonitor.monitoring.coreos.
                     properties:
                       enabled:
+                        description: Enabled indicates whether to use a PrometheusOperator
+                          custom resources as targets or not.
                         type: boolean
                       podMonitorSelector:
                         additionalProperties:
                           type: string
+                        description: |-
+                          PodMonitors to be selected for target discovery.
+                          This is a map of {key,value} pairs.
                         type: object
                       scrapeClasses:
+                        description: ScrapeClasses to be referenced by PodMonitors
+                          and ServiceMonitors to include common configuration.
                         items:
+                          description: AnyConfig represent parts of the config.
                           type: object
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-preserve-unknown-fields: true
                       scrapeInterval:
                         default: 30s
+                        description: |-
+                          Interval between consecutive scrapes. Equivalent to the same setting on the Prometheus CRD.
+
+                          Default: "30s"
                         format: duration
                         type: string
                       serviceMonitorSelector:
                         additionalProperties:
                           type: string
+                        description: |-
+                          ServiceMonitors to be selected for target discovery.
+                          This is a map of {key,value} pairs.
                         type: object
                     type: object
                   replicas:
+                    description: Replicas is the number of pod instances for the underlying
+                      TargetAllocator.
                     format: int32
                     type: integer
                   resources:
+                    description: Resources to set on the OpenTelemetryTargetAllocator
+                      containers.
                     properties:
                       claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
                         items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used.
                               type: string
                             request:
+                              description: Request is the name chosen for a request
+                                in the referenced claim.
                               type: string
                           required:
                           - name
@@ -3396,6 +5803,9 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.
                         type: object
                       requests:
                         additionalProperties:
@@ -3404,111 +5814,216 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                   securityContext:
+                    description: |-
+                      SecurityContext configures the container security context for
+                      the targetallocator.
                     properties:
                       allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process.
                         type: boolean
                       appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                          overrides the pod's appArmorProfile.
                         properties:
                           localhostProfile:
+                            description: localhostProfile indicates a profile loaded
+                              on the node that should be used.
                             type: string
                           type:
+                            description: type indicates which kind of AppArmor profile
+                              will be applied.
                             type: string
                         required:
                         - type
                         type: object
                       capabilities:
+                        description: The capabilities to add/drop when running containers.
                         properties:
                           add:
+                            description: Added capabilities
                             items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           drop:
+                            description: Removed capabilities
                             items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                         type: object
                       privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
                         type: boolean
                       procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers.
                         type: string
                       readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.
                         type: boolean
                       runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.
                         format: int64
                         type: integer
                       runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user.
                         type: boolean
                       runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
                         format: int64
                         type: integer
                       seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
                         properties:
                           level:
+                            description: Level is SELinux level label that applies
+                              to the container.
                             type: string
                           role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
                             type: string
                           type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
                             type: string
                           user:
+                            description: User is a SELinux user label that applies
+                              to the container.
                             type: string
                         type: object
                       seccompProfile:
+                        description: The seccomp options to use by this container.
                         properties:
                           localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used.
                             type: string
                           type:
+                            description: type indicates which kind of seccomp profile
+                              will be applied.
                             type: string
                         required:
                         - type
                         type: object
                       windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
                         properties:
                           gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.
                             type: string
                           gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
                           hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container.
                             type: boolean
                           runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process.
                             type: string
                         type: object
                     type: object
                   serviceAccount:
+                    description: ServiceAccount indicates the name of an existing
+                      service account to use with this instance.
                     type: string
                   tolerations:
+                    description: |-
+                      Toleration embedded kubernetes pod configuration option,
+                      controls how pods can be scheduled with matching taints
                     items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching...
                       properties:
                         effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects.
                           type: string
                         key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys.
                           type: string
                         operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                           type: string
                         tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is...
                           format: int64
                           type: integer
                         value:
+                          description: Value is the taint value the toleration matches
+                            to.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
+                    description: |-
+                      TopologySpreadConstraints embedded kubernetes pod configuration option,
+                      controls how pods are spread across your cluster among...
                     items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
                       properties:
                         labelSelector:
+                          description: LabelSelector is used to find matching pods.
                           properties:
                             matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
                               items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
                                   key:
+                                    description: key is the label key that the selector
+                                      applies to.
                                     type: string
                                   operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty.
                                     items:
                                       type: string
                                     type: array
@@ -3522,27 +6037,45 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
+                              description: matchLabels is a map of {key,value} pairs.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
+                          description: |-
+                            MatchLabelKeys is a set of pod label keys to select the pods over which
+                            spreading will be calculated.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
+                          description: MaxSkew describes the degree to which pods
+                            may be unevenly distributed.
                           format: int32
                           type: integer
                         minDomains:
+                          description: MinDomains indicates a minimum number of eligible
+                            domains.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
+                          description: |-
+                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                            when calculating pod topology spread skew.
                           type: string
                         nodeTaintsPolicy:
+                          description: |-
+                            NodeTaintsPolicy indicates how we will treat node taints when calculating
+                            pod topology spread skew.
                           type: string
                         topologyKey:
+                          description: TopologyKey is the key of node labels.
                           type: string
                         whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                            the spread constraint.
                           type: string
                       required:
                       - maxSkew
@@ -3552,37 +6085,76 @@ spec:
                     type: array
                 type: object
               terminationGracePeriodSeconds:
+                description: Duration in seconds the pod needs to terminate gracefully
+                  upon probe failure.
                 format: int64
                 type: integer
               tolerations:
+                description: |-
+                  Toleration to schedule OpenTelemetry Collector pods.
+                  This is only relevant to daemonset, statefulset, and deployment mode
                 items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching...
                   properties:
                     effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects.
                       type: string
                     key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys.
                       type: string
                     operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                       type: string
                     tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is...
                       format: int64
                       type: integer
                     value:
+                      description: Value is the taint value the toleration matches
+                        to.
                       type: string
                   type: object
                 type: array
               topologySpreadConstraints:
+                description: |-
+                  TopologySpreadConstraints embedded kubernetes pod configuration option,
+                  controls how pods are spread across your cluster among...
                 items:
+                  description: TopologySpreadConstraint specifies how to spread matching
+                    pods among the given topology.
                   properties:
                     labelSelector:
+                      description: LabelSelector is used to find matching pods.
                       properties:
                         matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
                           items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
+                                description: key is the label key that the selector
+                                  applies to.
                                 type: string
                               operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty.
                                 items:
                                   type: string
                                 type: array
@@ -3596,27 +6168,45 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
+                          description: matchLabels is a map of {key,value} pairs.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     matchLabelKeys:
+                      description: |-
+                        MatchLabelKeys is a set of pod label keys to select the pods over which
+                        spreading will be calculated.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     maxSkew:
+                      description: MaxSkew describes the degree to which pods may
+                        be unevenly distributed.
                       format: int32
                       type: integer
                     minDomains:
+                      description: MinDomains indicates a minimum number of eligible
+                        domains.
                       format: int32
                       type: integer
                     nodeAffinityPolicy:
+                      description: |-
+                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                        when calculating pod topology spread skew.
                       type: string
                     nodeTaintsPolicy:
+                      description: |-
+                        NodeTaintsPolicy indicates how we will treat node taints when calculating
+                        pod topology spread skew.
                       type: string
                     topologyKey:
+                      description: TopologyKey is the key of node labels.
                       type: string
                     whenUnsatisfiable:
+                      description: |-
+                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                        the spread constraint.
                       type: string
                   required:
                   - maxSkew
@@ -3625,38 +6215,66 @@ spec:
                   type: object
                 type: array
               trafficDistribution:
+                description: |-
+                  TrafficDistribution specifies how traffic to this service is routed.
+                  https://kubernetes.
                 type: string
               updateStrategy:
+                description: UpdateStrategy represents the strategy the operator will
+                  take replacing existing DaemonSet pods with new pods...
                 properties:
                   rollingUpdate:
+                    description: Rolling update config params. Present only if type
+                      = "RollingUpdate".
                     properties:
                       maxSurge:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          The maximum number of nodes with an existing available DaemonSet pod that
+                          can have an updated DaemonSet pod during during an...
                         x-kubernetes-int-or-string: true
                       maxUnavailable:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          The maximum number of DaemonSet pods that can be unavailable during the
+                          update.
                         x-kubernetes-int-or-string: true
                     type: object
                   type:
+                    description: Type of daemon set update. Can be "RollingUpdate"
+                      or "OnDelete". Default is RollingUpdate.
                     type: string
                 type: object
               upgradeStrategy:
+                description: UpgradeStrategy represents how the operator will handle
+                  upgrades to the CR when a newer version of the operator is deployed
                 enum:
                 - automatic
                 - none
                 type: string
               volumeClaimTemplates:
+                description: VolumeClaimTemplates will provide stable storage using
+                  PersistentVolumes. Only available when the mode=statefulset.
                 items:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
                   properties:
                     apiVersion:
+                      description: APIVersion defines the versioned schema of this
+                        representation of an object.
                       type: string
                     kind:
+                      description: Kind is a string value representing the REST resource
+                        this object represents.
                       type: string
                     metadata:
+                      description: |-
+                        Standard object's metadata.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.
                       properties:
                         annotations:
                           additionalProperties:
@@ -3676,19 +6294,32 @@ spec:
                           type: string
                       type: object
                     spec:
+                      description: |-
+                        spec defines the desired characteristics of a volume requested by a pod author.
+                        More info: https://kubernetes.
                       properties:
                         accessModes:
+                          description: |-
+                            accessModes contains the desired access modes the volume should have.
+                            More info: https://kubernetes.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         dataSource:
+                          description: |-
+                            dataSource field can be used to specify either:
+                            * An existing VolumeSnapshot object (snapshot.storage.k8s.
                           properties:
                             apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced.
                               type: string
                             kind:
+                              description: Kind is the type of resource being referenced
                               type: string
                             name:
+                              description: Name is the name of resource being referenced
                               type: string
                           required:
                           - kind
@@ -3696,20 +6327,32 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         dataSourceRef:
+                          description: |-
+                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                            volume is desired.
                           properties:
                             apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced.
                               type: string
                             kind:
+                              description: Kind is the type of resource being referenced
                               type: string
                             name:
+                              description: Name is the name of resource being referenced
                               type: string
                             namespace:
+                              description: |-
+                                Namespace is the namespace of resource being referenced
+                                Note that when a namespace is specified, a gateway.networking.k8s.
                               type: string
                           required:
                           - kind
                           - name
                           type: object
                         resources:
+                          description: resources represents the minimum resources
+                            the volume should have.
                           properties:
                             limits:
                               additionalProperties:
@@ -3718,6 +6361,9 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.
                               type: object
                             requests:
                               additionalProperties:
@@ -3726,18 +6372,35 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum amount of
+                                compute resources required.
                               type: object
                           type: object
                         selector:
+                          description: selector is a label query over volumes to consider
+                            for binding.
                           properties:
                             matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
                               items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
                                   key:
+                                    description: key is the label key that the selector
+                                      applies to.
                                     type: string
                                   operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty.
                                     items:
                                       type: string
                                     type: array
@@ -3751,28 +6414,51 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
+                              description: matchLabels is a map of {key,value} pairs.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         storageClassName:
+                          description: |-
+                            storageClassName is the name of the StorageClass required by the claim.
+                            More info: https://kubernetes.
                           type: string
                         volumeAttributesClassName:
+                          description: volumeAttributesClassName may be used to set
+                            the VolumeAttributesClass used by this claim.
                           type: string
                         volumeMode:
+                          description: |-
+                            volumeMode defines what type of volume is required by the claim.
+                            Value of Filesystem is implied when not included in claim spec.
                           type: string
                         volumeName:
+                          description: volumeName is the binding reference to the
+                            PersistentVolume backing this claim.
                           type: string
                       type: object
                     status:
+                      description: |-
+                        status represents the current information/status of a persistent volume claim.
+                        Read-only.
+                        More info: https://kubernetes.
                       properties:
                         accessModes:
+                          description: |-
+                            accessModes contains the actual access modes the volume backing the PVC has.
+                            More info: https://kubernetes.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         allocatedResourceStatuses:
                           additionalProperties:
+                            description: |-
+                              When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource
+                              that it does not recognizes,...
                             type: string
+                          description: allocatedResourceStatuses stores status of
+                            resource being resized for the given PVC.
                           type: object
                           x-kubernetes-map-type: granular
                         allocatedResources:
@@ -3782,6 +6468,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: allocatedResources tracks the resources allocated
+                            to a PVC including its capacity.
                           type: object
                         capacity:
                           additionalProperties:
@@ -3790,23 +6478,45 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: capacity represents the actual resources of
+                            the underlying volume.
                           type: object
                         conditions:
+                          description: conditions is the current Condition of persistent
+                            volume claim.
                           items:
+                            description: PersistentVolumeClaimCondition contains details
+                              about state of pvc
                             properties:
                               lastProbeTime:
+                                description: lastProbeTime is the time we probed the
+                                  condition.
                                 format: date-time
                                 type: string
                               lastTransitionTime:
+                                description: lastTransitionTime is the time the condition
+                                  transitioned from one status to another.
                                 format: date-time
                                 type: string
                               message:
+                                description: message is the human-readable message
+                                  indicating details about last transition.
                                 type: string
                               reason:
+                                description: |-
+                                  reason is a unique, this should be a short, machine understandable string that gives the reason
+                                  for condition's last transition.
                                 type: string
                               status:
+                                description: |-
+                                  Status is the status of the condition.
+                                  Can be True, False, Unknown.
+                                  More info: https://kubernetes.
                                 type: string
                               type:
+                                description: |-
+                                  Type is the type of the condition.
+                                  More info: https://kubernetes.
                                 type: string
                             required:
                             - status
@@ -3817,38 +6527,70 @@ spec:
                           - type
                           x-kubernetes-list-type: map
                         currentVolumeAttributesClassName:
+                          description: currentVolumeAttributesClassName is the current
+                            name of the VolumeAttributesClass the PVC is using.
                           type: string
                         modifyVolumeStatus:
+                          description: ModifyVolumeStatus represents the status object
+                            of ControllerModifyVolume operation.
                           properties:
                             status:
+                              description: status is the status of the ControllerModifyVolume
+                                operation.
                               type: string
                             targetVolumeAttributesClassName:
+                              description: targetVolumeAttributesClassName is the
+                                name of the VolumeAttributesClass the PVC currently
+                                being reconciled
                               type: string
                           required:
                           - status
                           type: object
                         phase:
+                          description: phase represents the current phase of PersistentVolumeClaim.
                           type: string
                       type: object
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
               volumeMounts:
+                description: VolumeMounts represents the mount points to use in the
+                  underlying collector deployment(s)
                 items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
                   properties:
                     mountPath:
+                      description: |-
+                        Path within the container at which the volume should be mounted.  Must
+                        not contain ':'.
                       type: string
                     mountPropagation:
+                      description: |-
+                        mountPropagation determines how mounts are propagated from the host
+                        to container and the other way around.
                       type: string
                     name:
+                      description: This must match the Name of a Volume.
                       type: string
                     readOnly:
+                      description: |-
+                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                        Defaults to false.
                       type: boolean
                     recursiveReadOnly:
+                      description: |-
+                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                        recursively.
                       type: string
                     subPath:
+                      description: |-
+                        Path within the volume from which the container's volume should be mounted.
+                        Defaults to "" (volume's root).
                       type: string
                     subPathExpr:
+                      description: Expanded path within the volume from which the
+                        container's volume should be mounted.
                       type: string
                   required:
                   - mountPath
@@ -3857,111 +6599,212 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               volumes:
+                description: Volumes represents which volumes to use in the underlying
+                  collector deployment(s).
                 items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
+                      description: |-
+                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
                           format: int32
                           type: integer
                         readOnly:
+                          description: |-
+                            readOnly value true will force the readOnly setting in VolumeMounts.
+                            More info: https://kubernetes.
                           type: boolean
                         volumeID:
+                          description: |-
+                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                            More info: https://kubernetes.
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
+                      description: |-
+                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        Deprecated: AzureDisk is deprecated.
                       properties:
                         cachingMode:
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
                           type: string
                         diskName:
+                          description: diskName is the Name of the data disk in the
+                            blob storage
                           type: string
                         diskURI:
+                          description: diskURI is the URI of data disk in the blob
+                            storage
                           type: string
                         fsType:
                           default: ext4
+                          description: |-
+                            fsType is Filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
                           type: string
                         kind:
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account ...'
                           type: string
                         readOnly:
                           default: false
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
+                      description: |-
+                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        Deprecated: AzureFile is deprecated.
                       properties:
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
                           type: string
                         shareName:
+                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
+                      description: cephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime.
                       properties:
                         monitors:
+                          description: |-
+                            monitors is Required: Monitors is a collection of Ceph monitors
+                            More info: https://examples.k8s.io/volumes/cephfs/README.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         path:
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretFile:
+                          description: 'secretFile is Optional: SecretFile is the
+                            path to key ring for User, default is /etc/ceph/user.'
                           type: string
                         secretRef:
+                          description: 'secretRef is Optional: SecretRef is reference
+                            to the authentication secret for User, default is empty.'
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
+                          description: |-
+                            user is optional: User is the rados user name, default is admin
+                            More info: https://examples.k8s.io/volumes/cephfs/README.
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
+                      description: |-
+                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        Deprecated: Cinder is deprecated.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is optional: points to a secret object containing parameters used to connect
+                            to OpenStack.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
+                          description: |-
+                            volumeID used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
+                      description: configMap represents a configMap that should populate
+                        this volume
                       properties:
                         defaultMode:
+                          description: 'defaultMode is optional: mode bits used to
+                            set permissions on created files by default.'
                           format: int32
                           type: integer
                         items:
+                          description: |-
+                            items if unspecified, each key-value pair in the Data field of the referenced
+                            ConfigMap will be projected into the volume as a...
                           items:
+                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
+                                description: key is the key to project.
                                 type: string
                               mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file.'
                                 format: int32
                                 type: integer
                               path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
                                 type: string
                             required:
                             - key
@@ -3971,67 +6814,119 @@ spec:
                           x-kubernetes-list-type: atomic
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
+                      description: csi (Container Storage Interface) represents ephemeral
+                        storage that is handled by certain external CSI drivers.
                       properties:
                         driver:
+                          description: driver is the name of the CSI driver that handles
+                            this volume.
                           type: string
                         fsType:
+                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
                           type: string
                         nodePublishSecretRef:
+                          description: |-
+                            nodePublishSecretRef is a reference to the secret object containing
+                            sensitive information to pass to the CSI driver to complete...
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
+                          description: |-
+                            readOnly specifies a read-only configuration for the volume.
+                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
+                          description: |-
+                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                            driver.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
+                      description: downwardAPI represents downward API about the pod
+                        that should populate this volume
                       properties:
                         defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default.'
                           format: int32
                           type: integer
                         items:
+                          description: Items is a list of downward API volume file
                           items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
                             properties:
                               fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name, namespace and uid
+                                  are supported.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
+                                description: |-
+                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                  between 0000 and 0777 or a decimal value...
                                 format: int32
                                 type: integer
                               path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path.'
                                 type: string
                               resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, requests.cpu and requests.
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -4044,21 +6939,35 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     emptyDir:
+                      description: |-
+                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                        More info: https://kubernetes.
                       properties:
                         medium:
+                          description: medium represents what type of storage medium
+                            should back this directory.
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
+                          description: sizeLimit is the total amount of local storage
+                            required for this EmptyDir volume.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
+                      description: ephemeral represents a volume that is handled by
+                        a cluster storage driver.
                       properties:
                         volumeClaimTemplate:
+                          description: Will be used to create a stand-alone PVC to
+                            provision the volume.
                           properties:
                             metadata:
+                              description: |-
+                                May contain labels and annotations that will be copied into the PVC
+                                when creating it.
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -4078,19 +6987,32 @@ spec:
                                   type: string
                               type: object
                             spec:
+                              description: The specification for the PersistentVolumeClaim.
                               properties:
                                 accessModes:
+                                  description: |-
+                                    accessModes contains the desired access modes the volume should have.
+                                    More info: https://kubernetes.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 dataSource:
+                                  description: |-
+                                    dataSource field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.
                                   properties:
                                     apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced.
                                       type: string
                                     kind:
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -4098,20 +7020,34 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
+                                  description: |-
+                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                    volume is desired.
                                   properties:
                                     apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced.
                                       type: string
                                     kind:
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                     namespace:
+                                      description: |-
+                                        Namespace is the namespace of resource being referenced
+                                        Note that when a namespace is specified, a gateway.networking.k8s.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
+                                  description: resources represents the minimum resources
+                                    the volume should have.
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -4120,6 +7056,9 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -4128,18 +7067,36 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
                                       type: object
                                   type: object
                                 selector:
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -4153,16 +7110,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
+                                  description: |-
+                                    storageClassName is the name of the StorageClass required by the claim.
+                                    More info: https://kubernetes.
                                   type: string
                                 volumeAttributesClassName:
+                                  description: volumeAttributesClassName may be used
+                                    to set the VolumeAttributesClass used by this
+                                    claim.
                                   type: string
                                 volumeMode:
+                                  description: |-
+                                    volumeMode defines what type of volume is required by the claim.
+                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
+                                  description: volumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -4170,41 +7140,78 @@ spec:
                           type: object
                       type: object
                     fc:
+                      description: fc represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         lun:
+                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         wwids:
+                          description: |-
+                            wwids Optional: FC volume world wide identifiers (wwids)
+                            Either wwids or combination of targetWWNs and lun must be set, but not...
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                       type: object
                     flexVolume:
+                      description: |-
+                        flexVolume represents a generic volume resource that is
+                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
+                          description: driver is the name of the driver to use for
+                            this volume.
                           type: string
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         options:
                           additionalProperties:
                             type: string
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
                           type: object
                         readOnly:
+                          description: |-
+                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is Optional: secretRef is reference to the secret object containing
+                            sensitive information to pass to the plugin...
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -4212,98 +7219,184 @@ spec:
                       - driver
                       type: object
                     flocker:
+                      description: flocker represents a Flocker volume attached to
+                        a kubelet's host machine.
                       properties:
                         datasetName:
+                          description: |-
+                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                            should be considered as deprecated
                           type: string
                         datasetUUID:
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
+                      description: |-
+                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         fsType:
+                          description: fsType is filesystem type of the volume that
+                            you want to mount.
                           type: string
                         partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
                           format: int32
                           type: integer
                         pdName:
+                          description: |-
+                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                            More info: https://kubernetes.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://kubernetes.
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
+                      description: |-
+                        gitRepo represents a git repository at a particular revision.
+                        Deprecated: GitRepo is deprecated.
                       properties:
                         directory:
+                          description: |-
+                            directory is the target directory name.
+                            Must not contain or start with '..'.  If '.
                           type: string
                         repository:
+                          description: repository is the URL
                           type: string
                         revision:
+                          description: revision is the commit hash for the specified
+                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
+                      description: glusterfs represents a Glusterfs mount on the host
+                        that shares a pod's lifetime.
                       properties:
                         endpoints:
+                          description: endpoints is the endpoint name that details
+                            Glusterfs topology.
                           type: string
                         path:
+                          description: |-
+                            path is the Glusterfs volume path.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
+                      description: |-
+                        hostPath represents a pre-existing file or directory on the host
+                        machine that is directly exposed to the container.
                       properties:
                         path:
+                          description: |-
+                            path of the directory on the host.
+                            If the path is a symlink, it will follow the link to the real path.
                           type: string
                         type:
+                          description: |-
+                            type for HostPath Volume
+                            Defaults to ""
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     image:
+                      description: image represents an OCI object (a container image
+                        or artifact) pulled and mounted on the kubelet's host machine.
                       properties:
                         pullPolicy:
+                          description: |-
+                            Policy for pulling OCI objects. Possible values are:
+                            Always: the kubelet always attempts to pull the reference.
                           type: string
                         reference:
+                          description: |-
+                            Required: Image or artifact reference to be used.
+                            Behaves in the same way as pod.spec.containers[*].image.
                           type: string
                       type: object
                     iscsi:
+                      description: |-
+                        iscsi represents an ISCSI Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         chapAuthDiscovery:
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
                           type: boolean
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         initiatorName:
+                          description: initiatorName is the custom iSCSI Initiator
+                            Name.
                           type: string
                         iqn:
+                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
                           default: default
+                          description: |-
+                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
                           type: string
                         lun:
+                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
+                          description: portals is the iSCSI Target Portal List.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
                           type: boolean
                         secretRef:
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
+                          description: targetPortal is iSCSI Target Portal.
                           type: string
                       required:
                       - iqn
@@ -4311,68 +7404,140 @@ spec:
                       - targetPortal
                       type: object
                     name:
+                      description: |-
+                        name of the volume.
+                        Must be a DNS_LABEL and unique within the pod.
+                        More info: https://kubernetes.
                       type: string
                     nfs:
+                      description: |-
+                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                        More info: https://kubernetes.
                       properties:
                         path:
+                          description: |-
+                            path that is exported by the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                         server:
+                          description: |-
+                            server is the hostname or IP address of the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
+                      description: |-
+                        persistentVolumeClaimVolumeSource represents a reference to a
+                        PersistentVolumeClaim in the same namespace.
                       properties:
                         claimName:
+                          description: claimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
+                      description: photonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         pdID:
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
+                      description: portworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
+                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
                       properties:
                         defaultMode:
+                          description: defaultMode are the mode bits used to set permissions
+                            on created files by default.
                           format: int32
                           type: integer
                         sources:
+                          description: |-
+                            sources is the list of volume projections. Each entry in this list
+                            handles one source.
                           items:
+                            description: |-
+                              Projection that may be projected along with other supported volume types.
+                              Exactly one of these fields must be set.
                             properties:
                               clusterTrustBundle:
+                                description: |-
+                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                  of ClusterTrustBundle objects in an auto-updating file.
                                 properties:
                                   labelSelector:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this label selector.  Only has
+                                      effect if signerName is set.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -4386,31 +7551,58 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
+                                    description: |-
+                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                      with signerName and labelSelector.
                                     type: string
                                   optional:
+                                    description: |-
+                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                      aren't available.
                                     type: boolean
                                   path:
+                                    description: Relative path from the volume root
+                                      to write the bundle.
                                     type: string
                                   signerName:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this signer name.
+                                      Mutually-exclusive with name.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
+                                description: configMap information about the configMap
+                                  data to project
                                 properties:
                                   items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a...
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: key is the key to project.
                                           type: string
                                         mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
                                           type: string
                                       required:
                                       - key
@@ -4420,42 +7612,80 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
                                 properties:
                                   items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
                                     items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
                                       properties:
                                         fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name, namespace and uid are supported.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value...
                                           format: int32
                                           type: integer
                                         path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path.'
                                           type: string
                                         resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to
+                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -4468,39 +7698,76 @@ spec:
                                     x-kubernetes-list-type: atomic
                                 type: object
                               podCertificate:
+                                description: |-
+                                  Projects an auto-rotating credential bundle (private key and certificate
+                                  chain) that the pod can use either as a TLS client or...
                                 properties:
                                   certificateChainPath:
+                                    description: |-
+                                      Write the certificate chain at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.
                                     type: string
                                   credentialBundlePath:
+                                    description: Write the credential bundle at this
+                                      path in the projected volume.
                                     type: string
                                   keyPath:
+                                    description: |-
+                                      Write the key at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.
                                     type: string
                                   keyType:
+                                    description: The type of keypair Kubelet will
+                                      generate for the pod.
                                     type: string
                                   maxExpirationSeconds:
+                                    description: |-
+                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                      certificate.
                                     format: int32
                                     type: integer
                                   signerName:
+                                    description: Kubelet's generated CSRs will be
+                                      addressed to this signer.
                                     type: string
                                   userAnnotations:
                                     additionalProperties:
                                       type: string
+                                    description: |-
+                                      userAnnotations allow pod authors to pass additional information to
+                                      the signer implementation.
                                     type: object
                                 required:
                                 - keyType
                                 - signerName
                                 type: object
                               secret:
+                                description: secret information about the secret data
+                                  to project
                                 properties:
                                   items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a...
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: key is the key to project.
                                           type: string
                                         mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
                                           type: string
                                       required:
                                       - key
@@ -4510,19 +7777,35 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
+                                    description: audience is the intended audience
+                                      of the token.
                                     type: string
                                   expirationSeconds:
+                                    description: |-
+                                      expirationSeconds is the requested duration of validity of the service
+                                      account token.
                                     format: int64
                                     type: integer
                                   path:
+                                    description: |-
+                                      path is the path relative to the mount point of the file to project the
+                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -4532,84 +7815,168 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     quobyte:
+                      description: quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime.
                       properties:
                         group:
+                          description: |-
+                            group to map volume access to
+                            Default is no group
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                         registry:
+                          description: |-
+                            registry represents a single or multiple Quobyte Registry services
+                            specified as a string as host:port pair (multiple entries...
                           type: string
                         tenant:
+                          description: |-
+                            tenant owning the given Quobyte volume in the Backend
+                            Used with dynamically provisioned Quobyte volumes, value is set by the...
                           type: string
                         user:
+                          description: |-
+                            user to map volume access to
+                            Defaults to serivceaccount user
                           type: string
                         volume:
+                          description: volume is a string that references an already
+                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
+                      description: rbd represents a Rados Block Device mount on the
+                        host that shares a pod's lifetime.
                       properties:
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         image:
+                          description: |-
+                            image is the rados image name.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
                           default: /etc/ceph/keyring
+                          description: |-
+                            keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring.
+                            More info: https://examples.k8s.
                           type: string
                         monitors:
+                          description: |-
+                            monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         pool:
                           default: rbd
+                          description: |-
+                            pool is the rados pool name.
+                            Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://examples.k8s.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is name of the authentication secret for RBDUser. If provided
+                            overrides keyring.
+                            Default is nil.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
                           default: admin
+                          description: |-
+                            user is the rados user name.
+                            Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
+                      description: scaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
                           default: xfs
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         gateway:
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
                           type: string
                         protectionDomain:
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef references to the secret for ScaleIO user and other
+                            sensitive information.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
                           type: boolean
                         storageMode:
                           default: ThinProvisioned
+                          description: storageMode indicates whether the storage for
+                            a volume should be ThickProvisioned or ThinProvisioned.
                           type: string
                         storagePool:
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
                           type: string
                         system:
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
                           type: string
                         volumeName:
+                          description: |-
+                            volumeName is the name of a volume already created in the ScaleIO system
+                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -4617,19 +7984,35 @@ spec:
                       - system
                       type: object
                     secret:
+                      description: |-
+                        secret represents a secret that should populate this volume.
+                        More info: https://kubernetes.
                       properties:
                         defaultMode:
+                          description: 'defaultMode is Optional: mode bits used to
+                            set permissions on created files by default.'
                           format: int32
                           type: integer
                         items:
+                          description: |-
+                            items If unspecified, each key-value pair in the Data field of the referenced
+                            Secret will be projected into the volume as a...
                           items:
+                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
+                                description: key is the key to project.
                                 type: string
                               mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file.'
                                 format: int32
                                 type: integer
                               path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
                                 type: string
                             required:
                             - key
@@ -4638,37 +8021,75 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         optional:
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
                           type: boolean
                         secretName:
+                          description: |-
+                            secretName is the name of the secret in the pod's namespace to use.
+                            More info: https://kubernetes.
                           type: string
                       type: object
                     storageos:
+                      description: storageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef specifies the secret to use for obtaining the StorageOS API
+                            credentials.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
+                          description: |-
+                            volumeName is the human-readable name of the StorageOS volume.  Volume
+                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
+                          description: volumeNamespace specifies the scope of the
+                            volume within StorageOS.
                           type: string
                       type: object
                     vsphereVolume:
+                      description: vsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
                           type: string
                         storagePolicyID:
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
                           type: string
                         volumePath:
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -4683,28 +8104,52 @@ spec:
             - managementState
             type: object
           status:
+            description: OpenTelemetryCollectorStatus defines the observed state of
+              OpenTelemetryCollector.
             properties:
               image:
+                description: Image indicates the container image to use for the OpenTelemetry
+                  Collector.
                 type: string
               messages:
+                description: |-
+                  Messages about actions performed by the operator on this resource.
+
+                  Deprecated: use Kubernetes events instead.
                 items:
                   type: string
                 type: array
                 x-kubernetes-list-type: atomic
               replicas:
+                description: |-
+                  Replicas is currently not being set and might be removed in the next version.
+
+                  Deprecated: use "OpenTelemetryCollector.Status.
                 format: int32
                 type: integer
               scale:
+                description: Scale is the OpenTelemetryCollector's scale subresource
+                  status.
                 properties:
                   replicas:
+                    description: |-
+                      The total number non-terminated pods targeted by this
+                      OpenTelemetryCollector's deployment or statefulSet.
                     format: int32
                     type: integer
                   selector:
+                    description: |-
+                      The selector used to match the OpenTelemetryCollector's
+                      deployment or statefulSet pods.
                     type: string
                   statusReplicas:
+                    description: |-
+                      StatusReplicas is the number of pods targeted by this OpenTelemetryCollector's with a Ready Condition /
+                      Total number of...
                     type: string
                 type: object
               version:
+                description: Version of the managed OpenTelemetry Collector (operand)
                 type: string
             type: object
         type: object
@@ -4741,70 +8186,129 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
+        description: OpenTelemetryCollector is the Schema for the opentelemetrycollectors
+          API.
         properties:
           apiVersion:
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
             type: string
           kind:
+            description: Kind is a string value representing the REST resource this
+              object represents.
             type: string
           metadata:
             type: object
           spec:
+            description: OpenTelemetryCollectorSpec defines the desired state of OpenTelemetryCollector.
             properties:
               additionalContainers:
+                description: AdditionalContainers allows injecting additional containers
+                  into the generated pod definition.
                 items:
+                  description: A single application container that you want to run
+                    within a pod.
                   properties:
                     args:
+                      description: |-
+                        Arguments to the entrypoint.
+                        The container image's CMD is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     command:
+                      description: |-
+                        Entrypoint array. Not executed within a shell.
+                        The container image's ENTRYPOINT is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     env:
+                      description: |-
+                        List of environment variables to set in the container.
+                        Cannot be updated.
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any...
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
                                 properties:
                                   key:
+                                    description: The key within the env file. An invalid
+                                      key will prevent the pod from starting.
                                     type: string
                                   optional:
                                     default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
                                     type: boolean
                                   path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
                                     type: string
                                   volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
                                     type: string
                                 required:
                                 - key
@@ -4813,29 +8317,47 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -4850,25 +8372,45 @@ spec:
                       - name
                       x-kubernetes-list-type: map
                     envFrom:
+                      description: List of sources to populate environment variables
+                        in the container.
                       items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps or Secrets
                         properties:
                           configMapRef:
+                            description: The ConfigMap to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
+                            description: The Secret to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the Secret must be defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
@@ -4876,31 +8418,60 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     image:
+                      description: |-
+                        Container image name.
+                        More info: https://kubernetes.
                       type: string
                     imagePullPolicy:
+                      description: |-
+                        Image pull policy.
+                        One of Always, Never, IfNotPresent.
                       type: string
                     lifecycle:
+                      description: |-
+                        Actions that the management system should take in response to container lifecycle events.
+                        Cannot be updated.
                       properties:
                         postStart:
+                          description: PostStart is called immediately after a container
+                            is created.
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -4909,58 +8480,100 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
+                          description: |-
+                            PreStop is called immediately before a container is terminated due to an
+                            API request or management event such as...
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -4969,75 +8582,128 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         stopSignal:
+                          description: StopSignal defines which signal will be sent
+                            to a container when it is being stopped.
                           type: string
                       type: object
                     livenessProbe:
+                      description: |-
+                        Periodic probe of container liveness.
+                        Container will be restarted if the probe fails.
+                        Cannot be updated.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -5046,62 +8712,114 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     name:
+                      description: |-
+                        Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
                       type: string
                     ports:
+                      description: |-
+                        List of ports to expose from the container. Not specifying a port here
+                        DOES NOT prevent that port from being exposed.
                       items:
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
                           containerPort:
+                            description: |-
+                              Number of port to expose on the pod's IP address.
+                              This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
+                            description: What host IP to bind the external port to.
                             type: string
                           hostPort:
+                            description: |-
+                              Number of port to expose on the host.
+                              If specified, this must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           name:
+                            description: |-
+                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                              named port in a pod must have a unique name.
                             type: string
                           protocol:
                             default: TCP
+                            description: |-
+                              Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -5112,39 +8830,68 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
+                      description: |-
+                        Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe fails.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -5153,51 +8900,92 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     resizePolicy:
+                      description: |-
+                        Resources resize policy for the container.
+                        This field cannot be set on ephemeral containers.
                       items:
+                        description: ContainerResizePolicy represents resource resize
+                          policy for the container.
                         properties:
                           resourceName:
+                            description: |-
+                              Name of the resource to which this resource resize policy applies.
+                              Supported values: cpu, memory.
                             type: string
                           restartPolicy:
+                            description: |-
+                              Restart policy to apply when specified resource is resized.
+                              If not specified, it defaults to NotRequired.
                             type: string
                         required:
                         - resourceName
@@ -5206,13 +8994,26 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     resources:
+                      description: |-
+                        Compute Resources required by this container.
+                        Cannot be updated.
+                        More info: https://kubernetes.
                       properties:
                         claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
                           items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used.
                                 type: string
                               request:
+                                description: Request is the name chosen for a request
+                                  in the referenced claim.
                                 type: string
                             required:
                             - name
@@ -5228,6 +9029,9 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.
                           type: object
                         requests:
                           additionalProperties:
@@ -5236,20 +9040,41 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: Requests describes the minimum amount of compute
+                            resources required.
                           type: object
                       type: object
                     restartPolicy:
+                      description: |-
+                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                        This overrides the pod-level restart policy.
                       type: string
                     restartPolicyRules:
+                      description: |-
+                        Represents a list of rules to be checked to determine if the
+                        container should be restarted on exit.
                       items:
+                        description: ContainerRestartRule describes how a container
+                          exit is handled.
                         properties:
                           action:
+                            description: |-
+                              Specifies the action taken on a container exit if the requirements
+                              are satisfied.
                             type: string
                           exitCodes:
+                            description: Represents the exit codes to check on container
+                              exits.
                             properties:
                               operator:
+                                description: |-
+                                  Represents the relationship between the container exit code(s) and the
+                                  specified values.
                                 type: string
                               values:
+                                description: |-
+                                  Specifies the set of values to check for container exit codes.
+                                  At most 255 elements are allowed.
                                 items:
                                   format: int32
                                   type: integer
@@ -5264,111 +9089,202 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     securityContext:
+                      description: SecurityContext defines the security options the
+                        container should be run with.
                       properties:
                         allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process.
                           type: boolean
                         appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile loaded
+                                on the node that should be used.
                               type: string
                             type:
+                              description: type indicates which kind of AppArmor profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         capabilities:
+                          description: The capabilities to add/drop when running containers.
                           properties:
                             add:
+                              description: Added capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             drop:
+                              description: Removed capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
                           type: boolean
                         procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers.
                           type: string
                         readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.
                           type: boolean
                         runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user.
                           type: boolean
                         runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by this container.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used.
                               type: string
                             type:
+                              description: type indicates which kind of seccomp profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
                           properties:
                             gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container.
                               type: boolean
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process.
                               type: string
                           type: object
                       type: object
                     startupProbe:
+                      description: StartupProbe indicates that the Pod has successfully
+                        initialized.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -5377,61 +9293,112 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime.
                       type: boolean
                     stdinOnce:
+                      description: |-
+                        Whether the container runtime should close the stdin channel after it has been opened by
+                        a single attach.
                       type: boolean
                     terminationMessagePath:
+                      description: |-
+                        Optional: Path at which the file to which the container's termination message
+                        will be written is mounted into the container's...
                       type: string
                     terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated.
                       type: string
                     tty:
+                      description: |-
+                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                        Default is false.
                       type: boolean
                     volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
                       items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
                         properties:
                           devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
                             type: string
                           name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -5442,21 +9409,44 @@ spec:
                       - devicePath
                       x-kubernetes-list-type: map
                     volumeMounts:
+                      description: |-
+                        Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
                       items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
+                            description: |-
+                              Path within the container at which the volume should be mounted.  Must
+                              not contain ':'.
                             type: string
                           mountPropagation:
+                            description: |-
+                              mountPropagation determines how mounts are propagated from the host
+                              to container and the other way around.
                             type: string
                           name:
+                            description: This must match the Name of a Volume.
                             type: string
                           readOnly:
+                            description: |-
+                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                              Defaults to false.
                             type: boolean
                           recursiveReadOnly:
+                            description: |-
+                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                              recursively.
                             type: string
                           subPath:
+                            description: |-
+                              Path within the volume from which the container's volume should be mounted.
+                              Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted.
                             type: string
                         required:
                         - mountPath
@@ -5467,28 +9457,53 @@ spec:
                       - mountPath
                       x-kubernetes-list-type: map
                     workingDir:
+                      description: Container's working directory.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               affinity:
+                description: If specified, indicates the pod's scheduling constraints
                 properties:
                   nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may...
                         items:
+                          description: |-
+                            An empty preferred scheduling term matches all objects with implicit weight 0
+                            (i.e. it's a no-op).
                           properties:
                             preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
                               properties:
                                 matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -5500,13 +9515,26 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -5520,6 +9548,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -5529,18 +9559,39 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the...
                         properties:
                           nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
                             items:
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
                               properties:
                                 matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -5552,13 +9603,26 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -5579,22 +9643,48 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may...
                         items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -5608,29 +9698,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -5644,20 +9758,30 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -5667,18 +9791,40 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the...
                         items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be...
                           properties:
                             labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -5692,29 +9838,52 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -5728,15 +9897,22 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the...
                               type: string
                           required:
                           - topologyKey
@@ -5745,22 +9921,49 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                   podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the anti-affinity expressions specified by this field, but it...
                         items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -5774,29 +9977,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -5810,20 +10037,30 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -5833,18 +10070,40 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the anti-affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto...
                         items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be...
                           properties:
                             labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -5858,29 +10117,52 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -5894,15 +10176,22 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the...
                               type: string
                           required:
                           - topologyKey
@@ -5914,22 +10203,42 @@ spec:
               args:
                 additionalProperties:
                   type: string
+                description: Args is the set of arguments to pass to the main container's
+                  binary.
                 type: object
               autoscaler:
+                description: |-
+                  Autoscaler specifies the pod autoscaling configuration to use
+                  for the workload.
                 properties:
                   behavior:
+                    description: |-
+                      HorizontalPodAutoscalerBehavior configures the scaling behavior of the target
+                      in both Up and Down directions (scaleUp and...
                     properties:
                       scaleDown:
+                        description: scaleDown is scaling policy for scaling Down.
                         properties:
                           policies:
+                            description: policies is a list of potential scaling polices
+                              which can be used during scaling.
                             items:
+                              description: HPAScalingPolicy is a single policy which
+                                must hold true for a specified past interval.
                               properties:
                                 periodSeconds:
+                                  description: periodSeconds specifies the window
+                                    of time for which the policy should hold true.
                                   format: int32
                                   type: integer
                                 type:
+                                  description: type is used to specify the scaling
+                                    policy.
                                   type: string
                                 value:
+                                  description: |-
+                                    value contains the amount of change which is permitted by the policy.
+                                    It must be greater than zero
                                   format: int32
                                   type: integer
                               required:
@@ -5940,28 +10249,49 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           selectPolicy:
+                            description: |-
+                              selectPolicy is used to specify which policy should be used.
+                              If not set, the default value Max is used.
                             type: string
                           stabilizationWindowSeconds:
+                            description: |-
+                              stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                              considered while scaling up or...
                             format: int32
                             type: integer
                           tolerance:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              tolerance is the tolerance on the ratio between the current and desired
+                              metric value under which no updates are made to the...
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                         type: object
                       scaleUp:
+                        description: scaleUp is scaling policy for scaling Up.
                         properties:
                           policies:
+                            description: policies is a list of potential scaling polices
+                              which can be used during scaling.
                             items:
+                              description: HPAScalingPolicy is a single policy which
+                                must hold true for a specified past interval.
                               properties:
                                 periodSeconds:
+                                  description: periodSeconds specifies the window
+                                    of time for which the policy should hold true.
                                   format: int32
                                   type: integer
                                 type:
+                                  description: type is used to specify the scaling
+                                    policy.
                                   type: string
                                 value:
+                                  description: |-
+                                    value contains the amount of change which is permitted by the policy.
+                                    It must be greater than zero
                                   format: int32
                                   type: integer
                               required:
@@ -5972,41 +10302,80 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           selectPolicy:
+                            description: |-
+                              selectPolicy is used to specify which policy should be used.
+                              If not set, the default value Max is used.
                             type: string
                           stabilizationWindowSeconds:
+                            description: |-
+                              stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                              considered while scaling up or...
                             format: int32
                             type: integer
                           tolerance:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              tolerance is the tolerance on the ratio between the current and desired
+                              metric value under which no updates are made to the...
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                         type: object
                     type: object
                   maxReplicas:
+                    description: MaxReplicas sets an upper bound to the autoscaling
+                      feature. If MaxReplicas is set autoscaling is enabled.
                     format: int32
                     minimum: 1
                     type: integer
                   metrics:
+                    description: Metrics is meant to provide a customizable way to
+                      configure HPA metrics.
                     items:
+                      description: |-
+                        MetricSpec defines a subset of metrics to be defined for the HPA's metric array
+                        more metric type can be supported as needed.
                       properties:
                         pods:
+                          description: |-
+                            PodsMetricSource indicates how to scale on a metric describing each pod in
+                            the current scale target (for example,...
                           properties:
                             metric:
+                              description: metric identifies the target metric by
+                                name and selector
                               properties:
                                 name:
+                                  description: name is the name of the given metric
                                   type: string
                                 selector:
+                                  description: |-
+                                    selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                    When set, it is passed as an...
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -6020,6 +10389,8 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -6027,22 +10398,34 @@ spec:
                               - name
                               type: object
                             target:
+                              description: target specifies the target value for the
+                                given metric
                               properties:
                                 averageUtilization:
+                                  description: |-
+                                    averageUtilization is the target value of the average of the
+                                    resource metric across all relevant pods, represented as a...
                                   format: int32
                                   type: integer
                                 averageValue:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    averageValue is the target value of the average of the
+                                    metric across all relevant pods (as a quantity)
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
                                   type: string
                                 value:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               required:
@@ -6053,39 +10436,54 @@ spec:
                           - target
                           type: object
                         type:
+                          description: MetricSourceType indicates the type of metric.
                           type: string
                       required:
                       - type
                       type: object
                     type: array
                   minReplicas:
+                    description: MinReplicas sets a lower bound to the autoscaling
+                      feature.  Set this if you are using autoscaling. It must be
+                      at least 1
                     format: int32
                     minimum: 1
                     type: integer
                   targetCPUUtilization:
+                    description: TargetCPUUtilization sets the target average CPU
+                      used across all replicas.
                     format: int32
                     minimum: 1
                     type: integer
                   targetMemoryUtilization:
+                    description: TargetMemoryUtilization sets the target average memory
+                      utilization across all replicas
                     format: int32
                     minimum: 1
                     type: integer
                 type: object
               config:
+                description: Config is the raw JSON to be used as the collector's
+                  configuration.
                 properties:
                   connectors:
+                    description: AnyConfig represent parts of the config.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   exporters:
+                    description: AnyConfig represent parts of the config.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   extensions:
+                    description: AnyConfig represent parts of the config.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   processors:
+                    description: AnyConfig represent parts of the config.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   receivers:
+                    description: AnyConfig represent parts of the config.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   service:
@@ -6096,6 +10494,8 @@ spec:
                         type: array
                       pipelines:
                         additionalProperties:
+                          description: Pipeline is a struct of component type to a
+                            list of component IDs.
                           properties:
                             exporters:
                               items:
@@ -6116,6 +10516,7 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       telemetry:
+                        description: AnyConfig represent parts of the config.
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                     required:
@@ -6129,14 +10530,21 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               configVersions:
                 default: 3
+                description: ConfigVersions defines the number versions to keep for
+                  the collector config.
                 minimum: 1
                 type: integer
               configmaps:
+                description: |-
+                  ConfigMaps is a list of ConfigMaps in the same namespace as the OpenTelemetryCollector
+                  object, which shall be mounted into the...
                 items:
                   properties:
                     mountpath:
                       type: string
                     name:
+                      description: Configmap defines name and path where the configMaps
+                        should be mounted.
                       type: string
                   required:
                   - mountpath
@@ -6144,85 +10552,149 @@ spec:
                   type: object
                 type: array
               daemonSetUpdateStrategy:
+                description: UpdateStrategy represents the strategy the operator will
+                  take replacing existing DaemonSet pods with new pods...
                 properties:
                   rollingUpdate:
+                    description: Rolling update config params. Present only if type
+                      = "RollingUpdate".
                     properties:
                       maxSurge:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          The maximum number of nodes with an existing available DaemonSet pod that
+                          can have an updated DaemonSet pod during during an...
                         x-kubernetes-int-or-string: true
                       maxUnavailable:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          The maximum number of DaemonSet pods that can be unavailable during the
+                          update.
                         x-kubernetes-int-or-string: true
                     type: object
                   type:
+                    description: Type of daemon set update. Can be "RollingUpdate"
+                      or "OnDelete". Default is RollingUpdate.
                     type: string
                 type: object
               deploymentUpdateStrategy:
+                description: UpdateStrategy represents the strategy the operator will
+                  take replacing existing Deployment pods with new pods...
                 properties:
                   rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if DeploymentStrategyType =
+                      RollingUpdate.
                     properties:
                       maxSurge:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          The maximum number of pods that can be scheduled above the desired number of
+                          pods.
                         x-kubernetes-int-or-string: true
                       maxUnavailable:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: The maximum number of pods that can be unavailable
+                          during the update.
                         x-kubernetes-int-or-string: true
                     type: object
                   type:
+                    description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                      Default is RollingUpdate.
                     type: string
                 type: object
               dnsPolicy:
+                description: DNSPolicy defines how a pod's DNS will be configured.
                 type: string
               env:
+                description: Environment variables to set on the generated pods.
                 items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
                   properties:
                     name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any...
                       type: string
                     valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
                           properties:
                             key:
+                              description: The key to select.
                               type: string
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.'
                           properties:
                             apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
                               type: string
                           required:
                           - fieldPath
                           type: object
                           x-kubernetes-map-type: atomic
                         fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
                           properties:
                             key:
+                              description: The key within the env file. An invalid
+                                key will prevent the pod from starting.
                               type: string
                             optional:
                               default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
                               type: boolean
                             path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
                               type: string
                             volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
                               type: string
                           required:
                           - key
@@ -6231,29 +10703,46 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.
                           properties:
                             containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
+                              description: 'Required: resource to select'
                               type: string
                           required:
                           - resource
                           type: object
                           x-kubernetes-map-type: atomic
                         secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
@@ -6265,39 +10754,65 @@ spec:
                   type: object
                 type: array
               envFrom:
+                description: List of sources to populate environment variables on
+                  the generated pods.
                 items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
                   properties:
                     configMapRef:
+                      description: The ConfigMap to select from
                       properties:
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: Specify whether the ConfigMap must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     secretRef:
+                      description: The Secret to select from
                       properties:
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: Specify whether the Secret must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
               hostAliases:
+                description: HostAliases is an optional list of hosts and IPs that
+                  will be injected into the pod's hosts file if specified.
                 items:
+                  description: |-
+                    HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                    pod's hosts file.
                   properties:
                     hostnames:
+                      description: Hostnames for the above IP address.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     ip:
+                      description: IP address of the host file entry.
                       type: string
                   required:
                   - ip
@@ -6305,20 +10820,36 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               hostNetwork:
+                description: HostNetwork indicates if the pod should run in the host
+                  networking namespace.
                 type: boolean
               hostPID:
+                description: HostPID indicates if the pod should have access to the
+                  host process ID namespace.
                 type: boolean
               hostUsers:
+                description: HostUsers isolates pod processes in a separate user namespace,
+                  reducing the risk of privilege escalation.
                 type: boolean
               httpRoute:
+                description: HttpRoute is used to specify how OpenTelemetry Collector
+                  is exposed via Gateway API HTTPRoute.
                 properties:
                   enabled:
+                    description: Enabled indicates whether the HTTP route configuration
+                      is enabled.
                     type: boolean
                   gateway:
+                    description: Gateway specifies the name of the Gateway resource
+                      to associate with the HTTP route.
                     type: string
                   gatewayNamespace:
+                    description: |-
+                      GatewayNamespace specifies the namespace of the Gateway resource.
+                      Default is the same namespace as the collector.
                     type: string
                   hostnames:
+                    description: Hostnames specifies the hostnames for the HTTP route.
                     items:
                       type: string
                     type: array
@@ -6327,22 +10858,39 @@ spec:
                 - gateway
                 type: object
               image:
+                description: Image indicates the container image to use for the generated
+                  pods.
                 type: string
               imagePullPolicy:
+                description: ImagePullPolicy indicates the pull policy to be used
+                  for retrieving the container image.
                 type: string
               ingress:
+                description: Ingress is used to specify how OpenTelemetry Collector
+                  is exposed.
                 properties:
                   annotations:
                     additionalProperties:
                       type: string
+                    description: |-
+                      Annotations to add to ingress.
+                      e.g. 'cert-manager.io/cluster-issuer: "letsencrypt"'
                     type: object
                   hostname:
+                    description: Hostname by which the ingress proxy can be reached.
                     type: string
                   ingressClassName:
+                    description: IngressClassName is the name of an IngressClass cluster
+                      resource.
                     type: string
                   route:
+                    description: |-
+                      Route is an OpenShift specific section that is only considered when
+                      type "route" is used.
                     properties:
                       termination:
+                        description: Termination indicates termination type. By default
+                          "edge" is used.
                         enum:
                         - insecure
                         - edge
@@ -6351,83 +10899,148 @@ spec:
                         type: string
                     type: object
                   ruleType:
+                    description: RuleType defines how Ingress exposes collector receivers.
                     enum:
                     - path
                     - subdomain
                     type: string
                   tls:
+                    description: TLS configuration.
                     items:
+                      description: IngressTLS describes the transport layer security
+                        associated with an ingress.
                       properties:
                         hosts:
+                          description: |-
+                            hosts is a list of hosts included in the TLS certificate. The values in
+                            this list must match the name/s used in the tlsSecret.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         secretName:
+                          description: |-
+                            secretName is the name of the secret used to terminate TLS traffic on
+                            port 443.
                           type: string
                       type: object
                     type: array
                   type:
+                    description: |-
+                      Type default value is: ""
+                      Supported types are: ingress, route
                     enum:
                     - ingress
                     - route
                     type: string
                 type: object
               initContainers:
+                description: InitContainers allows injecting initContainers to the
+                  generated pod definition.
                 items:
+                  description: A single application container that you want to run
+                    within a pod.
                   properties:
                     args:
+                      description: |-
+                        Arguments to the entrypoint.
+                        The container image's CMD is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     command:
+                      description: |-
+                        Entrypoint array. Not executed within a shell.
+                        The container image's ENTRYPOINT is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     env:
+                      description: |-
+                        List of environment variables to set in the container.
+                        Cannot be updated.
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any...
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
                                 properties:
                                   key:
+                                    description: The key within the env file. An invalid
+                                      key will prevent the pod from starting.
                                     type: string
                                   optional:
                                     default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
                                     type: boolean
                                   path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
                                     type: string
                                   volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
                                     type: string
                                 required:
                                 - key
@@ -6436,29 +11049,47 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -6473,25 +11104,45 @@ spec:
                       - name
                       x-kubernetes-list-type: map
                     envFrom:
+                      description: List of sources to populate environment variables
+                        in the container.
                       items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps or Secrets
                         properties:
                           configMapRef:
+                            description: The ConfigMap to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
+                            description: The Secret to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the Secret must be defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
@@ -6499,31 +11150,60 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     image:
+                      description: |-
+                        Container image name.
+                        More info: https://kubernetes.
                       type: string
                     imagePullPolicy:
+                      description: |-
+                        Image pull policy.
+                        One of Always, Never, IfNotPresent.
                       type: string
                     lifecycle:
+                      description: |-
+                        Actions that the management system should take in response to container lifecycle events.
+                        Cannot be updated.
                       properties:
                         postStart:
+                          description: PostStart is called immediately after a container
+                            is created.
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -6532,58 +11212,100 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
+                          description: |-
+                            PreStop is called immediately before a container is terminated due to an
+                            API request or management event such as...
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -6592,75 +11314,128 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         stopSignal:
+                          description: StopSignal defines which signal will be sent
+                            to a container when it is being stopped.
                           type: string
                       type: object
                     livenessProbe:
+                      description: |-
+                        Periodic probe of container liveness.
+                        Container will be restarted if the probe fails.
+                        Cannot be updated.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -6669,62 +11444,114 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     name:
+                      description: |-
+                        Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
                       type: string
                     ports:
+                      description: |-
+                        List of ports to expose from the container. Not specifying a port here
+                        DOES NOT prevent that port from being exposed.
                       items:
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
                           containerPort:
+                            description: |-
+                              Number of port to expose on the pod's IP address.
+                              This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
+                            description: What host IP to bind the external port to.
                             type: string
                           hostPort:
+                            description: |-
+                              Number of port to expose on the host.
+                              If specified, this must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           name:
+                            description: |-
+                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                              named port in a pod must have a unique name.
                             type: string
                           protocol:
                             default: TCP
+                            description: |-
+                              Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -6735,39 +11562,68 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
+                      description: |-
+                        Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe fails.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -6776,51 +11632,92 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     resizePolicy:
+                      description: |-
+                        Resources resize policy for the container.
+                        This field cannot be set on ephemeral containers.
                       items:
+                        description: ContainerResizePolicy represents resource resize
+                          policy for the container.
                         properties:
                           resourceName:
+                            description: |-
+                              Name of the resource to which this resource resize policy applies.
+                              Supported values: cpu, memory.
                             type: string
                           restartPolicy:
+                            description: |-
+                              Restart policy to apply when specified resource is resized.
+                              If not specified, it defaults to NotRequired.
                             type: string
                         required:
                         - resourceName
@@ -6829,13 +11726,26 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     resources:
+                      description: |-
+                        Compute Resources required by this container.
+                        Cannot be updated.
+                        More info: https://kubernetes.
                       properties:
                         claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
                           items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used.
                                 type: string
                               request:
+                                description: Request is the name chosen for a request
+                                  in the referenced claim.
                                 type: string
                             required:
                             - name
@@ -6851,6 +11761,9 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.
                           type: object
                         requests:
                           additionalProperties:
@@ -6859,20 +11772,41 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: Requests describes the minimum amount of compute
+                            resources required.
                           type: object
                       type: object
                     restartPolicy:
+                      description: |-
+                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                        This overrides the pod-level restart policy.
                       type: string
                     restartPolicyRules:
+                      description: |-
+                        Represents a list of rules to be checked to determine if the
+                        container should be restarted on exit.
                       items:
+                        description: ContainerRestartRule describes how a container
+                          exit is handled.
                         properties:
                           action:
+                            description: |-
+                              Specifies the action taken on a container exit if the requirements
+                              are satisfied.
                             type: string
                           exitCodes:
+                            description: Represents the exit codes to check on container
+                              exits.
                             properties:
                               operator:
+                                description: |-
+                                  Represents the relationship between the container exit code(s) and the
+                                  specified values.
                                 type: string
                               values:
+                                description: |-
+                                  Specifies the set of values to check for container exit codes.
+                                  At most 255 elements are allowed.
                                 items:
                                   format: int32
                                   type: integer
@@ -6887,111 +11821,202 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     securityContext:
+                      description: SecurityContext defines the security options the
+                        container should be run with.
                       properties:
                         allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process.
                           type: boolean
                         appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile loaded
+                                on the node that should be used.
                               type: string
                             type:
+                              description: type indicates which kind of AppArmor profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         capabilities:
+                          description: The capabilities to add/drop when running containers.
                           properties:
                             add:
+                              description: Added capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             drop:
+                              description: Removed capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
                           type: boolean
                         procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers.
                           type: string
                         readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.
                           type: boolean
                         runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user.
                           type: boolean
                         runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by this container.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used.
                               type: string
                             type:
+                              description: type indicates which kind of seccomp profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
                           properties:
                             gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container.
                               type: boolean
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process.
                               type: string
                           type: object
                       type: object
                     startupProbe:
+                      description: StartupProbe indicates that the Pod has successfully
+                        initialized.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -7000,61 +12025,112 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime.
                       type: boolean
                     stdinOnce:
+                      description: |-
+                        Whether the container runtime should close the stdin channel after it has been opened by
+                        a single attach.
                       type: boolean
                     terminationMessagePath:
+                      description: |-
+                        Optional: Path at which the file to which the container's termination message
+                        will be written is mounted into the container's...
                       type: string
                     terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated.
                       type: string
                     tty:
+                      description: |-
+                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                        Default is false.
                       type: boolean
                     volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
                       items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
                         properties:
                           devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
                             type: string
                           name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -7065,21 +12141,44 @@ spec:
                       - devicePath
                       x-kubernetes-list-type: map
                     volumeMounts:
+                      description: |-
+                        Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
                       items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
+                            description: |-
+                              Path within the container at which the volume should be mounted.  Must
+                              not contain ':'.
                             type: string
                           mountPropagation:
+                            description: |-
+                              mountPropagation determines how mounts are propagated from the host
+                              to container and the other way around.
                             type: string
                           name:
+                            description: This must match the Name of a Volume.
                             type: string
                           readOnly:
+                            description: |-
+                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                              Defaults to false.
                             type: boolean
                           recursiveReadOnly:
+                            description: |-
+                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                              recursively.
                             type: string
                           subPath:
+                            description: |-
+                              Path within the volume from which the container's volume should be mounted.
+                              Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted.
                             type: string
                         required:
                         - mountPath
@@ -7090,40 +12189,69 @@ spec:
                       - mountPath
                       x-kubernetes-list-type: map
                     workingDir:
+                      description: Container's working directory.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               ipFamilies:
+                description: |-
+                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                  to express the family of an IP expressed by a type (e.g.
                 items:
+                  description: |-
+                    IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                    to express the family of an IP expressed by a type (e.g.
                   type: string
                 type: array
               ipFamilyPolicy:
                 default: SingleStack
+                description: IPFamilyPolicy represents the dual-stack-ness requested
+                  or required by a Service
                 type: string
               lifecycle:
+                description: Actions that the management system should take in response
+                  to container lifecycle events. Cannot be updated.
                 properties:
                   postStart:
+                    description: PostStart is called immediately after a container
+                      is created.
                     properties:
                       exec:
+                        description: Exec specifies a command to execute in the container.
                         properties:
                           command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the...
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                         type: object
                       httpGet:
+                        description: HTTPGet specifies an HTTP GET request to perform.
                         properties:
                           host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
                             items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
                               properties:
                                 name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
+                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -7132,58 +12260,97 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           path:
+                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       sleep:
+                        description: Sleep represents a duration that the container
+                          should sleep.
                         properties:
                           seconds:
+                            description: Seconds is the number of seconds to sleep.
                             format: int64
                             type: integer
                         required:
                         - seconds
                         type: object
                       tcpSocket:
+                        description: |-
+                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                          for backward compatibility.
                         properties:
                           host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                     type: object
                   preStop:
+                    description: |-
+                      PreStop is called immediately before a container is terminated due to an
+                      API request or management event such as...
                     properties:
                       exec:
+                        description: Exec specifies a command to execute in the container.
                         properties:
                           command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the...
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                         type: object
                       httpGet:
+                        description: HTTPGet specifies an HTTP GET request to perform.
                         properties:
                           host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
                             items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
                               properties:
                                 name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
+                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -7192,75 +12359,123 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           path:
+                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       sleep:
+                        description: Sleep represents a duration that the container
+                          should sleep.
                         properties:
                           seconds:
+                            description: Seconds is the number of seconds to sleep.
                             format: int64
                             type: integer
                         required:
                         - seconds
                         type: object
                       tcpSocket:
+                        description: |-
+                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                          for backward compatibility.
                         properties:
                           host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                     type: object
                   stopSignal:
+                    description: StopSignal defines which signal will be sent to a
+                      container when it is being stopped.
                     type: string
                 type: object
               livenessProbe:
+                description: Liveness config for the OpenTelemetry Collector except
+                  the probe handler which is auto generated from the health extension
+                  of...
                 properties:
                   failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
                     format: int32
                     minimum: 1
                     type: integer
                   initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      Defaults to 0 seconds.
                     format: int32
                     minimum: 0
                     type: integer
                   periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
                     format: int32
                     minimum: 1
                     type: integer
                   successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1.
                     format: int32
                     minimum: 1
                     type: integer
                   terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure.
                     format: int64
                     minimum: 1
                     type: integer
                   timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.
                     format: int32
                     minimum: 1
                     type: integer
                 type: object
               managementState:
                 default: managed
+                description: |-
+                  ManagementState defines if the CR should be managed by the operator or not.
+                  Default is managed.
                 enum:
                 - managed
                 - unmanaged
                 type: string
               mode:
+                description: Mode represents how the collector should be deployed
+                  (deployment, daemonset, statefulset or sidecar)
                 enum:
                 - daemonset
                 - deployment
@@ -7268,140 +12483,250 @@ spec:
                 - statefulset
                 type: string
               networkPolicy:
+                description: NetworkPolicy defines the network policy to be applied
+                  to the OpenTelemetry Collector pods.
                 properties:
                   enabled:
+                    description: |-
+                      Enable enables the NetworkPolicy.
+                      The default value is taken from the operator feature-gate `--feature-gates=+operand.
                     type: boolean
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
+                description: NodeSelector to schedule generated pods.
                 type: object
               observability:
+                description: ObservabilitySpec defines how telemetry data gets handled.
                 properties:
                   metrics:
+                    description: Metrics defines the metrics configuration for operands.
                     properties:
                       disablePrometheusAnnotations:
+                        description: |-
+                          DisablePrometheusAnnotations controls the automatic addition of default Prometheus annotations
+                          ('prometheus.
                         type: boolean
                       enableMetrics:
+                        description: EnableMetrics specifies if ServiceMonitor or
+                          PodMonitor(for sidecar mode) should be created for the service
+                          managed by the...
                         type: boolean
                       extraLabels:
                         additionalProperties:
                           type: string
+                        description: ExtraLabels are additional labels to be added
+                          to the ServiceMonitor
                         type: object
                     type: object
                 type: object
               persistentVolumeClaimRetentionPolicy:
+                description: |-
+                  PersistentVolumeClaimRetentionPolicy describes the lifecycle of persistent volume claims
+                  created from volumeClaimTemplates.
                 properties:
                   whenDeleted:
+                    description: |-
+                      WhenDeleted specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is deleted.
                     type: string
                   whenScaled:
+                    description: |-
+                      WhenScaled specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is scaled down.
                     type: string
                 type: object
               podAnnotations:
                 additionalProperties:
                   type: string
+                description: |-
+                  PodAnnotations is the set of annotations that will be attached to
+                  the generated pods.
                 type: object
               podDisruptionBudget:
+                description: |-
+                  PodDisruptionBudget specifies the pod disruption budget configuration to use
+                  for the generated workload.
                 properties:
                   maxUnavailable:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      An eviction is allowed if at most "maxUnavailable" pods selected by
+                      "selector" are unavailable after the eviction, i.e.
                     x-kubernetes-int-or-string: true
                   minAvailable:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      An eviction is allowed if at least "minAvailable" pods selected by
+                      "selector" will still be available after the eviction, i.e.
                     x-kubernetes-int-or-string: true
                 type: object
               podDnsConfig:
+                description: PodDNSConfig defines the DNS parameters of a pod in addition
+                  to those generated from DNSPolicy.
                 properties:
                   nameservers:
+                    description: |-
+                      A list of DNS name server IP addresses.
+                      This will be appended to the base nameservers generated from DNSPolicy.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
                   options:
+                    description: |-
+                      A list of DNS resolver options.
+                      This will be merged with the base options generated from DNSPolicy.
                     items:
+                      description: PodDNSConfigOption defines DNS resolver options
+                        of a pod.
                       properties:
                         name:
+                          description: |-
+                            Name is this DNS resolver option's name.
+                            Required.
                           type: string
                         value:
+                          description: Value is this DNS resolver option's value.
                           type: string
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
                   searches:
+                    description: |-
+                      A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from DNSPolicy.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
               podManagementPolicy:
+                description: PodManagementPolicy defines the pod creation and termination
+                  order in StatefulSet.
                 enum:
                 - OrderedReady
                 - Parallel
                 type: string
               podSecurityContext:
+                description: |-
+                  PodSecurityContext configures the pod security context for the
+                  generated pod, when running as a deployment, daemonset,
+                  or...
                 properties:
                   appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by the containers in this pod.
+                      Note that this field cannot be set when spec.os.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile loaded on
+                          the node that should be used.
                         type: string
                       type:
+                        description: type indicates which kind of AppArmor profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   fsGroup:
+                    description: A special supplemental group that applies to all
+                      containers in a pod.
                     format: int64
                     type: integer
                   fsGroupChangePolicy:
+                    description: |-
+                      fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                      before being exposed inside Pod.
                     type: string
                   runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in SecurityContext.
                     format: int64
                     type: integer
                   runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user.
                     type: boolean
                   runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
                     format: int64
                     type: integer
                   seLinuxChangePolicy:
+                    description: seLinuxChangePolicy defines how the container's SELinux
+                      label is applied to all volumes used by the Pod.
                     type: string
                   seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
                     properties:
                       level:
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
+                    description: |-
+                      The seccomp options to use by the containers in this pod.
+                      Note that this field cannot be set when spec.os.name is windows.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used.
                         type: string
                       type:
+                        description: type indicates which kind of seccomp profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   supplementalGroups:
+                    description: |-
+                      A list of groups applied to the first process run in each container, in
+                      addition to the container's primary GID and fsGroup (if...
                     items:
                       format: int64
                       type: integer
                     type: array
                     x-kubernetes-list-type: atomic
                   supplementalGroupsPolicy:
+                    description: |-
+                      Defines how supplemental groups of the first container processes are calculated.
+                      Valid values are "Merge" and "Strict".
                     type: string
                   sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod.
                     items:
+                      description: Sysctl defines a kernel parameter to be set
                       properties:
                         name:
+                          description: Name of a property to set
                           type: string
                         value:
+                          description: Value of a property to set
                           type: string
                       required:
                       - name
@@ -7410,42 +12735,72 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   windowsOptions:
+                    description: The Windows specific settings applied to all containers.
                     properties:
                       gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.
                         type: string
                       gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container.
                         type: boolean
                       runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process.
                         type: string
                     type: object
                 type: object
               ports:
+                description: Ports allows a set of ports to be exposed by the underlying
+                  v1.Service & v1.ContainerPort.
                 items:
+                  description: PortsSpec defines the OpenTelemetryCollector's container/service
+                    ports additional specifications.
                   properties:
                     appProtocol:
+                      description: The application protocol for this port.
                       type: string
                     hostPort:
+                      description: Allows defining which port to bind to the host
+                        in the Container.
                       format: int32
                       maximum: 65535
                       minimum: 0
                       type: integer
                     name:
+                      description: |-
+                        The name of this port within the service. This must be a DNS_LABEL.
+                        All ports within a ServiceSpec must have unique names.
                       type: string
                     nodePort:
+                      description: |-
+                        The port on each node on which this service is exposed when type is
+                        NodePort or LoadBalancer.  Usually assigned by the system.
                       format: int32
                       type: integer
                     port:
+                      description: The port that will be exposed by this service.
                       format: int32
                       type: integer
                     protocol:
                       default: TCP
+                      description: |-
+                        The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                        Default is TCP.
                       type: string
                     targetPort:
                       anyOf:
                       - type: integer
                       - type: string
+                      description: |-
+                        Number or name of the port to access on the pods targeted by the service.
+                        Number must be in the range 1 to 65535.
                       x-kubernetes-int-or-string: true
                   required:
                   - port
@@ -7453,46 +12808,83 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               priorityClassName:
+                description: |-
+                  If specified, indicates the pod's priority.
+                  If not specified, the pod priority will be default or zero if there is no
+                  default.
                 type: string
               readinessProbe:
+                description: Readiness config for the OpenTelemetry Collector except
+                  the probe handler which is auto generated from the health extension
+                  of...
                 properties:
                   failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
                     format: int32
                     minimum: 1
                     type: integer
                   initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      Defaults to 0 seconds.
                     format: int32
                     minimum: 0
                     type: integer
                   periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
                     format: int32
                     minimum: 1
                     type: integer
                   successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1.
                     format: int32
                     minimum: 1
                     type: integer
                   terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure.
                     format: int64
                     minimum: 1
                     type: integer
                   timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.
                     format: int32
                     minimum: 1
                     type: integer
                 type: object
               replicas:
                 default: 1
+                description: Replicas is the number of pod instances for the underlying
+                  replicaset. Set this if you are not using autoscaling.
                 format: int32
                 type: integer
               resources:
+                description: Resources to set on generated pods.
                 properties:
                   claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
                     items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used.
                           type: string
                         request:
+                          description: Request is the name chosen for a request in
+                            the referenced claim.
                           type: string
                       required:
                       - name
@@ -7508,6 +12900,9 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.
                     type: object
                   requests:
                     additionalProperties:
@@ -7516,132 +12911,250 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
+                    description: Requests describes the minimum amount of compute
+                      resources required.
                     type: object
                 type: object
               securityContext:
+                description: |-
+                  SecurityContext configures the container security context for
+                  the generated main container.
                 properties:
                   allowPrivilegeEscalation:
+                    description: |-
+                      AllowPrivilegeEscalation controls whether a process can gain more
+                      privileges than its parent process.
                     type: boolean
                   appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                      overrides the pod's appArmorProfile.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile loaded on
+                          the node that should be used.
                         type: string
                       type:
+                        description: type indicates which kind of AppArmor profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   capabilities:
+                    description: The capabilities to add/drop when running containers.
                     properties:
                       add:
+                        description: Added capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       drop:
+                        description: Removed capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                     type: object
                   privileged:
+                    description: |-
+                      Run container in privileged mode.
+                      Processes in privileged containers are essentially equivalent to root on the host.
                     type: boolean
                   procMount:
+                    description: procMount denotes the type of proc mount to use for
+                      the containers.
                     type: string
                   readOnlyRootFilesystem:
+                    description: |-
+                      Whether this container has a read-only root filesystem.
+                      Default is false.
+                      Note that this field cannot be set when spec.os.
                     type: boolean
                   runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in PodSecurityContext.
                     format: int64
                     type: integer
                   runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user.
                     type: boolean
                   runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
                     format: int64
                     type: integer
                   seLinuxOptions:
+                    description: The SELinux context to be applied to the container.
                     properties:
                       level:
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
+                    description: The seccomp options to use by this container.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used.
                         type: string
                       type:
+                        description: type indicates which kind of seccomp profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   windowsOptions:
+                    description: |-
+                      The Windows specific settings applied to all containers.
+                      If unspecified, the options from the PodSecurityContext will be used.
                     properties:
                       gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.
                         type: string
                       gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container.
                         type: boolean
                       runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process.
                         type: string
                     type: object
                 type: object
               serviceAccount:
+                description: ServiceAccount indicates the name of an existing service
+                  account to use with this instance.
                 type: string
               serviceName:
+                description: |-
+                  ServiceName sets the serviceName of the StatefulSet.
+                  If not specified, it will default to "<name>-headless".
                 type: string
               shareProcessNamespace:
+                description: ShareProcessNamespace indicates if the pod's containers
+                  should share process namespace.
                 type: boolean
               startupProbe:
+                description: Startup config for the OpenTelemetry Collector except
+                  the probe handler which is auto generated from the health extension
+                  of...
                 properties:
                   failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
                     format: int32
                     minimum: 1
                     type: integer
                   initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      Defaults to 0 seconds.
                     format: int32
                     minimum: 0
                     type: integer
                   periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
                     format: int32
                     minimum: 1
                     type: integer
                   successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1.
                     format: int32
                     minimum: 1
                     type: integer
                   terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure.
                     format: int64
                     minimum: 1
                     type: integer
                   timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.
                     format: int32
                     minimum: 1
                     type: integer
                 type: object
               targetAllocator:
+                description: TargetAllocator indicates a value which determines whether
+                  to spawn a target allocation resource or not.
                 properties:
                   affinity:
+                    description: If specified, indicates the pod's scheduling constraints
                     properties:
                       nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may...
                             items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op).
                               properties:
                                 preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
                                   properties:
                                     matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
                                       items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
                                         properties:
                                           key:
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -7653,13 +13166,26 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
                                       items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
                                         properties:
                                           key:
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -7673,6 +13199,8 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -7682,18 +13210,39 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the...
                             properties:
                               nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
                                 items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
                                   properties:
                                     matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
                                       items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
                                         properties:
                                           key:
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -7705,13 +13254,26 @@ spec:
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
                                       items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
                                         properties:
                                           key:
+                                            description: The label key that the selector
+                                              applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                             type: string
                                           values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -7732,22 +13294,50 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                       podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may...
                             items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
                               properties:
                                 podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7761,29 +13351,53 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7797,20 +13411,30 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the...
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -7820,18 +13444,41 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the...
                             items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be...
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -7845,29 +13492,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -7881,15 +13552,22 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
@@ -7898,22 +13576,50 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
                         properties:
                           preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it...
                             items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
                               properties:
                                 podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
                                   properties:
                                     labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7927,29 +13633,53 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to.
                                       properties:
                                         matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
                                           items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
+                                                description: key is the label key
+                                                  that the selector applies to.
                                                 type: string
                                               operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
                                                 items:
                                                   type: string
                                                 type: array
@@ -7963,20 +13693,30 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
                                       items:
                                         type: string
                                       type: array
                                       x-kubernetes-list-type: atomic
                                     topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the...
                                       type: string
                                   required:
                                   - topologyKey
                                   type: object
                                 weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
                                   format: int32
                                   type: integer
                               required:
@@ -7986,18 +13726,41 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto...
                             items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be...
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -8011,29 +13774,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -8047,15 +13834,22 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
@@ -8066,6 +13860,8 @@ spec:
                     type: object
                   allocationStrategy:
                     default: consistent-hashing
+                    description: AllocationStrategy determines which strategy the
+                      target allocator should use for allocation.
                     enum:
                     - least-weighted
                     - consistent-hashing
@@ -8073,56 +13869,105 @@ spec:
                     type: string
                   collectorNotReadyGracePeriod:
                     default: 30s
+                    description: CollectorNotReadyGracePeriod defines the grace period
+                      after which a TargetAllocator stops considering a collector
+                      is target...
                     format: duration
                     type: string
                   collectorTargetReloadInterval:
                     default: 30s
+                    description: CollectorTargetReloadInterval defines the interval
+                      at which the Prometheus receiver will reload targets from the
+                      target...
                     format: duration
                     type: string
                   enabled:
+                    description: Enabled indicates whether to use a target allocation
+                      mechanism for Prometheus targets or not.
                     type: boolean
                   env:
+                    description: ENV vars to set on the OpenTelemetry TargetAllocator's
+                      Pods.
                     items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
                       properties:
                         name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
                           type: string
                         value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any...
                           type: string
                         valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
                           properties:
                             configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
                               properties:
                                 key:
+                                  description: The key to select.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
                               type: object
                               x-kubernetes-map-type: atomic
                             fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.'
                               properties:
                                 apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
                                   type: string
                                 fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
                                   type: string
                               required:
                               - fieldPath
                               type: object
                               x-kubernetes-map-type: atomic
                             fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
                               properties:
                                 key:
+                                  description: The key within the env file. An invalid
+                                    key will prevent the pod from starting.
                                   type: string
                                 optional:
                                   default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
                                   type: boolean
                                 path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
                                   type: string
                                 volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
                                   type: string
                               required:
                               - key
@@ -8131,29 +13976,47 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.
                               properties:
                                 containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
                                   type: string
                                 divisor:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 resource:
+                                  description: 'Required: resource to select'
                                   type: string
                               required:
                               - resource
                               type: object
                               x-kubernetes-map-type: atomic
                             secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
                               properties:
                                 key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
                                   default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty.
                                   type: string
                                 optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
                                   type: boolean
                               required:
                               - key
@@ -8166,103 +14029,183 @@ spec:
                     type: array
                   filterStrategy:
                     default: relabel-config
+                    description: FilterStrategy determines how to filter targets before
+                      allocating them among the collectors.
                     enum:
                     - ""
                     - relabel-config
                     type: string
                   image:
+                    description: Image indicates the container image to use for the
+                      OpenTelemetry TargetAllocator.
                     type: string
                   nodeSelector:
                     additionalProperties:
                       type: string
+                    description: NodeSelector to schedule OpenTelemetry TargetAllocator
+                      pods.
                     type: object
                   observability:
+                    description: ObservabilitySpec defines how telemetry data gets
+                      handled.
                     properties:
                       metrics:
+                        description: Metrics defines the metrics configuration for
+                          operands.
                         properties:
                           disablePrometheusAnnotations:
+                            description: |-
+                              DisablePrometheusAnnotations controls the automatic addition of default Prometheus annotations
+                              ('prometheus.
                             type: boolean
                           enableMetrics:
+                            description: EnableMetrics specifies if ServiceMonitor
+                              or PodMonitor(for sidecar mode) should be created for
+                              the service managed by the...
                             type: boolean
                           extraLabels:
                             additionalProperties:
                               type: string
+                            description: ExtraLabels are additional labels to be added
+                              to the ServiceMonitor
                             type: object
                         type: object
                     type: object
                   podDisruptionBudget:
+                    description: |-
+                      PodDisruptionBudget specifies the pod disruption budget configuration to use
+                      for the target allocator workload.
                     properties:
                       maxUnavailable:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          An eviction is allowed if at most "maxUnavailable" pods selected by
+                          "selector" are unavailable after the eviction, i.e.
                         x-kubernetes-int-or-string: true
                       minAvailable:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          An eviction is allowed if at least "minAvailable" pods selected by
+                          "selector" will still be available after the eviction, i.e.
                         x-kubernetes-int-or-string: true
                     type: object
                   podSecurityContext:
+                    description: |-
+                      PodSecurityContext configures the pod security context for the
+                      targetallocator.
                     properties:
                       appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.
                         properties:
                           localhostProfile:
+                            description: localhostProfile indicates a profile loaded
+                              on the node that should be used.
                             type: string
                           type:
+                            description: type indicates which kind of AppArmor profile
+                              will be applied.
                             type: string
                         required:
                         - type
                         type: object
                       fsGroup:
+                        description: A special supplemental group that applies to
+                          all containers in a pod.
                         format: int64
                         type: integer
                       fsGroupChangePolicy:
+                        description: |-
+                          fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                          before being exposed inside Pod.
                         type: string
                       runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in SecurityContext.
                         format: int64
                         type: integer
                       runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user.
                         type: boolean
                       runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
                         format: int64
                         type: integer
                       seLinuxChangePolicy:
+                        description: seLinuxChangePolicy defines how the container's
+                          SELinux label is applied to all volumes used by the Pod.
                         type: string
                       seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
                         properties:
                           level:
+                            description: Level is SELinux level label that applies
+                              to the container.
                             type: string
                           role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
                             type: string
                           type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
                             type: string
                           user:
+                            description: User is a SELinux user label that applies
+                              to the container.
                             type: string
                         type: object
                       seccompProfile:
+                        description: |-
+                          The seccomp options to use by the containers in this pod.
+                          Note that this field cannot be set when spec.os.name is windows.
                         properties:
                           localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used.
                             type: string
                           type:
+                            description: type indicates which kind of seccomp profile
+                              will be applied.
                             type: string
                         required:
                         - type
                         type: object
                       supplementalGroups:
+                        description: |-
+                          A list of groups applied to the first process run in each container, in
+                          addition to the container's primary GID and fsGroup (if...
                         items:
                           format: int64
                           type: integer
                         type: array
                         x-kubernetes-list-type: atomic
                       supplementalGroupsPolicy:
+                        description: |-
+                          Defines how supplemental groups of the first container processes are calculated.
+                          Valid values are "Merge" and "Strict".
                         type: string
                       sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod.
                         items:
+                          description: Sysctl defines a kernel parameter to be set
                           properties:
                             name:
+                              description: Name of a property to set
                               type: string
                             value:
+                              description: Value of a property to set
                               type: string
                           required:
                           - name
@@ -8271,44 +14214,83 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       windowsOptions:
+                        description: The Windows specific settings applied to all
+                          containers.
                         properties:
                           gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.
                             type: string
                           gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
                           hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container.
                             type: boolean
                           runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process.
                             type: string
                         type: object
                     type: object
                   prometheusCR:
+                    description: PrometheusCR defines the configuration for the retrieval
+                      of PrometheusOperator CRDs ( servicemonitor.monitoring.coreos.
                     properties:
                       allowNamespaces:
+                        description: AllowNamespaces Namespaces to scope the interaction
+                          of the Target Allocator and the apiserver (allow list).
                         items:
                           type: string
                         type: array
                       denyNamespaces:
+                        description: DenyNamespaces Namespaces to scope the interaction
+                          of the Target Allocator and the apiserver (deny list).
                         items:
                           type: string
                         type: array
                       enabled:
+                        description: Enabled indicates whether to use a PrometheusOperator
+                          custom resources as targets or not.
                         type: boolean
                       evaluationInterval:
                         default: 30s
+                        description: |-
+                          Default interval between rule evaluations.
+
+                          Default: "30s"
                         format: duration
                         type: string
                       podMonitorNamespaceSelector:
                         default: {}
+                        description: |-
+                          Namespaces to be selected for PodMonitor discovery.
+                          A label selector is a label query over a set of resources.
                         properties:
                           matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty.
                                   items:
                                     type: string
                                   type: array
@@ -8322,19 +14304,36 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
+                            description: matchLabels is a map of {key,value} pairs.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       podMonitorSelector:
+                        description: |-
+                          PodMonitors to be selected for target discovery.
+                          A label selector is a label query over a set of resources.
                         properties:
                           matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty.
                                   items:
                                     type: string
                                   type: array
@@ -8348,20 +14347,37 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
+                            description: matchLabels is a map of {key,value} pairs.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       probeNamespaceSelector:
                         default: {}
+                        description: |-
+                          Namespaces to be selected for Probe discovery.
+                          A label selector is a label query over a set of resources.
                         properties:
                           matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty.
                                   items:
                                     type: string
                                   type: array
@@ -8375,19 +14391,36 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
+                            description: matchLabels is a map of {key,value} pairs.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       probeSelector:
+                        description: |-
+                          Probes to be selected for target discovery.
+                          A label selector is a label query over a set of resources.
                         properties:
                           matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty.
                                   items:
                                     type: string
                                   type: array
@@ -8401,26 +14434,46 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
+                            description: matchLabels is a map of {key,value} pairs.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       scrapeClasses:
+                        description: ScrapeClasses to be referenced by PodMonitors
+                          and ServiceMonitors to include common configuration.
                         items:
+                          description: AnyConfig represent parts of the config.
                           type: object
                         type: array
                         x-kubernetes-list-type: atomic
                         x-kubernetes-preserve-unknown-fields: true
                       scrapeConfigNamespaceSelector:
                         default: {}
+                        description: |-
+                          Namespaces to be selected for ScrapeConfig discovery.
+                          A label selector is a label query over a set of resources.
                         properties:
                           matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty.
                                   items:
                                     type: string
                                   type: array
@@ -8434,19 +14487,36 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
+                            description: matchLabels is a map of {key,value} pairs.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       scrapeConfigSelector:
+                        description: |-
+                          ScrapeConfigs to be selected for target discovery.
+                          A label selector is a label query over a set of resources.
                         properties:
                           matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty.
                                   items:
                                     type: string
                                   type: array
@@ -8460,28 +14530,51 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
+                            description: matchLabels is a map of {key,value} pairs.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       scrapeInterval:
                         default: 30s
+                        description: |-
+                          Default interval between consecutive scrapes. Intervals set in ServiceMonitors and PodMonitors override it.
+
+                          Default: "30s"
                         format: duration
                         type: string
                       scrapeProtocols:
+                        description: ScrapeProtocols define the protocols to negotiate
+                          during a scrape.
                         items:
                           type: string
                         type: array
                       serviceMonitorNamespaceSelector:
                         default: {}
+                        description: |-
+                          Namespaces to be selected for ServiceMonitor discovery.
+                          A label selector is a label query over a set of resources.
                         properties:
                           matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty.
                                   items:
                                     type: string
                                   type: array
@@ -8495,19 +14588,36 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
+                            description: matchLabels is a map of {key,value} pairs.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       serviceMonitorSelector:
+                        description: |-
+                          ServiceMonitors to be selected for target discovery.
+                          A label selector is a label query over a set of resources.
                         properties:
                           matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
                             items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
+                                  description: key is the label key that the selector
+                                    applies to.
                                   type: string
                                 operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty.
                                   items:
                                     type: string
                                   type: array
@@ -8521,21 +14631,35 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
+                            description: matchLabels is a map of {key,value} pairs.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                     type: object
                   replicas:
+                    description: Replicas is the number of pod instances for the underlying
+                      TargetAllocator.
                     format: int32
                     type: integer
                   resources:
+                    description: Resources to set on the OpenTelemetryTargetAllocator
+                      containers.
                     properties:
                       claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
                         items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                           properties:
                             name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used.
                               type: string
                             request:
+                              description: Request is the name chosen for a request
+                                in the referenced claim.
                               type: string
                           required:
                           - name
@@ -8551,6 +14675,9 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.
                         type: object
                       requests:
                         additionalProperties:
@@ -8559,111 +14686,216 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        description: Requests describes the minimum amount of compute
+                          resources required.
                         type: object
                     type: object
                   securityContext:
+                    description: |-
+                      SecurityContext configures the container security context for
+                      the targetallocator.
                     properties:
                       allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process.
                         type: boolean
                       appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                          overrides the pod's appArmorProfile.
                         properties:
                           localhostProfile:
+                            description: localhostProfile indicates a profile loaded
+                              on the node that should be used.
                             type: string
                           type:
+                            description: type indicates which kind of AppArmor profile
+                              will be applied.
                             type: string
                         required:
                         - type
                         type: object
                       capabilities:
+                        description: The capabilities to add/drop when running containers.
                         properties:
                           add:
+                            description: Added capabilities
                             items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           drop:
+                            description: Removed capabilities
                             items:
+                              description: Capability represent POSIX capabilities
+                                type
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                         type: object
                       privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
                         type: boolean
                       procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers.
                         type: string
                       readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.
                         type: boolean
                       runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.
                         format: int64
                         type: integer
                       runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user.
                         type: boolean
                       runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
                         format: int64
                         type: integer
                       seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
                         properties:
                           level:
+                            description: Level is SELinux level label that applies
+                              to the container.
                             type: string
                           role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
                             type: string
                           type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
                             type: string
                           user:
+                            description: User is a SELinux user label that applies
+                              to the container.
                             type: string
                         type: object
                       seccompProfile:
+                        description: The seccomp options to use by this container.
                         properties:
                           localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used.
                             type: string
                           type:
+                            description: type indicates which kind of seccomp profile
+                              will be applied.
                             type: string
                         required:
                         - type
                         type: object
                       windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
                         properties:
                           gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.
                             type: string
                           gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
                             type: string
                           hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container.
                             type: boolean
                           runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process.
                             type: string
                         type: object
                     type: object
                   serviceAccount:
+                    description: ServiceAccount indicates the name of an existing
+                      service account to use with this instance.
                     type: string
                   tolerations:
+                    description: |-
+                      Toleration embedded kubernetes pod configuration option,
+                      controls how pods can be scheduled with matching taints
                     items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching...
                       properties:
                         effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects.
                           type: string
                         key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys.
                           type: string
                         operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                           type: string
                         tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is...
                           format: int64
                           type: integer
                         value:
+                          description: Value is the taint value the toleration matches
+                            to.
                           type: string
                       type: object
                     type: array
                   topologySpreadConstraints:
+                    description: |-
+                      TopologySpreadConstraints embedded kubernetes pod configuration option,
+                      controls how pods are spread across your cluster among...
                     items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
                       properties:
                         labelSelector:
+                          description: LabelSelector is used to find matching pods.
                           properties:
                             matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
                               items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
                                   key:
+                                    description: key is the label key that the selector
+                                      applies to.
                                     type: string
                                   operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty.
                                     items:
                                       type: string
                                     type: array
@@ -8677,27 +14909,45 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
+                              description: matchLabels is a map of {key,value} pairs.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         matchLabelKeys:
+                          description: |-
+                            MatchLabelKeys is a set of pod label keys to select the pods over which
+                            spreading will be calculated.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         maxSkew:
+                          description: MaxSkew describes the degree to which pods
+                            may be unevenly distributed.
                           format: int32
                           type: integer
                         minDomains:
+                          description: MinDomains indicates a minimum number of eligible
+                            domains.
                           format: int32
                           type: integer
                         nodeAffinityPolicy:
+                          description: |-
+                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                            when calculating pod topology spread skew.
                           type: string
                         nodeTaintsPolicy:
+                          description: |-
+                            NodeTaintsPolicy indicates how we will treat node taints when calculating
+                            pod topology spread skew.
                           type: string
                         topologyKey:
+                          description: TopologyKey is the key of node labels.
                           type: string
                         whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                            the spread constraint.
                           type: string
                       required:
                       - maxSkew
@@ -8707,37 +14957,74 @@ spec:
                     type: array
                 type: object
               terminationGracePeriodSeconds:
+                description: Duration in seconds the pod needs to terminate gracefully
+                  upon probe failure.
                 format: int64
                 type: integer
               tolerations:
+                description: Toleration to schedule the generated pods.
                 items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching...
                   properties:
                     effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects.
                       type: string
                     key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys.
                       type: string
                     operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                       type: string
                     tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is...
                       format: int64
                       type: integer
                     value:
+                      description: Value is the taint value the toleration matches
+                        to.
                       type: string
                   type: object
                 type: array
               topologySpreadConstraints:
+                description: |-
+                  TopologySpreadConstraints embedded kubernetes pod configuration option,
+                  controls how pods are spread across your cluster among...
                 items:
+                  description: TopologySpreadConstraint specifies how to spread matching
+                    pods among the given topology.
                   properties:
                     labelSelector:
+                      description: LabelSelector is used to find matching pods.
                       properties:
                         matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
                           items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
+                                description: key is the label key that the selector
+                                  applies to.
                                 type: string
                               operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty.
                                 items:
                                   type: string
                                 type: array
@@ -8751,27 +15038,45 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
+                          description: matchLabels is a map of {key,value} pairs.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     matchLabelKeys:
+                      description: |-
+                        MatchLabelKeys is a set of pod label keys to select the pods over which
+                        spreading will be calculated.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     maxSkew:
+                      description: MaxSkew describes the degree to which pods may
+                        be unevenly distributed.
                       format: int32
                       type: integer
                     minDomains:
+                      description: MinDomains indicates a minimum number of eligible
+                        domains.
                       format: int32
                       type: integer
                     nodeAffinityPolicy:
+                      description: |-
+                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                        when calculating pod topology spread skew.
                       type: string
                     nodeTaintsPolicy:
+                      description: |-
+                        NodeTaintsPolicy indicates how we will treat node taints when calculating
+                        pod topology spread skew.
                       type: string
                     topologyKey:
+                      description: TopologyKey is the key of node labels.
                       type: string
                     whenUnsatisfiable:
+                      description: |-
+                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                        the spread constraint.
                       type: string
                   required:
                   - maxSkew
@@ -8780,20 +15085,36 @@ spec:
                   type: object
                 type: array
               trafficDistribution:
+                description: |-
+                  TrafficDistribution specifies how traffic to this service is routed.
+                  https://kubernetes.
                 type: string
               upgradeStrategy:
+                description: UpgradeStrategy represents how the operator will handle
+                  upgrades to the CR when a newer version of the operator is deployed
                 enum:
                 - automatic
                 - none
                 type: string
               volumeClaimTemplates:
+                description: VolumeClaimTemplates will provide stable storage using
+                  PersistentVolumes.
                 items:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
                   properties:
                     apiVersion:
+                      description: APIVersion defines the versioned schema of this
+                        representation of an object.
                       type: string
                     kind:
+                      description: Kind is a string value representing the REST resource
+                        this object represents.
                       type: string
                     metadata:
+                      description: |-
+                        Standard object's metadata.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.
                       properties:
                         annotations:
                           additionalProperties:
@@ -8813,19 +15134,32 @@ spec:
                           type: string
                       type: object
                     spec:
+                      description: |-
+                        spec defines the desired characteristics of a volume requested by a pod author.
+                        More info: https://kubernetes.
                       properties:
                         accessModes:
+                          description: |-
+                            accessModes contains the desired access modes the volume should have.
+                            More info: https://kubernetes.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         dataSource:
+                          description: |-
+                            dataSource field can be used to specify either:
+                            * An existing VolumeSnapshot object (snapshot.storage.k8s.
                           properties:
                             apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced.
                               type: string
                             kind:
+                              description: Kind is the type of resource being referenced
                               type: string
                             name:
+                              description: Name is the name of resource being referenced
                               type: string
                           required:
                           - kind
@@ -8833,20 +15167,32 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         dataSourceRef:
+                          description: |-
+                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                            volume is desired.
                           properties:
                             apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced.
                               type: string
                             kind:
+                              description: Kind is the type of resource being referenced
                               type: string
                             name:
+                              description: Name is the name of resource being referenced
                               type: string
                             namespace:
+                              description: |-
+                                Namespace is the namespace of resource being referenced
+                                Note that when a namespace is specified, a gateway.networking.k8s.
                               type: string
                           required:
                           - kind
                           - name
                           type: object
                         resources:
+                          description: resources represents the minimum resources
+                            the volume should have.
                           properties:
                             limits:
                               additionalProperties:
@@ -8855,6 +15201,9 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.
                               type: object
                             requests:
                               additionalProperties:
@@ -8863,18 +15212,35 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: Requests describes the minimum amount of
+                                compute resources required.
                               type: object
                           type: object
                         selector:
+                          description: selector is a label query over volumes to consider
+                            for binding.
                           properties:
                             matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
                               items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
                                   key:
+                                    description: key is the label key that the selector
+                                      applies to.
                                     type: string
                                   operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty.
                                     items:
                                       type: string
                                     type: array
@@ -8888,28 +15254,51 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
+                              description: matchLabels is a map of {key,value} pairs.
                               type: object
                           type: object
                           x-kubernetes-map-type: atomic
                         storageClassName:
+                          description: |-
+                            storageClassName is the name of the StorageClass required by the claim.
+                            More info: https://kubernetes.
                           type: string
                         volumeAttributesClassName:
+                          description: volumeAttributesClassName may be used to set
+                            the VolumeAttributesClass used by this claim.
                           type: string
                         volumeMode:
+                          description: |-
+                            volumeMode defines what type of volume is required by the claim.
+                            Value of Filesystem is implied when not included in claim spec.
                           type: string
                         volumeName:
+                          description: volumeName is the binding reference to the
+                            PersistentVolume backing this claim.
                           type: string
                       type: object
                     status:
+                      description: |-
+                        status represents the current information/status of a persistent volume claim.
+                        Read-only.
+                        More info: https://kubernetes.
                       properties:
                         accessModes:
+                          description: |-
+                            accessModes contains the actual access modes the volume backing the PVC has.
+                            More info: https://kubernetes.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         allocatedResourceStatuses:
                           additionalProperties:
+                            description: |-
+                              When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource
+                              that it does not recognizes,...
                             type: string
+                          description: allocatedResourceStatuses stores status of
+                            resource being resized for the given PVC.
                           type: object
                           x-kubernetes-map-type: granular
                         allocatedResources:
@@ -8919,6 +15308,8 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: allocatedResources tracks the resources allocated
+                            to a PVC including its capacity.
                           type: object
                         capacity:
                           additionalProperties:
@@ -8927,23 +15318,45 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: capacity represents the actual resources of
+                            the underlying volume.
                           type: object
                         conditions:
+                          description: conditions is the current Condition of persistent
+                            volume claim.
                           items:
+                            description: PersistentVolumeClaimCondition contains details
+                              about state of pvc
                             properties:
                               lastProbeTime:
+                                description: lastProbeTime is the time we probed the
+                                  condition.
                                 format: date-time
                                 type: string
                               lastTransitionTime:
+                                description: lastTransitionTime is the time the condition
+                                  transitioned from one status to another.
                                 format: date-time
                                 type: string
                               message:
+                                description: message is the human-readable message
+                                  indicating details about last transition.
                                 type: string
                               reason:
+                                description: |-
+                                  reason is a unique, this should be a short, machine understandable string that gives the reason
+                                  for condition's last transition.
                                 type: string
                               status:
+                                description: |-
+                                  Status is the status of the condition.
+                                  Can be True, False, Unknown.
+                                  More info: https://kubernetes.
                                 type: string
                               type:
+                                description: |-
+                                  Type is the type of the condition.
+                                  More info: https://kubernetes.
                                 type: string
                             required:
                             - status
@@ -8954,38 +15367,70 @@ spec:
                           - type
                           x-kubernetes-list-type: map
                         currentVolumeAttributesClassName:
+                          description: currentVolumeAttributesClassName is the current
+                            name of the VolumeAttributesClass the PVC is using.
                           type: string
                         modifyVolumeStatus:
+                          description: ModifyVolumeStatus represents the status object
+                            of ControllerModifyVolume operation.
                           properties:
                             status:
+                              description: status is the status of the ControllerModifyVolume
+                                operation.
                               type: string
                             targetVolumeAttributesClassName:
+                              description: targetVolumeAttributesClassName is the
+                                name of the VolumeAttributesClass the PVC currently
+                                being reconciled
                               type: string
                           required:
                           - status
                           type: object
                         phase:
+                          description: phase represents the current phase of PersistentVolumeClaim.
                           type: string
                       type: object
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
               volumeMounts:
+                description: VolumeMounts represents the mount points to use in the
+                  underlying deployment(s).
                 items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
                   properties:
                     mountPath:
+                      description: |-
+                        Path within the container at which the volume should be mounted.  Must
+                        not contain ':'.
                       type: string
                     mountPropagation:
+                      description: |-
+                        mountPropagation determines how mounts are propagated from the host
+                        to container and the other way around.
                       type: string
                     name:
+                      description: This must match the Name of a Volume.
                       type: string
                     readOnly:
+                      description: |-
+                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                        Defaults to false.
                       type: boolean
                     recursiveReadOnly:
+                      description: |-
+                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                        recursively.
                       type: string
                     subPath:
+                      description: |-
+                        Path within the volume from which the container's volume should be mounted.
+                        Defaults to "" (volume's root).
                       type: string
                     subPathExpr:
+                      description: Expanded path within the volume from which the
+                        container's volume should be mounted.
                       type: string
                   required:
                   - mountPath
@@ -8994,111 +15439,212 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               volumes:
+                description: Volumes represents which volumes to use in the underlying
+                  deployment(s).
                 items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
+                      description: |-
+                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
                           format: int32
                           type: integer
                         readOnly:
+                          description: |-
+                            readOnly value true will force the readOnly setting in VolumeMounts.
+                            More info: https://kubernetes.
                           type: boolean
                         volumeID:
+                          description: |-
+                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                            More info: https://kubernetes.
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
+                      description: |-
+                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        Deprecated: AzureDisk is deprecated.
                       properties:
                         cachingMode:
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
                           type: string
                         diskName:
+                          description: diskName is the Name of the data disk in the
+                            blob storage
                           type: string
                         diskURI:
+                          description: diskURI is the URI of data disk in the blob
+                            storage
                           type: string
                         fsType:
                           default: ext4
+                          description: |-
+                            fsType is Filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
                           type: string
                         kind:
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account ...'
                           type: string
                         readOnly:
                           default: false
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
+                      description: |-
+                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        Deprecated: AzureFile is deprecated.
                       properties:
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
                           type: string
                         shareName:
+                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
+                      description: cephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime.
                       properties:
                         monitors:
+                          description: |-
+                            monitors is Required: Monitors is a collection of Ceph monitors
+                            More info: https://examples.k8s.io/volumes/cephfs/README.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         path:
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretFile:
+                          description: 'secretFile is Optional: SecretFile is the
+                            path to key ring for User, default is /etc/ceph/user.'
                           type: string
                         secretRef:
+                          description: 'secretRef is Optional: SecretRef is reference
+                            to the authentication secret for User, default is empty.'
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
+                          description: |-
+                            user is optional: User is the rados user name, default is admin
+                            More info: https://examples.k8s.io/volumes/cephfs/README.
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
+                      description: |-
+                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        Deprecated: Cinder is deprecated.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is optional: points to a secret object containing parameters used to connect
+                            to OpenStack.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
+                          description: |-
+                            volumeID used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
+                      description: configMap represents a configMap that should populate
+                        this volume
                       properties:
                         defaultMode:
+                          description: 'defaultMode is optional: mode bits used to
+                            set permissions on created files by default.'
                           format: int32
                           type: integer
                         items:
+                          description: |-
+                            items if unspecified, each key-value pair in the Data field of the referenced
+                            ConfigMap will be projected into the volume as a...
                           items:
+                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
+                                description: key is the key to project.
                                 type: string
                               mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file.'
                                 format: int32
                                 type: integer
                               path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
                                 type: string
                             required:
                             - key
@@ -9108,67 +15654,119 @@ spec:
                           x-kubernetes-list-type: atomic
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
+                      description: csi (Container Storage Interface) represents ephemeral
+                        storage that is handled by certain external CSI drivers.
                       properties:
                         driver:
+                          description: driver is the name of the CSI driver that handles
+                            this volume.
                           type: string
                         fsType:
+                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
                           type: string
                         nodePublishSecretRef:
+                          description: |-
+                            nodePublishSecretRef is a reference to the secret object containing
+                            sensitive information to pass to the CSI driver to complete...
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
+                          description: |-
+                            readOnly specifies a read-only configuration for the volume.
+                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
+                          description: |-
+                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                            driver.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
+                      description: downwardAPI represents downward API about the pod
+                        that should populate this volume
                       properties:
                         defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default.'
                           format: int32
                           type: integer
                         items:
+                          description: Items is a list of downward API volume file
                           items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
                             properties:
                               fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name, namespace and uid
+                                  are supported.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
+                                description: |-
+                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                  between 0000 and 0777 or a decimal value...
                                 format: int32
                                 type: integer
                               path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path.'
                                 type: string
                               resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, requests.cpu and requests.
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -9181,21 +15779,35 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     emptyDir:
+                      description: |-
+                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                        More info: https://kubernetes.
                       properties:
                         medium:
+                          description: medium represents what type of storage medium
+                            should back this directory.
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
+                          description: sizeLimit is the total amount of local storage
+                            required for this EmptyDir volume.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
+                      description: ephemeral represents a volume that is handled by
+                        a cluster storage driver.
                       properties:
                         volumeClaimTemplate:
+                          description: Will be used to create a stand-alone PVC to
+                            provision the volume.
                           properties:
                             metadata:
+                              description: |-
+                                May contain labels and annotations that will be copied into the PVC
+                                when creating it.
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -9215,19 +15827,32 @@ spec:
                                   type: string
                               type: object
                             spec:
+                              description: The specification for the PersistentVolumeClaim.
                               properties:
                                 accessModes:
+                                  description: |-
+                                    accessModes contains the desired access modes the volume should have.
+                                    More info: https://kubernetes.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 dataSource:
+                                  description: |-
+                                    dataSource field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.
                                   properties:
                                     apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced.
                                       type: string
                                     kind:
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -9235,20 +15860,34 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
+                                  description: |-
+                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                    volume is desired.
                                   properties:
                                     apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced.
                                       type: string
                                     kind:
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                     namespace:
+                                      description: |-
+                                        Namespace is the namespace of resource being referenced
+                                        Note that when a namespace is specified, a gateway.networking.k8s.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
+                                  description: resources represents the minimum resources
+                                    the volume should have.
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -9257,6 +15896,9 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -9265,18 +15907,36 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
                                       type: object
                                   type: object
                                 selector:
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -9290,16 +15950,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
+                                  description: |-
+                                    storageClassName is the name of the StorageClass required by the claim.
+                                    More info: https://kubernetes.
                                   type: string
                                 volumeAttributesClassName:
+                                  description: volumeAttributesClassName may be used
+                                    to set the VolumeAttributesClass used by this
+                                    claim.
                                   type: string
                                 volumeMode:
+                                  description: |-
+                                    volumeMode defines what type of volume is required by the claim.
+                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
+                                  description: volumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -9307,41 +15980,78 @@ spec:
                           type: object
                       type: object
                     fc:
+                      description: fc represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         lun:
+                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         wwids:
+                          description: |-
+                            wwids Optional: FC volume world wide identifiers (wwids)
+                            Either wwids or combination of targetWWNs and lun must be set, but not...
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                       type: object
                     flexVolume:
+                      description: |-
+                        flexVolume represents a generic volume resource that is
+                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
+                          description: driver is the name of the driver to use for
+                            this volume.
                           type: string
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         options:
                           additionalProperties:
                             type: string
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
                           type: object
                         readOnly:
+                          description: |-
+                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is Optional: secretRef is reference to the secret object containing
+                            sensitive information to pass to the plugin...
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -9349,98 +16059,184 @@ spec:
                       - driver
                       type: object
                     flocker:
+                      description: flocker represents a Flocker volume attached to
+                        a kubelet's host machine.
                       properties:
                         datasetName:
+                          description: |-
+                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                            should be considered as deprecated
                           type: string
                         datasetUUID:
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
+                      description: |-
+                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         fsType:
+                          description: fsType is filesystem type of the volume that
+                            you want to mount.
                           type: string
                         partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
                           format: int32
                           type: integer
                         pdName:
+                          description: |-
+                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                            More info: https://kubernetes.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://kubernetes.
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
+                      description: |-
+                        gitRepo represents a git repository at a particular revision.
+                        Deprecated: GitRepo is deprecated.
                       properties:
                         directory:
+                          description: |-
+                            directory is the target directory name.
+                            Must not contain or start with '..'.  If '.
                           type: string
                         repository:
+                          description: repository is the URL
                           type: string
                         revision:
+                          description: revision is the commit hash for the specified
+                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
+                      description: glusterfs represents a Glusterfs mount on the host
+                        that shares a pod's lifetime.
                       properties:
                         endpoints:
+                          description: endpoints is the endpoint name that details
+                            Glusterfs topology.
                           type: string
                         path:
+                          description: |-
+                            path is the Glusterfs volume path.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
+                      description: |-
+                        hostPath represents a pre-existing file or directory on the host
+                        machine that is directly exposed to the container.
                       properties:
                         path:
+                          description: |-
+                            path of the directory on the host.
+                            If the path is a symlink, it will follow the link to the real path.
                           type: string
                         type:
+                          description: |-
+                            type for HostPath Volume
+                            Defaults to ""
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     image:
+                      description: image represents an OCI object (a container image
+                        or artifact) pulled and mounted on the kubelet's host machine.
                       properties:
                         pullPolicy:
+                          description: |-
+                            Policy for pulling OCI objects. Possible values are:
+                            Always: the kubelet always attempts to pull the reference.
                           type: string
                         reference:
+                          description: |-
+                            Required: Image or artifact reference to be used.
+                            Behaves in the same way as pod.spec.containers[*].image.
                           type: string
                       type: object
                     iscsi:
+                      description: |-
+                        iscsi represents an ISCSI Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         chapAuthDiscovery:
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
                           type: boolean
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         initiatorName:
+                          description: initiatorName is the custom iSCSI Initiator
+                            Name.
                           type: string
                         iqn:
+                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
                           default: default
+                          description: |-
+                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
                           type: string
                         lun:
+                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
+                          description: portals is the iSCSI Target Portal List.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
                           type: boolean
                         secretRef:
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
+                          description: targetPortal is iSCSI Target Portal.
                           type: string
                       required:
                       - iqn
@@ -9448,68 +16244,140 @@ spec:
                       - targetPortal
                       type: object
                     name:
+                      description: |-
+                        name of the volume.
+                        Must be a DNS_LABEL and unique within the pod.
+                        More info: https://kubernetes.
                       type: string
                     nfs:
+                      description: |-
+                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                        More info: https://kubernetes.
                       properties:
                         path:
+                          description: |-
+                            path that is exported by the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                         server:
+                          description: |-
+                            server is the hostname or IP address of the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
+                      description: |-
+                        persistentVolumeClaimVolumeSource represents a reference to a
+                        PersistentVolumeClaim in the same namespace.
                       properties:
                         claimName:
+                          description: claimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
+                      description: photonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         pdID:
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
+                      description: portworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
+                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
                       properties:
                         defaultMode:
+                          description: defaultMode are the mode bits used to set permissions
+                            on created files by default.
                           format: int32
                           type: integer
                         sources:
+                          description: |-
+                            sources is the list of volume projections. Each entry in this list
+                            handles one source.
                           items:
+                            description: |-
+                              Projection that may be projected along with other supported volume types.
+                              Exactly one of these fields must be set.
                             properties:
                               clusterTrustBundle:
+                                description: |-
+                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                  of ClusterTrustBundle objects in an auto-updating file.
                                 properties:
                                   labelSelector:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this label selector.  Only has
+                                      effect if signerName is set.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -9523,31 +16391,58 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
+                                    description: |-
+                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                      with signerName and labelSelector.
                                     type: string
                                   optional:
+                                    description: |-
+                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                      aren't available.
                                     type: boolean
                                   path:
+                                    description: Relative path from the volume root
+                                      to write the bundle.
                                     type: string
                                   signerName:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this signer name.
+                                      Mutually-exclusive with name.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
+                                description: configMap information about the configMap
+                                  data to project
                                 properties:
                                   items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a...
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: key is the key to project.
                                           type: string
                                         mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
                                           type: string
                                       required:
                                       - key
@@ -9557,42 +16452,80 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
                                 properties:
                                   items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
                                     items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
                                       properties:
                                         fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name, namespace and uid are supported.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value...
                                           format: int32
                                           type: integer
                                         path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path.'
                                           type: string
                                         resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to
+                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -9605,39 +16538,76 @@ spec:
                                     x-kubernetes-list-type: atomic
                                 type: object
                               podCertificate:
+                                description: |-
+                                  Projects an auto-rotating credential bundle (private key and certificate
+                                  chain) that the pod can use either as a TLS client or...
                                 properties:
                                   certificateChainPath:
+                                    description: |-
+                                      Write the certificate chain at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.
                                     type: string
                                   credentialBundlePath:
+                                    description: Write the credential bundle at this
+                                      path in the projected volume.
                                     type: string
                                   keyPath:
+                                    description: |-
+                                      Write the key at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.
                                     type: string
                                   keyType:
+                                    description: The type of keypair Kubelet will
+                                      generate for the pod.
                                     type: string
                                   maxExpirationSeconds:
+                                    description: |-
+                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                      certificate.
                                     format: int32
                                     type: integer
                                   signerName:
+                                    description: Kubelet's generated CSRs will be
+                                      addressed to this signer.
                                     type: string
                                   userAnnotations:
                                     additionalProperties:
                                       type: string
+                                    description: |-
+                                      userAnnotations allow pod authors to pass additional information to
+                                      the signer implementation.
                                     type: object
                                 required:
                                 - keyType
                                 - signerName
                                 type: object
                               secret:
+                                description: secret information about the secret data
+                                  to project
                                 properties:
                                   items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a...
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: key is the key to project.
                                           type: string
                                         mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
                                           type: string
                                       required:
                                       - key
@@ -9647,19 +16617,35 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
+                                    description: audience is the intended audience
+                                      of the token.
                                     type: string
                                   expirationSeconds:
+                                    description: |-
+                                      expirationSeconds is the requested duration of validity of the service
+                                      account token.
                                     format: int64
                                     type: integer
                                   path:
+                                    description: |-
+                                      path is the path relative to the mount point of the file to project the
+                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -9669,84 +16655,168 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     quobyte:
+                      description: quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime.
                       properties:
                         group:
+                          description: |-
+                            group to map volume access to
+                            Default is no group
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                         registry:
+                          description: |-
+                            registry represents a single or multiple Quobyte Registry services
+                            specified as a string as host:port pair (multiple entries...
                           type: string
                         tenant:
+                          description: |-
+                            tenant owning the given Quobyte volume in the Backend
+                            Used with dynamically provisioned Quobyte volumes, value is set by the...
                           type: string
                         user:
+                          description: |-
+                            user to map volume access to
+                            Defaults to serivceaccount user
                           type: string
                         volume:
+                          description: volume is a string that references an already
+                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
+                      description: rbd represents a Rados Block Device mount on the
+                        host that shares a pod's lifetime.
                       properties:
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         image:
+                          description: |-
+                            image is the rados image name.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
                           default: /etc/ceph/keyring
+                          description: |-
+                            keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring.
+                            More info: https://examples.k8s.
                           type: string
                         monitors:
+                          description: |-
+                            monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         pool:
                           default: rbd
+                          description: |-
+                            pool is the rados pool name.
+                            Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://examples.k8s.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is name of the authentication secret for RBDUser. If provided
+                            overrides keyring.
+                            Default is nil.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
                           default: admin
+                          description: |-
+                            user is the rados user name.
+                            Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
+                      description: scaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
                           default: xfs
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         gateway:
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
                           type: string
                         protectionDomain:
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef references to the secret for ScaleIO user and other
+                            sensitive information.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
                           type: boolean
                         storageMode:
                           default: ThinProvisioned
+                          description: storageMode indicates whether the storage for
+                            a volume should be ThickProvisioned or ThinProvisioned.
                           type: string
                         storagePool:
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
                           type: string
                         system:
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
                           type: string
                         volumeName:
+                          description: |-
+                            volumeName is the name of a volume already created in the ScaleIO system
+                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -9754,19 +16824,35 @@ spec:
                       - system
                       type: object
                     secret:
+                      description: |-
+                        secret represents a secret that should populate this volume.
+                        More info: https://kubernetes.
                       properties:
                         defaultMode:
+                          description: 'defaultMode is Optional: mode bits used to
+                            set permissions on created files by default.'
                           format: int32
                           type: integer
                         items:
+                          description: |-
+                            items If unspecified, each key-value pair in the Data field of the referenced
+                            Secret will be projected into the volume as a...
                           items:
+                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
+                                description: key is the key to project.
                                 type: string
                               mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file.'
                                 format: int32
                                 type: integer
                               path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
                                 type: string
                             required:
                             - key
@@ -9775,37 +16861,75 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         optional:
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
                           type: boolean
                         secretName:
+                          description: |-
+                            secretName is the name of the secret in the pod's namespace to use.
+                            More info: https://kubernetes.
                           type: string
                       type: object
                     storageos:
+                      description: storageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef specifies the secret to use for obtaining the StorageOS API
+                            credentials.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
+                          description: |-
+                            volumeName is the human-readable name of the StorageOS volume.  Volume
+                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
+                          description: volumeNamespace specifies the scope of the
+                            volume within StorageOS.
                           type: string
                       type: object
                     vsphereVolume:
+                      description: vsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
                           type: string
                         storagePolicyID:
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
                           type: string
                         volumePath:
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -9835,20 +16959,36 @@ spec:
               rule: '!(self.mode == ''sidecar'' && size(self.additionalContainers)
                 > 0) || !has(self.additionalContainers)'
           status:
+            description: OpenTelemetryCollectorStatus defines the observed state of
+              OpenTelemetryCollector.
             properties:
               image:
+                description: Image indicates the container image to use for the OpenTelemetry
+                  Collector.
                 type: string
               scale:
+                description: Scale is the OpenTelemetryCollector's scale subresource
+                  status.
                 properties:
                   replicas:
+                    description: |-
+                      The total number non-terminated pods targeted by this
+                      OpenTelemetryCollector's deployment or statefulSet.
                     format: int32
                     type: integer
                   selector:
+                    description: |-
+                      The selector used to match the OpenTelemetryCollector's
+                      deployment or statefulSet pods.
                     type: string
                   statusReplicas:
+                    description: |-
+                      StatusReplicas is the number of pods targeted by this OpenTelemetryCollector's with a Ready Condition /
+                      Total number of...
                     type: string
                 type: object
               version:
+                description: Version of the managed OpenTelemetry Collector (operand)
                 type: string
             type: object
         type: object

--- a/config/crd/bases/opentelemetry.io_targetallocators.yaml
+++ b/config/crd/bases/opentelemetry.io_targetallocators.yaml
@@ -28,70 +28,128 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: TargetAllocator is the Schema for the targetallocators API.
         properties:
           apiVersion:
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
             type: string
           kind:
+            description: Kind is a string value representing the REST resource this
+              object represents.
             type: string
           metadata:
             type: object
           spec:
+            description: TargetAllocatorSpec defines the desired state of TargetAllocator.
             properties:
               additionalContainers:
+                description: AdditionalContainers allows injecting additional containers
+                  into the generated pod definition.
                 items:
+                  description: A single application container that you want to run
+                    within a pod.
                   properties:
                     args:
+                      description: |-
+                        Arguments to the entrypoint.
+                        The container image's CMD is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     command:
+                      description: |-
+                        Entrypoint array. Not executed within a shell.
+                        The container image's ENTRYPOINT is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     env:
+                      description: |-
+                        List of environment variables to set in the container.
+                        Cannot be updated.
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any...
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
                                 properties:
                                   key:
+                                    description: The key within the env file. An invalid
+                                      key will prevent the pod from starting.
                                     type: string
                                   optional:
                                     default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
                                     type: boolean
                                   path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
                                     type: string
                                   volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
                                     type: string
                                 required:
                                 - key
@@ -100,29 +158,47 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -137,25 +213,45 @@ spec:
                       - name
                       x-kubernetes-list-type: map
                     envFrom:
+                      description: List of sources to populate environment variables
+                        in the container.
                       items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps or Secrets
                         properties:
                           configMapRef:
+                            description: The ConfigMap to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
+                            description: The Secret to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the Secret must be defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
@@ -163,31 +259,60 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     image:
+                      description: |-
+                        Container image name.
+                        More info: https://kubernetes.
                       type: string
                     imagePullPolicy:
+                      description: |-
+                        Image pull policy.
+                        One of Always, Never, IfNotPresent.
                       type: string
                     lifecycle:
+                      description: |-
+                        Actions that the management system should take in response to container lifecycle events.
+                        Cannot be updated.
                       properties:
                         postStart:
+                          description: PostStart is called immediately after a container
+                            is created.
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -196,58 +321,100 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
+                          description: |-
+                            PreStop is called immediately before a container is terminated due to an
+                            API request or management event such as...
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -256,75 +423,128 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         stopSignal:
+                          description: StopSignal defines which signal will be sent
+                            to a container when it is being stopped.
                           type: string
                       type: object
                     livenessProbe:
+                      description: |-
+                        Periodic probe of container liveness.
+                        Container will be restarted if the probe fails.
+                        Cannot be updated.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -333,62 +553,114 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     name:
+                      description: |-
+                        Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
                       type: string
                     ports:
+                      description: |-
+                        List of ports to expose from the container. Not specifying a port here
+                        DOES NOT prevent that port from being exposed.
                       items:
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
                           containerPort:
+                            description: |-
+                              Number of port to expose on the pod's IP address.
+                              This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
+                            description: What host IP to bind the external port to.
                             type: string
                           hostPort:
+                            description: |-
+                              Number of port to expose on the host.
+                              If specified, this must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           name:
+                            description: |-
+                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                              named port in a pod must have a unique name.
                             type: string
                           protocol:
                             default: TCP
+                            description: |-
+                              Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -399,39 +671,68 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
+                      description: |-
+                        Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe fails.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -440,51 +741,92 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     resizePolicy:
+                      description: |-
+                        Resources resize policy for the container.
+                        This field cannot be set on ephemeral containers.
                       items:
+                        description: ContainerResizePolicy represents resource resize
+                          policy for the container.
                         properties:
                           resourceName:
+                            description: |-
+                              Name of the resource to which this resource resize policy applies.
+                              Supported values: cpu, memory.
                             type: string
                           restartPolicy:
+                            description: |-
+                              Restart policy to apply when specified resource is resized.
+                              If not specified, it defaults to NotRequired.
                             type: string
                         required:
                         - resourceName
@@ -493,13 +835,26 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     resources:
+                      description: |-
+                        Compute Resources required by this container.
+                        Cannot be updated.
+                        More info: https://kubernetes.
                       properties:
                         claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
                           items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used.
                                 type: string
                               request:
+                                description: Request is the name chosen for a request
+                                  in the referenced claim.
                                 type: string
                             required:
                             - name
@@ -515,6 +870,9 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.
                           type: object
                         requests:
                           additionalProperties:
@@ -523,20 +881,41 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: Requests describes the minimum amount of compute
+                            resources required.
                           type: object
                       type: object
                     restartPolicy:
+                      description: |-
+                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                        This overrides the pod-level restart policy.
                       type: string
                     restartPolicyRules:
+                      description: |-
+                        Represents a list of rules to be checked to determine if the
+                        container should be restarted on exit.
                       items:
+                        description: ContainerRestartRule describes how a container
+                          exit is handled.
                         properties:
                           action:
+                            description: |-
+                              Specifies the action taken on a container exit if the requirements
+                              are satisfied.
                             type: string
                           exitCodes:
+                            description: Represents the exit codes to check on container
+                              exits.
                             properties:
                               operator:
+                                description: |-
+                                  Represents the relationship between the container exit code(s) and the
+                                  specified values.
                                 type: string
                               values:
+                                description: |-
+                                  Specifies the set of values to check for container exit codes.
+                                  At most 255 elements are allowed.
                                 items:
                                   format: int32
                                   type: integer
@@ -551,111 +930,202 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     securityContext:
+                      description: SecurityContext defines the security options the
+                        container should be run with.
                       properties:
                         allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process.
                           type: boolean
                         appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile loaded
+                                on the node that should be used.
                               type: string
                             type:
+                              description: type indicates which kind of AppArmor profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         capabilities:
+                          description: The capabilities to add/drop when running containers.
                           properties:
                             add:
+                              description: Added capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             drop:
+                              description: Removed capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
                           type: boolean
                         procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers.
                           type: string
                         readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.
                           type: boolean
                         runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user.
                           type: boolean
                         runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by this container.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used.
                               type: string
                             type:
+                              description: type indicates which kind of seccomp profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
                           properties:
                             gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container.
                               type: boolean
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process.
                               type: string
                           type: object
                       type: object
                     startupProbe:
+                      description: StartupProbe indicates that the Pod has successfully
+                        initialized.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -664,61 +1134,112 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime.
                       type: boolean
                     stdinOnce:
+                      description: |-
+                        Whether the container runtime should close the stdin channel after it has been opened by
+                        a single attach.
                       type: boolean
                     terminationMessagePath:
+                      description: |-
+                        Optional: Path at which the file to which the container's termination message
+                        will be written is mounted into the container's...
                       type: string
                     terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated.
                       type: string
                     tty:
+                      description: |-
+                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                        Default is false.
                       type: boolean
                     volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
                       items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
                         properties:
                           devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
                             type: string
                           name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -729,21 +1250,44 @@ spec:
                       - devicePath
                       x-kubernetes-list-type: map
                     volumeMounts:
+                      description: |-
+                        Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
                       items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
+                            description: |-
+                              Path within the container at which the volume should be mounted.  Must
+                              not contain ':'.
                             type: string
                           mountPropagation:
+                            description: |-
+                              mountPropagation determines how mounts are propagated from the host
+                              to container and the other way around.
                             type: string
                           name:
+                            description: This must match the Name of a Volume.
                             type: string
                           readOnly:
+                            description: |-
+                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                              Defaults to false.
                             type: boolean
                           recursiveReadOnly:
+                            description: |-
+                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                              recursively.
                             type: string
                           subPath:
+                            description: |-
+                              Path within the volume from which the container's volume should be mounted.
+                              Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted.
                             type: string
                         required:
                         - mountPath
@@ -754,28 +1298,53 @@ spec:
                       - mountPath
                       x-kubernetes-list-type: map
                     workingDir:
+                      description: Container's working directory.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               affinity:
+                description: If specified, indicates the pod's scheduling constraints
                 properties:
                   nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may...
                         items:
+                          description: |-
+                            An empty preferred scheduling term matches all objects with implicit weight 0
+                            (i.e. it's a no-op).
                           properties:
                             preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
                               properties:
                                 matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -787,13 +1356,26 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -807,6 +1389,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -816,18 +1400,39 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the...
                         properties:
                           nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
                             items:
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
                               properties:
                                 matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -839,13 +1444,26 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
                                   items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                         type: string
                                       values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -866,22 +1484,48 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may...
                         items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -895,29 +1539,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -931,20 +1599,30 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -954,18 +1632,40 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the...
                         items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be...
                           properties:
                             labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -979,29 +1679,52 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -1015,15 +1738,22 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the...
                               type: string
                           required:
                           - topologyKey
@@ -1032,22 +1762,49 @@ spec:
                         x-kubernetes-list-type: atomic
                     type: object
                   podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
                     properties:
                       preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the anti-affinity expressions specified by this field, but it...
                         items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
                           properties:
                             podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
                               properties:
                                 labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -1061,29 +1818,53 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -1097,20 +1878,30 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the...
                                   type: string
                               required:
                               - topologyKey
                               type: object
                             weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
                               format: int32
                               type: integer
                           required:
@@ -1120,18 +1911,40 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the anti-affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto...
                         items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be...
                           properties:
                             labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -1145,29 +1958,52 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
                                   items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the
+                                          selector applies to.
                                         type: string
                                       operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty.
                                         items:
                                           type: string
                                         type: array
@@ -1181,15 +2017,22 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs.
                                   type: object
                               type: object
                               x-kubernetes-map-type: atomic
                             namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to.
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the...
                               type: string
                           required:
                           - topologyKey
@@ -1200,6 +2043,8 @@ spec:
                 type: object
               allocationStrategy:
                 default: consistent-hashing
+                description: AllocationStrategy determines which strategy the target
+                  allocator should use for allocation.
                 enum:
                 - least-weighted
                 - consistent-hashing
@@ -1208,55 +2053,99 @@ spec:
               args:
                 additionalProperties:
                   type: string
+                description: Args is the set of arguments to pass to the main container's
+                  binary.
                 type: object
               collectorNotReadyGracePeriod:
                 default: 30s
+                description: CollectorNotReadyGracePeriod defines the grace period
+                  after which a TargetAllocator stops considering a collector is target...
                 format: duration
                 type: string
               dnsPolicy:
+                description: DNSPolicy defines how a pod's DNS will be configured.
                 type: string
               env:
+                description: Environment variables to set on the generated pods.
                 items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
                   properties:
                     name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any...
                       type: string
                     valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
                       properties:
                         configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
                           properties:
                             key:
+                              description: The key to select.
                               type: string
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
                               type: boolean
                           required:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
                         fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.'
                           properties:
                             apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
                               type: string
                             fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
                               type: string
                           required:
                           - fieldPath
                           type: object
                           x-kubernetes-map-type: atomic
                         fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
                           properties:
                             key:
+                              description: The key within the env file. An invalid
+                                key will prevent the pod from starting.
                               type: string
                             optional:
                               default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
                               type: boolean
                             path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
                               type: string
                             volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
                               type: string
                           required:
                           - key
@@ -1265,29 +2154,46 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.
                           properties:
                             containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
                               type: string
                             divisor:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             resource:
+                              description: 'Required: resource to select'
                               type: string
                           required:
                           - resource
                           type: object
                           x-kubernetes-map-type: atomic
                         secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
                           properties:
                             key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
                               type: string
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                             optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
                               type: boolean
                           required:
                           - key
@@ -1299,25 +2205,44 @@ spec:
                   type: object
                 type: array
               envFrom:
+                description: List of sources to populate environment variables on
+                  the generated pods.
                 items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                    or Secrets
                   properties:
                     configMapRef:
+                      description: The ConfigMap to select from
                       properties:
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: Specify whether the ConfigMap must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     prefix:
+                      description: |-
+                        Optional text to prepend to the name of each environment variable.
+                        May consist of any printable ASCII characters except '='.
                       type: string
                     secretRef:
+                      description: The Secret to select from
                       properties:
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: Specify whether the Secret must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
@@ -1325,21 +2250,33 @@ spec:
                 type: array
               filterStrategy:
                 default: relabel-config
+                description: FilterStrategy determines how to filter targets before
+                  allocating them among the collectors.
                 enum:
                 - ""
                 - relabel-config
                 type: string
               global:
+                description: |-
+                  GlobalConfig configures the global configuration for Prometheus
+                  For more info, see https://prometheus.
                 type: object
               hostAliases:
+                description: HostAliases is an optional list of hosts and IPs that
+                  will be injected into the pod's hosts file if specified.
                 items:
+                  description: |-
+                    HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                    pod's hosts file.
                   properties:
                     hostnames:
+                      description: Hostnames for the above IP address.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     ip:
+                      description: IP address of the host file entry.
                       type: string
                   required:
                   - ip
@@ -1347,70 +2284,132 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               hostNetwork:
+                description: HostNetwork indicates if the pod should run in the host
+                  networking namespace.
                 type: boolean
               hostPID:
+                description: HostPID indicates if the pod should have access to the
+                  host process ID namespace.
                 type: boolean
               hostUsers:
+                description: HostUsers isolates pod processes in a separate user namespace,
+                  reducing the risk of privilege escalation.
                 type: boolean
               image:
+                description: Image indicates the container image to use for the generated
+                  pods.
                 type: string
               imagePullPolicy:
+                description: ImagePullPolicy indicates the pull policy to be used
+                  for retrieving the container image.
                 type: string
               initContainers:
+                description: InitContainers allows injecting initContainers to the
+                  generated pod definition.
                 items:
+                  description: A single application container that you want to run
+                    within a pod.
                   properties:
                     args:
+                      description: |-
+                        Arguments to the entrypoint.
+                        The container image's CMD is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     command:
+                      description: |-
+                        Entrypoint array. Not executed within a shell.
+                        The container image's ENTRYPOINT is used if this is not provided.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     env:
+                      description: |-
+                        List of environment variables to set in the container.
+                        Cannot be updated.
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any...
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
                                 - key
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
                                 properties:
                                   key:
+                                    description: The key within the env file. An invalid
+                                      key will prevent the pod from starting.
                                     type: string
                                   optional:
                                     default: false
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
                                     type: boolean
                                   path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
                                     type: string
                                   volumeName:
+                                    description: The name of the volume mount containing
+                                      the env file.
                                     type: string
                                 required:
                                 - key
@@ -1419,29 +2418,47 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
                                 type: object
                                 x-kubernetes-map-type: atomic
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                 - key
@@ -1456,25 +2473,45 @@ spec:
                       - name
                       x-kubernetes-list-type: map
                     envFrom:
+                      description: List of sources to populate environment variables
+                        in the container.
                       items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps or Secrets
                         properties:
                           configMapRef:
+                            description: The ConfigMap to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
                           prefix:
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
+                            description: The Secret to select from
                             properties:
                               name:
                                 default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty.
                                 type: string
                               optional:
+                                description: Specify whether the Secret must be defined
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
@@ -1482,31 +2519,60 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     image:
+                      description: |-
+                        Container image name.
+                        More info: https://kubernetes.
                       type: string
                     imagePullPolicy:
+                      description: |-
+                        Image pull policy.
+                        One of Always, Never, IfNotPresent.
                       type: string
                     lifecycle:
+                      description: |-
+                        Actions that the management system should take in response to container lifecycle events.
+                        Cannot be updated.
                       properties:
                         postStart:
+                          description: PostStart is called immediately after a container
+                            is created.
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -1515,58 +2581,100 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         preStop:
+                          description: |-
+                            PreStop is called immediately before a container is terminated due to an
+                            API request or management event such as...
                           properties:
                             exec:
+                              description: Exec specifies a command to execute in
+                                the container.
                               properties:
                                 command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the...
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
+                              description: HTTPGet specifies an HTTP GET request to
+                                perform.
                               properties:
                                 host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
                                   type: string
                                 httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
                                   items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
                                     properties:
                                       name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                         type: string
                                       value:
+                                        description: The header field value
                                         type: string
                                     required:
                                     - name
@@ -1575,75 +2683,128 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 path:
+                                  description: Path to access on the HTTP server.
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                                 scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
                                   type: string
                               required:
                               - port
                               type: object
                             sleep:
+                              description: Sleep represents a duration that the container
+                                should sleep.
                               properties:
                                 seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
                                   format: int64
                                   type: integer
                               required:
                               - seconds
                               type: object
                             tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for backward compatibility.
                               properties:
                                 host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                   type: string
                                 port:
                                   anyOf:
                                   - type: integer
                                   - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
                               required:
                               - port
                               type: object
                           type: object
                         stopSignal:
+                          description: StopSignal defines which signal will be sent
+                            to a container when it is being stopped.
                           type: string
                       type: object
                     livenessProbe:
+                      description: |-
+                        Periodic probe of container liveness.
+                        Container will be restarted if the probe fails.
+                        Cannot be updated.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -1652,62 +2813,114 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     name:
+                      description: |-
+                        Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
                       type: string
                     ports:
+                      description: |-
+                        List of ports to expose from the container. Not specifying a port here
+                        DOES NOT prevent that port from being exposed.
                       items:
+                        description: ContainerPort represents a network port in a
+                          single container.
                         properties:
                           containerPort:
+                            description: |-
+                              Number of port to expose on the pod's IP address.
+                              This must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           hostIP:
+                            description: What host IP to bind the external port to.
                             type: string
                           hostPort:
+                            description: |-
+                              Number of port to expose on the host.
+                              If specified, this must be a valid port number, 0 < x < 65536.
                             format: int32
                             type: integer
                           name:
+                            description: |-
+                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                              named port in a pod must have a unique name.
                             type: string
                           protocol:
                             default: TCP
+                            description: |-
+                              Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
                             type: string
                         required:
                         - containerPort
@@ -1718,39 +2931,68 @@ spec:
                       - protocol
                       x-kubernetes-list-type: map
                     readinessProbe:
+                      description: |-
+                        Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe fails.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -1759,51 +3001,92 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     resizePolicy:
+                      description: |-
+                        Resources resize policy for the container.
+                        This field cannot be set on ephemeral containers.
                       items:
+                        description: ContainerResizePolicy represents resource resize
+                          policy for the container.
                         properties:
                           resourceName:
+                            description: |-
+                              Name of the resource to which this resource resize policy applies.
+                              Supported values: cpu, memory.
                             type: string
                           restartPolicy:
+                            description: |-
+                              Restart policy to apply when specified resource is resized.
+                              If not specified, it defaults to NotRequired.
                             type: string
                         required:
                         - resourceName
@@ -1812,13 +3095,26 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     resources:
+                      description: |-
+                        Compute Resources required by this container.
+                        Cannot be updated.
+                        More info: https://kubernetes.
                       properties:
                         claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
                           items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                             properties:
                               name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used.
                                 type: string
                               request:
+                                description: Request is the name chosen for a request
+                                  in the referenced claim.
                                 type: string
                             required:
                             - name
@@ -1834,6 +3130,9 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.
                           type: object
                         requests:
                           additionalProperties:
@@ -1842,20 +3141,41 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: Requests describes the minimum amount of compute
+                            resources required.
                           type: object
                       type: object
                     restartPolicy:
+                      description: |-
+                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                        This overrides the pod-level restart policy.
                       type: string
                     restartPolicyRules:
+                      description: |-
+                        Represents a list of rules to be checked to determine if the
+                        container should be restarted on exit.
                       items:
+                        description: ContainerRestartRule describes how a container
+                          exit is handled.
                         properties:
                           action:
+                            description: |-
+                              Specifies the action taken on a container exit if the requirements
+                              are satisfied.
                             type: string
                           exitCodes:
+                            description: Represents the exit codes to check on container
+                              exits.
                             properties:
                               operator:
+                                description: |-
+                                  Represents the relationship between the container exit code(s) and the
+                                  specified values.
                                 type: string
                               values:
+                                description: |-
+                                  Specifies the set of values to check for container exit codes.
+                                  At most 255 elements are allowed.
                                 items:
                                   format: int32
                                   type: integer
@@ -1870,111 +3190,202 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     securityContext:
+                      description: SecurityContext defines the security options the
+                        container should be run with.
                       properties:
                         allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process.
                           type: boolean
                         appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile loaded
+                                on the node that should be used.
                               type: string
                             type:
+                              description: type indicates which kind of AppArmor profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         capabilities:
+                          description: The capabilities to add/drop when running containers.
                           properties:
                             add:
+                              description: Added capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                             drop:
+                              description: Removed capabilities
                               items:
+                                description: Capability represent POSIX capabilities
+                                  type
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
                           type: boolean
                         procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers.
                           type: string
                         readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.
                           type: boolean
                         runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user.
                           type: boolean
                         runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by this container.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used.
                               type: string
                             type:
+                              description: type indicates which kind of seccomp profile
+                                will be applied.
                               type: string
                           required:
                           - type
                           type: object
                         windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
                           properties:
                             gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             hostProcess:
+                              description: HostProcess determines if a container should
+                                be run as a 'Host Process' container.
                               type: boolean
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process.
                               type: string
                           type: object
                       type: object
                     startupProbe:
+                      description: StartupProbe indicates that the Pod has successfully
+                        initialized.
                       properties:
                         exec:
+                          description: Exec specifies a command to execute in the
+                            container.
                           properties:
                             command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the...
                               items:
                                 type: string
                               type: array
                               x-kubernetes-list-type: atomic
                           type: object
                         failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
                           format: int32
                           type: integer
                         grpc:
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
                               format: int32
                               type: integer
                             service:
                               default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.
                               type: string
                           required:
                           - port
                           type: object
                         httpGet:
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
                               items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
                                 properties:
                                   name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
+                                    description: The header field value
                                     type: string
                                 required:
                                 - name
@@ -1983,61 +3394,112 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             path:
+                              description: Path to access on the HTTP server.
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
                               type: string
                           required:
                           - port
                           type: object
                         initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                         periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
                           format: int32
                           type: integer
                         successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1.
                           format: int32
                           type: integer
                         tcpSocket:
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
                               type: string
                             port:
                               anyOf:
                               - type: integer
                               - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                           - port
                           type: object
                         terminationGracePeriodSeconds:
+                          description: Optional duration in seconds the pod needs
+                            to terminate gracefully upon probe failure.
                           format: int64
                           type: integer
                         timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.
                           format: int32
                           type: integer
                       type: object
                     stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime.
                       type: boolean
                     stdinOnce:
+                      description: |-
+                        Whether the container runtime should close the stdin channel after it has been opened by
+                        a single attach.
                       type: boolean
                     terminationMessagePath:
+                      description: |-
+                        Optional: Path at which the file to which the container's termination message
+                        will be written is mounted into the container's...
                       type: string
                     terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated.
                       type: string
                     tty:
+                      description: |-
+                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                        Default is false.
                       type: boolean
                     volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
                       items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
                         properties:
                           devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
                             type: string
                           name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
                             type: string
                         required:
                         - devicePath
@@ -2048,21 +3510,44 @@ spec:
                       - devicePath
                       x-kubernetes-list-type: map
                     volumeMounts:
+                      description: |-
+                        Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
                       items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
                         properties:
                           mountPath:
+                            description: |-
+                              Path within the container at which the volume should be mounted.  Must
+                              not contain ':'.
                             type: string
                           mountPropagation:
+                            description: |-
+                              mountPropagation determines how mounts are propagated from the host
+                              to container and the other way around.
                             type: string
                           name:
+                            description: This must match the Name of a Volume.
                             type: string
                           readOnly:
+                            description: |-
+                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                              Defaults to false.
                             type: boolean
                           recursiveReadOnly:
+                            description: |-
+                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                              recursively.
                             type: string
                           subPath:
+                            description: |-
+                              Path within the volume from which the container's volume should be mounted.
+                              Defaults to "" (volume's root).
                             type: string
                           subPathExpr:
+                            description: Expanded path within the volume from which
+                              the container's volume should be mounted.
                             type: string
                         required:
                         - mountPath
@@ -2073,40 +3558,69 @@ spec:
                       - mountPath
                       x-kubernetes-list-type: map
                     workingDir:
+                      description: Container's working directory.
                       type: string
                   required:
                   - name
                   type: object
                 type: array
               ipFamilies:
+                description: |-
+                  IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                  to express the family of an IP expressed by a type (e.g.
                 items:
+                  description: |-
+                    IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                    to express the family of an IP expressed by a type (e.g.
                   type: string
                 type: array
               ipFamilyPolicy:
                 default: SingleStack
+                description: IPFamilyPolicy represents the dual-stack-ness requested
+                  or required by a Service
                 type: string
               lifecycle:
+                description: Actions that the management system should take in response
+                  to container lifecycle events. Cannot be updated.
                 properties:
                   postStart:
+                    description: PostStart is called immediately after a container
+                      is created.
                     properties:
                       exec:
+                        description: Exec specifies a command to execute in the container.
                         properties:
                           command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the...
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                         type: object
                       httpGet:
+                        description: HTTPGet specifies an HTTP GET request to perform.
                         properties:
                           host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
                             items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
                               properties:
                                 name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
+                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -2115,58 +3629,97 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           path:
+                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       sleep:
+                        description: Sleep represents a duration that the container
+                          should sleep.
                         properties:
                           seconds:
+                            description: Seconds is the number of seconds to sleep.
                             format: int64
                             type: integer
                         required:
                         - seconds
                         type: object
                       tcpSocket:
+                        description: |-
+                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                          for backward compatibility.
                         properties:
                           host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                     type: object
                   preStop:
+                    description: |-
+                      PreStop is called immediately before a container is terminated due to an
+                      API request or management event such as...
                     properties:
                       exec:
+                        description: Exec specifies a command to execute in the container.
                         properties:
                           command:
+                            description: |-
+                              Command is the command line to execute inside the container, the working directory for the
+                              command  is root ('/') in the...
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                         type: object
                       httpGet:
+                        description: HTTPGet specifies an HTTP GET request to perform.
                         properties:
                           host:
+                            description: |-
+                              Host name to connect to, defaults to the pod IP. You probably want to set
+                              "Host" in httpHeaders instead.
                             type: string
                           httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
                             items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
                               properties:
                                 name:
+                                  description: |-
+                                    The header field name.
+                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                   type: string
                                 value:
+                                  description: The header field value
                                   type: string
                               required:
                               - name
@@ -2175,75 +3728,124 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           path:
+                            description: Path to access on the HTTP server.
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Name or number of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                           scheme:
+                            description: |-
+                              Scheme to use for connecting to the host.
+                              Defaults to HTTP.
                             type: string
                         required:
                         - port
                         type: object
                       sleep:
+                        description: Sleep represents a duration that the container
+                          should sleep.
                         properties:
                           seconds:
+                            description: Seconds is the number of seconds to sleep.
                             format: int64
                             type: integer
                         required:
                         - seconds
                         type: object
                       tcpSocket:
+                        description: |-
+                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                          for backward compatibility.
                         properties:
                           host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
                             type: string
                           port:
                             anyOf:
                             - type: integer
                             - type: string
+                            description: |-
+                              Number or name of the port to access on the container.
+                              Number must be in the range 1 to 65535.
+                              Name must be an IANA_SVC_NAME.
                             x-kubernetes-int-or-string: true
                         required:
                         - port
                         type: object
                     type: object
                   stopSignal:
+                    description: StopSignal defines which signal will be sent to a
+                      container when it is being stopped.
                     type: string
                 type: object
               livenessProbe:
+                description: LivenessProbe defines the liveness probe configuration
+                  for the Target Allocator container.
                 properties:
                   exec:
+                    description: Exec specifies a command to execute in the container.
                     properties:
                       command:
+                        description: |-
+                          Command is the command line to execute inside the container, the working directory for the
+                          command  is root ('/') in the...
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                     type: object
                   failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
                     format: int32
                     type: integer
                   grpc:
+                    description: GRPC specifies a GRPC HealthCheckRequest.
                     properties:
                       port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
                         format: int32
                         type: integer
                       service:
                         default: ""
+                        description: |-
+                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                          (see https://github.
                         type: string
                     required:
                     - port
                     type: object
                   httpGet:
+                    description: HTTPGet specifies an HTTP GET request to perform.
                     properties:
                       host:
+                        description: |-
+                          Host name to connect to, defaults to the pod IP. You probably want to set
+                          "Host" in httpHeaders instead.
                         type: string
                       httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
                         items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
                           properties:
                             name:
+                              description: |-
+                                The header field name.
+                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
                               type: string
                             value:
+                              description: The header field value
                               type: string
                           required:
                           - name
@@ -2252,174 +3854,306 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       path:
+                        description: Path to access on the HTTP server.
                         type: string
                       port:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
                         x-kubernetes-int-or-string: true
                       scheme:
+                        description: |-
+                          Scheme to use for connecting to the host.
+                          Defaults to HTTP.
                         type: string
                     required:
                     - port
                     type: object
                   initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      More info: https://kubernetes.
                     format: int32
                     type: integer
                   periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
                     format: int32
                     type: integer
                   successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1.
                     format: int32
                     type: integer
                   tcpSocket:
+                    description: TCPSocket specifies a connection to a TCP port.
                     properties:
                       host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
                         type: string
                       port:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
                         x-kubernetes-int-or-string: true
                     required:
                     - port
                     type: object
                   terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure.
                     format: int64
                     type: integer
                   timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.
                     format: int32
                     type: integer
                 type: object
               managementState:
                 default: managed
+                description: |-
+                  ManagementState defines if the CR should be managed by the operator or not.
+                  Default is managed.
                 enum:
                 - managed
                 - unmanaged
                 type: string
               networkPolicy:
+                description: NetworkPolicy defines the network policy to be applied
+                  to the Target Allocator pods.
                 properties:
                   enabled:
+                    description: |-
+                      Enable enables the NetworkPolicy.
+                      The default value is taken from the operator feature-gate `--feature-gates=+operand.
                     type: boolean
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
+                description: NodeSelector to schedule generated pods.
                 type: object
               observability:
+                description: ObservabilitySpec defines how telemetry data gets handled.
                 properties:
                   metrics:
+                    description: Metrics defines the metrics configuration for operands.
                     properties:
                       disablePrometheusAnnotations:
+                        description: |-
+                          DisablePrometheusAnnotations controls the automatic addition of default Prometheus annotations
+                          ('prometheus.
                         type: boolean
                       enableMetrics:
+                        description: EnableMetrics specifies if ServiceMonitor or
+                          PodMonitor(for sidecar mode) should be created for the service
+                          managed by the...
                         type: boolean
                       extraLabels:
                         additionalProperties:
                           type: string
+                        description: ExtraLabels are additional labels to be added
+                          to the ServiceMonitor
                         type: object
                     type: object
                 type: object
               podAnnotations:
                 additionalProperties:
                   type: string
+                description: |-
+                  PodAnnotations is the set of annotations that will be attached to
+                  the generated pods.
                 type: object
               podDisruptionBudget:
+                description: |-
+                  PodDisruptionBudget specifies the pod disruption budget configuration to use
+                  for the generated workload.
                 properties:
                   maxUnavailable:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      An eviction is allowed if at most "maxUnavailable" pods selected by
+                      "selector" are unavailable after the eviction, i.e.
                     x-kubernetes-int-or-string: true
                   minAvailable:
                     anyOf:
                     - type: integer
                     - type: string
+                    description: |-
+                      An eviction is allowed if at least "minAvailable" pods selected by
+                      "selector" will still be available after the eviction, i.e.
                     x-kubernetes-int-or-string: true
                 type: object
               podDnsConfig:
+                description: PodDNSConfig defines the DNS parameters of a pod in addition
+                  to those generated from DNSPolicy.
                 properties:
                   nameservers:
+                    description: |-
+                      A list of DNS name server IP addresses.
+                      This will be appended to the base nameservers generated from DNSPolicy.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
                   options:
+                    description: |-
+                      A list of DNS resolver options.
+                      This will be merged with the base options generated from DNSPolicy.
                     items:
+                      description: PodDNSConfigOption defines DNS resolver options
+                        of a pod.
                       properties:
                         name:
+                          description: |-
+                            Name is this DNS resolver option's name.
+                            Required.
                           type: string
                         value:
+                          description: Value is this DNS resolver option's value.
                           type: string
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
                   searches:
+                    description: |-
+                      A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from DNSPolicy.
                     items:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
               podSecurityContext:
+                description: |-
+                  PodSecurityContext configures the pod security context for the
+                  generated pod, when running as a deployment, daemonset,
+                  or...
                 properties:
                   appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by the containers in this pod.
+                      Note that this field cannot be set when spec.os.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile loaded on
+                          the node that should be used.
                         type: string
                       type:
+                        description: type indicates which kind of AppArmor profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   fsGroup:
+                    description: A special supplemental group that applies to all
+                      containers in a pod.
                     format: int64
                     type: integer
                   fsGroupChangePolicy:
+                    description: |-
+                      fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                      before being exposed inside Pod.
                     type: string
                   runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in SecurityContext.
                     format: int64
                     type: integer
                   runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user.
                     type: boolean
                   runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
                     format: int64
                     type: integer
                   seLinuxChangePolicy:
+                    description: seLinuxChangePolicy defines how the container's SELinux
+                      label is applied to all volumes used by the Pod.
                     type: string
                   seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
                     properties:
                       level:
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
+                    description: |-
+                      The seccomp options to use by the containers in this pod.
+                      Note that this field cannot be set when spec.os.name is windows.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used.
                         type: string
                       type:
+                        description: type indicates which kind of seccomp profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   supplementalGroups:
+                    description: |-
+                      A list of groups applied to the first process run in each container, in
+                      addition to the container's primary GID and fsGroup (if...
                     items:
                       format: int64
                       type: integer
                     type: array
                     x-kubernetes-list-type: atomic
                   supplementalGroupsPolicy:
+                    description: |-
+                      Defines how supplemental groups of the first container processes are calculated.
+                      Valid values are "Merge" and "Strict".
                     type: string
                   sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod.
                     items:
+                      description: Sysctl defines a kernel parameter to be set
                       properties:
                         name:
+                          description: Name of a property to set
                           type: string
                         value:
+                          description: Value of a property to set
                           type: string
                       required:
                       - name
@@ -2428,42 +4162,72 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   windowsOptions:
+                    description: The Windows specific settings applied to all containers.
                     properties:
                       gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.
                         type: string
                       gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container.
                         type: boolean
                       runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process.
                         type: string
                     type: object
                 type: object
               ports:
+                description: Ports allows a set of ports to be exposed by the underlying
+                  v1.Service & v1.ContainerPort.
                 items:
+                  description: PortsSpec defines the OpenTelemetryCollector's container/service
+                    ports additional specifications.
                   properties:
                     appProtocol:
+                      description: The application protocol for this port.
                       type: string
                     hostPort:
+                      description: Allows defining which port to bind to the host
+                        in the Container.
                       format: int32
                       maximum: 65535
                       minimum: 0
                       type: integer
                     name:
+                      description: |-
+                        The name of this port within the service. This must be a DNS_LABEL.
+                        All ports within a ServiceSpec must have unique names.
                       type: string
                     nodePort:
+                      description: |-
+                        The port on each node on which this service is exposed when type is
+                        NodePort or LoadBalancer.  Usually assigned by the system.
                       format: int32
                       type: integer
                     port:
+                      description: The port that will be exposed by this service.
                       format: int32
                       type: integer
                     protocol:
                       default: TCP
+                      description: |-
+                        The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                        Default is TCP.
                       type: string
                     targetPort:
                       anyOf:
                       - type: integer
                       - type: string
+                      description: |-
+                        Number or name of the port to access on the pods targeted by the service.
+                        Number must be in the range 1 to 65535.
                       x-kubernetes-int-or-string: true
                   required:
                   - port
@@ -2471,34 +4235,66 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               priorityClassName:
+                description: |-
+                  If specified, indicates the pod's priority.
+                  If not specified, the pod priority will be default or zero if there is no
+                  default.
                 type: string
               prometheusCR:
+                description: PrometheusCR defines the configuration for the retrieval
+                  of PrometheusOperator CRDs ( servicemonitor.monitoring.coreos.
                 properties:
                   allowNamespaces:
+                    description: AllowNamespaces Namespaces to scope the interaction
+                      of the Target Allocator and the apiserver (allow list).
                     items:
                       type: string
                     type: array
                   denyNamespaces:
+                    description: DenyNamespaces Namespaces to scope the interaction
+                      of the Target Allocator and the apiserver (deny list).
                     items:
                       type: string
                     type: array
                   enabled:
+                    description: Enabled indicates whether to use a PrometheusOperator
+                      custom resources as targets or not.
                     type: boolean
                   evaluationInterval:
                     default: 30s
+                    description: |-
+                      Default interval between rule evaluations.
+
+                      Default: "30s"
                     format: duration
                     type: string
                   podMonitorNamespaceSelector:
                     default: {}
+                    description: |-
+                      Namespaces to be selected for PodMonitor discovery.
+                      A label selector is a label query over a set of resources.
                     properties:
                       matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty.
                               items:
                                 type: string
                               type: array
@@ -2512,19 +4308,36 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
+                        description: matchLabels is a map of {key,value} pairs.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   podMonitorSelector:
+                    description: |-
+                      PodMonitors to be selected for target discovery.
+                      A label selector is a label query over a set of resources.
                     properties:
                       matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty.
                               items:
                                 type: string
                               type: array
@@ -2538,20 +4351,37 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
+                        description: matchLabels is a map of {key,value} pairs.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   probeNamespaceSelector:
                     default: {}
+                    description: |-
+                      Namespaces to be selected for Probe discovery.
+                      A label selector is a label query over a set of resources.
                     properties:
                       matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty.
                               items:
                                 type: string
                               type: array
@@ -2565,19 +4395,36 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
+                        description: matchLabels is a map of {key,value} pairs.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   probeSelector:
+                    description: |-
+                      Probes to be selected for target discovery.
+                      A label selector is a label query over a set of resources.
                     properties:
                       matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty.
                               items:
                                 type: string
                               type: array
@@ -2591,26 +4438,46 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
+                        description: matchLabels is a map of {key,value} pairs.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   scrapeClasses:
+                    description: ScrapeClasses to be referenced by PodMonitors and
+                      ServiceMonitors to include common configuration.
                     items:
+                      description: AnyConfig represent parts of the config.
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
                     x-kubernetes-preserve-unknown-fields: true
                   scrapeConfigNamespaceSelector:
                     default: {}
+                    description: |-
+                      Namespaces to be selected for ScrapeConfig discovery.
+                      A label selector is a label query over a set of resources.
                     properties:
                       matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty.
                               items:
                                 type: string
                               type: array
@@ -2624,19 +4491,36 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
+                        description: matchLabels is a map of {key,value} pairs.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   scrapeConfigSelector:
+                    description: |-
+                      ScrapeConfigs to be selected for target discovery.
+                      A label selector is a label query over a set of resources.
                     properties:
                       matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty.
                               items:
                                 type: string
                               type: array
@@ -2650,28 +4534,51 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
+                        description: matchLabels is a map of {key,value} pairs.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   scrapeInterval:
                     default: 30s
+                    description: |-
+                      Default interval between consecutive scrapes. Intervals set in ServiceMonitors and PodMonitors override it.
+
+                      Default: "30s"
                     format: duration
                     type: string
                   scrapeProtocols:
+                    description: ScrapeProtocols define the protocols to negotiate
+                      during a scrape.
                     items:
                       type: string
                     type: array
                   serviceMonitorNamespaceSelector:
                     default: {}
+                    description: |-
+                      Namespaces to be selected for ServiceMonitor discovery.
+                      A label selector is a label query over a set of resources.
                     properties:
                       matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty.
                               items:
                                 type: string
                               type: array
@@ -2685,19 +4592,36 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
+                        description: matchLabels is a map of {key,value} pairs.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                   serviceMonitorSelector:
+                    description: |-
+                      ServiceMonitors to be selected for target discovery.
+                      A label selector is a label query over a set of resources.
                     properties:
                       matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
                           properties:
                             key:
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
                               type: string
                             values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty.
                               items:
                                 type: string
                               type: array
@@ -2711,44 +4635,72 @@ spec:
                       matchLabels:
                         additionalProperties:
                           type: string
+                        description: matchLabels is a map of {key,value} pairs.
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
                 type: object
               readinessProbe:
+                description: ReadinessProbe defines the readiness probe configuration
+                  for the Target Allocator container.
                 properties:
                   exec:
+                    description: Exec specifies a command to execute in the container.
                     properties:
                       command:
+                        description: |-
+                          Command is the command line to execute inside the container, the working directory for the
+                          command  is root ('/') in the...
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                     type: object
                   failureThreshold:
+                    description: |-
+                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                      Defaults to 3. Minimum value is 1.
                     format: int32
                     type: integer
                   grpc:
+                    description: GRPC specifies a GRPC HealthCheckRequest.
                     properties:
                       port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
                         format: int32
                         type: integer
                       service:
                         default: ""
+                        description: |-
+                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                          (see https://github.
                         type: string
                     required:
                     - port
                     type: object
                   httpGet:
+                    description: HTTPGet specifies an HTTP GET request to perform.
                     properties:
                       host:
+                        description: |-
+                          Host name to connect to, defaults to the pod IP. You probably want to set
+                          "Host" in httpHeaders instead.
                         type: string
                       httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
                         items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
                           properties:
                             name:
+                              description: |-
+                                The header field name.
+                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
                               type: string
                             value:
+                              description: The header field value
                               type: string
                           required:
                           - name
@@ -2757,57 +4709,99 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       path:
+                        description: Path to access on the HTTP server.
                         type: string
                       port:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
                         x-kubernetes-int-or-string: true
                       scheme:
+                        description: |-
+                          Scheme to use for connecting to the host.
+                          Defaults to HTTP.
                         type: string
                     required:
                     - port
                     type: object
                   initialDelaySeconds:
+                    description: |-
+                      Number of seconds after the container has started before liveness probes are initiated.
+                      More info: https://kubernetes.
                     format: int32
                     type: integer
                   periodSeconds:
+                    description: |-
+                      How often (in seconds) to perform the probe.
+                      Default to 10 seconds. Minimum value is 1.
                     format: int32
                     type: integer
                   successThreshold:
+                    description: |-
+                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                      Defaults to 1.
                     format: int32
                     type: integer
                   tcpSocket:
+                    description: TCPSocket specifies a connection to a TCP port.
                     properties:
                       host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
                         type: string
                       port:
                         anyOf:
                         - type: integer
                         - type: string
+                        description: |-
+                          Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535.
+                          Name must be an IANA_SVC_NAME.
                         x-kubernetes-int-or-string: true
                     required:
                     - port
                     type: object
                   terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure.
                     format: int64
                     type: integer
                   timeoutSeconds:
+                    description: |-
+                      Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1.
+                      More info: https://kubernetes.
                     format: int32
                     type: integer
                 type: object
               replicas:
                 default: 1
+                description: Replicas is the number of pod instances for the underlying
+                  replicaset. Set this if you are not using autoscaling.
                 format: int32
                 type: integer
               resources:
+                description: Resources to set on generated pods.
                 properties:
                   claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
                     items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                       properties:
                         name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used.
                           type: string
                         request:
+                          description: Request is the name chosen for a request in
+                            the referenced claim.
                           type: string
                       required:
                       - name
@@ -2823,6 +4817,9 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.
                     type: object
                   requests:
                     additionalProperties:
@@ -2831,122 +4828,230 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
+                    description: Requests describes the minimum amount of compute
+                      resources required.
                     type: object
                 type: object
               scrapeConfigs:
+                description: ScrapeConfigs define static Prometheus scrape configurations
+                  for the target allocator.
                 items:
+                  description: AnyConfig represent parts of the config.
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
                 x-kubernetes-preserve-unknown-fields: true
               securityContext:
+                description: |-
+                  SecurityContext configures the container security context for
+                  the generated main container.
                 properties:
                   allowPrivilegeEscalation:
+                    description: |-
+                      AllowPrivilegeEscalation controls whether a process can gain more
+                      privileges than its parent process.
                     type: boolean
                   appArmorProfile:
+                    description: |-
+                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                      overrides the pod's appArmorProfile.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile loaded on
+                          the node that should be used.
                         type: string
                       type:
+                        description: type indicates which kind of AppArmor profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   capabilities:
+                    description: The capabilities to add/drop when running containers.
                     properties:
                       add:
+                        description: Added capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       drop:
+                        description: Removed capabilities
                         items:
+                          description: Capability represent POSIX capabilities type
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                     type: object
                   privileged:
+                    description: |-
+                      Run container in privileged mode.
+                      Processes in privileged containers are essentially equivalent to root on the host.
                     type: boolean
                   procMount:
+                    description: procMount denotes the type of proc mount to use for
+                      the containers.
                     type: string
                   readOnlyRootFilesystem:
+                    description: |-
+                      Whether this container has a read-only root filesystem.
+                      Default is false.
+                      Note that this field cannot be set when spec.os.
                     type: boolean
                   runAsGroup:
+                    description: |-
+                      The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset.
+                      May also be set in PodSecurityContext.
                     format: int64
                     type: integer
                   runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user.
                     type: boolean
                   runAsUser:
+                    description: |-
+                      The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
                     format: int64
                     type: integer
                   seLinuxOptions:
+                    description: The SELinux context to be applied to the container.
                     properties:
                       level:
+                        description: Level is SELinux level label that applies to
+                          the container.
                         type: string
                       role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
                         type: string
                       type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
                         type: string
                       user:
+                        description: User is a SELinux user label that applies to
+                          the container.
                         type: string
                     type: object
                   seccompProfile:
+                    description: The seccomp options to use by this container.
                     properties:
                       localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used.
                         type: string
                       type:
+                        description: type indicates which kind of seccomp profile
+                          will be applied.
                         type: string
                     required:
                     - type
                     type: object
                   windowsOptions:
+                    description: |-
+                      The Windows specific settings applied to all containers.
+                      If unspecified, the options from the PodSecurityContext will be used.
                     properties:
                       gmsaCredentialSpec:
+                        description: |-
+                          GMSACredentialSpec is where the GMSA admission webhook
+                          (https://github.
                         type: string
                       gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
                         type: string
                       hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container.
                         type: boolean
                       runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process.
                         type: string
                     type: object
                 type: object
               serviceAccount:
+                description: ServiceAccount indicates the name of an existing service
+                  account to use with this instance.
                 type: string
               shareProcessNamespace:
+                description: ShareProcessNamespace indicates if the pod's containers
+                  should share process namespace.
                 type: boolean
               terminationGracePeriodSeconds:
+                description: Duration in seconds the pod needs to terminate gracefully
+                  upon probe failure.
                 format: int64
                 type: integer
               tolerations:
+                description: Toleration to schedule the generated pods.
                 items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching...
                   properties:
                     effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects.
                       type: string
                     key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys.
                       type: string
                     operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                       type: string
                     tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is...
                       format: int64
                       type: integer
                     value:
+                      description: Value is the taint value the toleration matches
+                        to.
                       type: string
                   type: object
                 type: array
               topologySpreadConstraints:
+                description: |-
+                  TopologySpreadConstraints embedded kubernetes pod configuration option,
+                  controls how pods are spread across your cluster among...
                 items:
+                  description: TopologySpreadConstraint specifies how to spread matching
+                    pods among the given topology.
                   properties:
                     labelSelector:
+                      description: LabelSelector is used to find matching pods.
                       properties:
                         matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
                           items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
                             properties:
                               key:
+                                description: key is the label key that the selector
+                                  applies to.
                                 type: string
                               operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
                               values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty.
                                 items:
                                   type: string
                                 type: array
@@ -2960,27 +5065,45 @@ spec:
                         matchLabels:
                           additionalProperties:
                             type: string
+                          description: matchLabels is a map of {key,value} pairs.
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
                     matchLabelKeys:
+                      description: |-
+                        MatchLabelKeys is a set of pod label keys to select the pods over which
+                        spreading will be calculated.
                       items:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
                     maxSkew:
+                      description: MaxSkew describes the degree to which pods may
+                        be unevenly distributed.
                       format: int32
                       type: integer
                     minDomains:
+                      description: MinDomains indicates a minimum number of eligible
+                        domains.
                       format: int32
                       type: integer
                     nodeAffinityPolicy:
+                      description: |-
+                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                        when calculating pod topology spread skew.
                       type: string
                     nodeTaintsPolicy:
+                      description: |-
+                        NodeTaintsPolicy indicates how we will treat node taints when calculating
+                        pod topology spread skew.
                       type: string
                     topologyKey:
+                      description: TopologyKey is the key of node labels.
                       type: string
                     whenUnsatisfiable:
+                      description: |-
+                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                        the spread constraint.
                       type: string
                   required:
                   - maxSkew
@@ -2989,23 +5112,48 @@ spec:
                   type: object
                 type: array
               trafficDistribution:
+                description: |-
+                  TrafficDistribution specifies how traffic to this service is routed.
+                  https://kubernetes.
                 type: string
               volumeMounts:
+                description: VolumeMounts represents the mount points to use in the
+                  underlying deployment(s).
                 items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
                   properties:
                     mountPath:
+                      description: |-
+                        Path within the container at which the volume should be mounted.  Must
+                        not contain ':'.
                       type: string
                     mountPropagation:
+                      description: |-
+                        mountPropagation determines how mounts are propagated from the host
+                        to container and the other way around.
                       type: string
                     name:
+                      description: This must match the Name of a Volume.
                       type: string
                     readOnly:
+                      description: |-
+                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                        Defaults to false.
                       type: boolean
                     recursiveReadOnly:
+                      description: |-
+                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                        recursively.
                       type: string
                     subPath:
+                      description: |-
+                        Path within the volume from which the container's volume should be mounted.
+                        Defaults to "" (volume's root).
                       type: string
                     subPathExpr:
+                      description: Expanded path within the volume from which the
+                        container's volume should be mounted.
                       type: string
                   required:
                   - mountPath
@@ -3014,111 +5162,212 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               volumes:
+                description: Volumes represents which volumes to use in the underlying
+                  deployment(s).
                 items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
                   properties:
                     awsElasticBlockStore:
+                      description: |-
+                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
                           format: int32
                           type: integer
                         readOnly:
+                          description: |-
+                            readOnly value true will force the readOnly setting in VolumeMounts.
+                            More info: https://kubernetes.
                           type: boolean
                         volumeID:
+                          description: |-
+                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                            More info: https://kubernetes.
                           type: string
                       required:
                       - volumeID
                       type: object
                     azureDisk:
+                      description: |-
+                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        Deprecated: AzureDisk is deprecated.
                       properties:
                         cachingMode:
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
                           type: string
                         diskName:
+                          description: diskName is the Name of the data disk in the
+                            blob storage
                           type: string
                         diskURI:
+                          description: diskURI is the URI of data disk in the blob
+                            storage
                           type: string
                         fsType:
                           default: ext4
+                          description: |-
+                            fsType is Filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
                           type: string
                         kind:
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account ...'
                           type: string
                         readOnly:
                           default: false
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                       required:
                       - diskName
                       - diskURI
                       type: object
                     azureFile:
+                      description: |-
+                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        Deprecated: AzureFile is deprecated.
                       properties:
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretName:
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
                           type: string
                         shareName:
+                          description: shareName is the azure share Name
                           type: string
                       required:
                       - secretName
                       - shareName
                       type: object
                     cephfs:
+                      description: cephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime.
                       properties:
                         monitors:
+                          description: |-
+                            monitors is Required: Monitors is a collection of Ceph monitors
+                            More info: https://examples.k8s.io/volumes/cephfs/README.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         path:
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretFile:
+                          description: 'secretFile is Optional: SecretFile is the
+                            path to key ring for User, default is /etc/ceph/user.'
                           type: string
                         secretRef:
+                          description: 'secretRef is Optional: SecretRef is reference
+                            to the authentication secret for User, default is empty.'
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
+                          description: |-
+                            user is optional: User is the rados user name, default is admin
+                            More info: https://examples.k8s.io/volumes/cephfs/README.
                           type: string
                       required:
                       - monitors
                       type: object
                     cinder:
+                      description: |-
+                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        Deprecated: Cinder is deprecated.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is optional: points to a secret object containing parameters used to connect
+                            to OpenStack.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeID:
+                          description: |-
+                            volumeID used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                           type: string
                       required:
                       - volumeID
                       type: object
                     configMap:
+                      description: configMap represents a configMap that should populate
+                        this volume
                       properties:
                         defaultMode:
+                          description: 'defaultMode is optional: mode bits used to
+                            set permissions on created files by default.'
                           format: int32
                           type: integer
                         items:
+                          description: |-
+                            items if unspecified, each key-value pair in the Data field of the referenced
+                            ConfigMap will be projected into the volume as a...
                           items:
+                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
+                                description: key is the key to project.
                                 type: string
                               mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file.'
                                 format: int32
                                 type: integer
                               path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
                                 type: string
                             required:
                             - key
@@ -3128,67 +5377,119 @@ spec:
                           x-kubernetes-list-type: atomic
                         name:
                           default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty.
                           type: string
                         optional:
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
                           type: boolean
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
+                      description: csi (Container Storage Interface) represents ephemeral
+                        storage that is handled by certain external CSI drivers.
                       properties:
                         driver:
+                          description: driver is the name of the CSI driver that handles
+                            this volume.
                           type: string
                         fsType:
+                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
                           type: string
                         nodePublishSecretRef:
+                          description: |-
+                            nodePublishSecretRef is a reference to the secret object containing
+                            sensitive information to pass to the CSI driver to complete...
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         readOnly:
+                          description: |-
+                            readOnly specifies a read-only configuration for the volume.
+                            Defaults to false (read/write).
                           type: boolean
                         volumeAttributes:
                           additionalProperties:
                             type: string
+                          description: |-
+                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                            driver.
                           type: object
                       required:
                       - driver
                       type: object
                     downwardAPI:
+                      description: downwardAPI represents downward API about the pod
+                        that should populate this volume
                       properties:
                         defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default.'
                           format: int32
                           type: integer
                         items:
+                          description: Items is a list of downward API volume file
                           items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
                             properties:
                               fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name, namespace and uid
+                                  are supported.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                 - fieldPath
                                 type: object
                                 x-kubernetes-map-type: atomic
                               mode:
+                                description: |-
+                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                  between 0000 and 0777 or a decimal value...
                                 format: int32
                                 type: integer
                               path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path.'
                                 type: string
                               resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, requests.cpu and requests.
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                     - type: integer
                                     - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                 - resource
@@ -3201,21 +5502,35 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     emptyDir:
+                      description: |-
+                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                        More info: https://kubernetes.
                       properties:
                         medium:
+                          description: medium represents what type of storage medium
+                            should back this directory.
                           type: string
                         sizeLimit:
                           anyOf:
                           - type: integer
                           - type: string
+                          description: sizeLimit is the total amount of local storage
+                            required for this EmptyDir volume.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                       type: object
                     ephemeral:
+                      description: ephemeral represents a volume that is handled by
+                        a cluster storage driver.
                       properties:
                         volumeClaimTemplate:
+                          description: Will be used to create a stand-alone PVC to
+                            provision the volume.
                           properties:
                             metadata:
+                              description: |-
+                                May contain labels and annotations that will be copied into the PVC
+                                when creating it.
                               properties:
                                 annotations:
                                   additionalProperties:
@@ -3235,19 +5550,32 @@ spec:
                                   type: string
                               type: object
                             spec:
+                              description: The specification for the PersistentVolumeClaim.
                               properties:
                                 accessModes:
+                                  description: |-
+                                    accessModes contains the desired access modes the volume should have.
+                                    More info: https://kubernetes.
                                   items:
                                     type: string
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 dataSource:
+                                  description: |-
+                                    dataSource field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.
                                   properties:
                                     apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced.
                                       type: string
                                     kind:
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                   required:
                                   - kind
@@ -3255,20 +5583,34 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 dataSourceRef:
+                                  description: |-
+                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                    volume is desired.
                                   properties:
                                     apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced.
                                       type: string
                                     kind:
+                                      description: Kind is the type of resource being
+                                        referenced
                                       type: string
                                     name:
+                                      description: Name is the name of resource being
+                                        referenced
                                       type: string
                                     namespace:
+                                      description: |-
+                                        Namespace is the namespace of resource being referenced
+                                        Note that when a namespace is specified, a gateway.networking.k8s.
                                       type: string
                                   required:
                                   - kind
                                   - name
                                   type: object
                                 resources:
+                                  description: resources represents the minimum resources
+                                    the volume should have.
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -3277,6 +5619,9 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.
                                       type: object
                                     requests:
                                       additionalProperties:
@@ -3285,18 +5630,36 @@ spec:
                                         - type: string
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
+                                      description: Requests describes the minimum
+                                        amount of compute resources required.
                                       type: object
                                   type: object
                                 selector:
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
                                   properties:
                                     matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
                                       items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
                                         properties:
                                           key:
+                                            description: key is the label key that
+                                              the selector applies to.
                                             type: string
                                           operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
                                             type: string
                                           values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
                                             items:
                                               type: string
                                             type: array
@@ -3310,16 +5673,29 @@ spec:
                                     matchLabels:
                                       additionalProperties:
                                         type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs.
                                       type: object
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 storageClassName:
+                                  description: |-
+                                    storageClassName is the name of the StorageClass required by the claim.
+                                    More info: https://kubernetes.
                                   type: string
                                 volumeAttributesClassName:
+                                  description: volumeAttributesClassName may be used
+                                    to set the VolumeAttributesClass used by this
+                                    claim.
                                   type: string
                                 volumeMode:
+                                  description: |-
+                                    volumeMode defines what type of volume is required by the claim.
+                                    Value of Filesystem is implied when not included in claim spec.
                                   type: string
                                 volumeName:
+                                  description: volumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                           required:
@@ -3327,41 +5703,78 @@ spec:
                           type: object
                       type: object
                     fc:
+                      description: fc represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         lun:
+                          description: 'lun is Optional: FC target lun number'
                           format: int32
                           type: integer
                         readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         targetWWNs:
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         wwids:
+                          description: |-
+                            wwids Optional: FC volume world wide identifiers (wwids)
+                            Either wwids or combination of targetWWNs and lun must be set, but not...
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                       type: object
                     flexVolume:
+                      description: |-
+                        flexVolume represents a generic volume resource that is
+                        provisioned/attached using an exec based plugin.
                       properties:
                         driver:
+                          description: driver is the name of the driver to use for
+                            this volume.
                           type: string
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         options:
                           additionalProperties:
                             type: string
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
                           type: object
                         readOnly:
+                          description: |-
+                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is Optional: secretRef is reference to the secret object containing
+                            sensitive information to pass to the plugin...
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -3369,98 +5782,184 @@ spec:
                       - driver
                       type: object
                     flocker:
+                      description: flocker represents a Flocker volume attached to
+                        a kubelet's host machine.
                       properties:
                         datasetName:
+                          description: |-
+                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                            should be considered as deprecated
                           type: string
                         datasetUUID:
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
                           type: string
                       type: object
                     gcePersistentDisk:
+                      description: |-
+                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         fsType:
+                          description: fsType is filesystem type of the volume that
+                            you want to mount.
                           type: string
                         partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
                           format: int32
                           type: integer
                         pdName:
+                          description: |-
+                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                            More info: https://kubernetes.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://kubernetes.
                           type: boolean
                       required:
                       - pdName
                       type: object
                     gitRepo:
+                      description: |-
+                        gitRepo represents a git repository at a particular revision.
+                        Deprecated: GitRepo is deprecated.
                       properties:
                         directory:
+                          description: |-
+                            directory is the target directory name.
+                            Must not contain or start with '..'.  If '.
                           type: string
                         repository:
+                          description: repository is the URL
                           type: string
                         revision:
+                          description: revision is the commit hash for the specified
+                            revision.
                           type: string
                       required:
                       - repository
                       type: object
                     glusterfs:
+                      description: glusterfs represents a Glusterfs mount on the host
+                        that shares a pod's lifetime.
                       properties:
                         endpoints:
+                          description: endpoints is the endpoint name that details
+                            Glusterfs topology.
                           type: string
                         path:
+                          description: |-
+                            path is the Glusterfs volume path.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                       required:
                       - endpoints
                       - path
                       type: object
                     hostPath:
+                      description: |-
+                        hostPath represents a pre-existing file or directory on the host
+                        machine that is directly exposed to the container.
                       properties:
                         path:
+                          description: |-
+                            path of the directory on the host.
+                            If the path is a symlink, it will follow the link to the real path.
                           type: string
                         type:
+                          description: |-
+                            type for HostPath Volume
+                            Defaults to ""
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                           type: string
                       required:
                       - path
                       type: object
                     image:
+                      description: image represents an OCI object (a container image
+                        or artifact) pulled and mounted on the kubelet's host machine.
                       properties:
                         pullPolicy:
+                          description: |-
+                            Policy for pulling OCI objects. Possible values are:
+                            Always: the kubelet always attempts to pull the reference.
                           type: string
                         reference:
+                          description: |-
+                            Required: Image or artifact reference to be used.
+                            Behaves in the same way as pod.spec.containers[*].image.
                           type: string
                       type: object
                     iscsi:
+                      description: |-
+                        iscsi represents an ISCSI Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
                       properties:
                         chapAuthDiscovery:
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
                           type: boolean
                         chapAuthSession:
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
                           type: boolean
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         initiatorName:
+                          description: initiatorName is the custom iSCSI Initiator
+                            Name.
                           type: string
                         iqn:
+                          description: iqn is the target iSCSI Qualified Name.
                           type: string
                         iscsiInterface:
                           default: default
+                          description: |-
+                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
                           type: string
                         lun:
+                          description: lun represents iSCSI Target Lun number.
                           format: int32
                           type: integer
                         portals:
+                          description: portals is the iSCSI Target Portal List.
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
                           type: boolean
                         secretRef:
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         targetPortal:
+                          description: targetPortal is iSCSI Target Portal.
                           type: string
                       required:
                       - iqn
@@ -3468,68 +5967,140 @@ spec:
                       - targetPortal
                       type: object
                     name:
+                      description: |-
+                        name of the volume.
+                        Must be a DNS_LABEL and unique within the pod.
+                        More info: https://kubernetes.
                       type: string
                     nfs:
+                      description: |-
+                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                        More info: https://kubernetes.
                       properties:
                         path:
+                          description: |-
+                            path that is exported by the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                         server:
+                          description: |-
+                            server is the hostname or IP address of the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                           type: string
                       required:
                       - path
                       - server
                       type: object
                     persistentVolumeClaim:
+                      description: |-
+                        persistentVolumeClaimVolumeSource represents a reference to a
+                        PersistentVolumeClaim in the same namespace.
                       properties:
                         claimName:
+                          description: claimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
                           type: boolean
                       required:
                       - claimName
                       type: object
                     photonPersistentDisk:
+                      description: photonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         pdID:
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
                           type: string
                       required:
                       - pdID
                       type: object
                     portworxVolume:
+                      description: portworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         volumeID:
+                          description: volumeID uniquely identifies a Portworx volume
                           type: string
                       required:
                       - volumeID
                       type: object
                     projected:
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
                       properties:
                         defaultMode:
+                          description: defaultMode are the mode bits used to set permissions
+                            on created files by default.
                           format: int32
                           type: integer
                         sources:
+                          description: |-
+                            sources is the list of volume projections. Each entry in this list
+                            handles one source.
                           items:
+                            description: |-
+                              Projection that may be projected along with other supported volume types.
+                              Exactly one of these fields must be set.
                             properties:
                               clusterTrustBundle:
+                                description: |-
+                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                  of ClusterTrustBundle objects in an auto-updating file.
                                 properties:
                                   labelSelector:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this label selector.  Only has
+                                      effect if signerName is set.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
                                         items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
                                               items:
                                                 type: string
                                               type: array
@@ -3543,31 +6114,58 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   name:
+                                    description: |-
+                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                      with signerName and labelSelector.
                                     type: string
                                   optional:
+                                    description: |-
+                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                      aren't available.
                                     type: boolean
                                   path:
+                                    description: Relative path from the volume root
+                                      to write the bundle.
                                     type: string
                                   signerName:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this signer name.
+                                      Mutually-exclusive with name.
                                     type: string
                                 required:
                                 - path
                                 type: object
                               configMap:
+                                description: configMap information about the configMap
+                                  data to project
                                 properties:
                                   items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a...
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: key is the key to project.
                                           type: string
                                         mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
                                           type: string
                                       required:
                                       - key
@@ -3577,42 +6175,80 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               downwardAPI:
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
                                 properties:
                                   items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
                                     items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
                                       properties:
                                         fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name, namespace and uid are supported.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                           - fieldPath
                                           type: object
                                           x-kubernetes-map-type: atomic
                                         mode:
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value...
                                           format: int32
                                           type: integer
                                         path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path.'
                                           type: string
                                         resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                               - type: integer
                                               - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to
+                                                select'
                                               type: string
                                           required:
                                           - resource
@@ -3625,39 +6261,76 @@ spec:
                                     x-kubernetes-list-type: atomic
                                 type: object
                               podCertificate:
+                                description: |-
+                                  Projects an auto-rotating credential bundle (private key and certificate
+                                  chain) that the pod can use either as a TLS client or...
                                 properties:
                                   certificateChainPath:
+                                    description: |-
+                                      Write the certificate chain at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.
                                     type: string
                                   credentialBundlePath:
+                                    description: Write the credential bundle at this
+                                      path in the projected volume.
                                     type: string
                                   keyPath:
+                                    description: |-
+                                      Write the key at this path in the projected volume.
+
+                                      Most applications should use credentialBundlePath.
                                     type: string
                                   keyType:
+                                    description: The type of keypair Kubelet will
+                                      generate for the pod.
                                     type: string
                                   maxExpirationSeconds:
+                                    description: |-
+                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                      certificate.
                                     format: int32
                                     type: integer
                                   signerName:
+                                    description: Kubelet's generated CSRs will be
+                                      addressed to this signer.
                                     type: string
                                   userAnnotations:
                                     additionalProperties:
                                       type: string
+                                    description: |-
+                                      userAnnotations allow pod authors to pass additional information to
+                                      the signer implementation.
                                     type: object
                                 required:
                                 - keyType
                                 - signerName
                                 type: object
                               secret:
+                                description: secret information about the secret data
+                                  to project
                                 properties:
                                   items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a...
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: key is the key to project.
                                           type: string
                                         mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
                                           type: string
                                       required:
                                       - key
@@ -3667,19 +6340,35 @@ spec:
                                     x-kubernetes-list-type: atomic
                                   name:
                                     default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty.
                                     type: string
                                   optional:
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
                                     type: boolean
                                 type: object
                                 x-kubernetes-map-type: atomic
                               serviceAccountToken:
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
                                 properties:
                                   audience:
+                                    description: audience is the intended audience
+                                      of the token.
                                     type: string
                                   expirationSeconds:
+                                    description: |-
+                                      expirationSeconds is the requested duration of validity of the service
+                                      account token.
                                     format: int64
                                     type: integer
                                   path:
+                                    description: |-
+                                      path is the path relative to the mount point of the file to project the
+                                      token into.
                                     type: string
                                 required:
                                 - path
@@ -3689,84 +6378,168 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     quobyte:
+                      description: quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime.
                       properties:
                         group:
+                          description: |-
+                            group to map volume access to
+                            Default is no group
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                            Defaults to false.
                           type: boolean
                         registry:
+                          description: |-
+                            registry represents a single or multiple Quobyte Registry services
+                            specified as a string as host:port pair (multiple entries...
                           type: string
                         tenant:
+                          description: |-
+                            tenant owning the given Quobyte volume in the Backend
+                            Used with dynamically provisioned Quobyte volumes, value is set by the...
                           type: string
                         user:
+                          description: |-
+                            user to map volume access to
+                            Defaults to serivceaccount user
                           type: string
                         volume:
+                          description: volume is a string that references an already
+                            created Quobyte volume by name.
                           type: string
                       required:
                       - registry
                       - volume
                       type: object
                     rbd:
+                      description: rbd represents a Rados Block Device mount on the
+                        host that shares a pod's lifetime.
                       properties:
                         fsType:
+                          description: fsType is the filesystem type of the volume
+                            that you want to mount.
                           type: string
                         image:
+                          description: |-
+                            image is the rados image name.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         keyring:
                           default: /etc/ceph/keyring
+                          description: |-
+                            keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring.
+                            More info: https://examples.k8s.
                           type: string
                         monitors:
+                          description: |-
+                            monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           items:
                             type: string
                           type: array
                           x-kubernetes-list-type: atomic
                         pool:
                           default: rbd
+                          description: |-
+                            pool is the rados pool name.
+                            Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://examples.k8s.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef is name of the authentication secret for RBDUser. If provided
+                            overrides keyring.
+                            Default is nil.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         user:
                           default: admin
+                          description: |-
+                            user is the rados user name.
+                            Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                           type: string
                       required:
                       - image
                       - monitors
                       type: object
                     scaleIO:
+                      description: scaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
                       properties:
                         fsType:
                           default: xfs
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         gateway:
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
                           type: string
                         protectionDomain:
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef references to the secret for ScaleIO user and other
+                            sensitive information.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         sslEnabled:
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
                           type: boolean
                         storageMode:
                           default: ThinProvisioned
+                          description: storageMode indicates whether the storage for
+                            a volume should be ThickProvisioned or ThinProvisioned.
                           type: string
                         storagePool:
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
                           type: string
                         system:
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
                           type: string
                         volumeName:
+                          description: |-
+                            volumeName is the name of a volume already created in the ScaleIO system
+                            that is associated with this volume source.
                           type: string
                       required:
                       - gateway
@@ -3774,19 +6547,35 @@ spec:
                       - system
                       type: object
                     secret:
+                      description: |-
+                        secret represents a secret that should populate this volume.
+                        More info: https://kubernetes.
                       properties:
                         defaultMode:
+                          description: 'defaultMode is Optional: mode bits used to
+                            set permissions on created files by default.'
                           format: int32
                           type: integer
                         items:
+                          description: |-
+                            items If unspecified, each key-value pair in the Data field of the referenced
+                            Secret will be projected into the volume as a...
                           items:
+                            description: Maps a string key to a path within a volume.
                             properties:
                               key:
+                                description: key is the key to project.
                                 type: string
                               mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file.'
                                 format: int32
                                 type: integer
                               path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
                                 type: string
                             required:
                             - key
@@ -3795,37 +6584,75 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         optional:
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
                           type: boolean
                         secretName:
+                          description: |-
+                            secretName is the name of the secret in the pod's namespace to use.
+                            More info: https://kubernetes.
                           type: string
                       type: object
                     storageos:
+                      description: storageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex.
                           type: string
                         readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
                           type: boolean
                         secretRef:
+                          description: |-
+                            secretRef specifies the secret to use for obtaining the StorageOS API
+                            credentials.
                           properties:
                             name:
                               default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         volumeName:
+                          description: |-
+                            volumeName is the human-readable name of the StorageOS volume.  Volume
+                            names are only unique within a namespace.
                           type: string
                         volumeNamespace:
+                          description: volumeNamespace specifies the scope of the
+                            volume within StorageOS.
                           type: string
                       type: object
                     vsphereVolume:
+                      description: vsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine.
                       properties:
                         fsType:
+                          description: |-
+                            fsType is filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
                           type: string
                         storagePolicyID:
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
                           type: string
                         storagePolicyName:
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
                           type: string
                         volumePath:
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
                           type: string
                       required:
                       - volumePath
@@ -3837,10 +6664,15 @@ spec:
                 x-kubernetes-list-type: atomic
             type: object
           status:
+            description: TargetAllocatorStatus defines the observed state of Target
+              Allocator.
             properties:
               image:
+                description: Image indicates the container image to use for the Target
+                  Allocator.
                 type: string
               version:
+                description: Version of the managed Target Allocator (operand)
                 type: string
             type: object
         type: object


### PR DESCRIPTION
## Summary

Restores CRD field descriptions that were removed in #2703 to keep CRD sizes manageable.

- Sets `maxDescLen=128` (previously `maxDescLen=0`) in the `controller-gen` CRD generation options, restoring truncated but meaningful descriptions for all operator-defined fields
- Updates the `make install` target to use `kubectl apply --server-side` to support the larger CRD payloads

## Background

PR #2703 set `maxDescLen=0` because `kubectl apply -f crd-file.yaml` was failing due to CRD size. This removed all field descriptions from the generated CRDs, making `kubectl explain` and API documentation less useful.

With `maxDescLen=128`, the largest CRD (OpenTelemetryCollectors) grows from ~400KB to ~900KB, which is within etcd's object size limits. Using `--server-side` apply avoids the `last-applied-configuration` annotation that doubles the payload for client-side apply.

## CRD sizes with this change

| CRD | Before (maxDescLen=0) | After (maxDescLen=128) |
|-----|----------------------|------------------------|
| opentelemetrycollectors | 405KB | 900KB |
| targetallocators | 153KB | 346KB |
| instrumentations | 92KB | 185KB |
| opampbridges | 73KB | 166KB |
| clusterobservabilities | 5KB | 11KB |

## Example

Before:
```yaml
configVersions:
  default: 3
  minimum: 1
  type: integer
```

After:
```yaml
configVersions:
  default: 3
  description: ConfigVersions defines the number versions to keep for
    the collector config. Each config version is stored in a separate ConfigMap.
  minimum: 1
  type: integer
```

Resolves: #2737

## Test plan

- [x] `make manifests` regenerates CRDs with descriptions present
- [x] Verified `kubectl explain` shows field descriptions for operator-owned types
- [x] CRD sizes verified to be within etcd object size limits