### PR TITLE
Fix e2e image publishing workflow

### DIFF
--- a/.github/workflows/publish-test-e2e-images.yaml
+++ b/.github/workflows/publish-test-e2e-images.yaml
@@ -15,9 +15,6 @@ on:
       - '.github/workflows/reusable-publish-test-e2e-images.yaml'
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -25,6 +22,7 @@ concurrency:
 jobs:
   bridge-server:
     permissions: # required by the reusable workflow
+      contents: read
       packages: write
       attestations: write
       id-token: write
@@ -34,6 +32,7 @@ jobs:
       platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
   golang:
     permissions: # required by the reusable workflow
+      contents: read
       packages: write
       attestations: write
       id-token: write
@@ -43,6 +42,7 @@ jobs:
       platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
   python-latest:
     permissions: # required by the reusable workflow
+      contents: read
       packages: write
       attestations: write
       id-token: write
@@ -52,6 +52,7 @@ jobs:
       platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
   python-oldest:
     permissions: # required by the reusable workflow
+      contents: read
       packages: write
       attestations: write
       id-token: write
@@ -63,6 +64,7 @@ jobs:
       platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
   java:
     permissions: # required by the reusable workflow
+      contents: read
       packages: write
       attestations: write
       id-token: write
@@ -72,6 +74,7 @@ jobs:
       platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
   apache-httpd:
     permissions: # required by the reusable workflow
+      contents: read
       packages: write
       attestations: write
       id-token: write
@@ -81,6 +84,7 @@ jobs:
       platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
   dotnet:
     permissions: # required by the reusable workflow
+      contents: read
       packages: write
       attestations: write
       id-token: write
@@ -90,6 +94,7 @@ jobs:
       platforms: linux/arm64,linux/amd64
   nodejs:
     permissions: # required by the reusable workflow
+      contents: read
       packages: write
       attestations: write
       id-token: write
@@ -99,6 +104,7 @@ jobs:
       platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
   metrics-basic-auth:
     permissions: # required by the reusable workflow
+      contents: read
       packages: write
       attestations: write
       id-token: write

--- a/tests/test-e2e-apps/java/Dockerfile
+++ b/tests/test-e2e-apps/java/Dockerfile
@@ -13,8 +13,13 @@ RUN curl -s "https://get.sdkman.io" | bash
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && sdk install springboot && spring init /app"
 
 WORKDIR /app
+# Pin Gradle wrapper — `spring init` scaffolds a wrapper at whatever version Spring CLI currently
+# ships, which can be incompatible with our pinned spring-boot plugin in build.gradle.
+RUN sed -i 's|gradle-[0-9.]\+-bin.zip|gradle-8.10-bin.zip|' /app/gradle/wrapper/gradle-wrapper.properties
 COPY DemoApplication.java /app/src/main/java/com/example/app/
 COPY build.gradle .
+# Remove the Application.java scaffolded by `spring init` so the plugin doesn't see two main classes.
+RUN find /app/src/main/java -name 'Application.java' -delete
 RUN ./gradlew bootJar --no-daemon
 
 FROM docker.io/library/eclipse-temurin:17.0.8.1_1-jre


### PR DESCRIPTION
This workflow was failing for a while. It doesn't matter that much, since all these apps are basically static, but we should rebuild them occasionally.

The problem was that permissions blocks for jobs overwrite the per-workflow one, so all permissions need to be explicitly declared for each job.

Had to do a somewhat hacky fix to the Java test app.
