### PR TITLE
Add a workflow to mark PRs as stale and close them

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,27 @@
+name: "Close stale PRs"
+
+on:
+  schedule:
+    - cron: "0 9 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-label: "stale"
+          stale-pr-message: >-
+            This PR was marked stale due to lack of activity. It will be closed in 14 days.
+          close-pr-message: >-
+            Closed as inactive. Feel free to reopen if this PR is still being worked on.
+          exempt-pr-labels: "never-stale,pinned,security"


### PR DESCRIPTION
PRs are marked as stale after 60 days and closed 14 days later. Issues are unaffected for now. The workflow runs once on each weekday.
