### PR TITLE
[chore] Move builder test data into yaml files

### DIFF
--- a/internal/controllers/builder_test.go
+++ b/internal/controllers/builder_test.go
@@ -4,23 +4,17 @@
 package controllers
 
 import (
+	"bytes"
 	"testing"
 
-	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
 	go_yaml "github.com/goccy/go-yaml"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/require"
 	colfeaturegate "go.opentelemetry.io/collector/featuregate"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	policyV1 "k8s.io/api/policy/v1"
+	"gotest.tools/v3/golden"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	sigsyaml "sigs.k8s.io/yaml"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
@@ -28,35 +22,33 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/targetallocator"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
 
-var (
-	selectorLabels = map[string]string{
-		"app.kubernetes.io/managed-by": "opentelemetry-operator",
-		"app.kubernetes.io/part-of":    "opentelemetry",
-		"app.kubernetes.io/component":  "opentelemetry-collector",
-		"app.kubernetes.io/instance":   "test.test",
+// renderObjects serializes a list of client.Object into a multi-document YAML
+// string suitable for diffing against a golden file. TypeMeta is populated
+// from testScheme when known, so the generated fixtures stay readable even
+// though the builder itself does not set apiVersion/kind on returned objects.
+// Types not registered in testScheme (e.g. cert-manager) are emitted without
+// apiVersion/kind.
+func renderObjects(t *testing.T, objs []client.Object) string {
+	t.Helper()
+	var buf bytes.Buffer
+	for i, obj := range objs {
+		if i > 0 {
+			buf.WriteString("---\n")
+		}
+		if obj.GetObjectKind().GroupVersionKind().Empty() {
+			if gvks, _, err := testScheme.ObjectKinds(obj); err == nil && len(gvks) > 0 {
+				obj.GetObjectKind().SetGroupVersionKind(gvks[0])
+			}
+		}
+		out, err := sigsyaml.Marshal(obj)
+		require.NoError(t, err)
+		buf.Write(out)
 	}
-	basePolicy     = corev1.ServiceInternalTrafficPolicyCluster
-	pathTypePrefix = networkingv1.PathTypePrefix
-)
-
-var opampbridgeSelectorLabels = map[string]string{
-	"app.kubernetes.io/managed-by": "opentelemetry-operator",
-	"app.kubernetes.io/part-of":    "opentelemetry",
-	"app.kubernetes.io/component":  "opentelemetry-opamp-bridge",
-	"app.kubernetes.io/instance":   "test.test",
-}
-
-var taSelectorLabels = map[string]string{
-	"app.kubernetes.io/managed-by": "opentelemetry-operator",
-	"app.kubernetes.io/part-of":    "opentelemetry",
-	"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-	"app.kubernetes.io/instance":   "test.test",
-	"app.kubernetes.io/name":       "test-targetallocator",
+	return buf.String()
 }
 
 func TestBuildCollector(t *testing.T) {
@@ -76,944 +68,79 @@ service:
 	err := go_yaml.Unmarshal([]byte(goodConfigYaml), &goodConfig)
 	require.NoError(t, err)
 
-	goodConfigHash, _ := manifestutils.GetConfigMapSHA(goodConfig)
-	goodConfigHash = goodConfigHash[:8]
-
 	one := int32(1)
 	trueVal := true
-	tcp := corev1.ProtocolTCP
-	type args struct {
-		instance v1beta1.OpenTelemetryCollector
-	}
+
 	tests := []struct {
-		name    string
-		args    args
-		want    []client.Object
-		wantErr bool
+		name     string
+		instance v1beta1.OpenTelemetryCollector
+		wantFile string
+		wantErr  bool
 	}{
 		{
 			name: "base case",
-			args: args{
-				instance: v1beta1.OpenTelemetryCollector{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-					},
-					Spec: v1beta1.OpenTelemetryCollectorSpec{
-						OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
-							Image:    "test",
-							Replicas: &one,
-						},
-						Mode:   "deployment",
-						Config: goodConfig,
-						NetworkPolicy: v1beta1.NetworkPolicy{
-							Enabled: &trueVal,
-						},
-					},
+			instance: v1beta1.OpenTelemetryCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
 				},
-			},
-			want: []client.Object{
-				&appsv1.Deployment{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: appsv1.DeploymentSpec{
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+						Image:    "test",
 						Replicas: &one,
-						Selector: &metav1.LabelSelector{
-							MatchLabels: selectorLabels,
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app.kubernetes.io/component":  "opentelemetry-collector",
-									"app.kubernetes.io/instance":   "test.test",
-									"app.kubernetes.io/managed-by": "opentelemetry-operator",
-									"app.kubernetes.io/name":       "test-collector",
-									"app.kubernetes.io/part-of":    "opentelemetry",
-									"app.kubernetes.io/version":    "latest",
-								},
-								Annotations: map[string]string{
-									"opentelemetry-operator-config/sha256": "2d266e55025628659355f1271b689d6fb53648ef6cd5595831f5835d18e59a25",
-									"prometheus.io/path":                   "/metrics",
-									"prometheus.io/port":                   "8888",
-									"prometheus.io/scrape":                 "true",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Volumes: []corev1.Volume{
-									{
-										Name: "otc-internal",
-										VolumeSource: corev1.VolumeSource{
-											ConfigMap: &corev1.ConfigMapVolumeSource{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "test-collector-" + goodConfigHash,
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "collector.yaml",
-														Path: "collector.yaml",
-													},
-												},
-											},
-										},
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "otc-container",
-										Image: "test",
-										Args: []string{
-											"--config=/conf/collector.yaml",
-										},
-										Ports: []corev1.ContainerPort{
-											{
-												Name:          "examplereceiver",
-												HostPort:      0,
-												ContainerPort: 12345,
-											},
-											{
-												Name:          "metrics",
-												HostPort:      0,
-												ContainerPort: 8888,
-												Protocol:      "TCP",
-											},
-										},
-										Env: []corev1.EnvVar{
-											{
-												Name: "POD_NAME",
-												ValueFrom: &corev1.EnvVarSource{
-													FieldRef: &corev1.ObjectFieldSelector{
-														FieldPath: "metadata.name",
-													},
-												},
-											},
-											{
-												Name: "GOMEMLIMIT",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.memory",
-														ContainerName: "otc-container",
-													},
-												},
-											},
-											{
-												Name: "GOMAXPROCS",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.cpu",
-														ContainerName: "otc-container",
-													},
-												},
-											},
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "otc-internal",
-												MountPath: "/conf",
-											},
-										},
-									},
-								},
-								ShareProcessNamespace: ptr.To(false),
-								DNSPolicy:             "ClusterFirst",
-								DNSConfig:             &corev1.PodDNSConfig{},
-								ServiceAccountName:    "test-collector",
-							},
-						},
 					},
-				},
-				&policyV1.PodDisruptionBudget{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: policyV1.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: selectorLabels,
-						},
-						MaxUnavailable: &intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: 1,
-						},
-					},
-				},
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-" + goodConfigHash,
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Data: map[string]string{
-						"collector.yaml": "receivers:\n  examplereceiver:\n    endpoint: 0.0.0.0:12345\nexporters:\n  debug: null\nservice:\n  pipelines:\n    metrics:\n      exporters:\n        - debug\n      receivers:\n        - examplereceiver\n",
-					},
-				},
-				&corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":                      "opentelemetry-collector",
-							"app.kubernetes.io/instance":                       "test.test",
-							"app.kubernetes.io/managed-by":                     "opentelemetry-operator",
-							"app.kubernetes.io/name":                           "test-collector",
-							"app.kubernetes.io/part-of":                        "opentelemetry",
-							"app.kubernetes.io/version":                        "latest",
-							"operator.opentelemetry.io/collector-service-type": "base",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "examplereceiver",
-								Port: 12345,
-							},
-						},
-						Selector:              selectorLabels,
-						InternalTrafficPolicy: &basePolicy,
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-headless",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":                          "opentelemetry-collector",
-							"app.kubernetes.io/instance":                           "test.test",
-							"app.kubernetes.io/managed-by":                         "opentelemetry-operator",
-							"app.kubernetes.io/name":                               "test-collector",
-							"app.kubernetes.io/part-of":                            "opentelemetry",
-							"app.kubernetes.io/version":                            "latest",
-							"operator.opentelemetry.io/collector-headless-service": "Exists",
-							"operator.opentelemetry.io/collector-service-type":     "headless",
-						},
-						Annotations: map[string]string{
-							"service.beta.openshift.io/serving-cert-secret-name": "test-collector-headless-tls",
-						},
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "examplereceiver",
-								Port: 12345,
-							},
-						},
-						Selector:              selectorLabels,
-						InternalTrafficPolicy: &basePolicy,
-						ClusterIP:             "None",
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-monitoring",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":                            "opentelemetry-collector",
-							"app.kubernetes.io/instance":                             "test.test",
-							"app.kubernetes.io/managed-by":                           "opentelemetry-operator",
-							"app.kubernetes.io/name":                                 "test-collector-monitoring",
-							"app.kubernetes.io/part-of":                              "opentelemetry",
-							"app.kubernetes.io/version":                              "latest",
-							"operator.opentelemetry.io/collector-service-type":       "monitoring",
-							"operator.opentelemetry.io/collector-monitoring-service": "Exists",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "monitoring",
-								Port: 8888,
-							},
-						},
-						Selector: selectorLabels,
-					},
-				},
-				&networkingv1.NetworkPolicy{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-networkpolicy",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector-networkpolicy",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: networkingv1.NetworkPolicySpec{
-						PodSelector: metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app.kubernetes.io/component":  "opentelemetry-collector",
-								"app.kubernetes.io/instance":   "test.test",
-								"app.kubernetes.io/managed-by": "opentelemetry-operator",
-								"app.kubernetes.io/part-of":    "opentelemetry",
-							},
-						},
-						Ingress: []networkingv1.NetworkPolicyIngressRule{
-							{
-								Ports: []networkingv1.NetworkPolicyPort{
-									{
-										Protocol: &tcp,
-										Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 12345},
-									},
-									{
-										Protocol: &tcp,
-										Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 8888},
-									},
-								},
-							},
-						},
-						PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+					Mode:   "deployment",
+					Config: goodConfig,
+					NetworkPolicy: v1beta1.NetworkPolicy{
+						Enabled: &trueVal,
 					},
 				},
 			},
-			wantErr: false,
+			wantFile: "build_collector_base.yaml",
 		},
 		{
 			name: "ingress",
-			args: args{
-				instance: v1beta1.OpenTelemetryCollector{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-					},
-					Spec: v1beta1.OpenTelemetryCollectorSpec{
-						OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
-							Image:    "test",
-							Replicas: &one,
-						},
-						Mode: "deployment",
-						Ingress: v1beta1.Ingress{
-							Type:     v1beta1.IngressTypeIngress,
-							Hostname: "example.com",
-							Annotations: map[string]string{
-								"something": "true",
-							},
-						},
-						Config: goodConfig,
-					},
+			instance: v1beta1.OpenTelemetryCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
 				},
-			},
-			want: []client.Object{
-				&appsv1.Deployment{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: appsv1.DeploymentSpec{
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+						Image:    "test",
 						Replicas: &one,
-						Selector: &metav1.LabelSelector{
-							MatchLabels: selectorLabels,
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app.kubernetes.io/component":  "opentelemetry-collector",
-									"app.kubernetes.io/instance":   "test.test",
-									"app.kubernetes.io/managed-by": "opentelemetry-operator",
-									"app.kubernetes.io/name":       "test-collector",
-									"app.kubernetes.io/part-of":    "opentelemetry",
-									"app.kubernetes.io/version":    "latest",
-								},
-								Annotations: map[string]string{
-									"opentelemetry-operator-config/sha256": "2d266e55025628659355f1271b689d6fb53648ef6cd5595831f5835d18e59a25",
-									"prometheus.io/path":                   "/metrics",
-									"prometheus.io/port":                   "8888",
-									"prometheus.io/scrape":                 "true",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Volumes: []corev1.Volume{
-									{
-										Name: "otc-internal",
-										VolumeSource: corev1.VolumeSource{
-											ConfigMap: &corev1.ConfigMapVolumeSource{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "test-collector-" + goodConfigHash,
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "collector.yaml",
-														Path: "collector.yaml",
-													},
-												},
-											},
-										},
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "otc-container",
-										Image: "test",
-										Args: []string{
-											"--config=/conf/collector.yaml",
-										},
-										Ports: []corev1.ContainerPort{
-											{
-												Name:          "examplereceiver",
-												HostPort:      0,
-												ContainerPort: 12345,
-											},
-											{
-												Name:          "metrics",
-												HostPort:      0,
-												ContainerPort: 8888,
-												Protocol:      "TCP",
-											},
-										},
-										Env: []corev1.EnvVar{
-											{
-												Name: "POD_NAME",
-												ValueFrom: &corev1.EnvVarSource{
-													FieldRef: &corev1.ObjectFieldSelector{
-														FieldPath: "metadata.name",
-													},
-												},
-											},
-											{
-												Name: "GOMEMLIMIT",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.memory",
-														ContainerName: "otc-container",
-													},
-												},
-											},
-											{
-												Name: "GOMAXPROCS",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.cpu",
-														ContainerName: "otc-container",
-													},
-												},
-											},
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "otc-internal",
-												MountPath: "/conf",
-											},
-										},
-									},
-								},
-								ShareProcessNamespace: ptr.To(false),
-								DNSPolicy:             "ClusterFirst",
-								DNSConfig:             &corev1.PodDNSConfig{},
-								ServiceAccountName:    "test-collector",
-							},
-						},
 					},
-				},
-				&policyV1.PodDisruptionBudget{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: policyV1.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: selectorLabels,
-						},
-						MaxUnavailable: &intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: 1,
-						},
-					},
-				},
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-" + goodConfigHash,
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Data: map[string]string{
-						"collector.yaml": "receivers:\n  examplereceiver:\n    endpoint: 0.0.0.0:12345\nexporters:\n  debug: null\nservice:\n  pipelines:\n    metrics:\n      exporters:\n        - debug\n      receivers:\n        - examplereceiver\n",
-					},
-				},
-				&corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":                      "opentelemetry-collector",
-							"app.kubernetes.io/instance":                       "test.test",
-							"app.kubernetes.io/managed-by":                     "opentelemetry-operator",
-							"app.kubernetes.io/name":                           "test-collector",
-							"app.kubernetes.io/part-of":                        "opentelemetry",
-							"app.kubernetes.io/version":                        "latest",
-							"operator.opentelemetry.io/collector-service-type": "base",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "examplereceiver",
-								Port: 12345,
-							},
-						},
-						Selector:              selectorLabels,
-						InternalTrafficPolicy: &basePolicy,
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-headless",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":                          "opentelemetry-collector",
-							"app.kubernetes.io/instance":                           "test.test",
-							"app.kubernetes.io/managed-by":                         "opentelemetry-operator",
-							"app.kubernetes.io/name":                               "test-collector",
-							"app.kubernetes.io/part-of":                            "opentelemetry",
-							"app.kubernetes.io/version":                            "latest",
-							"operator.opentelemetry.io/collector-service-type":     "headless",
-							"operator.opentelemetry.io/collector-headless-service": "Exists",
-						},
-						Annotations: map[string]string{
-							"service.beta.openshift.io/serving-cert-secret-name": "test-collector-headless-tls",
-						},
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "examplereceiver",
-								Port: 12345,
-							},
-						},
-						Selector:              selectorLabels,
-						InternalTrafficPolicy: &basePolicy,
-						ClusterIP:             "None",
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-monitoring",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":                            "opentelemetry-collector",
-							"app.kubernetes.io/instance":                             "test.test",
-							"app.kubernetes.io/managed-by":                           "opentelemetry-operator",
-							"app.kubernetes.io/name":                                 "test-collector-monitoring",
-							"app.kubernetes.io/part-of":                              "opentelemetry",
-							"app.kubernetes.io/version":                              "latest",
-							"operator.opentelemetry.io/collector-service-type":       "monitoring",
-							"operator.opentelemetry.io/collector-monitoring-service": "Exists",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "monitoring",
-								Port: 8888,
-							},
-						},
-						Selector: selectorLabels,
-					},
-				},
-				&networkingv1.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-ingress",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-ingress",
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
+					Mode: "deployment",
+					Ingress: v1beta1.Ingress{
+						Type:     v1beta1.IngressTypeIngress,
+						Hostname: "example.com",
 						Annotations: map[string]string{
 							"something": "true",
 						},
 					},
