### PR TITLE
feat(collector): skip service provisioning for sidecar mode

### DIFF
--- a/.chloggen/skip-services-sidecar-mode.yaml
+++ b/.chloggen/skip-services-sidecar-mode.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Skip provisioning Services, Ingress, NetworkPolicy, and HPA for sidecar mode collectors since the operator does not control the Pod lifecycle in that mode. PodMonitors are still provisioned when metrics are enabled.
+
+# One or more tracking issues related to the change
+issues: [4934]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/manifests/collector/collector.go
+++ b/internal/manifests/collector/collector.go
@@ -37,7 +37,6 @@ func Build(params manifests.Params) ([]client.Object, error) {
 	manifestFactories = append(manifestFactories, []manifests.K8sManifestFactory[manifests.Params]{
 		manifests.Factory(ConfigMap),
 		manifests.Factory(ServiceAccount),
-		manifests.Factory(TargetAllocator),
 	}...)
 
 	// Services, ingress, network policies, and autoscalers only make sense when
@@ -54,6 +53,8 @@ func Build(params manifests.Params) ([]client.Object, error) {
 			manifests.Factory(NetworkPolicy),
 		}...)
 	}
+
+	manifestFactories = append(manifestFactories, manifests.Factory(TargetAllocator))
 
 	if params.OtelCol.Spec.Observability.Metrics.EnableMetrics {
 		if params.OtelCol.Spec.Mode == v1beta1.ModeSidecar {

--- a/internal/manifests/collector/collector.go
+++ b/internal/manifests/collector/collector.go
@@ -36,16 +36,24 @@ func Build(params manifests.Params) ([]client.Object, error) {
 	}
 	manifestFactories = append(manifestFactories, []manifests.K8sManifestFactory[manifests.Params]{
 		manifests.Factory(ConfigMap),
-		manifests.Factory(HorizontalPodAutoscaler),
 		manifests.Factory(ServiceAccount),
-		manifests.Factory(Service),
-		manifests.Factory(HeadlessService),
-		manifests.Factory(MonitoringService),
-		manifests.Factory(ExtensionService),
-		manifests.Factory(Ingress),
-		manifests.Factory(NetworkPolicy),
 		manifests.Factory(TargetAllocator),
 	}...)
+
+	// Services, ingress, network policies, and autoscalers only make sense when
+	// the operator controls the collector Pod. In sidecar mode the Pod is owned
+	// by the user's workload, so these resources are not provisioned.
+	if params.OtelCol.Spec.Mode != v1beta1.ModeSidecar {
+		manifestFactories = append(manifestFactories, []manifests.K8sManifestFactory[manifests.Params]{
+			manifests.Factory(HorizontalPodAutoscaler),
+			manifests.Factory(Service),
+			manifests.Factory(HeadlessService),
+			manifests.Factory(MonitoringService),
+			manifests.Factory(ExtensionService),
+			manifests.Factory(Ingress),
+			manifests.Factory(NetworkPolicy),
+		}...)
+	}
 
 	if params.OtelCol.Spec.Observability.Metrics.EnableMetrics {
 		if params.OtelCol.Spec.Mode == v1beta1.ModeSidecar {

--- a/internal/manifests/collector/collector_test.go
+++ b/internal/manifests/collector/collector_test.go
@@ -181,7 +181,7 @@ func TestBuild(t *testing.T) {
 			wantErr:         false,
 		},
 		{
-			name: "sidecar mode skips deployment manifests",
+			name: "sidecar mode skips service and other pod-controlling manifests",
 			params: manifests.Params{
 				Log: logger,
 				OtelCol: v1beta1.OpenTelemetryCollector{
@@ -190,6 +190,27 @@ func TestBuild(t *testing.T) {
 					},
 				},
 				Config: config.New(),
+			},
+			expectedObjects: 2,
+			wantErr:         false,
+		},
+		{
+			name: "sidecar mode with metrics enabled builds pod monitor but no services",
+			params: manifests.Params{
+				Log: logger,
+				OtelCol: v1beta1.OpenTelemetryCollector{
+					Spec: v1beta1.OpenTelemetryCollectorSpec{
+						Mode: v1beta1.ModeSidecar,
+						Observability: v1beta1.ObservabilitySpec{
+							Metrics: v1beta1.MetricsConfigSpec{
+								EnableMetrics: true,
+							},
+						},
+					},
+				},
+				Config: config.Config{
+					PrometheusCRAvailability: prometheus.Available,
+				},
 			},
 			expectedObjects: 3,
 			wantErr:         false,

--- a/tests/e2e-sidecar/smoke-sidecar/01-error.yaml
+++ b/tests/e2e-sidecar/smoke-sidecar/01-error.yaml
@@ -1,0 +1,17 @@
+# These resources must NOT be created for sidecar-mode collectors.
+# The operator injects the collector as a sidecar into the user's Pod,
+# so Services, HPA, and Ingress are non-functional and must be skipped.
+apiVersion: v1
+kind: Service
+metadata:
+  name: sidecar-for-my-app-collector
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sidecar-for-my-app-collector-headless
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sidecar-for-my-app-collector-monitoring

--- a/tests/e2e-sidecar/smoke-sidecar/chainsaw-test.yaml
+++ b/tests/e2e-sidecar/smoke-sidecar/chainsaw-test.yaml
@@ -18,6 +18,8 @@ spec:
         file: 01-install-app.yaml
     - assert:
         file: 01-assert.yaml
+    - error:
+        file: 01-error.yaml
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
 apiVersion: chainsaw.kyverno.io/v1alpha1
@@ -39,3 +41,5 @@ spec:
         file: 01-install-app.yaml
     - assert:
         file: 01-assert-native.yaml
+    - error:
+        file: 01-error.yaml


### PR DESCRIPTION
**Description:** In sidecar mode, the operator does not control the Pod lifecycle — the collector container is injected into the user's workload Pod by a mutating webhook. Provisioning Services, Ingress, NetworkPolicies, and HorizontalPodAutoscalers for sidecar-mode collectors is therefore unnecessary and creates confusing, non-functional resources in the namespace.

This change moves the following manifest factories behind a `mode != sidecar` guard, so they are only built when the operator actually manages the Pod (Deployment, StatefulSet, DaemonSet modes):

- `Service` (base)
- `HeadlessService`
- `MonitoringService`
- `ExtensionService`
- `HorizontalPodAutoscaler`
- `Ingress`
- `NetworkPolicy`

`PodMonitor` continues to be provisioned in sidecar mode when `spec.observability.metrics.enableMetrics` is set, because PodMonitors select Pods by label and work regardless of who owns the Pod. `ConfigMap`, `ServiceAccount`, and `TargetAllocator` are also still provisioned unconditionally.

- Resolves: #4934

**Testing:** Updated the existing sidecar-mode unit test to expect 2 objects (ConfigMap + ServiceAccount) instead of 3, and added a new test case verifying that a PodMonitor is still built in sidecar mode when metrics are enabled.

**Documentation:** No documentation changes required; the behavior change follows naturally from the sidecar semantics already described in the docs.