### PR TITLE
Upgrade to Java 2.27.0 by default

### DIFF
--- a/.chloggen/feat_upgrade-default-java-instrumentation.yaml
+++ b/.chloggen/feat_upgrade-default-java-instrumentation.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update default Java auto-instrumentation version from 1.33.6 to 2.27.0
+
+# One or more tracking issues related to the change
+issues: [4996]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This is a breaking change due to HTTP semantic convention changes between versions.
+  Existing Instrumentation CRs using a 1.x.x version will NOT be automatically upgraded.
+  To upgrade, manually update the image in your Instrumentation CR after reviewing the migration guide.
+  See https://github.com/open-telemetry/opentelemetry-operator/issues/2542 for details.

--- a/internal/instrumentation/upgrade/upgrade.go
+++ b/internal/instrumentation/upgrade/upgrade.go
@@ -117,7 +117,11 @@ func (u *InstrumentationUpgrade) upgrade(_ context.Context, inst v1alpha1.Instru
 					if warningMsg != "" {
 						msg = fmt.Sprintf("Automated upgrade blocked for %s: %s", instCfg.language, warningMsg)
 					}
-					u.Recorder.Eventf(upgraded, nil, corev1.EventTypeWarning, "UpgradeBlocked", "Upgrade", msg)
+					// Include the language in the event action so that two events
+					// for the same Instrumentation but different languages are
+					// not aggregated into one by the events.k8s.io broadcaster
+					// (which keys by type/action/reason/regarding, not note).
+					u.Recorder.Eventf(upgraded, nil, corev1.EventTypeWarning, "UpgradeBlocked", fmt.Sprintf("Upgrade-%s", instCfg.language), msg)
 					u.Logger.Info("upgrade blocked for unupgradable instrumentation version",
 						"name", inst.Name,
 						"namespace", inst.Namespace,

--- a/internal/version/unupgradable.go
+++ b/internal/version/unupgradable.go
@@ -17,6 +17,9 @@ const (
 	dotNet130WarningMessage = ".NET instrumentation 1.3.0 contains breaking HTTP semantic convention changes. " +
 		"See https://opentelemetry.io/blog/2023/http-conventions-declared-stable/ for a general description of the changes. " +
 		"To upgrade, manually set the image on this Instrumentation resource to 1.3.0 or higher."
+	java200WarningMessage = "Java instrumentation 2.0.0 contains breaking HTTP semantic convention changes. " +
+		"See https://opentelemetry.io/blog/2023/http-conventions-declared-stable/ for a general description of the changes. " +
+		"To upgrade, manually set the image on this Instrumentation resource to 2.0.0 or higher."
 )
 
 // unupgradableInstrumentationVersions contains instrumentation versions that cannot be automatically upgraded from.
@@ -24,6 +27,9 @@ const (
 var unupgradableInstrumentationVersions = map[constants.InstrumentationLanguage]map[string]string{
 	constants.InstrumentationLanguageDotNet: {
 		"1.3.0": dotNet130WarningMessage,
+	},
+	constants.InstrumentationLanguageJava: {
+		"2.0.0": java200WarningMessage,
 	},
 }
 

--- a/internal/version/unupgradable_test.go
+++ b/internal/version/unupgradable_test.go
@@ -80,6 +80,19 @@ func TestIsInstrumentationVersionUnupgradable(t *testing.T) {
 			wantMessage: "Breaking changes in dotNet agent.",
 		},
 		{
+			name:         "java upgrade across breaking 2.0.0 is blocked",
+			language:     constants.InstrumentationLanguageJava,
+			image:        "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.33.6",
+			defaultImage: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.27.0",
+			unupgradableMap: map[constants.InstrumentationLanguage]map[string]string{
+				constants.InstrumentationLanguageJava: {
+					"2.0.0": "Breaking changes in Java agent.",
+				},
+			},
+			wantBlocked: true,
+			wantMessage: "Breaking changes in Java agent.",
+		},
+		{
 			name:         "different repo skips check",
 			language:     constants.InstrumentationLanguageJava,
 			image:        "my-registry.io/custom/java:v1.0.0",

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/00-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/00-assert.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   dotnet:
     image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
+  java:
+    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.33.6"

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/00-install-instrumentation-blocked.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/00-install-instrumentation-blocked.yaml
@@ -9,3 +9,5 @@ spec:
     type: always_on
   dotnet:
     image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
+  java:
+    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.33.6"

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/01-assert.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   dotnet:
     image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
+  java:
+    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.33.6"

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/02-assert.yaml
@@ -5,17 +5,9 @@ metadata:
 spec:
   dotnet:
     image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
+  java:
+    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.33.6"
 status:
   upgradeBlockedVersions:
     dotnet: "Automated upgrade blocked for dotnet: .NET instrumentation 1.3.0 contains breaking HTTP semantic convention changes. See https://opentelemetry.io/blog/2023/http-conventions-declared-stable/ for a general description of the changes. To upgrade, manually set the image on this Instrumentation resource to 1.3.0 or higher."
----
-apiVersion: events.k8s.io/v1
-kind: Event
-note: "Automated upgrade blocked for dotnet: .NET instrumentation 1.3.0 contains breaking HTTP semantic convention changes. See https://opentelemetry.io/blog/2023/http-conventions-declared-stable/ for a general description of the changes. To upgrade, manually set the image on this Instrumentation resource to 1.3.0 or higher."
-reason: "UpgradeBlocked"
-regarding:
-  apiVersion: opentelemetry.io/v1alpha1
-  kind: Instrumentation
-  name: upgrade-test
-reportingController: opentelemetry-operator
-type: Warning
+    java: "Automated upgrade blocked for java: Java instrumentation 2.0.0 contains breaking HTTP semantic convention changes. See https://opentelemetry.io/blog/2023/http-conventions-declared-stable/ for a general description of the changes. To upgrade, manually set the image on this Instrumentation resource to 2.0.0 or higher."

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/chainsaw-test.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   # This test modifies the operator deployment to verify upgrade blocking behavior.
   steps:
-  - name: Create instrumentation with blocked dotnet version and verify webhook warning
+  - name: Create instrumentation with blocked dotnet and java versions and verify webhook warnings
     try:
     - script:
         timeout: 30s
@@ -16,7 +16,7 @@ spec:
           (contains($stdout, 'cannot be automatically upgraded')): true
     - assert:
         file: 00-assert.yaml
-  - name: Patch operator to use old dotnet version as default
+  - name: Patch operator to use old dotnet and java versions as defaults
     try:
     - script:
         timeout: 5m
@@ -26,12 +26,13 @@ spec:
           set -eo pipefail
           NS=opentelemetry-operator-system
           DEPLOY=opentelemetry-operator-controller-manager
-          OLD_IMG="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
+          OLD_DOTNET_IMG="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
+          OLD_JAVA_IMG="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.33.6"
 
-          # Add the dotnet image arg to override the compiled-in default
+          # Add the dotnet and java image args to override the compiled-in defaults
           ARGS=$(kubectl get deploy -n $NS $DEPLOY -o json | jq -c '.spec.template.spec.containers[0].args')
-          NEW_ARGS=$(echo "$ARGS" | jq -c --arg img "$OLD_IMG" \
-            '[.[] | select(startswith("--auto-instrumentation-dotnet-image=") | not)] + ["--auto-instrumentation-dotnet-image=" + $img]')
+          NEW_ARGS=$(echo "$ARGS" | jq -c --arg dotnet "$OLD_DOTNET_IMG" --arg java "$OLD_JAVA_IMG" \
+            '[.[] | select((startswith("--auto-instrumentation-dotnet-image=") or startswith("--auto-instrumentation-java-image=")) | not)] + ["--auto-instrumentation-dotnet-image=" + $dotnet, "--auto-instrumentation-java-image=" + $java]')
 
           kubectl patch deploy -n $NS $DEPLOY --type='json' \
             -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/args\",\"value\":$NEW_ARGS}]"
@@ -43,7 +44,7 @@ spec:
         file: 01-install-instrumentation-upgrade-test.yaml
     - assert:
         file: 01-assert.yaml
-  - name: Restore operator to default dotnet version and trigger upgrade
+  - name: Restore operator to default dotnet and java versions and trigger upgrade
     try:
     - script:
         timeout: 5m
@@ -54,9 +55,9 @@ spec:
           NS=opentelemetry-operator-system
           DEPLOY=opentelemetry-operator-controller-manager
 
-          # Remove the override arg so the operator uses its compiled-in default (1.15.0)
+          # Remove the override args so the operator uses its compiled-in defaults
           ARGS=$(kubectl get deploy -n $NS $DEPLOY -o json | jq -c '.spec.template.spec.containers[0].args')
-          NEW_ARGS=$(echo "$ARGS" | jq -c '[.[] | select(startswith("--auto-instrumentation-dotnet-image=") | not)]')
+          NEW_ARGS=$(echo "$ARGS" | jq -c '[.[] | select((startswith("--auto-instrumentation-dotnet-image=") or startswith("--auto-instrumentation-java-image=")) | not)]')
 
           kubectl patch deploy -n $NS $DEPLOY --type='json' \
             -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/args\",\"value\":$NEW_ARGS}]"
@@ -64,9 +65,57 @@ spec:
           kubectl rollout status deploy/$DEPLOY -n $NS --timeout=120s
           # Give the upgrade mechanism time to process existing Instrumentation CRs
           sleep 5
-  - name: Assert upgrade was blocked with status and event
+  - name: Assert upgrades were blocked
     try:
-    # DotNet image should still be 1.2.0 (not upgraded to 1.15.0)
-    # and the status should reflect the blocked upgrade
+    # DotNet image should still be 1.2.0 and Java image should still be 1.33.6
+    # (neither upgraded to their respective compiled-in defaults), and the
+    # Instrumentation status should record the blocked upgrade reason for both
+    # languages.
     - assert:
         file: 02-assert.yaml
+    # Verify both UpgradeBlocked events were emitted by the operator. We do
+    # this in a script (instead of two chainsaw `assert` blocks on the Event
+    # resource) because chainsaw's assertion-tree matcher cannot reliably
+    # disambiguate two Events that share every field except `note` — it picks
+    # one actual event and compares it against both expected matchers, which
+    # fails for at least one of them.
+    - script:
+        timeout: 90s
+        shell: /bin/bash
+        content: |
+          #!/bin/bash
+          set -eo pipefail
+          # Events are queued by the operator's event recorder and flushed
+          # asynchronously, so the Instrumentation status may be updated before
+          # the events surface in the API. Retry briefly to allow them to land.
+          notes=""
+          missing=()
+          for _ in {1..30}; do
+            events_json=$(kubectl get events.events.k8s.io -n "$NAMESPACE" -o json)
+            notes=$(jq -r '.items[] | select(.reason == "UpgradeBlocked" and .regarding.name == "upgrade-test") | .note' <<<"$events_json")
+            missing=()
+            grep -qF "Automated upgrade blocked for dotnet:" <<<"$notes" || missing+=("dotnet")
+            grep -qF "Automated upgrade blocked for java:"   <<<"$notes" || missing+=("java")
+            [ ${#missing[@]} -eq 0 ] && exit 0
+            sleep 2
+          done
+          echo "Missing UpgradeBlocked events for: ${missing[*]}" >&2
+          echo "Notes for UpgradeBlocked / upgrade-test events:" >&2
+          echo "$notes" >&2
+          echo "All events in namespace $NAMESPACE:" >&2
+          jq '.items[] | {reason, type, regarding: .regarding.name, note}' <<<"$events_json" >&2
+          exit 1
+    catch:
+    - get:
+        apiVersion: opentelemetry.io/v1alpha1
+        kind: Instrumentation
+        name: upgrade-test
+        format: yaml
+    - get:
+        apiVersion: events.k8s.io/v1
+        kind: Event
+        format: yaml
+    - podLogs:
+        namespace: opentelemetry-operator-system
+        selector: app.kubernetes.io/name=opentelemetry-operator
+        container: manager

--- a/versions.txt
+++ b/versions.txt
@@ -14,8 +14,7 @@ targetallocator=0.150.0
 operator-opamp-bridge=0.150.0
 
 # Represents the current release of Java instrumentation.
-# This version should not be greater than 1.x.x.
-autoinstrumentation-java=1.33.6
+autoinstrumentation-java=2.27.0
 
 # Represents the current release of NodeJS instrumentation.
 # Should match value in autoinstrumentation/nodejs/package.json


### PR DESCRIPTION
**Description:**

Block automated upgrades across the breaking 2.0.0 boundary so existing 1.x.x Instrumentation CRs are not upgraded silently — users must update the image manually after reviewing the migration guide.

The Java equivalent to https://github.com/open-telemetry/opentelemetry-operator/pull/5007.

**Link to tracking Issue(s):**

- Related: https://github.com/open-telemetry/opentelemetry-operator/issues/2542

**Testing:**

Modified an existing itegration test for dotnet.