-					Spec: networkingv1.IngressSpec{
-						Rules: []networkingv1.IngressRule{
-							{
-								Host: "example.com",
-								IngressRuleValue: networkingv1.IngressRuleValue{
-									HTTP: &networkingv1.HTTPIngressRuleValue{
-										Paths: []networkingv1.HTTPIngressPath{
-											{
-												Path:     "/examplereceiver",
-												PathType: &pathTypePrefix,
-												Backend: networkingv1.IngressBackend{
-													Service: &networkingv1.IngressServiceBackend{
-														Name: "test-collector",
-														Port: networkingv1.ServiceBackendPort{
-															Name: "examplereceiver",
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
+					Config: goodConfig,
 				},
 			},
-			wantErr: false,
+			wantFile: "build_collector_ingress.yaml",
 		},
 		{
 			name: "specified service account case",
-			args: args{
-				instance: v1beta1.OpenTelemetryCollector{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
+			instance: v1beta1.OpenTelemetryCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+						Image:          "test",
+						Replicas:       &one,
+						ServiceAccount: "my-special-sa",
 					},
-					Spec: v1beta1.OpenTelemetryCollectorSpec{
-						OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
-							Image:          "test",
-							Replicas:       &one,
-							ServiceAccount: "my-special-sa",
-						},
-						Mode:   "deployment",
-						Config: goodConfig,
-					},
+					Mode:   "deployment",
+					Config: goodConfig,
 				},
 			},
-			want: []client.Object{
-				&appsv1.Deployment{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: appsv1.DeploymentSpec{
-						Replicas: &one,
-						Selector: &metav1.LabelSelector{
-							MatchLabels: selectorLabels,
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app.kubernetes.io/component":  "opentelemetry-collector",
-									"app.kubernetes.io/instance":   "test.test",
-									"app.kubernetes.io/managed-by": "opentelemetry-operator",
-									"app.kubernetes.io/name":       "test-collector",
-									"app.kubernetes.io/part-of":    "opentelemetry",
-									"app.kubernetes.io/version":    "latest",
-								},
-								Annotations: map[string]string{
-									"opentelemetry-operator-config/sha256": "2d266e55025628659355f1271b689d6fb53648ef6cd5595831f5835d18e59a25",
-									"prometheus.io/path":                   "/metrics",
-									"prometheus.io/port":                   "8888",
-									"prometheus.io/scrape":                 "true",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Volumes: []corev1.Volume{
-									{
-										Name: "otc-internal",
-										VolumeSource: corev1.VolumeSource{
-											ConfigMap: &corev1.ConfigMapVolumeSource{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "test-collector-" + goodConfigHash,
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "collector.yaml",
-														Path: "collector.yaml",
-													},
-												},
-											},
-										},
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "otc-container",
-										Image: "test",
-										Args: []string{
-											"--config=/conf/collector.yaml",
-										},
-										Ports: []corev1.ContainerPort{
-											{
-												Name:          "examplereceiver",
-												HostPort:      0,
-												ContainerPort: 12345,
-											},
-											{
-												Name:          "metrics",
-												HostPort:      0,
-												ContainerPort: 8888,
-												Protocol:      "TCP",
-											},
-										},
-										Env: []corev1.EnvVar{
-											{
-												Name: "POD_NAME",
-												ValueFrom: &corev1.EnvVarSource{
-													FieldRef: &corev1.ObjectFieldSelector{
-														FieldPath: "metadata.name",
-													},
-												},
-											},
-											{
-												Name: "GOMEMLIMIT",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.memory",
-														ContainerName: "otc-container",
-													},
-												},
-											},
-											{
-												Name: "GOMAXPROCS",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.cpu",
-														ContainerName: "otc-container",
-													},
-												},
-											},
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "otc-internal",
-												MountPath: "/conf",
-											},
-										},
-									},
-								},
-								ShareProcessNamespace: ptr.To(false),
-								DNSPolicy:             "ClusterFirst",
-								DNSConfig:             &corev1.PodDNSConfig{},
-								ServiceAccountName:    "my-special-sa",
-							},
-						},
-					},
-				},
-				&policyV1.PodDisruptionBudget{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: policyV1.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: selectorLabels,
-						},
-						MaxUnavailable: &intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: 1,
-						},
-					},
-				},
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-" + goodConfigHash,
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Data: map[string]string{
-						"collector.yaml": "receivers:\n  examplereceiver:\n    endpoint: 0.0.0.0:12345\nexporters:\n  debug: null\nservice:\n  pipelines:\n    metrics:\n      exporters:\n        - debug\n      receivers:\n        - examplereceiver\n",
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":                      "opentelemetry-collector",
-							"app.kubernetes.io/instance":                       "test.test",
-							"app.kubernetes.io/managed-by":                     "opentelemetry-operator",
-							"app.kubernetes.io/name":                           "test-collector",
-							"app.kubernetes.io/part-of":                        "opentelemetry",
-							"app.kubernetes.io/version":                        "latest",
-							"operator.opentelemetry.io/collector-service-type": "base",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "examplereceiver",
-								Port: 12345,
-							},
-						},
-						Selector:              selectorLabels,
-						InternalTrafficPolicy: &basePolicy,
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-headless",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":                          "opentelemetry-collector",
-							"app.kubernetes.io/instance":                           "test.test",
-							"app.kubernetes.io/managed-by":                         "opentelemetry-operator",
-							"app.kubernetes.io/name":                               "test-collector",
-							"app.kubernetes.io/part-of":                            "opentelemetry",
-							"app.kubernetes.io/version":                            "latest",
-							"operator.opentelemetry.io/collector-service-type":     "headless",
-							"operator.opentelemetry.io/collector-headless-service": "Exists",
-						},
-						Annotations: map[string]string{
-							"service.beta.openshift.io/serving-cert-secret-name": "test-collector-headless-tls",
-						},
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "examplereceiver",
-								Port: 12345,
-							},
-						},
-						Selector:              selectorLabels,
-						InternalTrafficPolicy: &basePolicy,
-						ClusterIP:             "None",
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-monitoring",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":                            "opentelemetry-collector",
-							"app.kubernetes.io/instance":                             "test.test",
-							"app.kubernetes.io/managed-by":                           "opentelemetry-operator",
-							"app.kubernetes.io/name":                                 "test-collector-monitoring",
-							"app.kubernetes.io/part-of":                              "opentelemetry",
-							"app.kubernetes.io/version":                              "latest",
-							"operator.opentelemetry.io/collector-service-type":       "monitoring",
-							"operator.opentelemetry.io/collector-monitoring-service": "Exists",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "monitoring",
-								Port: 8888,
-							},
-						},
-						Selector: selectorLabels,
-					},
-				},
-			},
-			wantErr: false,
+			wantFile: "build_collector_service_account.yaml",
 		},
 	}
 	for _, tt := range tests {
@@ -1026,239 +153,55 @@ service:
 			params := manifests.Params{
 				Log:     logr.Discard(),
 				Config:  cfg,
-				OtelCol: tt.args.instance,
+				OtelCol: tt.instance,
 			}
 			got, err := BuildCollector(params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildAll() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			require.Equal(t, tt.want, got)
+			golden.Assert(t, renderObjects(t, got), tt.wantFile)
 		})
 	}
 }
 
 func TestBuildAll_OpAMPBridge(t *testing.T) {
 	one := int32(1)
-	type args struct {
-		instance v1alpha1.OpAMPBridge
-	}
+
 	tests := []struct {
-		name    string
-		args    args
-		want    []client.Object
-		wantErr bool
+		name     string
+		instance v1alpha1.OpAMPBridge
+		wantFile string
+		wantErr  bool
 	}{
 		{
 			name: "base case",
-			args: args{
-				instance: v1alpha1.OpAMPBridge{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
+			instance: v1alpha1.OpAMPBridge{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: v1alpha1.OpAMPBridgeSpec{
+					Replicas: &one,
+					Image:    "test",
+					Endpoint: "ws://opamp-server:4320/v1/opamp",
+					Capabilities: map[v1alpha1.OpAMPBridgeCapability]bool{
+						v1alpha1.OpAMPBridgeCapabilityReportsStatus:                  true,
+						v1alpha1.OpAMPBridgeCapabilityAcceptsRemoteConfig:            true,
+						v1alpha1.OpAMPBridgeCapabilityReportsEffectiveConfig:         true,
+						v1alpha1.OpAMPBridgeCapabilityReportsOwnTraces:               true,
+						v1alpha1.OpAMPBridgeCapabilityReportsOwnMetrics:              true,
+						v1alpha1.OpAMPBridgeCapabilityReportsOwnLogs:                 true,
+						v1alpha1.OpAMPBridgeCapabilityAcceptsOpAMPConnectionSettings: true,
+						v1alpha1.OpAMPBridgeCapabilityAcceptsOtherConnectionSettings: true,
+						v1alpha1.OpAMPBridgeCapabilityAcceptsRestartCommand:          true,
+						v1alpha1.OpAMPBridgeCapabilityReportsHealth:                  true,
+						v1alpha1.OpAMPBridgeCapabilityReportsRemoteConfig:            true,
 					},
-					Spec: v1alpha1.OpAMPBridgeSpec{
-						Replicas: &one,
-						Image:    "test",
-						Endpoint: "ws://opamp-server:4320/v1/opamp",
-						Capabilities: map[v1alpha1.OpAMPBridgeCapability]bool{
-							v1alpha1.OpAMPBridgeCapabilityReportsStatus:                  true,
-							v1alpha1.OpAMPBridgeCapabilityAcceptsRemoteConfig:            true,
-							v1alpha1.OpAMPBridgeCapabilityReportsEffectiveConfig:         true,
-							v1alpha1.OpAMPBridgeCapabilityReportsOwnTraces:               true,
-							v1alpha1.OpAMPBridgeCapabilityReportsOwnMetrics:              true,
-							v1alpha1.OpAMPBridgeCapabilityReportsOwnLogs:                 true,
-							v1alpha1.OpAMPBridgeCapabilityAcceptsOpAMPConnectionSettings: true,
-							v1alpha1.OpAMPBridgeCapabilityAcceptsOtherConnectionSettings: true,
-							v1alpha1.OpAMPBridgeCapabilityAcceptsRestartCommand:          true,
-							v1alpha1.OpAMPBridgeCapabilityReportsHealth:                  true,
-							v1alpha1.OpAMPBridgeCapabilityReportsRemoteConfig:            true,
-						},
-						ComponentsAllowed: map[string][]string{"receivers": {"otlp"}, "processors": {"memory_limiter"}, "exporters": {"debug"}},
-					},
+					ComponentsAllowed: map[string][]string{"receivers": {"otlp"}, "processors": {"memory_limiter"}, "exporters": {"debug"}},
 				},
 			},
-			want: []client.Object{
-				&appsv1.Deployment{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-opamp-bridge",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-opamp-bridge",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-opamp-bridge",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: appsv1.DeploymentSpec{
-						Replicas: &one,
-						Selector: &metav1.LabelSelector{
-							MatchLabels: opampbridgeSelectorLabels,
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app.kubernetes.io/component":  "opentelemetry-opamp-bridge",
-									"app.kubernetes.io/instance":   "test.test",
-									"app.kubernetes.io/managed-by": "opentelemetry-operator",
-									"app.kubernetes.io/name":       "test-opamp-bridge",
-									"app.kubernetes.io/part-of":    "opentelemetry",
-									"app.kubernetes.io/version":    "latest",
-								},
-								Annotations: map[string]string{
-									"opentelemetry-opampbridge-config/hash": "05e1dc681267a9bc28fc2877ab464a98b9bd043843f14ffc0b4a394b5c86ba9f",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Volumes: []corev1.Volume{
-									{
-										Name: "opamp-bridge-internal",
-										VolumeSource: corev1.VolumeSource{
-											ConfigMap: &corev1.ConfigMapVolumeSource{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "test-opamp-bridge",
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "remoteconfiguration.yaml",
-														Path: "remoteconfiguration.yaml",
-													},
-												},
-											},
-										},
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "opamp-bridge-container",
-										Image: "test",
-										Env: []corev1.EnvVar{
-											{
-												Name: "OTELCOL_NAMESPACE",
-												ValueFrom: &corev1.EnvVarSource{
-													FieldRef: &corev1.ObjectFieldSelector{
-														FieldPath: "metadata.namespace",
-													},
-												},
-											},
-											{
-												Name: "GOMEMLIMIT",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.memory",
-														ContainerName: "opamp-bridge-container",
-													},
-												},
-											},
-											{
-												Name: "GOMAXPROCS",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.cpu",
-														ContainerName: "opamp-bridge-container",
-													},
-												},
-											},
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "opamp-bridge-internal",
-												MountPath: "/conf",
-											},
-										},
-									},
-								},
-								DNSPolicy:          "ClusterFirst",
-								DNSConfig:          &corev1.PodDNSConfig{},
-								ServiceAccountName: "test-opamp-bridge",
-							},
-						},
-					},
-				},
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-opamp-bridge",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-opamp-bridge",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-opamp-bridge",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Data: map[string]string{
-						"remoteconfiguration.yaml": `capabilities:
-  AcceptsOpAMPConnectionSettings: true
-  AcceptsOtherConnectionSettings: true
-  AcceptsRemoteConfig: true
-  AcceptsRestartCommand: true
-  ReportsEffectiveConfig: true
-  ReportsHealth: true
-  ReportsOwnLogs: true
-  ReportsOwnMetrics: true
-  ReportsOwnTraces: true
-  ReportsRemoteConfig: true
-  ReportsStatus: true
-componentsAllowed:
-  exporters:
-  - debug
-  processors:
-  - memory_limiter
-  receivers:
-  - otlp
-endpoint: ws://opamp-server:4320/v1/opamp
-`,
-					},
-				},
-				&corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-opamp-bridge",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-opamp-bridge",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-opamp-bridge",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-opamp-bridge",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-opamp-bridge",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-opamp-bridge",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name:       "opamp-bridge",
-								Port:       80,
-								TargetPort: intstr.FromInt(8080),
-							},
-						},
-						Selector: opampbridgeSelectorLabels,
-					},
-				},
-			},
-			wantErr: false,
+			wantFile: "build_opamp_bridge_base.yaml",
 		},
 	}
 	for _, tt := range tests {
@@ -1275,13 +218,13 @@ endpoint: ws://opamp-server:4320/v1/opamp
 				Log:    logr.Discard(),
 				Config: cfg,
 			})
-			params := reconciler.getParams(tt.args.instance)
+			params := reconciler.getParams(tt.instance)
 			got, err := BuildOpAMPBridge(params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildAll() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			require.Equal(t, tt.want, got)
+			golden.Assert(t, renderObjects(t, got), tt.wantFile)
 		})
 	}
 }
@@ -1317,258 +260,32 @@ service:
 	err := go_yaml.Unmarshal([]byte(goodConfigYaml), &goodConfig)
 	require.NoError(t, err)
 
-	goodConfigHash, _ := manifestutils.GetConfigMapSHA(goodConfig)
-	goodConfigHash = goodConfigHash[:8]
-
 	one := int32(1)
-	type args struct {
-		instance v1beta1.OpenTelemetryCollector
-	}
+
 	tests := []struct {
 		name         string
-		args         args
-		want         []client.Object
+		instance     v1beta1.OpenTelemetryCollector
+		wantFile     string
 		featuregates []*colfeaturegate.Gate
 		wantErr      bool
 	}{
 		{
 			name: "base case",
-			args: args{
-				instance: v1beta1.OpenTelemetryCollector{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-					},
-					Spec: v1beta1.OpenTelemetryCollectorSpec{
-						OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
-							Image:    "test",
-							Replicas: &one,
-						},
-						Mode:   "statefulset",
-						Config: goodConfig,
-						TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-							Enabled:            true,
-							FilterStrategy:     "relabel-config",
-							AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
-							PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-								Enabled: true,
-							},
-						},
-					},
+			instance: v1beta1.OpenTelemetryCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
 				},
