### PR TITLE
[chore] Bump python-oldest e2e test image from 3.9 to 3.10

### DIFF
--- a/.github/workflows/publish-test-e2e-images.yaml
+++ b/.github/workflows/publish-test-e2e-images.yaml
@@ -59,8 +59,8 @@ jobs:
     uses: ./.github/workflows/reusable-publish-test-e2e-images.yaml
     with:
       path: python
-      build-args: 'python_version=3.9'
-      tag-suffix: '-3.9'
+      build-args: 'python_version=3.10'
+      tag-suffix: '-3.10'
       platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
   java:
     permissions: # required by the reusable workflow


### PR DESCRIPTION
**Description:**

Python instrumentation no longer supports Python 3.9. Python 3.9 is broken with the upstream Python instrumentation because the requests dependency uses PEP 604 union syntax (str | bytes) which is only available from 3.10. 

Bumping the oldest-supported test image to 3.10 unblocks the instrumentation-python-oldest e2e test.

**Link to tracking Issue(s):** <Issue number if applicable>

- Relates: https://github.com/open-telemetry/opentelemetry-operator/issues/5072
