### PR TITLE
docs: document Node.js module lookup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,18 @@ NodeJS:
 instrumentation.opentelemetry.io/inject-nodejs: "true"
 ```
 
+Node.js resolves modules from the injected auto-instrumentation script path. If an instrumentation
+package needs to load an application dependency from the application's `node_modules` directory, set
+`NODE_PATH` with the application dependency path in the `Instrumentation` resource:
+
+```yaml
+spec:
+  nodejs:
+    env:
+      - name: NODE_PATH
+        value: /home/node/app/node_modules
+```
+
 Python:
 Python auto-instrumentation also honors an annotation that will permit it to run it on images with a different C library than glibc.
 


### PR DESCRIPTION
Fixes #3653

## Summary
- explain when Node.js auto-instrumentation may need `NODE_PATH` to find application dependencies
- add an `Instrumentation.spec.nodejs.env` example for setting `NODE_PATH`

## Verification
- `git diff --check`