### PR TITLE
Fix SLSA provenance workflow permissions

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -132,6 +132,7 @@ jobs:
 
   slsa-provenance:
     permissions:
+      actions: read
       contents: read
       id-token: write
       packages: write


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-operator/actions/runs/25485661344

```
Invalid workflow file: .github/workflows/publish-images.yaml#L133
The workflow is not valid. .github/workflows/publish-images.yaml (Line: 133, Col: 3): Error calling workflow 'slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a'. The nested job 'generator' is requesting 'actions: read', but is only allowed 'actions: none'.

```