### PR TITLE
[chore] Add github.com/docker/docker CVEs to govulncheck exceptions

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -108,10 +108,18 @@ jobs:
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      id: setup-go
       with:
         go-version: "~1.26.2"
 
-    - name: Govulncheck
-      uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+    - name: Cache tools
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
-        repo-checkout: false
+        path: bin
+        key: tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
+
+    - name: Install tools
+      run: make install-tools
+
+    - name: Govulncheck
+      run: make govulncheck-run

--- a/Makefile
+++ b/Makefile
@@ -686,6 +686,7 @@ CHLOGGEN ?= $(LOCALBIN)/chloggen
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 CHAINSAW ?= $(LOCALBIN)/chainsaw
 GOTESTSUM ?= $(LOCALBIN)/gotestsum
+GOVULNCHECK ?= $(LOCALBIN)/govulncheck
 
 # renovate: datasource=go depName=sigs.k8s.io/kustomize/kustomize/v5
 KUSTOMIZE_VERSION ?= v5.8.1
@@ -701,10 +702,12 @@ CHAINSAW_VERSION ?= v0.2.15-beta.3.0.20260401082229-93b1e3d86203
 GOTESTSUM_VERSION ?= v1.13.0
 # renovate: datasource=git-refs packageName=https://github.com/kubernetes-sigs/controller-runtime versioning=loose
 ENVTEST_VERSION ?= release-0.23
+# renovate: datasource=go depName=golang.org/x/vuln/cmd/govulncheck
+GOVULNCHECK_VERSION ?= v1.3.0
 
 # Install all development tools
 .PHONY: install-tools
-install-tools: kustomize golangci-lint kind controller-gen envtest crdoc operator-sdk chainsaw gotestsum cmctl
+install-tools: kustomize golangci-lint kind controller-gen envtest crdoc operator-sdk chainsaw gotestsum cmctl govulncheck
 
 # Download kustomize locally if necessary
 .PHONY: kustomize
@@ -747,6 +750,16 @@ chainsaw: ## Find or download chainsaw
 .PHONY: gotestsum
 gotestsum: ## Find or download gotestsum
 	$(call go-install-tool,$(GOTESTSUM),gotest.tools/gotestsum,$(GOTESTSUM_VERSION))
+
+# Download govulncheck locally if necessary
+.PHONY: govulncheck
+govulncheck: ## Download govulncheck locally if necessary.
+	$(call go-install-tool,$(GOVULNCHECK),golang.org/x/vuln/cmd/govulncheck,$(GOVULNCHECK_VERSION))
+
+# Run govulncheck with the project's CVE exception list
+.PHONY: govulncheck-run
+govulncheck-run: govulncheck ## Run govulncheck, applying excepted CVEs from hack/govulncheck.sh.
+	GOVULNCHECK=$(GOVULNCHECK) ./hack/govulncheck.sh
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/hack/govulncheck.sh
+++ b/hack/govulncheck.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Run govulncheck and filter out CVEs that are explicitly excepted.
+#
+# govulncheck always exits 0 with -format json, leaving pass/fail to the
+# consumer. We mirror text-mode behavior: fail on findings with a function
+# frame in the trace (i.e. reachable in the call graph). We also fail if any
+# excepted CVE is no longer detected, so the exception list stays current.
+set -euo pipefail
+
+# Excepted CVEs. See https://github.com/open-telemetry/opentelemetry-operator/issues/4926
+EXCEPTED_CVES='["CVE-2026-34040","CVE-2026-33997"]'
+
+GOVULNCHECK="${GOVULNCHECK:-govulncheck}"
+
+vuln_json=$(mktemp)
+trap 'rm -f "$vuln_json"' EXIT
+
+"$GOVULNCHECK" -format json ./... > "$vuln_json"
+
+called_osv=$(jq -r '
+  .finding? | select(. != null) |
+  select(.trace | any(has("function"))) |
+  .osv
+' "$vuln_json" | sort -u)
+
+called_osv_json=$(printf '%s\n' "$called_osv" | jq -R . | jq -sc 'map(select(. != ""))')
+called_cves=$(jq -r --argjson ids "$called_osv_json" '
+  .osv? | select(. != null) |
+  select(.id as $id | $ids | index($id)) |
+  (.aliases // [])[]
+' "$vuln_json" | sort -u)
+
+called_cves_json=$(printf '%s\n' "$called_cves" | jq -R . | jq -sc 'map(select(. != ""))')
+stale=$(jq -nr --argjson ex "$EXCEPTED_CVES" --argjson called "$called_cves_json" '
+  ($ex - $called)[]
+')
+
+if [ -n "$stale" ]; then
+  echo "Stale exceptions (CVE no longer detected as called by govulncheck):" >&2
+  echo "$stale" >&2
+  echo "Remove these from EXCEPTED_CVES in hack/govulncheck.sh." >&2
+  exit 1
+fi
+
+if [ -z "$called_osv" ]; then
+  echo "No called vulnerabilities found."
+  exit 0
+fi
+
+excepted_osv=$(jq -r --argjson ex "$EXCEPTED_CVES" '
+  .osv? | select(. != null) |
+  select(((.aliases // []) - $ex) != (.aliases // [])) |
+  .id
+' "$vuln_json" | sort -u)
+
+unexpected=$(comm -23 <(echo "$called_osv") <(echo "$excepted_osv"))
+
+if [ -n "$unexpected" ]; then
+  echo "Unexpected vulnerabilities found (not in exception list):" >&2
+  echo "$unexpected" >&2
+  exit 1
+fi
+
+echo "Only excepted vulnerabilities found:"
+echo "$called_osv"


### PR DESCRIPTION
Add a govulncheck script allowing us to set exceptions and install govulncheck like other tools, so it's easier to run locally. The script fails if the exceptions aren't present in govulncheck output, so we're forced to remove them once they're not applicable anymore.

Addresses failures from https://github.com/open-telemetry/opentelemetry-operator/issues/4926 and the exceptions should be dropped after we resolve it.