### PR TITLE
[chore] Migrate Go dependency updates from dependabot to renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: weekly
-    # Create a group of dependencies to be updated together in one pull request
-    groups:
-      golang-org-x:
-        patterns:
-          - "golang.org/x/*"
-      prometheus:
-        patterns:
-          - "github.com/prometheus-operator/prometheus-operator"
-          - "github.com/prometheus-operator/prometheus-operator/*"
-          - "github.com/prometheus/prometheus"
-          - "github.com/prometheus/prometheus/*"
-          - "github.com/prometheus/client_go"
-          - "github.com/prometheus/client_go/*"
-      kubernetes:
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-      otel:
-        patterns:
-          - "go.opentelemetry.io/otel"
-          - "go.opentelemetry.io/otel/*"
-
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "labels": ["dependencies"],
-  "enabledManagers": ["regex", "npm", "pip_requirements"],
+  "enabledManagers": ["regex", "npm", "pip_requirements", "gomod"],
   "customManagers": [
     {
       "customType": "regex",
@@ -128,6 +128,39 @@
       "groupName": "kind node images",
       "schedule": ["on monday"],
       "commitMessageTopic": "kind node images"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchFileNames": ["tests/test-e2e-apps/**/go.mod"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "schedule": ["on monday"]
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["golang.org/x/**"],
+      "groupName": "golang.org/x"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/prometheus-operator/prometheus-operator{,/**}",
+        "github.com/prometheus/prometheus{,/**}",
+        "github.com/prometheus/client_go{,/**}"
+      ],
+      "groupName": "prometheus"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"],
+      "groupName": "kubernetes"
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["go.opentelemetry.io/otel{,/**}"],
+      "groupName": "opentelemetry"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -155,7 +155,10 @@
     {
       "matchManagers": ["gomod"],
       "matchPackageNames": ["k8s.io/**", "sigs.k8s.io/**"],
-      "groupName": "kubernetes"
+      "groupName": "kubernetes",
+      "group": {
+        "commitMessageTopic": "kubernetes group to {{#each upgrades}}{{#if (equals depName \"k8s.io/api\")}}{{newVersion}}{{/if}}{{/each}}"
+      }
     },
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
We've wanted to do this for a while, and dependabot's uncertain support for multi-module updates will make https://github.com/open-telemetry/opentelemetry-operator/pull/5077 a bigger pain to maintain. Might as well make the change sooner rather than later.

See https://github.com/swiatekm/opentelemetry-operator/pulls for how the current updates look in practice.