-			},
-			want: []client.Object{
-				&appsv1.StatefulSet{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+						Image:    "test",
+						Replicas: &one,
 					},
-					Spec: appsv1.StatefulSetSpec{
-						ServiceName: "test-collector-headless",
-						Replicas:    &one,
-						Selector: &metav1.LabelSelector{
-							MatchLabels: selectorLabels,
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app.kubernetes.io/component":  "opentelemetry-collector",
-									"app.kubernetes.io/instance":   "test.test",
-									"app.kubernetes.io/managed-by": "opentelemetry-operator",
-									"app.kubernetes.io/name":       "test-collector",
-									"app.kubernetes.io/part-of":    "opentelemetry",
-									"app.kubernetes.io/version":    "latest",
-								},
-								Annotations: map[string]string{
-									"opentelemetry-operator-config/sha256": "42773025f65feaf30df59a306a9e38f1aaabe94c8310983beaddb7f648d699b0",
-									"prometheus.io/path":                   "/metrics",
-									"prometheus.io/port":                   "8888",
-									"prometheus.io/scrape":                 "true",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Volumes: []corev1.Volume{
-									{
-										Name: "otc-internal",
-										VolumeSource: corev1.VolumeSource{
-											ConfigMap: &corev1.ConfigMapVolumeSource{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "test-collector-" + goodConfigHash,
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "collector.yaml",
-														Path: "collector.yaml",
-													},
-												},
-											},
-										},
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "otc-container",
-										Image: "test",
-										Args: []string{
-											"--config=/conf/collector.yaml",
-										},
-										Env: []corev1.EnvVar{
-											{
-												Name: "POD_NAME",
-												ValueFrom: &corev1.EnvVarSource{
-													FieldRef: &corev1.ObjectFieldSelector{
-														FieldPath: "metadata.name",
-													},
-												},
-											},
-											{
-												Name: "GOMEMLIMIT",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.memory",
-														ContainerName: "otc-container",
-													},
-												},
-											},
-											{
-												Name: "GOMAXPROCS",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.cpu",
-														ContainerName: "otc-container",
-													},
-												},
-											},
-										},
-										Ports: []corev1.ContainerPort{
-											{
-												Name:          "metrics",
-												HostPort:      0,
-												ContainerPort: 8888,
-												Protocol:      "TCP",
-											},
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "otc-internal",
-												MountPath: "/conf",
-											},
-										},
-									},
-								},
-								ShareProcessNamespace: ptr.To(false),
-								DNSPolicy:             "ClusterFirst",
-								DNSConfig:             &corev1.PodDNSConfig{},
-								ServiceAccountName:    "test-collector",
-							},
-						},
-						PodManagementPolicy: "Parallel",
-					},
-				},
-				&policyV1.PodDisruptionBudget{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: policyV1.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: selectorLabels,
-						},
-						MaxUnavailable: &intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: 1,
-						},
-					},
-				},
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-" + goodConfigHash,
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Data: map[string]string{
-						"collector.yaml": "exporters:\n    debug: null\nreceivers:\n    prometheus:\n        config: {}\n        target_allocator:\n            collector_id: ${POD_NAME}\n            endpoint: http://test-targetallocator:80\n            interval: 30s\nservice:\n    pipelines:\n        metrics:\n            exporters:\n                - debug\n            receivers:\n                - prometheus\n",
-					},
-				},
-				&corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-monitoring",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":                            "opentelemetry-collector",
-							"app.kubernetes.io/instance":                             "test.test",
-							"app.kubernetes.io/managed-by":                           "opentelemetry-operator",
-							"app.kubernetes.io/name":                                 "test-collector-monitoring",
-							"app.kubernetes.io/part-of":                              "opentelemetry",
-							"app.kubernetes.io/version":                              "latest",
-							"operator.opentelemetry.io/collector-service-type":       "monitoring",
-							"operator.opentelemetry.io/collector-monitoring-service": "Exists",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "monitoring",
-								Port: 8888,
-							},
-						},
-						Selector: selectorLabels,
-					},
-				},
-				&v1alpha1.TargetAllocator{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-						},
-					},
-					Spec: v1alpha1.TargetAllocatorSpec{
-						FilterStrategy:     v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
+					Mode:   "statefulset",
+					Config: goodConfig,
+					TargetAllocator: v1beta1.TargetAllocatorEmbedded{
+						Enabled:            true,
+						FilterStrategy:     "relabel-config",
 						AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
 						PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
 							Enabled: true,
@@ -1576,253 +293,28 @@ service:
 					},
 				},
 			},
-			wantErr: false,
+			wantFile: "build_collector_ta_cr_base.yaml",
 		},
 		{
 			name: "enable metrics case",
-			args: args{
-				instance: v1beta1.OpenTelemetryCollector{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-					},
-					Spec: v1beta1.OpenTelemetryCollectorSpec{
-						OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
-							Image:    "test",
-							Replicas: &one,
-						},
-						Mode:   "statefulset",
-						Config: goodConfig,
-						TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-							Enabled: true,
-							PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-								Enabled: true,
-							},
-							FilterStrategy: "relabel-config",
-							Observability: v1beta1.ObservabilitySpec{
-								Metrics: v1beta1.MetricsConfigSpec{
-									EnableMetrics: true,
-								},
-							},
-						},
-					},
+			instance: v1beta1.OpenTelemetryCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
 				},
-			},
-			want: []client.Object{
-				&appsv1.StatefulSet{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+						Image:    "test",
+						Replicas: &one,
 					},
-					Spec: appsv1.StatefulSetSpec{
-						ServiceName: "test-collector-headless",
-						Replicas:    &one,
-						Selector: &metav1.LabelSelector{
-							MatchLabels: selectorLabels,
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app.kubernetes.io/component":  "opentelemetry-collector",
-									"app.kubernetes.io/instance":   "test.test",
-									"app.kubernetes.io/managed-by": "opentelemetry-operator",
-									"app.kubernetes.io/name":       "test-collector",
-									"app.kubernetes.io/part-of":    "opentelemetry",
-									"app.kubernetes.io/version":    "latest",
-								},
-								Annotations: map[string]string{
-									"opentelemetry-operator-config/sha256": "42773025f65feaf30df59a306a9e38f1aaabe94c8310983beaddb7f648d699b0",
-									"prometheus.io/path":                   "/metrics",
-									"prometheus.io/port":                   "8888",
-									"prometheus.io/scrape":                 "true",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Volumes: []corev1.Volume{
-									{
-										Name: "otc-internal",
-										VolumeSource: corev1.VolumeSource{
-											ConfigMap: &corev1.ConfigMapVolumeSource{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "test-collector-" + goodConfigHash,
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "collector.yaml",
-														Path: "collector.yaml",
-													},
-												},
-											},
-										},
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "otc-container",
-										Image: "test",
-										Args: []string{
-											"--config=/conf/collector.yaml",
-										},
-										Env: []corev1.EnvVar{
-											{
-												Name: "POD_NAME",
-												ValueFrom: &corev1.EnvVarSource{
-													FieldRef: &corev1.ObjectFieldSelector{
-														FieldPath: "metadata.name",
-													},
-												},
-											},
-											{
-												Name: "GOMEMLIMIT",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.memory",
-														ContainerName: "otc-container",
-													},
-												},
-											},
-											{
-												Name: "GOMAXPROCS",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.cpu",
-														ContainerName: "otc-container",
-													},
-												},
-											},
-										},
-										Ports: []corev1.ContainerPort{
-											{
-												Name:          "metrics",
-												HostPort:      0,
-												ContainerPort: 8888,
-												Protocol:      "TCP",
-											},
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "otc-internal",
-												MountPath: "/conf",
-											},
-										},
-									},
-								},
-								ShareProcessNamespace: ptr.To(false),
-								DNSPolicy:             "ClusterFirst",
-								DNSConfig:             &corev1.PodDNSConfig{},
-								ServiceAccountName:    "test-collector",
-							},
-						},
-						PodManagementPolicy: "Parallel",
-					},
-				},
-				&policyV1.PodDisruptionBudget{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: policyV1.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: selectorLabels,
-						},
-						MaxUnavailable: &intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: 1,
-						},
-					},
-				},
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-" + goodConfigHash,
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-					Data: map[string]string{
-						"collector.yaml": "exporters:\n    debug: null\nreceivers:\n    prometheus:\n        config: {}\n        target_allocator:\n            collector_id: ${POD_NAME}\n            endpoint: http://test-targetallocator:80\n            interval: 30s\nservice:\n    pipelines:\n        metrics:\n            exporters:\n                - debug\n            receivers:\n                - prometheus\n",
-					},
-				},
-				&corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-collector",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-collector",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-collector-monitoring",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":                            "opentelemetry-collector",
-							"app.kubernetes.io/instance":                             "test.test",
-							"app.kubernetes.io/managed-by":                           "opentelemetry-operator",
-							"app.kubernetes.io/name":                                 "test-collector-monitoring",
-							"app.kubernetes.io/part-of":                              "opentelemetry",
-							"app.kubernetes.io/version":                              "latest",
-							"operator.opentelemetry.io/collector-service-type":       "monitoring",
-							"operator.opentelemetry.io/collector-monitoring-service": "Exists",
-						},
-						Annotations: map[string]string{},
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "monitoring",
-								Port: 8888,
-							},
-						},
-						Selector: selectorLabels,
-					},
-				},
-				&v1alpha1.TargetAllocator{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-						},
-					},
-					Spec: v1alpha1.TargetAllocatorSpec{
-						FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
+					Mode:   "statefulset",
+					Config: goodConfig,
+					TargetAllocator: v1beta1.TargetAllocatorEmbedded{
+						Enabled: true,
 						PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
 							Enabled: true,
 						},
+						FilterStrategy: "relabel-config",
 						Observability: v1beta1.ObservabilitySpec{
 							Metrics: v1beta1.MetricsConfigSpec{
 								EnableMetrics: true,
@@ -1831,7 +323,7 @@ service:
 					},
 				},
 			},
-			wantErr:      false,
+			wantFile:     "build_collector_ta_cr_enable_metrics.yaml",
 			featuregates: []*colfeaturegate.Gate{},
 		},
 	}
@@ -1846,7 +338,7 @@ service:
 			params := manifests.Params{
 				Log:     logr.Discard(),
 				Config:  cfg,
-				OtelCol: tt.args.instance,
+				OtelCol: tt.instance,
 			}
 			targetAllocator, err := collector.TargetAllocator(params)
 			require.NoError(t, err)
@@ -1871,314 +363,61 @@ service:
 				t.Errorf("BuildAll() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			require.Equal(t, tt.want, got)
+			golden.Assert(t, renderObjects(t, got), tt.wantFile)
 		})
 	}
 }
 
 func TestBuildTargetAllocator(t *testing.T) {
-	type args struct {
-		instance  v1alpha1.TargetAllocator
-		collector *v1beta1.OpenTelemetryCollector
-	}
 	tests := []struct {
 		name         string
-		args         args
-		want         []client.Object
+		instance     v1alpha1.TargetAllocator
+		collector    *v1beta1.OpenTelemetryCollector
+		wantFile     string
 		featuregates []*colfeaturegate.Gate
 		wantErr      bool
 		cfg          config.Config
 	}{
 		{
 			name: "base case",
-			args: args{
-				instance: v1alpha1.TargetAllocator{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-						Labels:    nil,
+			instance: v1alpha1.TargetAllocator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Labels:    nil,
+				},
+				Spec: v1alpha1.TargetAllocatorSpec{
+					FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
+					ScrapeConfigs: []v1beta1.AnyConfig{
+						{Object: map[string]any{
+							"job_name": "example",
+							"metric_relabel_configs": []any{
+								map[string]any{
+									"replacement":   "$1_$2",
+									"source_labels": []any{"job"},
+									"target_label":  "job",
+								},
+							},
+							"relabel_configs": []any{
+								map[string]any{
+									"replacement":   "my_service_$1",
+									"source_labels": []any{"__meta_service_id"},
+									"target_label":  "job",
+								},
+								map[string]any{
+									"replacement":   "$1",
+									"source_labels": []any{"__meta_service_name"},
+									"target_label":  "instance",
+								},
+							},
+						}},
 					},
-					Spec: v1alpha1.TargetAllocatorSpec{
-						FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
-						ScrapeConfigs: []v1beta1.AnyConfig{
-							{Object: map[string]any{
-								"job_name": "example",
-								"metric_relabel_configs": []any{
-									map[string]any{
-										"replacement":   "$1_$2",
-										"source_labels": []any{"job"},
-										"target_label":  "job",
-									},
-								},
-								"relabel_configs": []any{
-									map[string]any{
-										"replacement":   "my_service_$1",
-										"source_labels": []any{"__meta_service_id"},
-										"target_label":  "job",
-									},
-									map[string]any{
-										"replacement":   "$1",
-										"source_labels": []any{"__meta_service_name"},
-										"target_label":  "instance",
-									},
-								},
-							}},
-						},
-						PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-							Enabled: true,
-						},
+					PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
+						Enabled: true,
 					},
 				},
 			},
-			want: []client.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Data: map[string]string{
-						"targetallocator.yaml": `allocation_strategy: consistent-hashing
-collector_selector: null
-config:
-  scrape_configs:
-  - job_name: example
-    metric_relabel_configs:
-    - replacement: $1_$2
-      source_labels:
-      - job
-      target_label: job
-    relabel_configs:
-    - replacement: my_service_$1
-      source_labels:
-      - __meta_service_id
-      target_label: job
-    - replacement: $1
-      source_labels:
-      - __meta_service_name
-      target_label: instance
-filter_strategy: relabel-config
-prometheus_cr:
-  enabled: true
-  pod_monitor_namespace_selector: null
-  pod_monitor_selector: null
-  probe_namespace_selector: null
-  probe_selector: null
-  scrape_config_namespace_selector: null
-  scrape_config_selector: null
-  service_monitor_namespace_selector: null
-  service_monitor_selector: null
-`,
-					},
-				},
-				&appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Spec: appsv1.DeploymentSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: taSelectorLabels,
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-									"app.kubernetes.io/instance":   "test.test",
-									"app.kubernetes.io/managed-by": "opentelemetry-operator",
-									"app.kubernetes.io/name":       "test-targetallocator",
-									"app.kubernetes.io/part-of":    "opentelemetry",
-									"app.kubernetes.io/version":    "latest",
-								},
-								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "7a839fe32950e427672bf7038e88d953ceecf1531457af7c43dc78300dc85eca",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Volumes: []corev1.Volume{
-									{
-										Name: "ta-internal",
-										VolumeSource: corev1.VolumeSource{
-											ConfigMap: &corev1.ConfigMapVolumeSource{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "test-targetallocator",
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "targetallocator.yaml",
-														Path: "targetallocator.yaml",
-													},
-												},
-											},
-										},
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "ta-container",
-										Image: "default-ta-allocator",
-										Env: []corev1.EnvVar{
-											{
-												Name: "OTELCOL_NAMESPACE",
-												ValueFrom: &corev1.EnvVarSource{
-													FieldRef: &corev1.ObjectFieldSelector{
-														FieldPath: "metadata.namespace",
-													},
-												},
-											},
-											{
-												Name: "GOMEMLIMIT",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.memory",
-														ContainerName: "ta-container",
-													},
-												},
-											},
-											{
-												Name: "GOMAXPROCS",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.cpu",
-														ContainerName: "ta-container",
-													},
-												},
-											},
-										},
-										Ports: []corev1.ContainerPort{
-											{
-												Name:          "http",
-												HostPort:      0,
-												ContainerPort: 8080,
-												Protocol:      "TCP",
-											},
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "ta-internal",
-												MountPath: "/conf",
-											},
-										},
-										LivenessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/livez",
-													Port: intstr.FromInt(8080),
-												},
-											},
-										},
-										ReadinessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/readyz",
-													Port: intstr.FromInt(8080),
-												},
-											},
-										},
-									},
-								},
-								DNSPolicy:             "ClusterFirst",
-								DNSConfig:             &corev1.PodDNSConfig{},
-								ShareProcessNamespace: ptr.To(false),
-								ServiceAccountName:    "test-targetallocator",
-							},
-						},
-					},
-				},
-				&corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "targetallocation",
-								Port: 80,
-								TargetPort: intstr.IntOrString{
-									Type:   1,
-									StrVal: "http",
-								},
-							},
-						},
-						Selector: taSelectorLabels,
-					},
-				},
-				&policyV1.PodDisruptionBudget{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{
-							"opentelemetry-targetallocator-config/hash": "7a839fe32950e427672bf7038e88d953ceecf1531457af7c43dc78300dc85eca",
-						},
-					},
-					Spec: policyV1.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-								"app.kubernetes.io/instance":   "test.test",
-								"app.kubernetes.io/managed-by": "opentelemetry-operator",
-								"app.kubernetes.io/name":       "test-targetallocator",
-								"app.kubernetes.io/part-of":    "opentelemetry",
-							},
-						},
-						MaxUnavailable: &intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: 1,
-						},
-					},
-				},
-			},
-			wantErr: false,
+			wantFile: "build_target_allocator_base.yaml",
 			cfg: config.Config{
 				CollectorImage:                "default-collector",
 				TargetAllocatorImage:          "default-ta-allocator",
@@ -2188,332 +427,50 @@ prometheus_cr:
 		},
 		{
 			name: "enable metrics case",
-			args: args{
-				instance: v1alpha1.TargetAllocator{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-						Labels:    nil,
-					},
-					Spec: v1alpha1.TargetAllocatorSpec{
-						FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
-						ScrapeConfigs: []v1beta1.AnyConfig{
-							{Object: map[string]any{
-								"job_name": "example",
-								"metric_relabel_configs": []any{
-									map[string]any{
-										"replacement":   "$1_$2",
-										"source_labels": []any{"job"},
-										"target_label":  "job",
-									},
+			instance: v1alpha1.TargetAllocator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Labels:    nil,
+				},
+				Spec: v1alpha1.TargetAllocatorSpec{
+					FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
+					ScrapeConfigs: []v1beta1.AnyConfig{
+						{Object: map[string]any{
+							"job_name": "example",
+							"metric_relabel_configs": []any{
+								map[string]any{
+									"replacement":   "$1_$2",
+									"source_labels": []any{"job"},
+									"target_label":  "job",
 								},
-								"relabel_configs": []any{
-									map[string]any{
-										"replacement":   "my_service_$1",
-										"source_labels": []any{"__meta_service_id"},
-										"target_label":  "job",
-									},
-									map[string]any{
-										"replacement":   "$1",
-										"source_labels": []any{"__meta_service_name"},
-										"target_label":  "instance",
-									},
-								},
-							}},
-						},
-						PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-							Enabled: true,
-						},
-						AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
-						Observability: v1beta1.ObservabilitySpec{
-							Metrics: v1beta1.MetricsConfigSpec{
-								EnableMetrics: true,
 							},
+							"relabel_configs": []any{
+								map[string]any{
+									"replacement":   "my_service_$1",
+									"source_labels": []any{"__meta_service_id"},
+									"target_label":  "job",
+								},
+								map[string]any{
+									"replacement":   "$1",
+									"source_labels": []any{"__meta_service_name"},
+									"target_label":  "instance",
+								},
+							},
+						}},
+					},
+					PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
+						Enabled: true,
+					},
+					AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
+					Observability: v1beta1.ObservabilitySpec{
+						Metrics: v1beta1.MetricsConfigSpec{
+							EnableMetrics: true,
 						},
 					},
 				},
 			},
-			want: []client.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Data: map[string]string{
-						"targetallocator.yaml": `allocation_strategy: consistent-hashing
-collector_selector: null
-config:
-  scrape_configs:
-  - job_name: example
-    metric_relabel_configs:
-    - replacement: $1_$2
-      source_labels:
-      - job
-      target_label: job
-    relabel_configs:
-    - replacement: my_service_$1
-      source_labels:
-      - __meta_service_id
-      target_label: job
-    - replacement: $1
-      source_labels:
-      - __meta_service_name
-      target_label: instance
-filter_strategy: relabel-config
-prometheus_cr:
-  enabled: true
-  pod_monitor_namespace_selector: null
-  pod_monitor_selector: null
-  probe_namespace_selector: null
-  probe_selector: null
-  scrape_config_namespace_selector: null
-  scrape_config_selector: null
-  service_monitor_namespace_selector: null
-  service_monitor_selector: null
-`,
-					},
-				},
-				&appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Spec: appsv1.DeploymentSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: taSelectorLabels,
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-									"app.kubernetes.io/instance":   "test.test",
-									"app.kubernetes.io/managed-by": "opentelemetry-operator",
-									"app.kubernetes.io/name":       "test-targetallocator",
-									"app.kubernetes.io/part-of":    "opentelemetry",
-									"app.kubernetes.io/version":    "latest",
-								},
-								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "7a839fe32950e427672bf7038e88d953ceecf1531457af7c43dc78300dc85eca",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Volumes: []corev1.Volume{
-									{
-										Name: "ta-internal",
-										VolumeSource: corev1.VolumeSource{
-											ConfigMap: &corev1.ConfigMapVolumeSource{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "test-targetallocator",
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "targetallocator.yaml",
-														Path: "targetallocator.yaml",
-													},
-												},
-											},
-										},
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "ta-container",
-										Image: "default-ta-allocator",
-										Env: []corev1.EnvVar{
-											{
-												Name: "OTELCOL_NAMESPACE",
-												ValueFrom: &corev1.EnvVarSource{
-													FieldRef: &corev1.ObjectFieldSelector{
-														FieldPath: "metadata.namespace",
-													},
-												},
-											},
-											{
-												Name: "GOMEMLIMIT",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.memory",
-														ContainerName: "ta-container",
-													},
-												},
-											},
-											{
-												Name: "GOMAXPROCS",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.cpu",
-														ContainerName: "ta-container",
-													},
-												},
-											},
-										},
-										Ports: []corev1.ContainerPort{
-											{
-												Name:          "http",
-												HostPort:      0,
-												ContainerPort: 8080,
-												Protocol:      "TCP",
-											},
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "ta-internal",
-												MountPath: "/conf",
-											},
-										},
-										LivenessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/livez",
-													Port: intstr.FromInt(8080),
-												},
-											},
-										},
-										ReadinessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/readyz",
-													Port: intstr.FromInt(8080),
-												},
-											},
-										},
-									},
-								},
-								ShareProcessNamespace: ptr.To(false),
-								DNSPolicy:             "ClusterFirst",
-								DNSConfig:             &corev1.PodDNSConfig{},
-								ServiceAccountName:    "test-targetallocator",
-							},
-						},
-					},
-				},
-				&corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "targetallocation",
-								Port: 80,
-								TargetPort: intstr.IntOrString{
-									Type:   1,
-									StrVal: "http",
-								},
-							},
-						},
-						Selector: taSelectorLabels,
-					},
-				},
-				&policyV1.PodDisruptionBudget{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{
-							"opentelemetry-targetallocator-config/hash": "7a839fe32950e427672bf7038e88d953ceecf1531457af7c43dc78300dc85eca",
-						},
-					},
-					Spec: policyV1.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-								"app.kubernetes.io/instance":   "test.test",
-								"app.kubernetes.io/managed-by": "opentelemetry-operator",
-								"app.kubernetes.io/name":       "test-targetallocator",
-								"app.kubernetes.io/part-of":    "opentelemetry",
-							},
-						},
-						MaxUnavailable: &intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: 1,
-						},
-					},
-				},
-				&monitoringv1.ServiceMonitor{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Spec: monitoringv1.ServiceMonitorSpec{
-						Endpoints: []monitoringv1.Endpoint{
-							{Port: "targetallocation"},
-						},
-						Selector: metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-								"app.kubernetes.io/instance":   "test.test",
-								"app.kubernetes.io/managed-by": "opentelemetry-operator",
-								"app.kubernetes.io/name":       "test-targetallocator",
-								"app.kubernetes.io/part-of":    "opentelemetry",
-							},
-						},
-						NamespaceSelector: monitoringv1.NamespaceSelector{
-							MatchNames: []string{"test"},
-						},
-					},
-				},
-			},
-			wantErr: false,
+			wantFile: "build_target_allocator_enable_metrics.yaml",
 			cfg: config.Config{
 				CollectorImage:                "default-collector",
 				TargetAllocatorImage:          "default-ta-allocator",
@@ -2523,52 +480,50 @@ prometheus_cr:
 		},
 		{
 			name: "collector present",
-			args: args{
-				instance: v1alpha1.TargetAllocator{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-						Labels:    nil,
-					},
-					Spec: v1alpha1.TargetAllocatorSpec{
-						FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
-						PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-							Enabled: true,
-						},
+			instance: v1alpha1.TargetAllocator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Labels:    nil,
+				},
+				Spec: v1alpha1.TargetAllocatorSpec{
+					FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
+					PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
+						Enabled: true,
 					},
 				},
