### PR TITLE
[chore] add cosign support for signing container images on main and release tags

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -9,6 +9,8 @@ on:
 
 env:
   PLATFORMS: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+  GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/opentelemetry-operator
+  DOCKERHUB_IMAGE: otel/opentelemetry-operator
 
 permissions:
   contents: read
@@ -21,6 +23,9 @@ jobs:
       id-token: write
     name: Publish container images
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      image: ${{ steps.release-image.outputs.image }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -32,7 +37,10 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Describe the current state
-        run: git describe --tags
+        run: |
+          # make sure that tags are available, but don't fail the workflow if none exist.
+          git fetch --tags || true
+          git describe --tags || echo "no-tag-$(git rev-parse --short HEAD)"
 
       - name: Set env vars for the job
         run: |
@@ -47,7 +55,8 @@ jobs:
           grep -v '\#' versions.txt | grep autoinstrumentation-apache-httpd | awk -F= '{print "AUTO_INSTRUMENTATION_APACHE_HTTPD_VERSION="$2}' >> $GITHUB_ENV
           grep -v '\#' versions.txt | grep autoinstrumentation-nginx | awk -F= '{print "AUTO_INSTRUMENTATION_NGINX_VERSION="$2}' >> $GITHUB_ENV
           echo "VERSION_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
-          echo "VERSION=$(git describe --tags | sed 's/^v//')" >> $GITHUB_ENV
+          VERSION="$(git describe --tags 2>/dev/null || echo "no-tag-$(git rev-parse --short HEAD)")"
+          echo "VERSION=${VERSION#v}" >> $GITHUB_ENV
 
       - name: Build the binary for each supported architecture
         run: |
@@ -62,13 +71,17 @@ jobs:
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: |
-            otel/opentelemetry-operator
-            ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{raw}}
             type=ref,event=branch
+
+      - name: Resolve release image name
+        id: release-image
+        run: echo "image=${GHCR_IMAGE}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -100,6 +113,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Operator image
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -110,3 +124,11 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Sign release images
+        if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          make cosign-sign IMAGE="${GHCR_IMAGE}" DIGEST="${DIGEST}"
+          make cosign-sign IMAGE="${DOCKERHUB_IMAGE}" DIGEST="${DIGEST}"

--- a/Makefile
+++ b/Makefile
@@ -961,6 +961,38 @@ catalog-build: opm bundle-build bundle-push ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	docker push $(CATALOG_IMG)
 
+##@ Supply Chain Security
+
+# Tool versions for supply chain securitya
+# renovate: datasource=github-releases depName=sigstore/cosign
+COSIGN_VERSION ?= v2.5.0
+COSIGN ?= $(LOCALBIN)/cosign
+
+
+# Download cosign locally if necessary
+.PHONY: cosign
+cosign: $(LOCALBIN)
+	@{ \
+	set -e ;\
+	if [ -x "$(COSIGN)" ] && "$(COSIGN)" version 2>/dev/null | grep -q "$(COSIGN_VERSION)"; then exit 0; fi ;\
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) ;\
+	curl -sSfL "https://github.com/sigstore/cosign/releases/download/$(COSIGN_VERSION)/cosign-$${OS}-$${ARCH}" -o "$(COSIGN)" ;\
+	chmod +x "$(COSIGN)" ;\
+	}
+
+# Sign container images with keyless cosign.
+# Usage: make cosign-sign IMAGE=ghcr.io/... DIGEST=sha256:...
+# Both IMAGE and DIGEST must be set.
+.PHONY: cosign-sign
+cosign-sign: cosign
+ifndef IMAGE
+	$(error IMAGE is not set. Usage: make cosign-sign IMAGE=<image> DIGEST=<digest>)
+endif
+ifndef DIGEST
+	$(error DIGEST is not set. Usage: make cosign-sign IMAGE=<image> DIGEST=<digest>)
+endif
+	$(COSIGN) sign --yes "$(IMAGE)@$(DIGEST)"
+
 ##@ Release
 
 .PHONY: create-release-issue


### PR DESCRIPTION
**Description:**
added Sigstore-Cosign keyless signing support for container images published by the release workflow.

### Changes

* Added `cosign` and `cosign-sign` targets to the `Makefile`
* Updated `publish-images.yaml` to:

  * add required OIDC permissions
  * expose image digest outputs
  * improve tag handling for non-tag builds
  * sign GHCR and Docker Hub images on `main` and release tags



**Link to tracking Issue(s):**

* Resolves: #5020
* Related to: #5009

**Testing:**
 - action: https://github.com/Horiodino/opentelemetry-operator/actions/runs/25534717115

**Documentation:**