-				collector: &v1beta1.OpenTelemetryCollector{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-					},
-					Spec: v1beta1.OpenTelemetryCollectorSpec{
-						Config: v1beta1.Config{
-							Receivers: v1beta1.AnyConfig{
-								Object: map[string]any{
-									"prometheus": map[string]any{
-										"config": map[string]any{
-											"scrape_configs": []any{
-												map[string]any{
-													"job_name": "example",
-													"metric_relabel_configs": []any{
-														map[string]any{
-															"replacement":   "$1_$2",
-															"source_labels": []any{"job"},
-															"target_label":  "job",
-														},
+			},
+			collector: &v1beta1.OpenTelemetryCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					Config: v1beta1.Config{
+						Receivers: v1beta1.AnyConfig{
+							Object: map[string]any{
+								"prometheus": map[string]any{
+									"config": map[string]any{
+										"scrape_configs": []any{
+											map[string]any{
+												"job_name": "example",
+												"metric_relabel_configs": []any{
+													map[string]any{
+														"replacement":   "$1_$2",
+														"source_labels": []any{"job"},
+														"target_label":  "job",
 													},
-													"relabel_configs": []any{
-														map[string]any{
-															"replacement":   "my_service_$1",
-															"source_labels": []any{"__meta_service_id"},
-															"target_label":  "job",
-														},
-														map[string]any{
-															"replacement":   "$1",
-															"source_labels": []any{"__meta_service_name"},
-															"target_label":  "instance",
-														},
+												},
+												"relabel_configs": []any{
+													map[string]any{
+														"replacement":   "my_service_$1",
+														"source_labels": []any{"__meta_service_id"},
+														"target_label":  "job",
+													},
+													map[string]any{
+														"replacement":   "$1",
+														"source_labels": []any{"__meta_service_name"},
+														"target_label":  "instance",
 													},
 												},
 											},
@@ -2580,261 +535,7 @@ prometheus_cr:
 					},
 				},
 			},
-			want: []client.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Data: map[string]string{
-						"targetallocator.yaml": `allocation_strategy: consistent-hashing
-collector_selector:
-  matchlabels:
-    app.kubernetes.io/component: opentelemetry-collector
-    app.kubernetes.io/instance: test.test
-    app.kubernetes.io/managed-by: opentelemetry-operator
-    app.kubernetes.io/part-of: opentelemetry
-  matchexpressions: []
-config:
-  scrape_configs:
-  - job_name: example
-    metric_relabel_configs:
-    - replacement: $1_$2
-      source_labels:
-      - job
-      target_label: job
-    relabel_configs:
-    - replacement: my_service_$1
-      source_labels:
-      - __meta_service_id
-      target_label: job
-    - replacement: $1
-      source_labels:
-      - __meta_service_name
-      target_label: instance
-filter_strategy: relabel-config
-prometheus_cr:
-  enabled: true
-  pod_monitor_namespace_selector: null
-  pod_monitor_selector: null
-  probe_namespace_selector: null
-  probe_selector: null
-  scrape_config_namespace_selector: null
-  scrape_config_selector: null
-  service_monitor_namespace_selector: null
-  service_monitor_selector: null
-`,
-					},
-				},
-				&appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Spec: appsv1.DeploymentSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: taSelectorLabels,
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-									"app.kubernetes.io/instance":   "test.test",
-									"app.kubernetes.io/managed-by": "opentelemetry-operator",
-									"app.kubernetes.io/name":       "test-targetallocator",
-									"app.kubernetes.io/part-of":    "opentelemetry",
-									"app.kubernetes.io/version":    "latest",
-								},
-								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "a81383bc4e7ebbf141d2fd9cde3dcd9758bc47f27af6cbaeb0f14ab6360e08c6",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Volumes: []corev1.Volume{
-									{
-										Name: "ta-internal",
-										VolumeSource: corev1.VolumeSource{
-											ConfigMap: &corev1.ConfigMapVolumeSource{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "test-targetallocator",
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "targetallocator.yaml",
-														Path: "targetallocator.yaml",
-													},
-												},
-											},
-										},
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "ta-container",
-										Image: "default-ta-allocator",
-										Env: []corev1.EnvVar{
-											{
-												Name: "OTELCOL_NAMESPACE",
-												ValueFrom: &corev1.EnvVarSource{
-													FieldRef: &corev1.ObjectFieldSelector{
-														FieldPath: "metadata.namespace",
-													},
-												},
-											},
-											{
-												Name: "GOMEMLIMIT",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.memory",
-														ContainerName: "ta-container",
-													},
-												},
-											},
-											{
-												Name: "GOMAXPROCS",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.cpu",
-														ContainerName: "ta-container",
-													},
-												},
-											},
-										},
-										Ports: []corev1.ContainerPort{
-											{
-												Name:          "http",
-												HostPort:      0,
-												ContainerPort: 8080,
-												Protocol:      "TCP",
-											},
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "ta-internal",
-												MountPath: "/conf",
-											},
-										},
-										LivenessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/livez",
-													Port: intstr.FromInt(8080),
-												},
-											},
-										},
-										ReadinessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/readyz",
-													Port: intstr.FromInt(8080),
-												},
-											},
-										},
-									},
-								},
-								DNSPolicy:             "ClusterFirst",
-								DNSConfig:             &corev1.PodDNSConfig{},
-								ShareProcessNamespace: ptr.To(false),
-								ServiceAccountName:    "test-targetallocator",
-							},
-						},
-					},
-				},
-				&corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "targetallocation",
-								Port: 80,
-								TargetPort: intstr.IntOrString{
-									Type:   1,
-									StrVal: "http",
-								},
-							},
-						},
-						Selector: taSelectorLabels,
-					},
-				},
-				&policyV1.PodDisruptionBudget{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{
-							"opentelemetry-targetallocator-config/hash": "a81383bc4e7ebbf141d2fd9cde3dcd9758bc47f27af6cbaeb0f14ab6360e08c6",
-						},
-					},
-					Spec: policyV1.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-								"app.kubernetes.io/instance":   "test.test",
-								"app.kubernetes.io/managed-by": "opentelemetry-operator",
-								"app.kubernetes.io/name":       "test-targetallocator",
-								"app.kubernetes.io/part-of":    "opentelemetry",
-							},
-						},
-						MaxUnavailable: &intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: 1,
-						},
-					},
-				},
-			},
-			wantErr: false,
+			wantFile: "build_target_allocator_collector_present.yaml",
 			cfg: config.Config{
 				CollectorImage:                "default-collector",
 				TargetAllocatorImage:          "default-ta-allocator",
@@ -2844,52 +545,50 @@ prometheus_cr:
 		},
 		{
 			name: "mtls",
-			args: args{
-				instance: v1alpha1.TargetAllocator{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-						Labels:    nil,
-					},
-					Spec: v1alpha1.TargetAllocatorSpec{
-						FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
-						PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-							Enabled: true,
-						},
+			instance: v1alpha1.TargetAllocator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Labels:    nil,
+				},
+				Spec: v1alpha1.TargetAllocatorSpec{
+					FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
+					PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
+						Enabled: true,
 					},
 				},
-				collector: &v1beta1.OpenTelemetryCollector{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-					},
-					Spec: v1beta1.OpenTelemetryCollectorSpec{
-						Config: v1beta1.Config{
-							Receivers: v1beta1.AnyConfig{
-								Object: map[string]any{
-									"prometheus": map[string]any{
-										"config": map[string]any{
-											"scrape_configs": []any{
-												map[string]any{
-													"job_name": "example",
-													"metric_relabel_configs": []any{
-														map[string]any{
-															"replacement":   "$1_$2",
-															"source_labels": []any{"job"},
-															"target_label":  "job",
-														},
+			},
+			collector: &v1beta1.OpenTelemetryCollector{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					Config: v1beta1.Config{
+						Receivers: v1beta1.AnyConfig{
+							Object: map[string]any{
+								"prometheus": map[string]any{
+									"config": map[string]any{
+										"scrape_configs": []any{
+											map[string]any{
+												"job_name": "example",
+												"metric_relabel_configs": []any{
+													map[string]any{
+														"replacement":   "$1_$2",
+														"source_labels": []any{"job"},
+														"target_label":  "job",
 													},
-													"relabel_configs": []any{
-														map[string]any{
-															"replacement":   "my_service_$1",
-															"source_labels": []any{"__meta_service_id"},
-															"target_label":  "job",
-														},
-														map[string]any{
-															"replacement":   "$1",
-															"source_labels": []any{"__meta_service_name"},
-															"target_label":  "instance",
-														},
+												},
+												"relabel_configs": []any{
+													map[string]any{
+														"replacement":   "my_service_$1",
+														"source_labels": []any{"__meta_service_id"},
+														"target_label":  "job",
+													},
+													map[string]any{
+														"replacement":   "$1",
+														"source_labels": []any{"__meta_service_name"},
+														"target_label":  "instance",
 													},
 												},
 											},
@@ -2901,435 +600,7 @@ prometheus_cr:
 					},
 				},
 			},
-			want: []client.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Data: map[string]string{
-						"targetallocator.yaml": `allocation_strategy: consistent-hashing
-collector_selector:
-  matchlabels:
-    app.kubernetes.io/component: opentelemetry-collector
-    app.kubernetes.io/instance: test.test
-    app.kubernetes.io/managed-by: opentelemetry-operator
-    app.kubernetes.io/part-of: opentelemetry
-  matchexpressions: []
-config:
-  scrape_configs:
-  - job_name: example
-    metric_relabel_configs:
-    - replacement: $1_$2
-      source_labels:
-      - job
-      target_label: job
-    relabel_configs:
-    - replacement: my_service_$1
-      source_labels:
-      - __meta_service_id
-      target_label: job
-    - replacement: $1
-      source_labels:
-      - __meta_service_name
-      target_label: instance
-filter_strategy: relabel-config
-https:
-  ca_file_path: /tls/ca.crt
-  enabled: true
-  listen_addr: :8443
-  tls_cert_file_path: /tls/tls.crt
-  tls_key_file_path: /tls/tls.key
-prometheus_cr:
-  enabled: true
-  pod_monitor_namespace_selector: null
-  pod_monitor_selector: null
-  probe_namespace_selector: null
-  probe_selector: null
-  scrape_config_namespace_selector: null
-  scrape_config_selector: null
-  service_monitor_namespace_selector: null
-  service_monitor_selector: null
-`,
-					},
-				},
-				&appsv1.Deployment{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Spec: appsv1.DeploymentSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: taSelectorLabels,
-						},
-						Template: corev1.PodTemplateSpec{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels: map[string]string{
-									"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-									"app.kubernetes.io/instance":   "test.test",
-									"app.kubernetes.io/managed-by": "opentelemetry-operator",
-									"app.kubernetes.io/name":       "test-targetallocator",
-									"app.kubernetes.io/part-of":    "opentelemetry",
-									"app.kubernetes.io/version":    "latest",
-								},
-								Annotations: map[string]string{
-									"opentelemetry-targetallocator-config/hash": "02ef308f21c5312c388985bd8ca91246d1df7a3a5031135ec176f3c975e2fa37",
-								},
-							},
-							Spec: corev1.PodSpec{
-								Volumes: []corev1.Volume{
-									{
-										Name: "ta-internal",
-										VolumeSource: corev1.VolumeSource{
-											ConfigMap: &corev1.ConfigMapVolumeSource{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "test-targetallocator",
-												},
-												Items: []corev1.KeyToPath{
-													{
-														Key:  "targetallocator.yaml",
-														Path: "targetallocator.yaml",
-													},
-												},
-											},
-										},
-									},
-									{
-										Name: "test-ta-server-cert",
-										VolumeSource: corev1.VolumeSource{
-											Secret: &corev1.SecretVolumeSource{
-												SecretName: "test-ta-server-cert",
-											},
-										},
-									},
-								},
-								Containers: []corev1.Container{
-									{
-										Name:  "ta-container",
-										Image: "default-ta-allocator",
-										Env: []corev1.EnvVar{
-											{
-												Name: "OTELCOL_NAMESPACE",
-												ValueFrom: &corev1.EnvVarSource{
-													FieldRef: &corev1.ObjectFieldSelector{
-														FieldPath: "metadata.namespace",
-													},
-												},
-											},
-											{
-												Name: "GOMEMLIMIT",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.memory",
-														ContainerName: "ta-container",
-													},
-												},
-											},
-											{
-												Name: "GOMAXPROCS",
-												ValueFrom: &corev1.EnvVarSource{
-													ResourceFieldRef: &corev1.ResourceFieldSelector{
-														Resource:      "limits.cpu",
-														ContainerName: "ta-container",
-													},
-												},
-											},
-										},
-										Ports: []corev1.ContainerPort{
-											{
-												Name:          "http",
-												HostPort:      0,
-												ContainerPort: 8080,
-												Protocol:      "TCP",
-											},
-											{
-												Name:          "https",
-												HostPort:      0,
-												ContainerPort: 8443,
-												Protocol:      "TCP",
-											},
-										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "ta-internal",
-												MountPath: "/conf",
-											},
-											{
-												Name:      "test-ta-server-cert",
-												MountPath: "/tls",
-											},
-										},
-										LivenessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/livez",
-													Port: intstr.FromInt(8080),
-												},
-											},
-										},
-										ReadinessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/readyz",
-													Port: intstr.FromInt(8080),
-												},
-											},
-										},
-									},
-								},
-								DNSPolicy:             "ClusterFirst",
-								DNSConfig:             &corev1.PodDNSConfig{},
-								ShareProcessNamespace: ptr.To(false),
-								ServiceAccountName:    "test-targetallocator",
-							},
-						},
-					},
-				},
-				&corev1.ServiceAccount{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-					},
-				},
-				&corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: nil,
-					},
-					Spec: corev1.ServiceSpec{
-						Ports: []corev1.ServicePort{
-							{
-								Name: "targetallocation",
-								Port: 80,
-								TargetPort: intstr.IntOrString{
-									Type:   1,
-									StrVal: "http",
-								},
-							},
-							{
-								Name: "targetallocation-https",
-								Port: 443,
-								TargetPort: intstr.IntOrString{
-									Type:   1,
-									StrVal: "https",
-								},
-							},
-						},
-						Selector: taSelectorLabels,
-					},
-				},
-				&policyV1.PodDisruptionBudget{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-targetallocator",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-targetallocator",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-						Annotations: map[string]string{
-							"opentelemetry-targetallocator-config/hash": "02ef308f21c5312c388985bd8ca91246d1df7a3a5031135ec176f3c975e2fa37",
-						},
-					},
-					Spec: policyV1.PodDisruptionBudgetSpec{
-						Selector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-								"app.kubernetes.io/instance":   "test.test",
-								"app.kubernetes.io/managed-by": "opentelemetry-operator",
-								"app.kubernetes.io/name":       "test-targetallocator",
-								"app.kubernetes.io/part-of":    "opentelemetry",
-							},
-						},
-						MaxUnavailable: &intstr.IntOrString{
-							Type:   intstr.Int,
-							IntVal: 1,
-						},
-					},
-				},
-				&cmv1.Issuer{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-self-signed-issuer",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-self-signed-issuer",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-					},
-					Spec: cmv1.IssuerSpec{
-						IssuerConfig: cmv1.IssuerConfig{
-							SelfSigned: &cmv1.SelfSignedIssuer{
-								CRLDistributionPoints: nil,
-							},
-						},
-					},
-				},
-				&cmv1.Certificate{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-ca-cert",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-ca-cert",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-					},
-					Spec: cmv1.CertificateSpec{
-						Subject: &cmv1.X509Subject{
-							OrganizationalUnits: []string{"opentelemetry-operator"},
-						},
-						CommonName:  "test-ca-cert",
-						Duration:    &metav1.Duration{Duration: targetallocator.CACertDuration},
-						RenewBefore: &metav1.Duration{Duration: targetallocator.CACertRenewBefore},
-						IsCA:        true,
-						SecretName:  "test-ca-cert",
-						IssuerRef: cmmetav1.IssuerReference{
-							Name: "test-self-signed-issuer",
-							Kind: "Issuer",
-						},
-					},
-				},
-				&cmv1.Issuer{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-ca-issuer",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-ca-issuer",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-					},
-					Spec: cmv1.IssuerSpec{
-						IssuerConfig: cmv1.IssuerConfig{
-							CA: &cmv1.CAIssuer{
-								SecretName: "test-ca-cert",
-							},
-						},
-					},
-				},
-				&cmv1.Certificate{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-ta-server-cert",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-ta-server-cert",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-					},
-					Spec: cmv1.CertificateSpec{
-						Subject: &cmv1.X509Subject{
-							OrganizationalUnits: []string{"opentelemetry-operator"},
-						},
-						Duration: &metav1.Duration{Duration: targetallocator.ClientCertDuration},
-						DNSNames: []string{
-							"test-targetallocator",
-							"test-targetallocator.test.svc",
-							"test-targetallocator.test.svc.cluster.local",
-						},
-						SecretName: "test-ta-server-cert",
-						IssuerRef: cmmetav1.IssuerReference{
-							Name: "test-ca-issuer",
-							Kind: "Issuer",
-						},
-						Usages: []cmv1.KeyUsage{
-							"client auth",
-							"server auth",
-						},
-					},
-				},
-				&cmv1.Certificate{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-ta-client-cert",
-						Namespace: "test",
-						Labels: map[string]string{
-							"app.kubernetes.io/component":  "opentelemetry-targetallocator",
-							"app.kubernetes.io/instance":   "test.test",
-							"app.kubernetes.io/managed-by": "opentelemetry-operator",
-							"app.kubernetes.io/name":       "test-ta-client-cert",
-							"app.kubernetes.io/part-of":    "opentelemetry",
-							"app.kubernetes.io/version":    "latest",
-						},
-					},
-					Spec: cmv1.CertificateSpec{
-						Subject: &cmv1.X509Subject{
-							OrganizationalUnits: []string{"opentelemetry-operator"},
-						},
-						Duration: &metav1.Duration{Duration: targetallocator.ClientCertDuration},
-						DNSNames: []string{
-							"test-targetallocator",
-							"test-targetallocator.test.svc",
-							"test-targetallocator.test.svc.cluster.local",
-						},
-						SecretName: "test-ta-client-cert",
-						IssuerRef: cmmetav1.IssuerReference{
-							Name: "test-ca-issuer",
-							Kind: "Issuer",
-						},
-						Usages: []cmv1.KeyUsage{
-							"client auth",
-							"server auth",
-						},
-					},
-				},
-			},
-			wantErr: false,
+			wantFile: "build_target_allocator_mtls.yaml",
 			cfg: config.Config{
 				CertManagerAvailability:       certmanager.Available,
 				CollectorImage:                "default-collector",
@@ -3345,8 +616,8 @@ prometheus_cr:
 			params := targetallocator.Params{
 				Log:             logr.Discard(),
 				Config:          tt.cfg,
-				TargetAllocator: tt.args.instance,
-				Collector:       tt.args.collector,
+				TargetAllocator: tt.instance,
+				Collector:       tt.collector,
 			}
 			registry := colfeaturegate.GlobalRegistry()
 			for _, gate := range tt.featuregates {
@@ -3366,9 +637,7 @@ prometheus_cr:
 				t.Errorf("BuildAll() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			require.Equal(t, tt.want[0], got[0])
-			require.Equal(t, tt.want[1], got[1])
-			require.Equal(t, tt.want, got)
+			golden.Assert(t, renderObjects(t, got), tt.wantFile)
 		})
 	}
 }

--- a/internal/controllers/builder_test.go
+++ b/internal/controllers/builder_test.go
@@ -31,7 +31,9 @@ import (
 // from testScheme when known, so the generated fixtures stay readable even
 // though the builder itself does not set apiVersion/kind on returned objects.
 // Types not registered in testScheme (e.g. cert-manager) are emitted without
-// apiVersion/kind.
+// apiVersion/kind. The top-level "status" field is stripped — the builder
+// must never set status, and zero-value status structs (Deployment, etc.)
+// would otherwise pollute the golden files.
 func renderObjects(t *testing.T, objs []client.Object) string {
 	t.Helper()
 	var buf bytes.Buffer
@@ -44,7 +46,12 @@ func renderObjects(t *testing.T, objs []client.Object) string {
 				obj.GetObjectKind().SetGroupVersionKind(gvks[0])
 			}
 		}
-		out, err := sigsyaml.Marshal(obj)
+		raw, err := sigsyaml.Marshal(obj)
+		require.NoError(t, err)
+		var m map[string]any
+		require.NoError(t, sigsyaml.Unmarshal(raw, &m))
+		delete(m, "status")
+		out, err := sigsyaml.Marshal(m)
 		require.NoError(t, err)
 		buf.Write(out)
 	}

--- a/internal/controllers/builder_test.go
+++ b/internal/controllers/builder_test.go
@@ -5,14 +5,14 @@ package controllers
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-logr/logr"
-	go_yaml "github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
 	colfeaturegate "go.opentelemetry.io/collector/featuregate"
 	"gotest.tools/v3/golden"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	sigsyaml "sigs.k8s.io/yaml"
 
@@ -51,96 +51,38 @@ func renderObjects(t *testing.T, objs []client.Object) string {
 	return buf.String()
 }
 
-func TestBuildCollector(t *testing.T) {
-	goodConfigYaml := `receivers:
-  examplereceiver:
-    endpoint: "0.0.0.0:12345"
-exporters:
-  debug:
-service:
-  pipelines:
-    metrics:
-      receivers: [examplereceiver]
-      exporters: [debug]
-`
-
-	goodConfig := v1beta1.Config{}
-	err := go_yaml.Unmarshal([]byte(goodConfigYaml), &goodConfig)
+// loadInput reads a YAML fixture from testdata/ and unmarshals it into T.
+// Used to keep test inputs out of Go source where possible.
+func loadInput[T any](t *testing.T, file string) T {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", file))
 	require.NoError(t, err)
+	var obj T
+	require.NoError(t, sigsyaml.Unmarshal(data, &obj))
+	return obj
+}
 
-	one := int32(1)
-	trueVal := true
-
+func TestBuildCollector(t *testing.T) {
 	tests := []struct {
-		name     string
-		instance v1beta1.OpenTelemetryCollector
-		wantFile string
-		wantErr  bool
+		name      string
+		inputFile string
+		wantFile  string
+		wantErr   bool
 	}{
 		{
-			name: "base case",
-			instance: v1beta1.OpenTelemetryCollector{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-				},
-				Spec: v1beta1.OpenTelemetryCollectorSpec{
-					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
-						Image:    "test",
-						Replicas: &one,
-					},
-					Mode:   "deployment",
-					Config: goodConfig,
-					NetworkPolicy: v1beta1.NetworkPolicy{
-						Enabled: &trueVal,
-					},
-				},
-			},
-			wantFile: "build_collector_base.yaml",
+			name:      "base case",
+			inputFile: "build_collector_base.input.yaml",
+			wantFile:  "build_collector_base.yaml",
 		},
 		{
-			name: "ingress",
-			instance: v1beta1.OpenTelemetryCollector{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-				},
-				Spec: v1beta1.OpenTelemetryCollectorSpec{
-					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
-						Image:    "test",
-						Replicas: &one,
-					},
-					Mode: "deployment",
-					Ingress: v1beta1.Ingress{
-						Type:     v1beta1.IngressTypeIngress,
-						Hostname: "example.com",
-						Annotations: map[string]string{
-							"something": "true",
-						},
-					},
-					Config: goodConfig,
-				},
-			},
-			wantFile: "build_collector_ingress.yaml",
+			name:      "ingress",
+			inputFile: "build_collector_ingress.input.yaml",
+			wantFile:  "build_collector_ingress.yaml",
 		},
 		{
-			name: "specified service account case",
-			instance: v1beta1.OpenTelemetryCollector{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-				},
-				Spec: v1beta1.OpenTelemetryCollectorSpec{
-					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
-						Image:          "test",
-						Replicas:       &one,
-						ServiceAccount: "my-special-sa",
-					},
-					Mode:   "deployment",
-					Config: goodConfig,
-				},
-			},
-			wantFile: "build_collector_service_account.yaml",
+			name:      "specified service account case",
+			inputFile: "build_collector_service_account.input.yaml",
+			wantFile:  "build_collector_service_account.yaml",
 		},
 	}
 	for _, tt := range tests {
@@ -153,7 +95,7 @@ service:
 			params := manifests.Params{
 				Log:     logr.Discard(),
 				Config:  cfg,
-				OtelCol: tt.instance,
+				OtelCol: loadInput[v1beta1.OpenTelemetryCollector](t, tt.inputFile),
 			}
 			got, err := BuildCollector(params)
 			if (err != nil) != tt.wantErr {
@@ -166,42 +108,16 @@ service:
 }
 
 func TestBuildAll_OpAMPBridge(t *testing.T) {
-	one := int32(1)
-
 	tests := []struct {
-		name     string
-		instance v1alpha1.OpAMPBridge
-		wantFile string
-		wantErr  bool
+		name      string
+		inputFile string
+		wantFile  string
+		wantErr   bool
 	}{
 		{
-			name: "base case",
-			instance: v1alpha1.OpAMPBridge{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-				},
-				Spec: v1alpha1.OpAMPBridgeSpec{
-					Replicas: &one,
-					Image:    "test",
-					Endpoint: "ws://opamp-server:4320/v1/opamp",
-					Capabilities: map[v1alpha1.OpAMPBridgeCapability]bool{
-						v1alpha1.OpAMPBridgeCapabilityReportsStatus:                  true,
-						v1alpha1.OpAMPBridgeCapabilityAcceptsRemoteConfig:            true,
-						v1alpha1.OpAMPBridgeCapabilityReportsEffectiveConfig:         true,
-						v1alpha1.OpAMPBridgeCapabilityReportsOwnTraces:               true,
-						v1alpha1.OpAMPBridgeCapabilityReportsOwnMetrics:              true,
-						v1alpha1.OpAMPBridgeCapabilityReportsOwnLogs:                 true,
-						v1alpha1.OpAMPBridgeCapabilityAcceptsOpAMPConnectionSettings: true,
-						v1alpha1.OpAMPBridgeCapabilityAcceptsOtherConnectionSettings: true,
-						v1alpha1.OpAMPBridgeCapabilityAcceptsRestartCommand:          true,
-						v1alpha1.OpAMPBridgeCapabilityReportsHealth:                  true,
-						v1alpha1.OpAMPBridgeCapabilityReportsRemoteConfig:            true,
-					},
-					ComponentsAllowed: map[string][]string{"receivers": {"otlp"}, "processors": {"memory_limiter"}, "exporters": {"debug"}},
-				},
-			},
-			wantFile: "build_opamp_bridge_base.yaml",
+			name:      "base case",
+			inputFile: "build_opamp_bridge_base.input.yaml",
+			wantFile:  "build_opamp_bridge_base.yaml",
 		},
 	}
 	for _, tt := range tests {
@@ -218,7 +134,7 @@ func TestBuildAll_OpAMPBridge(t *testing.T) {
 				Log:    logr.Discard(),
 				Config: cfg,
 			})
-			params := reconciler.getParams(tt.instance)
+			params := reconciler.getParams(loadInput[v1alpha1.OpAMPBridge](t, tt.inputFile))
 			got, err := BuildOpAMPBridge(params)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BuildAll() error = %v, wantErr %v", err, tt.wantErr)
@@ -230,99 +146,21 @@ func TestBuildAll_OpAMPBridge(t *testing.T) {
 }
 
 func TestBuildCollectorTargetAllocatorCR(t *testing.T) {
-	goodConfigYaml := `
-receivers:
-  prometheus:
-    config:
-      scrape_configs:
-      - job_name: 'example'
-        relabel_configs:
-        - source_labels: ['__meta_service_id']
-          target_label: 'job'
-          replacement: 'my_service_$$1'
-        - source_labels: ['__meta_service_name']
-          target_label: 'instance'
-          replacement: '$1'
-        metric_relabel_configs:
-        - source_labels: ['job']
-          target_label: 'job'
-          replacement: '$$1_$2'
-exporters:
-  debug:
-service:
-  pipelines:
-    metrics:
-      receivers: [prometheus]
-      exporters: [debug]
-`
-
-	goodConfig := v1beta1.Config{}
-	err := go_yaml.Unmarshal([]byte(goodConfigYaml), &goodConfig)
-	require.NoError(t, err)
-
-	one := int32(1)
-
 	tests := []struct {
 		name         string
-		instance     v1beta1.OpenTelemetryCollector
+		inputFile    string
 		wantFile     string
 		featuregates []*colfeaturegate.Gate
 		wantErr      bool
 	}{
 		{
-			name: "base case",
-			instance: v1beta1.OpenTelemetryCollector{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-				},
-				Spec: v1beta1.OpenTelemetryCollectorSpec{
-					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
-						Image:    "test",
-						Replicas: &one,
-					},
-					Mode:   "statefulset",
-					Config: goodConfig,
-					TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-						Enabled:            true,
-						FilterStrategy:     "relabel-config",
-						AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
-						PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-							Enabled: true,
-						},
-					},
-				},
-			},
-			wantFile: "build_collector_ta_cr_base.yaml",
+			name:      "base case",
+			inputFile: "build_collector_ta_cr_base.input.yaml",
+			wantFile:  "build_collector_ta_cr_base.yaml",
 		},
 		{
-			name: "enable metrics case",
-			instance: v1beta1.OpenTelemetryCollector{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-				},
-				Spec: v1beta1.OpenTelemetryCollectorSpec{
-					OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
-						Image:    "test",
-						Replicas: &one,
-					},
-					Mode:   "statefulset",
-					Config: goodConfig,
-					TargetAllocator: v1beta1.TargetAllocatorEmbedded{
-						Enabled: true,
-						PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-							Enabled: true,
-						},
-						FilterStrategy: "relabel-config",
-						Observability: v1beta1.ObservabilitySpec{
-							Metrics: v1beta1.MetricsConfigSpec{
-								EnableMetrics: true,
-							},
-						},
-					},
-				},
-			},
+			name:         "enable metrics case",
+			inputFile:    "build_collector_ta_cr_enable_metrics.input.yaml",
 			wantFile:     "build_collector_ta_cr_enable_metrics.yaml",
 			featuregates: []*colfeaturegate.Gate{},
 		},
@@ -338,15 +176,13 @@ service:
 			params := manifests.Params{
 				Log:     logr.Discard(),
 				Config:  cfg,
-				OtelCol: tt.instance,
+				OtelCol: loadInput[v1beta1.OpenTelemetryCollector](t, tt.inputFile),
 			}
 			targetAllocator, err := collector.TargetAllocator(params)
 			require.NoError(t, err)
 			params.TargetAllocator = targetAllocator
-			featuregates := []*colfeaturegate.Gate{}
-			featuregates = append(featuregates, tt.featuregates...)
 			registry := colfeaturegate.GlobalRegistry()
-			for _, gate := range featuregates {
+			for _, gate := range tt.featuregates {
 				current := gate.IsEnabled()
 				require.False(t, current, "only enable gates which are disabled by default")
 				if setErr := registry.Set(gate.ID(), true); setErr != nil {
@@ -369,238 +205,46 @@ service:
 }
 
 func TestBuildTargetAllocator(t *testing.T) {
+	defaultCfg := config.Config{
+		CollectorImage:                "default-collector",
+		TargetAllocatorImage:          "default-ta-allocator",
+		TargetAllocatorConfigMapEntry: "targetallocator.yaml",
+		CollectorConfigMapEntry:       "collector.yaml",
+	}
+
 	tests := []struct {
-		name         string
-		instance     v1alpha1.TargetAllocator
-		collector    *v1beta1.OpenTelemetryCollector
-		wantFile     string
-		featuregates []*colfeaturegate.Gate
-		wantErr      bool
-		cfg          config.Config
+		name          string
+		inputFile     string
+		collectorFile string
+		wantFile      string
+		featuregates  []*colfeaturegate.Gate
+		wantErr       bool
+		cfg           config.Config
 	}{
 		{
-			name: "base case",
-			instance: v1alpha1.TargetAllocator{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-					Labels:    nil,
-				},
-				Spec: v1alpha1.TargetAllocatorSpec{
-					FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
-					ScrapeConfigs: []v1beta1.AnyConfig{
-						{Object: map[string]any{
-							"job_name": "example",
-							"metric_relabel_configs": []any{
-								map[string]any{
-									"replacement":   "$1_$2",
-									"source_labels": []any{"job"},
-									"target_label":  "job",
-								},
-							},
-							"relabel_configs": []any{
-								map[string]any{
-									"replacement":   "my_service_$1",
-									"source_labels": []any{"__meta_service_id"},
-									"target_label":  "job",
-								},
-								map[string]any{
-									"replacement":   "$1",
-									"source_labels": []any{"__meta_service_name"},
-									"target_label":  "instance",
-								},
-							},
-						}},
-					},
-					PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-						Enabled: true,
-					},
-				},
-			},
-			wantFile: "build_target_allocator_base.yaml",
-			cfg: config.Config{
-				CollectorImage:                "default-collector",
-				TargetAllocatorImage:          "default-ta-allocator",
-				TargetAllocatorConfigMapEntry: "targetallocator.yaml",
-				CollectorConfigMapEntry:       "collector.yaml",
-			},
+			name:      "base case",
+			inputFile: "build_target_allocator_base.input.yaml",
+			wantFile:  "build_target_allocator_base.yaml",
+			cfg:       defaultCfg,
 		},
 		{
-			name: "enable metrics case",
-			instance: v1alpha1.TargetAllocator{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-					Labels:    nil,
-				},
-				Spec: v1alpha1.TargetAllocatorSpec{
-					FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
-					ScrapeConfigs: []v1beta1.AnyConfig{
-						{Object: map[string]any{
-							"job_name": "example",
-							"metric_relabel_configs": []any{
-								map[string]any{
-									"replacement":   "$1_$2",
-									"source_labels": []any{"job"},
-									"target_label":  "job",
-								},
-							},
-							"relabel_configs": []any{
-								map[string]any{
-									"replacement":   "my_service_$1",
-									"source_labels": []any{"__meta_service_id"},
-									"target_label":  "job",
-								},
-								map[string]any{
-									"replacement":   "$1",
-									"source_labels": []any{"__meta_service_name"},
-									"target_label":  "instance",
-								},
-							},
-						}},
-					},
-					PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-						Enabled: true,
-					},
-					AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
-					Observability: v1beta1.ObservabilitySpec{
-						Metrics: v1beta1.MetricsConfigSpec{
-							EnableMetrics: true,
-						},
-					},
-				},
-			},
-			wantFile: "build_target_allocator_enable_metrics.yaml",
-			cfg: config.Config{
-				CollectorImage:                "default-collector",
-				TargetAllocatorImage:          "default-ta-allocator",
-				TargetAllocatorConfigMapEntry: "targetallocator.yaml",
-				CollectorConfigMapEntry:       "collector.yaml",
-			},
+			name:      "enable metrics case",
+			inputFile: "build_target_allocator_enable_metrics.input.yaml",
+			wantFile:  "build_target_allocator_enable_metrics.yaml",
+			cfg:       defaultCfg,
 		},
 		{
-			name: "collector present",
-			instance: v1alpha1.TargetAllocator{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-					Labels:    nil,
-				},
-				Spec: v1alpha1.TargetAllocatorSpec{
-					FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
-					PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-						Enabled: true,
-					},
-				},
-			},
-			collector: &v1beta1.OpenTelemetryCollector{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-				},
-				Spec: v1beta1.OpenTelemetryCollectorSpec{
-					Config: v1beta1.Config{
-						Receivers: v1beta1.AnyConfig{
-							Object: map[string]any{
-								"prometheus": map[string]any{
-									"config": map[string]any{
-										"scrape_configs": []any{
-											map[string]any{
-												"job_name": "example",
-												"metric_relabel_configs": []any{
-													map[string]any{
-														"replacement":   "$1_$2",
-														"source_labels": []any{"job"},
-														"target_label":  "job",
-													},
-												},
-												"relabel_configs": []any{
-													map[string]any{
-														"replacement":   "my_service_$1",
-														"source_labels": []any{"__meta_service_id"},
-														"target_label":  "job",
-													},
-													map[string]any{
-														"replacement":   "$1",
-														"source_labels": []any{"__meta_service_name"},
-														"target_label":  "instance",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantFile: "build_target_allocator_collector_present.yaml",
-			cfg: config.Config{
-				CollectorImage:                "default-collector",
-				TargetAllocatorImage:          "default-ta-allocator",
-				TargetAllocatorConfigMapEntry: "targetallocator.yaml",
-				CollectorConfigMapEntry:       "collector.yaml",
-			},
+			name:          "collector present",
+			inputFile:     "build_target_allocator_minimal.input.yaml",
+			collectorFile: "build_target_allocator_collector.input.yaml",
+			wantFile:      "build_target_allocator_collector_present.yaml",
+			cfg:           defaultCfg,
 		},
 		{
-			name: "mtls",
-			instance: v1alpha1.TargetAllocator{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-					Labels:    nil,
-				},
-				Spec: v1alpha1.TargetAllocatorSpec{
-					FilterStrategy: v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
-					PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
-						Enabled: true,
-					},
-				},
-			},
-			collector: &v1beta1.OpenTelemetryCollector{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "test",
-				},
-				Spec: v1beta1.OpenTelemetryCollectorSpec{
-					Config: v1beta1.Config{
-						Receivers: v1beta1.AnyConfig{
-							Object: map[string]any{
-								"prometheus": map[string]any{
-									"config": map[string]any{
-										"scrape_configs": []any{
-											map[string]any{
-												"job_name": "example",
-												"metric_relabel_configs": []any{
-													map[string]any{
-														"replacement":   "$1_$2",
-														"source_labels": []any{"job"},
-														"target_label":  "job",
-													},
-												},
-												"relabel_configs": []any{
-													map[string]any{
-														"replacement":   "my_service_$1",
-														"source_labels": []any{"__meta_service_id"},
-														"target_label":  "job",
-													},
-													map[string]any{
-														"replacement":   "$1",
-														"source_labels": []any{"__meta_service_name"},
-														"target_label":  "instance",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantFile: "build_target_allocator_mtls.yaml",
+			name:          "mtls",
+			inputFile:     "build_target_allocator_minimal.input.yaml",
+			collectorFile: "build_target_allocator_collector.input.yaml",
+			wantFile:      "build_target_allocator_mtls.yaml",
 			cfg: config.Config{
 				CertManagerAvailability:       certmanager.Available,
 				CollectorImage:                "default-collector",
@@ -613,11 +257,16 @@ func TestBuildTargetAllocator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var collector *v1beta1.OpenTelemetryCollector
+			if tt.collectorFile != "" {
+				c := loadInput[v1beta1.OpenTelemetryCollector](t, tt.collectorFile)
+				collector = &c
+			}
 			params := targetallocator.Params{
 				Log:             logr.Discard(),
 				Config:          tt.cfg,
-				TargetAllocator: tt.instance,
-				Collector:       tt.collector,
+				TargetAllocator: loadInput[v1alpha1.TargetAllocator](t, tt.inputFile),
+				Collector:       collector,
 			}
 			registry := colfeaturegate.GlobalRegistry()
 			for _, gate := range tt.featuregates {

--- a/internal/controllers/targetallocator_reconciler_test.go
+++ b/internal/controllers/targetallocator_reconciler_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
@@ -38,6 +39,7 @@ func init() {
 	utilruntime.Must(routev1.AddToScheme(testScheme))
 	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
 	utilruntime.Must(v1beta1.AddToScheme(testScheme))
+	utilruntime.Must(cmv1.AddToScheme(testScheme))
 }
 
 func TestTargetAllocatorReconciler_GetCollector(t *testing.T) {

--- a/internal/controllers/testdata/build_collector_base.input.yaml
+++ b/internal/controllers/testdata/build_collector_base.input.yaml
@@ -1,0 +1,20 @@
+metadata:
+  name: test
+  namespace: test
+spec:
+  image: test
+  replicas: 1
+  mode: deployment
+  networkPolicy:
+    enabled: true
+  config:
+    receivers:
+      examplereceiver:
+        endpoint: "0.0.0.0:12345"
+    exporters:
+      debug:
+    service:
+      pipelines:
+        metrics:
+          receivers: [examplereceiver]
+          exporters: [debug]

--- a/internal/controllers/testdata/build_collector_base.yaml
+++ b/internal/controllers/testdata/build_collector_base.yaml
@@ -77,7 +77,6 @@ spec:
             path: collector.yaml
           name: test-collector-2d266e55
         name: otc-internal
-status: {}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -99,11 +98,6 @@ spec:
       app.kubernetes.io/instance: test.test
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/part-of: opentelemetry
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 ---
 apiVersion: v1
 data:
@@ -169,8 +163,6 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: v1
 kind: Service
@@ -200,8 +192,6 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: v1
 kind: Service
@@ -227,8 +217,6 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/internal/controllers/testdata/build_collector_base.yaml
+++ b/internal/controllers/testdata/build_collector_base.yaml
@@ -1,0 +1,259 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        opentelemetry-operator-config/sha256: 2d266e55025628659355f1271b689d6fb53648ef6cd5595831f5835d18e59a25
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: test-collector
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - args:
+        - --config=/conf/collector.yaml
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: otc-container
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: otc-container
+              divisor: "0"
+              resource: limits.cpu
+        image: test
+        name: otc-container
+        ports:
+        - containerPort: 12345
+          name: examplereceiver
+        - containerPort: 8888
+          name: metrics
+          protocol: TCP
+        resources: {}
+        volumeMounts:
+        - mountPath: /conf
+          name: otc-internal
+      dnsConfig: {}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: test-collector
+      shareProcessNamespace: false
+      volumes:
+      - configMap:
+          items:
+          - key: collector.yaml
+            path: collector.yaml
+          name: test-collector-2d266e55
+        name: otc-internal
+status: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---
+apiVersion: v1
+data:
+  collector.yaml: |
+    receivers:
+      examplereceiver:
+        endpoint: 0.0.0.0:12345
+    exporters:
+      debug: null
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - debug
+          receivers:
+            - examplereceiver
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector-2d266e55
+  namespace: test
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+    operator.opentelemetry.io/collector-service-type: base
+  name: test-collector
+  namespace: test
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: examplereceiver
+    port: 12345
+    targetPort: 0
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: test-collector-headless-tls
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+    operator.opentelemetry.io/collector-headless-service: Exists
+    operator.opentelemetry.io/collector-service-type: headless
+  name: test-collector-headless
+  namespace: test
+spec:
+  clusterIP: None
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: examplereceiver
+    port: 12345
+    targetPort: 0
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector-monitoring
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+    operator.opentelemetry.io/collector-monitoring-service: Exists
+    operator.opentelemetry.io/collector-service-type: monitoring
+  name: test-collector-monitoring
+  namespace: test
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    targetPort: 0
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector-networkpolicy
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector-networkpolicy
+  namespace: test
+spec:
+  ingress:
+  - ports:
+    - port: 12345
+      protocol: TCP
+    - port: 8888
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+  policyTypes:
+  - Ingress

--- a/internal/controllers/testdata/build_collector_ingress.input.yaml
+++ b/internal/controllers/testdata/build_collector_ingress.input.yaml
@@ -1,0 +1,23 @@
+metadata:
+  name: test
+  namespace: test
+spec:
+  image: test
+  replicas: 1
+  mode: deployment
+  ingress:
+    type: ingress
+    hostname: example.com
+    annotations:
+      something: "true"
+  config:
+    receivers:
+      examplereceiver:
+        endpoint: "0.0.0.0:12345"
+    exporters:
+      debug:
+    service:
+      pipelines:
+        metrics:
+          receivers: [examplereceiver]
+          exporters: [debug]

--- a/internal/controllers/testdata/build_collector_ingress.yaml
+++ b/internal/controllers/testdata/build_collector_ingress.yaml
@@ -77,7 +77,6 @@ spec:
             path: collector.yaml
           name: test-collector-2d266e55
         name: otc-internal
-status: {}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -99,11 +98,6 @@ spec:
       app.kubernetes.io/instance: test.test
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/part-of: opentelemetry
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 ---
 apiVersion: v1
 data:
@@ -169,8 +163,6 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: v1
 kind: Service
@@ -200,8 +192,6 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: v1
 kind: Service
@@ -227,8 +217,6 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -256,5 +244,3 @@ spec:
               name: examplereceiver
         path: /examplereceiver
         pathType: Prefix
-status:
-  loadBalancer: {}

--- a/internal/controllers/testdata/build_collector_ingress.yaml
+++ b/internal/controllers/testdata/build_collector_ingress.yaml
@@ -1,0 +1,260 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        opentelemetry-operator-config/sha256: 2d266e55025628659355f1271b689d6fb53648ef6cd5595831f5835d18e59a25
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: test-collector
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - args:
+        - --config=/conf/collector.yaml
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: otc-container
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: otc-container
+              divisor: "0"
+              resource: limits.cpu
+        image: test
+        name: otc-container
+        ports:
+        - containerPort: 12345
+          name: examplereceiver
+        - containerPort: 8888
+          name: metrics
+          protocol: TCP
+        resources: {}
+        volumeMounts:
+        - mountPath: /conf
+          name: otc-internal
+      dnsConfig: {}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: test-collector
+      shareProcessNamespace: false
+      volumes:
+      - configMap:
+          items:
+          - key: collector.yaml
+            path: collector.yaml
+          name: test-collector-2d266e55
+        name: otc-internal
+status: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---
+apiVersion: v1
+data:
+  collector.yaml: |
+    receivers:
+      examplereceiver:
+        endpoint: 0.0.0.0:12345
+    exporters:
+      debug: null
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - debug
+          receivers:
+            - examplereceiver
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector-2d266e55
+  namespace: test
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+    operator.opentelemetry.io/collector-service-type: base
+  name: test-collector
+  namespace: test
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: examplereceiver
+    port: 12345
+    targetPort: 0
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: test-collector-headless-tls
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+    operator.opentelemetry.io/collector-headless-service: Exists
+    operator.opentelemetry.io/collector-service-type: headless
+  name: test-collector-headless
+  namespace: test
+spec:
+  clusterIP: None
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: examplereceiver
+    port: 12345
+    targetPort: 0
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector-monitoring
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+    operator.opentelemetry.io/collector-monitoring-service: Exists
+    operator.opentelemetry.io/collector-service-type: monitoring
+  name: test-collector-monitoring
+  namespace: test
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    targetPort: 0
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    something: "true"
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-ingress
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-ingress
+  namespace: test
+spec:
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: test-collector
+            port:
+              name: examplereceiver
+        path: /examplereceiver
+        pathType: Prefix
+status:
+  loadBalancer: {}

--- a/internal/controllers/testdata/build_collector_service_account.input.yaml
+++ b/internal/controllers/testdata/build_collector_service_account.input.yaml
@@ -1,0 +1,19 @@
+metadata:
+  name: test
+  namespace: test
+spec:
+  image: test
+  replicas: 1
+  serviceAccount: my-special-sa
+  mode: deployment
+  config:
+    receivers:
+      examplereceiver:
+        endpoint: "0.0.0.0:12345"
+    exporters:
+      debug:
+    service:
+      pipelines:
+        metrics:
+          receivers: [examplereceiver]
+          exporters: [debug]

--- a/internal/controllers/testdata/build_collector_service_account.yaml
+++ b/internal/controllers/testdata/build_collector_service_account.yaml
@@ -77,7 +77,6 @@ spec:
             path: collector.yaml
           name: test-collector-2d266e55
         name: otc-internal
-status: {}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -99,11 +98,6 @@ spec:
       app.kubernetes.io/instance: test.test
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/part-of: opentelemetry
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 ---
 apiVersion: v1
 data:
@@ -156,8 +150,6 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: v1
 kind: Service
@@ -187,8 +179,6 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: v1
 kind: Service
@@ -214,5 +204,3 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}

--- a/internal/controllers/testdata/build_collector_service_account.yaml
+++ b/internal/controllers/testdata/build_collector_service_account.yaml
@@ -1,0 +1,218 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        opentelemetry-operator-config/sha256: 2d266e55025628659355f1271b689d6fb53648ef6cd5595831f5835d18e59a25
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: test-collector
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - args:
+        - --config=/conf/collector.yaml
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: otc-container
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: otc-container
+              divisor: "0"
+              resource: limits.cpu
+        image: test
+        name: otc-container
+        ports:
+        - containerPort: 12345
+          name: examplereceiver
+        - containerPort: 8888
+          name: metrics
+          protocol: TCP
+        resources: {}
+        volumeMounts:
+        - mountPath: /conf
+          name: otc-internal
+      dnsConfig: {}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: my-special-sa
+      shareProcessNamespace: false
+      volumes:
+      - configMap:
+          items:
+          - key: collector.yaml
+            path: collector.yaml
+          name: test-collector-2d266e55
+        name: otc-internal
+status: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---
+apiVersion: v1
+data:
+  collector.yaml: |
+    receivers:
+      examplereceiver:
+        endpoint: 0.0.0.0:12345
+    exporters:
+      debug: null
+    service:
+      pipelines:
+        metrics:
+          exporters:
+            - debug
+          receivers:
+            - examplereceiver
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector-2d266e55
+  namespace: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+    operator.opentelemetry.io/collector-service-type: base
+  name: test-collector
+  namespace: test
+spec:
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: examplereceiver
+    port: 12345
+    targetPort: 0
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: test-collector-headless-tls
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+    operator.opentelemetry.io/collector-headless-service: Exists
+    operator.opentelemetry.io/collector-service-type: headless
+  name: test-collector-headless
+  namespace: test
+spec:
+  clusterIP: None
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: examplereceiver
+    port: 12345
+    targetPort: 0
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector-monitoring
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+    operator.opentelemetry.io/collector-monitoring-service: Exists
+    operator.opentelemetry.io/collector-service-type: monitoring
+  name: test-collector-monitoring
+  namespace: test
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    targetPort: 0
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}

--- a/internal/controllers/testdata/build_collector_ta_cr_base.input.yaml
+++ b/internal/controllers/testdata/build_collector_ta_cr_base.input.yaml
@@ -1,0 +1,37 @@
+metadata:
+  name: test
+  namespace: test
+spec:
+  image: test
+  replicas: 1
+  mode: statefulset
+  targetAllocator:
+    enabled: true
+    filterStrategy: relabel-config
+    allocationStrategy: consistent-hashing
+    prometheusCR:
+      enabled: true
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: 'example'
+            relabel_configs:
+            - source_labels: ['__meta_service_id']
+              target_label: 'job'
+              replacement: 'my_service_$$1'
+            - source_labels: ['__meta_service_name']
+              target_label: 'instance'
+              replacement: '$1'
+            metric_relabel_configs:
+            - source_labels: ['job']
+              target_label: 'job'
+              replacement: '$$1_$2'
+    exporters:
+      debug:
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [debug]

--- a/internal/controllers/testdata/build_collector_ta_cr_base.yaml
+++ b/internal/controllers/testdata/build_collector_ta_cr_base.yaml
@@ -77,9 +77,6 @@ spec:
           name: test-collector-42773025
         name: otc-internal
   updateStrategy: {}
-status:
-  availableReplicas: 0
-  replicas: 0
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -101,11 +98,6 @@ spec:
       app.kubernetes.io/instance: test.test
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/part-of: opentelemetry
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 ---
 apiVersion: v1
 data:
@@ -175,8 +167,6 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: TargetAllocator
@@ -196,4 +186,3 @@ spec:
   prometheusCR:
     enabled: true
   resources: {}
-status: {}

--- a/internal/controllers/testdata/build_collector_ta_cr_base.yaml
+++ b/internal/controllers/testdata/build_collector_ta_cr_base.yaml
@@ -1,0 +1,199 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+  serviceName: test-collector-headless
+  template:
+    metadata:
+      annotations:
+        opentelemetry-operator-config/sha256: 42773025f65feaf30df59a306a9e38f1aaabe94c8310983beaddb7f648d699b0
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: test-collector
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - args:
+        - --config=/conf/collector.yaml
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: otc-container
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: otc-container
+              divisor: "0"
+              resource: limits.cpu
+        image: test
+        name: otc-container
+        ports:
+        - containerPort: 8888
+          name: metrics
+          protocol: TCP
+        resources: {}
+        volumeMounts:
+        - mountPath: /conf
+          name: otc-internal
+      dnsConfig: {}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: test-collector
+      shareProcessNamespace: false
+      volumes:
+      - configMap:
+          items:
+          - key: collector.yaml
+            path: collector.yaml
+          name: test-collector-42773025
+        name: otc-internal
+  updateStrategy: {}
+status:
+  availableReplicas: 0
+  replicas: 0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---
+apiVersion: v1
+data:
+  collector.yaml: |
+    exporters:
+        debug: null
+    receivers:
+        prometheus:
+            config: {}
+            target_allocator:
+                collector_id: ${POD_NAME}
+                endpoint: http://test-targetallocator:80
+                interval: 30s
+    service:
+        pipelines:
+            metrics:
+                exporters:
+                    - debug
+                receivers:
+                    - prometheus
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector-42773025
+  namespace: test
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector-monitoring
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+    operator.opentelemetry.io/collector-monitoring-service: Exists
+    operator.opentelemetry.io/collector-service-type: monitoring
+  name: test-collector-monitoring
+  namespace: test
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    targetPort: 0
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: TargetAllocator
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: opentelemetry-operator
+  name: test
+  namespace: test
+spec:
+  allocationStrategy: consistent-hashing
+  filterStrategy: relabel-config
+  global: null
+  networkPolicy: {}
+  observability:
+    metrics: {}
+  podDnsConfig: {}
+  prometheusCR:
+    enabled: true
+  resources: {}
+status: {}

--- a/internal/controllers/testdata/build_collector_ta_cr_enable_metrics.input.yaml
+++ b/internal/controllers/testdata/build_collector_ta_cr_enable_metrics.input.yaml
@@ -1,0 +1,39 @@
+metadata:
+  name: test
+  namespace: test
+spec:
+  image: test
+  replicas: 1
+  mode: statefulset
+  targetAllocator:
+    enabled: true
+    filterStrategy: relabel-config
+    prometheusCR:
+      enabled: true
+    observability:
+      metrics:
+        enableMetrics: true
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: 'example'
+            relabel_configs:
+            - source_labels: ['__meta_service_id']
+              target_label: 'job'
+              replacement: 'my_service_$$1'
+            - source_labels: ['__meta_service_name']
+              target_label: 'instance'
+              replacement: '$1'
+            metric_relabel_configs:
+            - source_labels: ['job']
+              target_label: 'job'
+              replacement: '$$1_$2'
+    exporters:
+      debug:
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [debug]

--- a/internal/controllers/testdata/build_collector_ta_cr_enable_metrics.yaml
+++ b/internal/controllers/testdata/build_collector_ta_cr_enable_metrics.yaml
@@ -1,0 +1,199 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+spec:
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+  serviceName: test-collector-headless
+  template:
+    metadata:
+      annotations:
+        opentelemetry-operator-config/sha256: 42773025f65feaf30df59a306a9e38f1aaabe94c8310983beaddb7f648d699b0
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: test-collector
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - args:
+        - --config=/conf/collector.yaml
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: otc-container
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: otc-container
+              divisor: "0"
+              resource: limits.cpu
+        image: test
+        name: otc-container
+        ports:
+        - containerPort: 8888
+          name: metrics
+          protocol: TCP
+        resources: {}
+        volumeMounts:
+        - mountPath: /conf
+          name: otc-internal
+      dnsConfig: {}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: test-collector
+      shareProcessNamespace: false
+      volumes:
+      - configMap:
+          items:
+          - key: collector.yaml
+            path: collector.yaml
+          name: test-collector-42773025
+        name: otc-internal
+  updateStrategy: {}
+status:
+  availableReplicas: 0
+  replicas: 0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---
+apiVersion: v1
+data:
+  collector.yaml: |
+    exporters:
+        debug: null
+    receivers:
+        prometheus:
+            config: {}
+            target_allocator:
+                collector_id: ${POD_NAME}
+                endpoint: http://test-targetallocator:80
+                interval: 30s
+    service:
+        pipelines:
+            metrics:
+                exporters:
+                    - debug
+                receivers:
+                    - prometheus
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector-42773025
+  namespace: test
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-collector
+  namespace: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-collector-monitoring
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+    operator.opentelemetry.io/collector-monitoring-service: Exists
+    operator.opentelemetry.io/collector-service-type: monitoring
+  name: test-collector-monitoring
+  namespace: test
+spec:
+  ports:
+  - name: monitoring
+    port: 8888
+    targetPort: 0
+  selector:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: TargetAllocator
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: opentelemetry-operator
+  name: test
+  namespace: test
+spec:
+  filterStrategy: relabel-config
+  global: null
+  networkPolicy: {}
+  observability:
+    metrics:
+      enableMetrics: true
+  podDnsConfig: {}
+  prometheusCR:
+    enabled: true
+  resources: {}
+status: {}

--- a/internal/controllers/testdata/build_collector_ta_cr_enable_metrics.yaml
+++ b/internal/controllers/testdata/build_collector_ta_cr_enable_metrics.yaml
@@ -77,9 +77,6 @@ spec:
           name: test-collector-42773025
         name: otc-internal
   updateStrategy: {}
-status:
-  availableReplicas: 0
-  replicas: 0
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -101,11 +98,6 @@ spec:
       app.kubernetes.io/instance: test.test
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/part-of: opentelemetry
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 ---
 apiVersion: v1
 data:
@@ -175,8 +167,6 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: opentelemetry.io/v1alpha1
 kind: TargetAllocator
@@ -196,4 +186,3 @@ spec:
   prometheusCR:
     enabled: true
   resources: {}
-status: {}

--- a/internal/controllers/testdata/build_opamp_bridge_base.input.yaml
+++ b/internal/controllers/testdata/build_opamp_bridge_base.input.yaml
@@ -1,0 +1,23 @@
+metadata:
+  name: test
+  namespace: test
+spec:
+  replicas: 1
+  image: test
+  endpoint: ws://opamp-server:4320/v1/opamp
+  capabilities:
+    AcceptsOpAMPConnectionSettings: true
+    AcceptsOtherConnectionSettings: true
+    AcceptsRemoteConfig: true
+    AcceptsRestartCommand: true
+    ReportsEffectiveConfig: true
+    ReportsHealth: true
+    ReportsOwnLogs: true
+    ReportsOwnMetrics: true
+    ReportsOwnTraces: true
+    ReportsRemoteConfig: true
+    ReportsStatus: true
+  componentsAllowed:
+    receivers: [otlp]
+    processors: [memory_limiter]
+    exporters: [debug]

--- a/internal/controllers/testdata/build_opamp_bridge_base.yaml
+++ b/internal/controllers/testdata/build_opamp_bridge_base.yaml
@@ -65,7 +65,6 @@ spec:
             path: remoteconfiguration.yaml
           name: test-opamp-bridge
         name: opamp-bridge-internal
-status: {}
 ---
 apiVersion: v1
 data:
@@ -137,5 +136,3 @@ spec:
     app.kubernetes.io/instance: test.test
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}

--- a/internal/controllers/testdata/build_opamp_bridge_base.yaml
+++ b/internal/controllers/testdata/build_opamp_bridge_base.yaml
@@ -1,0 +1,141 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-opamp-bridge
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-opamp-bridge
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-opamp-bridge
+  namespace: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-opamp-bridge
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        opentelemetry-opampbridge-config/hash: 05e1dc681267a9bc28fc2877ab464a98b9bd043843f14ffc0b4a394b5c86ba9f
+      labels:
+        app.kubernetes.io/component: opentelemetry-opamp-bridge
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: test-opamp-bridge
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - env:
+        - name: OTELCOL_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: opamp-bridge-container
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: opamp-bridge-container
+              divisor: "0"
+              resource: limits.cpu
+        image: test
+        name: opamp-bridge-container
+        resources: {}
+        volumeMounts:
+        - mountPath: /conf
+          name: opamp-bridge-internal
+      dnsConfig: {}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: test-opamp-bridge
+      volumes:
+      - configMap:
+          items:
+          - key: remoteconfiguration.yaml
+            path: remoteconfiguration.yaml
+          name: test-opamp-bridge
+        name: opamp-bridge-internal
+status: {}
+---
+apiVersion: v1
+data:
+  remoteconfiguration.yaml: |
+    capabilities:
+      AcceptsOpAMPConnectionSettings: true
+      AcceptsOtherConnectionSettings: true
+      AcceptsRemoteConfig: true
+      AcceptsRestartCommand: true
+      ReportsEffectiveConfig: true
+      ReportsHealth: true
+      ReportsOwnLogs: true
+      ReportsOwnMetrics: true
+      ReportsOwnTraces: true
+      ReportsRemoteConfig: true
+      ReportsStatus: true
+    componentsAllowed:
+      exporters:
+      - debug
+      processors:
+      - memory_limiter
+      receivers:
+      - otlp
+    endpoint: ws://opamp-server:4320/v1/opamp
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-opamp-bridge
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-opamp-bridge
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-opamp-bridge
+  namespace: test
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-opamp-bridge
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-opamp-bridge
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-opamp-bridge
+  namespace: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-opamp-bridge
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-opamp-bridge
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-opamp-bridge
+  namespace: test
+spec:
+  ports:
+  - name: opamp-bridge
+    port: 80
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/component: opentelemetry-opamp-bridge
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}

--- a/internal/controllers/testdata/build_target_allocator_base.input.yaml
+++ b/internal/controllers/testdata/build_target_allocator_base.input.yaml
@@ -1,0 +1,20 @@
+metadata:
+  name: test
+  namespace: test
+spec:
+  filterStrategy: relabel-config
+  scrapeConfigs:
+  - job_name: example
+    metric_relabel_configs:
+    - replacement: $1_$2
+      source_labels: [job]
+      target_label: job
+    relabel_configs:
+    - replacement: my_service_$1
+      source_labels: [__meta_service_id]
+      target_label: job
+    - replacement: $1
+      source_labels: [__meta_service_name]
+      target_label: instance
+  prometheusCR:
+    enabled: true

--- a/internal/controllers/testdata/build_target_allocator_base.yaml
+++ b/internal/controllers/testdata/build_target_allocator_base.yaml
@@ -123,7 +123,6 @@ spec:
             path: targetallocator.yaml
           name: test-targetallocator
         name: ta-internal
-status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -161,8 +160,6 @@ spec:
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/name: test-targetallocator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -187,8 +184,3 @@ spec:
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/name: test-targetallocator
       app.kubernetes.io/part-of: opentelemetry
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0

--- a/internal/controllers/testdata/build_target_allocator_base.yaml
+++ b/internal/controllers/testdata/build_target_allocator_base.yaml
@@ -1,0 +1,194 @@
+apiVersion: v1
+data:
+  targetallocator.yaml: |
+    allocation_strategy: consistent-hashing
+    collector_selector: null
+    config:
+      scrape_configs:
+      - job_name: example
+        metric_relabel_configs:
+        - replacement: $1_$2
+          source_labels:
+          - job
+          target_label: job
+        relabel_configs:
+        - replacement: my_service_$1
+          source_labels:
+          - __meta_service_id
+          target_label: job
+        - replacement: $1
+          source_labels:
+          - __meta_service_name
+          target_label: instance
+    filter_strategy: relabel-config
+    prometheus_cr:
+      enabled: true
+      pod_monitor_namespace_selector: null
+      pod_monitor_selector: null
+      probe_namespace_selector: null
+      probe_selector: null
+      scrape_config_namespace_selector: null
+      scrape_config_selector: null
+      service_monitor_namespace_selector: null
+      service_monitor_selector: null
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-targetallocator
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/name: test-targetallocator
+      app.kubernetes.io/part-of: opentelemetry
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        opentelemetry-targetallocator-config/hash: 7a839fe32950e427672bf7038e88d953ceecf1531457af7c43dc78300dc85eca
+      labels:
+        app.kubernetes.io/component: opentelemetry-targetallocator
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: test-targetallocator
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - env:
+        - name: OTELCOL_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: ta-container
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: ta-container
+              divisor: "0"
+              resource: limits.cpu
+        image: default-ta-allocator
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+        name: ta-container
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+        resources: {}
+        volumeMounts:
+        - mountPath: /conf
+          name: ta-internal
+      dnsConfig: {}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: test-targetallocator
+      shareProcessNamespace: false
+      volumes:
+      - configMap:
+          items:
+          - key: targetallocator.yaml
+            path: targetallocator.yaml
+          name: test-targetallocator
+        name: ta-internal
+status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  ports:
+  - name: targetallocation
+    port: 80
+    targetPort: http
+  selector:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    opentelemetry-targetallocator-config/hash: 7a839fe32950e427672bf7038e88d953ceecf1531457af7c43dc78300dc85eca
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-targetallocator
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/name: test-targetallocator
+      app.kubernetes.io/part-of: opentelemetry
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/internal/controllers/testdata/build_target_allocator_collector.input.yaml
+++ b/internal/controllers/testdata/build_target_allocator_collector.input.yaml
@@ -1,0 +1,21 @@
+metadata:
+  name: test
+  namespace: test
+spec:
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: example
+            metric_relabel_configs:
+            - replacement: $1_$2
+              source_labels: [job]
+              target_label: job
+            relabel_configs:
+            - replacement: my_service_$1
+              source_labels: [__meta_service_id]
+              target_label: job
+            - replacement: $1
+              source_labels: [__meta_service_name]
+              target_label: instance

--- a/internal/controllers/testdata/build_target_allocator_collector_present.yaml
+++ b/internal/controllers/testdata/build_target_allocator_collector_present.yaml
@@ -129,7 +129,6 @@ spec:
             path: targetallocator.yaml
           name: test-targetallocator
         name: ta-internal
-status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -167,8 +166,6 @@ spec:
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/name: test-targetallocator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -193,8 +190,3 @@ spec:
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/name: test-targetallocator
       app.kubernetes.io/part-of: opentelemetry
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0

--- a/internal/controllers/testdata/build_target_allocator_collector_present.yaml
+++ b/internal/controllers/testdata/build_target_allocator_collector_present.yaml
@@ -1,0 +1,200 @@
+apiVersion: v1
+data:
+  targetallocator.yaml: |
+    allocation_strategy: consistent-hashing
+    collector_selector:
+      matchlabels:
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/part-of: opentelemetry
+      matchexpressions: []
+    config:
+      scrape_configs:
+      - job_name: example
+        metric_relabel_configs:
+        - replacement: $1_$2
+          source_labels:
+          - job
+          target_label: job
+        relabel_configs:
+        - replacement: my_service_$1
+          source_labels:
+          - __meta_service_id
+          target_label: job
+        - replacement: $1
+          source_labels:
+          - __meta_service_name
+          target_label: instance
+    filter_strategy: relabel-config
+    prometheus_cr:
+      enabled: true
+      pod_monitor_namespace_selector: null
+      pod_monitor_selector: null
+      probe_namespace_selector: null
+      probe_selector: null
+      scrape_config_namespace_selector: null
+      scrape_config_selector: null
+      service_monitor_namespace_selector: null
+      service_monitor_selector: null
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-targetallocator
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/name: test-targetallocator
+      app.kubernetes.io/part-of: opentelemetry
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        opentelemetry-targetallocator-config/hash: a81383bc4e7ebbf141d2fd9cde3dcd9758bc47f27af6cbaeb0f14ab6360e08c6
+      labels:
+        app.kubernetes.io/component: opentelemetry-targetallocator
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: test-targetallocator
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - env:
+        - name: OTELCOL_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: ta-container
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: ta-container
+              divisor: "0"
+              resource: limits.cpu
+        image: default-ta-allocator
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+        name: ta-container
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+        resources: {}
+        volumeMounts:
+        - mountPath: /conf
+          name: ta-internal
+      dnsConfig: {}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: test-targetallocator
+      shareProcessNamespace: false
+      volumes:
+      - configMap:
+          items:
+          - key: targetallocator.yaml
+            path: targetallocator.yaml
+          name: test-targetallocator
+        name: ta-internal
+status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  ports:
+  - name: targetallocation
+    port: 80
+    targetPort: http
+  selector:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    opentelemetry-targetallocator-config/hash: a81383bc4e7ebbf141d2fd9cde3dcd9758bc47f27af6cbaeb0f14ab6360e08c6
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-targetallocator
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/name: test-targetallocator
+      app.kubernetes.io/part-of: opentelemetry
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0

--- a/internal/controllers/testdata/build_target_allocator_enable_metrics.input.yaml
+++ b/internal/controllers/testdata/build_target_allocator_enable_metrics.input.yaml
@@ -1,0 +1,24 @@
+metadata:
+  name: test
+  namespace: test
+spec:
+  filterStrategy: relabel-config
+  allocationStrategy: consistent-hashing
+  scrapeConfigs:
+  - job_name: example
+    metric_relabel_configs:
+    - replacement: $1_$2
+      source_labels: [job]
+      target_label: job
+    relabel_configs:
+    - replacement: my_service_$1
+      source_labels: [__meta_service_id]
+      target_label: job
+    - replacement: $1
+      source_labels: [__meta_service_name]
+      target_label: instance
+  prometheusCR:
+    enabled: true
+  observability:
+    metrics:
+      enableMetrics: true

--- a/internal/controllers/testdata/build_target_allocator_enable_metrics.yaml
+++ b/internal/controllers/testdata/build_target_allocator_enable_metrics.yaml
@@ -1,0 +1,220 @@
+apiVersion: v1
+data:
+  targetallocator.yaml: |
+    allocation_strategy: consistent-hashing
+    collector_selector: null
+    config:
+      scrape_configs:
+      - job_name: example
+        metric_relabel_configs:
+        - replacement: $1_$2
+          source_labels:
+          - job
+          target_label: job
+        relabel_configs:
+        - replacement: my_service_$1
+          source_labels:
+          - __meta_service_id
+          target_label: job
+        - replacement: $1
+          source_labels:
+          - __meta_service_name
+          target_label: instance
+    filter_strategy: relabel-config
+    prometheus_cr:
+      enabled: true
+      pod_monitor_namespace_selector: null
+      pod_monitor_selector: null
+      probe_namespace_selector: null
+      probe_selector: null
+      scrape_config_namespace_selector: null
+      scrape_config_selector: null
+      service_monitor_namespace_selector: null
+      service_monitor_selector: null
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-targetallocator
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/name: test-targetallocator
+      app.kubernetes.io/part-of: opentelemetry
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        opentelemetry-targetallocator-config/hash: 7a839fe32950e427672bf7038e88d953ceecf1531457af7c43dc78300dc85eca
+      labels:
+        app.kubernetes.io/component: opentelemetry-targetallocator
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: test-targetallocator
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - env:
+        - name: OTELCOL_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: ta-container
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: ta-container
+              divisor: "0"
+              resource: limits.cpu
+        image: default-ta-allocator
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+        name: ta-container
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+        resources: {}
+        volumeMounts:
+        - mountPath: /conf
+          name: ta-internal
+      dnsConfig: {}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: test-targetallocator
+      shareProcessNamespace: false
+      volumes:
+      - configMap:
+          items:
+          - key: targetallocator.yaml
+            path: targetallocator.yaml
+          name: test-targetallocator
+        name: ta-internal
+status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  ports:
+  - name: targetallocation
+    port: 80
+    targetPort: http
+  selector:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    opentelemetry-targetallocator-config/hash: 7a839fe32950e427672bf7038e88d953ceecf1531457af7c43dc78300dc85eca
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-targetallocator
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/name: test-targetallocator
+      app.kubernetes.io/part-of: opentelemetry
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  endpoints:
+  - port: targetallocation
+  namespaceSelector:
+    matchNames:
+    - test
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-targetallocator
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/name: test-targetallocator
+      app.kubernetes.io/part-of: opentelemetry

--- a/internal/controllers/testdata/build_target_allocator_enable_metrics.yaml
+++ b/internal/controllers/testdata/build_target_allocator_enable_metrics.yaml
@@ -123,7 +123,6 @@ spec:
             path: targetallocator.yaml
           name: test-targetallocator
         name: ta-internal
-status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -161,8 +160,6 @@ spec:
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/name: test-targetallocator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -187,11 +184,6 @@ spec:
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/name: test-targetallocator
       app.kubernetes.io/part-of: opentelemetry
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/internal/controllers/testdata/build_target_allocator_minimal.input.yaml
+++ b/internal/controllers/testdata/build_target_allocator_minimal.input.yaml
@@ -1,0 +1,7 @@
+metadata:
+  name: test
+  namespace: test
+spec:
+  filterStrategy: relabel-config
+  prometheusCR:
+    enabled: true

--- a/internal/controllers/testdata/build_target_allocator_mtls.yaml
+++ b/internal/controllers/testdata/build_target_allocator_mtls.yaml
@@ -143,7 +143,6 @@ spec:
       - name: test-ta-server-cert
         secret:
           secretName: test-ta-server-cert
-status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -184,8 +183,6 @@ spec:
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/name: test-targetallocator
     app.kubernetes.io/part-of: opentelemetry
-status:
-  loadBalancer: {}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -210,11 +207,6 @@ spec:
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/name: test-targetallocator
       app.kubernetes.io/part-of: opentelemetry
-status:
-  currentHealthy: 0
-  desiredHealthy: 0
-  disruptionsAllowed: 0
-  expectedPods: 0
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -230,7 +222,6 @@ metadata:
   namespace: test
 spec:
   selfSigned: {}
-status: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -256,7 +247,6 @@ spec:
   subject:
     organizationalUnits:
     - opentelemetry-operator
-status: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -273,7 +263,6 @@ metadata:
 spec:
   ca:
     secretName: test-ca-cert
-status: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -303,7 +292,6 @@ spec:
   usages:
   - client auth
   - server auth
-status: {}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -333,4 +321,3 @@ spec:
   usages:
   - client auth
   - server auth
-status: {}

--- a/internal/controllers/testdata/build_target_allocator_mtls.yaml
+++ b/internal/controllers/testdata/build_target_allocator_mtls.yaml
@@ -1,0 +1,336 @@
+apiVersion: v1
+data:
+  targetallocator.yaml: |
+    allocation_strategy: consistent-hashing
+    collector_selector:
+      matchlabels:
+        app.kubernetes.io/component: opentelemetry-collector
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/part-of: opentelemetry
+      matchexpressions: []
+    config:
+      scrape_configs:
+      - job_name: example
+        metric_relabel_configs:
+        - replacement: $1_$2
+          source_labels:
+          - job
+          target_label: job
+        relabel_configs:
+        - replacement: my_service_$1
+          source_labels:
+          - __meta_service_id
+          target_label: job
+        - replacement: $1
+          source_labels:
+          - __meta_service_name
+          target_label: instance
+    filter_strategy: relabel-config
+    https:
+      ca_file_path: /tls/ca.crt
+      enabled: true
+      listen_addr: :8443
+      tls_cert_file_path: /tls/tls.crt
+      tls_key_file_path: /tls/tls.key
+    prometheus_cr:
+      enabled: true
+      pod_monitor_namespace_selector: null
+      pod_monitor_selector: null
+      probe_namespace_selector: null
+      probe_selector: null
+      scrape_config_namespace_selector: null
+      scrape_config_selector: null
+      service_monitor_namespace_selector: null
+      service_monitor_selector: null
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-targetallocator
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/name: test-targetallocator
+      app.kubernetes.io/part-of: opentelemetry
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        opentelemetry-targetallocator-config/hash: 02ef308f21c5312c388985bd8ca91246d1df7a3a5031135ec176f3c975e2fa37
+      labels:
+        app.kubernetes.io/component: opentelemetry-targetallocator
+        app.kubernetes.io/instance: test.test
+        app.kubernetes.io/managed-by: opentelemetry-operator
+        app.kubernetes.io/name: test-targetallocator
+        app.kubernetes.io/part-of: opentelemetry
+        app.kubernetes.io/version: latest
+    spec:
+      containers:
+      - env:
+        - name: OTELCOL_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: ta-container
+              divisor: "0"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: ta-container
+              divisor: "0"
+              resource: limits.cpu
+        image: default-ta-allocator
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+        name: ta-container
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+        resources: {}
+        volumeMounts:
+        - mountPath: /conf
+          name: ta-internal
+        - mountPath: /tls
+          name: test-ta-server-cert
+      dnsConfig: {}
+      dnsPolicy: ClusterFirst
+      serviceAccountName: test-targetallocator
+      shareProcessNamespace: false
+      volumes:
+      - configMap:
+          items:
+          - key: targetallocator.yaml
+            path: targetallocator.yaml
+          name: test-targetallocator
+        name: ta-internal
+      - name: test-ta-server-cert
+        secret:
+          secretName: test-ta-server-cert
+status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  ports:
+  - name: targetallocation
+    port: 80
+    targetPort: http
+  - name: targetallocation-https
+    port: 443
+    targetPort: https
+  selector:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+status:
+  loadBalancer: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    opentelemetry-targetallocator-config/hash: 02ef308f21c5312c388985bd8ca91246d1df7a3a5031135ec176f3c975e2fa37
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-targetallocator
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-targetallocator
+  namespace: test
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-targetallocator
+      app.kubernetes.io/instance: test.test
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/name: test-targetallocator
+      app.kubernetes.io/part-of: opentelemetry
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-self-signed-issuer
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-self-signed-issuer
+  namespace: test
+spec:
+  selfSigned: {}
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-ca-cert
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-ca-cert
+  namespace: test
+spec:
+  commonName: test-ca-cert
+  duration: 17280h0m0s
+  isCA: true
+  issuerRef:
+    kind: Issuer
+    name: test-self-signed-issuer
+  renewBefore: 4344h0m0s
+  secretName: test-ca-cert
+  subject:
+    organizationalUnits:
+    - opentelemetry-operator
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-ca-issuer
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-ca-issuer
+  namespace: test
+spec:
+  ca:
+    secretName: test-ca-cert
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-ta-server-cert
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-ta-server-cert
+  namespace: test
+spec:
+  dnsNames:
+  - test-targetallocator
+  - test-targetallocator.test.svc
+  - test-targetallocator.test.svc.cluster.local
+  duration: 2160h0m0s
+  issuerRef:
+    kind: Issuer
+    name: test-ca-issuer
+  secretName: test-ta-server-cert
+  subject:
+    organizationalUnits:
+    - opentelemetry-operator
+  usages:
+  - client auth
+  - server auth
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: opentelemetry-targetallocator
+    app.kubernetes.io/instance: test.test
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/name: test-ta-client-cert
+    app.kubernetes.io/part-of: opentelemetry
+    app.kubernetes.io/version: latest
+  name: test-ta-client-cert
+  namespace: test
+spec:
+  dnsNames:
+  - test-targetallocator
+  - test-targetallocator.test.svc
+  - test-targetallocator.test.svc.cluster.local
+  duration: 2160h0m0s
+  issuerRef:
+    kind: Issuer
+    name: test-ca-issuer
+  secretName: test-ta-client-cert
+  subject:
+    organizationalUnits:
+    - opentelemetry-operator
+  usages:
+  - client auth
+  - server auth
+status: {}


### PR DESCRIPTION
The builder tests would define test data as Go structs. This made the tests hard to read and update. I moved the structs, both inputs and outputs, into yaml files. They're now compared using the `golden` package, so updates are built-in.