### PR TITLE
feat(target-allocator): add allowInsecureAuthSecrets option

### DIFF
--- a/.chloggen/feat-ta-allow-insecure-auth-secrets.yaml
+++ b/.chloggen/feat-ta-allow-insecure-auth-secrets.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add allowInsecureAuthSecrets option to serve auth secret values over plain HTTP without mTLS
+
+# One or more tracking issues related to the change
+issues: [3746]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds a new allowInsecureAuthSecrets field to both the TargetAllocator CRD and the
+  embedded TargetAllocator in the OpenTelemetryCollector CRD. When enabled, auth secret
+  values (e.g. basicAuth passwords) are served over plain HTTP instead of being masked.
+  This is useful when transport security is handled by a service mesh or equivalent.

--- a/apis/v1alpha1/targetallocator_types.go
+++ b/apis/v1alpha1/targetallocator_types.go
@@ -86,6 +86,11 @@ type TargetAllocatorSpec struct {
 	// NetworkPolicy defines the network policy to be applied to the Target Allocator pods.
 	// +optional
 	NetworkPolicy v1beta1.NetworkPolicy `json:"networkPolicy,omitempty"`
+	// AllowInsecureAuthSecrets controls whether auth secret values (e.g. basicAuth passwords)
+	// are served over plain HTTP without requiring mTLS. Only enable this when the target allocator
+	// endpoint is secured by a service mesh or equivalent transport-level security.
+	// +optional
+	AllowInsecureAuthSecrets bool `json:"allowInsecureAuthSecrets,omitempty"`
 	// CollectorNotReadyGracePeriod defines the grace period after which a TargetAllocator stops considering a collector is target assignable.
 	// The default is 30s, which means that if a collector becomes not Ready, the target allocator will wait for 30 seconds before reassigning its targets. The assumption is that the state is temporary, and an expensive target reallocation should be avoided if possible.
 	//

--- a/apis/v1beta1/opentelemetrycollector_types.go
+++ b/apis/v1beta1/opentelemetrycollector_types.go
@@ -223,6 +223,11 @@ type TargetAllocatorEmbedded struct {
 	//
 	// +optional
 	PodDisruptionBudget *PodDisruptionBudgetSpec `json:"podDisruptionBudget,omitempty"`
+	// AllowInsecureAuthSecrets controls whether auth secret values (e.g. basicAuth passwords)
+	// are served over plain HTTP without requiring mTLS. Only enable this when the target allocator
+	// endpoint is secured by a service mesh or equivalent transport-level security.
+	// +optional
+	AllowInsecureAuthSecrets bool `json:"allowInsecureAuthSecrets,omitempty"`
 	// CollectorNotReadyGracePeriod defines the grace period after which a TargetAllocator stops considering a collector is target assignable.
 	// The default is 30s, which means that if a collector becomes not Ready, the target allocator will wait for 30 seconds before reassigning its targets. The assumption is that the state is temporary, and an expensive target reallocation should be avoided if possible.
 	//

--- a/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -8087,6 +8087,8 @@ spec:
                     - consistent-hashing
                     - per-node
                     type: string
+                  allowInsecureAuthSecrets:
+                    type: boolean
                   collectorNotReadyGracePeriod:
                     default: 30s
                     format: duration

--- a/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
@@ -1207,6 +1207,8 @@ spec:
                 - consistent-hashing
                 - per-node
                 type: string
+              allowInsecureAuthSecrets:
+                type: boolean
               args:
                 additionalProperties:
                   type: string

--- a/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -8086,6 +8086,8 @@ spec:
                     - consistent-hashing
                     - per-node
                     type: string
+                  allowInsecureAuthSecrets:
+                    type: boolean
                   collectorNotReadyGracePeriod:
                     default: 30s
                     format: duration

--- a/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
@@ -1207,6 +1207,8 @@ spec:
                 - consistent-hashing
                 - per-node
                 type: string
+              allowInsecureAuthSecrets:
+                type: boolean
               args:
                 additionalProperties:
                   type: string

--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -426,23 +426,23 @@ Prerequisites:
 
 #### Alternative: allow insecure auth secrets
 
-If the connection between the target allocator and collectors is already secured by a service mesh (e.g. Istio, Linkerd) or equivalent transport-level security, you can skip mTLS setup and serve auth secret values over plain HTTP instead.
+If transport security is already handled by a service mesh or equivalent, you can skip the mTLS setup and serve auth secret values over plain HTTP.
 
-Set `allow_insecure_auth_secrets: true` in the target allocator config file, pass `--allow-insecure-auth-secrets` as a CLI flag, or set the `ALLOW_INSECURE_AUTH_SECRETS=true` environment variable.
-
-When using the `OpenTelemetryCollector` CR with an embedded target allocator, set it via the `env` field:
+**With the Operator (CRD):**
 
 ```yaml
 targetAllocator:
   enabled: true
-  env:
-    - name: ALLOW_INSECURE_AUTH_SECRETS
-      value: "true"
+  allowInsecureAuthSecrets: true
 ```
 
-> **Warning:** Only enable this when transport-level security is guaranteed by other means. Without mTLS or a service mesh, auth secrets will be transmitted in plaintext.
+This works on both the `OpenTelemetryCollector` CR (embedded target allocator) and the standalone `TargetAllocator` CR.
 
+**Standalone Target Allocator (without Operator):**
 
+Set `allow_insecure_auth_secrets: true` in the target allocator config file, or set the `ALLOW_INSECURE_AUTH_SECRETS=true` environment variable.
+
+> **Warning:** Only enable this when transport-level security is guaranteed by other means.
 
 # Design
 

--- a/cmd/otel-allocator/README.md
+++ b/cmd/otel-allocator/README.md
@@ -27,6 +27,7 @@ The Target Allocator uses a configuration file (by default under `/conf/targetal
 | `filter_strategy`                  | Filter strategy to apply to metrics                                           | `relabel-config`                              |                      |
 | `prometheus_cr`                    | Whether to watch Prometheus Custom Resources                                  |                                               |                      |
 | `https`                            | Whether to expose the target allocator endpoint over https                    |                                               |                      |
+| `allow_insecure_auth_secrets`      | Serve auth secret values over plain HTTP without mTLS                         | `false`                                       | `ALLOW_INSECURE_AUTH_SECRETS` |
 | `collector_not_ready_grace_period` | Wait time before assigning jobs to a new collector.                           | 30s                                           |                      |
 
 Additional configuration options are present under [./internal/config/config.go](./internal/config/config.go).
@@ -422,6 +423,24 @@ Prerequisites:
         ```
 
 - Enable the `operator.targetallocator.mtls` feature gate in the operator's deployment. 
+
+#### Alternative: allow insecure auth secrets
+
+If the connection between the target allocator and collectors is already secured by a service mesh (e.g. Istio, Linkerd) or equivalent transport-level security, you can skip mTLS setup and serve auth secret values over plain HTTP instead.
+
+Set `allow_insecure_auth_secrets: true` in the target allocator config file, pass `--allow-insecure-auth-secrets` as a CLI flag, or set the `ALLOW_INSECURE_AUTH_SECRETS=true` environment variable.
+
+When using the `OpenTelemetryCollector` CR with an embedded target allocator, set it via the `env` field:
+
+```yaml
+targetAllocator:
+  enabled: true
+  env:
+    - name: ALLOW_INSECURE_AUTH_SECRETS
+      value: "true"
+```
+
+> **Warning:** Only enable this when transport-level security is guaranteed by other means. Without mTLS or a service mesh, auth secrets will be transmitted in plaintext.
 
 
 

--- a/cmd/otel-allocator/internal/config/config.go
+++ b/cmd/otel-allocator/internal/config/config.go
@@ -73,6 +73,7 @@ type Config struct {
 	PrometheusCR                 PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
 	HTTPS                        HTTPSServerConfig     `yaml:"https,omitempty"`
 	CollectorNotReadyGracePeriod time.Duration         `yaml:"collector_not_ready_grace_period,omitempty"`
+	AllowInsecureAuthSecrets     bool                  `yaml:"allow_insecure_auth_secrets,omitempty"`
 }
 
 type PrometheusCRConfig struct {
@@ -315,6 +316,12 @@ func LoadFromCLI(target *Config, flagSet *pflag.FlagSet) error {
 		target.HTTPS.TLSKeyFilePath = tlsKeyFilePath
 	}
 
+	if allowInsecureAuthSecrets, changed, err := getAllowInsecureAuthSecrets(flagSet); err != nil {
+		return err
+	} else if changed {
+		target.AllowInsecureAuthSecrets = allowInsecureAuthSecrets
+	}
+
 	return nil
 }
 
@@ -322,6 +329,9 @@ func LoadFromCLI(target *Config, flagSet *pflag.FlagSet) error {
 func LoadFromEnv(target *Config) error {
 	if ns, ok := os.LookupEnv("OTELCOL_NAMESPACE"); ok {
 		target.CollectorNamespace = ns
+	}
+	if val, ok := os.LookupEnv("ALLOW_INSECURE_AUTH_SECRETS"); ok && val == "true" {
+		target.AllowInsecureAuthSecrets = true
 	}
 	return nil
 }

--- a/cmd/otel-allocator/internal/config/config_test.go
+++ b/cmd/otel-allocator/internal/config/config_test.go
@@ -794,6 +794,31 @@ func TestLoadFromEnv(t *testing.T) {
 	assert.Equal(t, namespace, cfg.CollectorNamespace)
 }
 
+func TestLoadFromEnvAllowInsecureAuthSecrets(t *testing.T) {
+	t.Run("not set defaults to false", func(t *testing.T) {
+		cfg := &Config{}
+		err := LoadFromEnv(cfg)
+		require.NoError(t, err)
+		assert.False(t, cfg.AllowInsecureAuthSecrets)
+	})
+
+	t.Run("set to true", func(t *testing.T) {
+		t.Setenv("ALLOW_INSECURE_AUTH_SECRETS", "true")
+		cfg := &Config{}
+		err := LoadFromEnv(cfg)
+		require.NoError(t, err)
+		assert.True(t, cfg.AllowInsecureAuthSecrets)
+	})
+
+	t.Run("set to false", func(t *testing.T) {
+		t.Setenv("ALLOW_INSECURE_AUTH_SECRETS", "false")
+		cfg := &Config{}
+		err := LoadFromEnv(cfg)
+		require.NoError(t, err)
+		assert.False(t, cfg.AllowInsecureAuthSecrets)
+	})
+}
+
 func TestValidateConfig(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -1187,5 +1212,93 @@ kube_config_file_path: "` + kubeConfigPath + `"
 		assert.Equal(t, testNamespace, config.CollectorNamespace, "Env var should override config file for namespace")
 		assert.Equal(t, cliListenAddr, config.ListenAddr, "CLI should override config file for listen address")
 		assert.True(t, config.PrometheusCR.Enabled, "CLI should override config file for prometheus CR enabled")
+	})
+}
+
+func TestAllowInsecureAuthSecrets(t *testing.T) {
+	createDummyKubeConfig := func(t *testing.T, dir string) string {
+		kubeConfigPath := filepath.Join(dir, "kube.config")
+		kubeConfigContent := `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://example.com
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+users:
+- name: test-user
+  user:
+    token: dummy-token
+`
+		err := os.WriteFile(kubeConfigPath, []byte(kubeConfigContent), 0o600)
+		require.NoError(t, err)
+		return kubeConfigPath
+	}
+
+	t.Run("defaults to false", func(t *testing.T) {
+		tempDir := t.TempDir()
+		emptyConfigPath := filepath.Join(tempDir, "empty.yaml")
+		err := os.WriteFile(emptyConfigPath, []byte("{}"), 0o600)
+		require.NoError(t, err)
+
+		kubeConfigPath := createDummyKubeConfig(t, tempDir)
+
+		args := []string{
+			"--" + configFilePathFlagName + "=" + emptyConfigPath,
+			"--" + kubeConfigPathFlagName + "=" + kubeConfigPath,
+		}
+
+		config, err := Load(args)
+		require.NoError(t, err)
+		assert.False(t, config.AllowInsecureAuthSecrets)
+	})
+
+	t.Run("can be enabled via config file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		kubeConfigPath := createDummyKubeConfig(t, tempDir)
+
+		configContent := fmt.Sprintf(`
+collector_namespace: default
+allow_insecure_auth_secrets: true
+kube_config_file_path: %q
+`, kubeConfigPath)
+		configPath := filepath.Join(tempDir, "config.yaml")
+		err := os.WriteFile(configPath, []byte(configContent), 0o600)
+		require.NoError(t, err)
+
+		args := []string{"--" + configFilePathFlagName + "=" + configPath}
+
+		config, err := Load(args)
+		require.NoError(t, err)
+		assert.True(t, config.AllowInsecureAuthSecrets)
+	})
+
+	t.Run("CLI flag overrides config file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		kubeConfigPath := createDummyKubeConfig(t, tempDir)
+
+		configContent := fmt.Sprintf(`
+collector_namespace: default
+allow_insecure_auth_secrets: false
+kube_config_file_path: %q
+`, kubeConfigPath)
+		configPath := filepath.Join(tempDir, "config.yaml")
+		err := os.WriteFile(configPath, []byte(configContent), 0o600)
+		require.NoError(t, err)
+
+		args := []string{
+			"--" + configFilePathFlagName + "=" + configPath,
+			"--" + allowInsecureAuthSecretsFlagName + "=true",
+		}
+
+		config, err := Load(args)
+		require.NoError(t, err)
+		assert.True(t, config.AllowInsecureAuthSecrets, "CLI flag should override config file")
 	})
 }

--- a/cmd/otel-allocator/internal/config/config_test.go
+++ b/cmd/otel-allocator/internal/config/config_test.go
@@ -1220,4 +1220,3 @@ kube_config_file_path: "` + kubeConfigPath + `"
 		assert.True(t, config.PrometheusCR.Enabled, "CLI should override config file for prometheus CR enabled")
 	})
 }
-

--- a/cmd/otel-allocator/internal/config/config_test.go
+++ b/cmd/otel-allocator/internal/config/config_test.go
@@ -1027,6 +1027,7 @@ users:
 		assert.Equal(t, DefaultFilterStrategy, config.FilterStrategy)
 		assert.False(t, config.PrometheusCR.Enabled)
 		assert.False(t, config.HTTPS.Enabled)
+		assert.False(t, config.AllowInsecureAuthSecrets)
 	})
 
 	t.Run("command-line has priority over config file for boolean values", func(t *testing.T) {
@@ -1037,6 +1038,7 @@ prometheus_cr:
   enabled: false
 https:
   enabled: false
+allow_insecure_auth_secrets: false
 `
 		configPath := filepath.Join(tempDir, "config.yaml")
 		err := os.WriteFile(configPath, []byte(configContent), 0o600)
@@ -1049,6 +1051,7 @@ https:
 			"--" + configFilePathFlagName + "=" + configPath,
 			"--" + prometheusCREnabledFlagName + "=true",
 			"--" + httpsEnabledFlagName + "=true",
+			"--" + allowInsecureAuthSecretsFlagName + "=true",
 			"--" + kubeConfigPathFlagName + "=" + kubeConfigPath,
 		}
 
@@ -1059,6 +1062,7 @@ https:
 		// Assert CLI values override config file
 		assert.True(t, config.PrometheusCR.Enabled, "CLI should override config file for prometheus CR enabled")
 		assert.True(t, config.HTTPS.Enabled, "CLI should override config file for HTTPS enabled")
+		assert.True(t, config.AllowInsecureAuthSecrets, "CLI should override config file for allow insecure auth secrets")
 	})
 
 	t.Run("command-line has priority over config file for string values", func(t *testing.T) {
@@ -1119,6 +1123,7 @@ kube_config_file_path: "/config/kube.config"
 		configContent := `
 collector_namespace: config-file-namespace
 listen_addr: "` + configListenAddr + `"
+allow_insecure_auth_secrets: true
 prometheus_cr:
   enabled: true
 https:
@@ -1146,6 +1151,7 @@ kube_config_file_path: "` + kubeConfigPath + `"
 		assert.Equal(t, ":7443", config.HTTPS.ListenAddr, "Config file should override defaults for HTTPS listen address")
 		assert.Equal(t, kubeConfigPath, config.KubeConfigFilePath, "Config file should set kube config path")
 		assert.Equal(t, "config-file-namespace", config.CollectorNamespace, "Config file should set collector namespace")
+		assert.True(t, config.AllowInsecureAuthSecrets, "Config file should override defaults for allow insecure auth secrets")
 	})
 
 	t.Run("environment variables are applied", func(t *testing.T) {
@@ -1215,90 +1221,3 @@ kube_config_file_path: "` + kubeConfigPath + `"
 	})
 }
 
-func TestAllowInsecureAuthSecrets(t *testing.T) {
-	createDummyKubeConfig := func(t *testing.T, dir string) string {
-		kubeConfigPath := filepath.Join(dir, "kube.config")
-		kubeConfigContent := `
-apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    server: https://example.com
-  name: test-cluster
-contexts:
-- context:
-    cluster: test-cluster
-    user: test-user
-  name: test-context
-current-context: test-context
-users:
-- name: test-user
-  user:
-    token: dummy-token
-`
-		err := os.WriteFile(kubeConfigPath, []byte(kubeConfigContent), 0o600)
-		require.NoError(t, err)
-		return kubeConfigPath
-	}
-
-	t.Run("defaults to false", func(t *testing.T) {
-		tempDir := t.TempDir()
-		emptyConfigPath := filepath.Join(tempDir, "empty.yaml")
-		err := os.WriteFile(emptyConfigPath, []byte("{}"), 0o600)
-		require.NoError(t, err)
-
-		kubeConfigPath := createDummyKubeConfig(t, tempDir)
-
-		args := []string{
-			"--" + configFilePathFlagName + "=" + emptyConfigPath,
-			"--" + kubeConfigPathFlagName + "=" + kubeConfigPath,
-		}
-
-		config, err := Load(args)
-		require.NoError(t, err)
-		assert.False(t, config.AllowInsecureAuthSecrets)
-	})
-
-	t.Run("can be enabled via config file", func(t *testing.T) {
-		tempDir := t.TempDir()
-		kubeConfigPath := createDummyKubeConfig(t, tempDir)
-
-		configContent := fmt.Sprintf(`
-collector_namespace: default
-allow_insecure_auth_secrets: true
-kube_config_file_path: %q
-`, kubeConfigPath)
-		configPath := filepath.Join(tempDir, "config.yaml")
-		err := os.WriteFile(configPath, []byte(configContent), 0o600)
-		require.NoError(t, err)
-
-		args := []string{"--" + configFilePathFlagName + "=" + configPath}
-
-		config, err := Load(args)
-		require.NoError(t, err)
-		assert.True(t, config.AllowInsecureAuthSecrets)
-	})
-
-	t.Run("CLI flag overrides config file", func(t *testing.T) {
-		tempDir := t.TempDir()
-		kubeConfigPath := createDummyKubeConfig(t, tempDir)
-
-		configContent := fmt.Sprintf(`
-collector_namespace: default
-allow_insecure_auth_secrets: false
-kube_config_file_path: %q
-`, kubeConfigPath)
-		configPath := filepath.Join(tempDir, "config.yaml")
-		err := os.WriteFile(configPath, []byte(configContent), 0o600)
-		require.NoError(t, err)
-
-		args := []string{
-			"--" + configFilePathFlagName + "=" + configPath,
-			"--" + allowInsecureAuthSecretsFlagName + "=true",
-		}
-
-		config, err := Load(args)
-		require.NoError(t, err)
-		assert.True(t, config.AllowInsecureAuthSecrets, "CLI flag should override config file")
-	})
-}

--- a/cmd/otel-allocator/internal/config/flags.go
+++ b/cmd/otel-allocator/internal/config/flags.go
@@ -12,16 +12,17 @@ import (
 
 // Flag names.
 const (
-	targetAllocatorName          = "target-allocator"
-	configFilePathFlagName       = "config-file"
-	listenAddrFlagName           = "listen-addr"
-	prometheusCREnabledFlagName  = "enable-prometheus-cr-watcher"
-	kubeConfigPathFlagName       = "kubeconfig-path"
-	httpsEnabledFlagName         = "enable-https-server"
-	listenAddrHttpsFlagName      = "listen-addr-https"
-	httpsCAFilePathFlagName      = "https-ca-file"
-	httpsTLSCertFilePathFlagName = "https-tls-cert-file"
-	httpsTLSKeyFilePathFlagName  = "https-tls-key-file"
+	targetAllocatorName              = "target-allocator"
+	configFilePathFlagName           = "config-file"
+	listenAddrFlagName               = "listen-addr"
+	prometheusCREnabledFlagName      = "enable-prometheus-cr-watcher"
+	kubeConfigPathFlagName           = "kubeconfig-path"
+	httpsEnabledFlagName             = "enable-https-server"
+	listenAddrHttpsFlagName          = "listen-addr-https"
+	httpsCAFilePathFlagName          = "https-ca-file"
+	httpsTLSCertFilePathFlagName     = "https-tls-cert-file"
+	httpsTLSKeyFilePathFlagName      = "https-tls-key-file"
+	allowInsecureAuthSecretsFlagName = "allow-insecure-auth-secrets"
 )
 
 // We can't bind this flag to our FlagSet, so we need to handle it separately.
@@ -38,6 +39,7 @@ func getFlagSet(errorHandling pflag.ErrorHandling) *pflag.FlagSet {
 	flagSet.String(httpsCAFilePathFlagName, "", "The path to the HTTPS server TLS CA file.")
 	flagSet.String(httpsTLSCertFilePathFlagName, "", "The path to the HTTPS server TLS certificate file.")
 	flagSet.String(httpsTLSKeyFilePathFlagName, "", "The path to the HTTPS server TLS key file.")
+	flagSet.Bool(allowInsecureAuthSecretsFlagName, false, "Serve scrape configs with secret values over plain HTTP without mTLS. Only enable when transport is secured by a service mesh or equivalent.")
 	zapFlagSet := flag.NewFlagSet("", flag.ErrorHandling(errorHandling))
 	zapCmdLineOpts.BindFlags(zapFlagSet)
 	flagSet.AddGoFlagSet(zapFlagSet)
@@ -78,6 +80,10 @@ func getHttpsTLSCertFilePath(flagSet *pflag.FlagSet) (value string, changed bool
 
 func getHttpsTLSKeyFilePath(flagSet *pflag.FlagSet) (value string, changed bool, err error) {
 	return getFlagValueAndChangedString(flagSet, httpsTLSKeyFilePathFlagName)
+}
+
+func getAllowInsecureAuthSecrets(flagSet *pflag.FlagSet) (value, changed bool, err error) {
+	return getFlagValueAndChangedBool(flagSet, allowInsecureAuthSecretsFlagName)
 }
 
 // getFlagValueAndChanged returns the given flag's string value and whether it was changed.

--- a/cmd/otel-allocator/internal/config/flags_test.go
+++ b/cmd/otel-allocator/internal/config/flags_test.go
@@ -19,6 +19,7 @@ func TestGetFlagSet(t *testing.T) {
 	assert.NotNil(t, fs.Lookup(listenAddrFlagName), "Flag %s not found", listenAddrFlagName)
 	assert.NotNil(t, fs.Lookup(prometheusCREnabledFlagName), "Flag %s not found", prometheusCREnabledFlagName)
 	assert.NotNil(t, fs.Lookup(kubeConfigPathFlagName), "Flag %s not found", kubeConfigPathFlagName)
+	assert.NotNil(t, fs.Lookup(allowInsecureAuthSecretsFlagName), "Flag %s not found", allowInsecureAuthSecretsFlagName)
 }
 
 func TestFlagGetters(t *testing.T) {
@@ -83,6 +84,15 @@ func TestFlagGetters(t *testing.T) {
 			expectedValue: "/path/to/tls.key",
 			getterFunc: func(fs *pflag.FlagSet) (any, error) {
 				value, _, err := getHttpsTLSKeyFilePath(fs)
+				return value, err
+			},
+		},
+		{
+			name:          "AllowInsecureAuthSecrets",
+			flagArgs:      []string{"--" + allowInsecureAuthSecretsFlagName, "true"},
+			expectedValue: true,
+			getterFunc: func(fs *pflag.FlagSet) (any, error) {
+				value, _, err := getAllowInsecureAuthSecrets(fs)
 				return value, err
 			},
 		},

--- a/cmd/otel-allocator/internal/server/server.go
+++ b/cmd/otel-allocator/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/pprof"
 	"net/url"
@@ -61,6 +62,7 @@ type Server struct {
 	scrapeConfigResponse                 []byte
 	ScrapeConfigMarshalledSecretResponse []byte
 	httpDuration                         metric.Float64Histogram
+	allowInsecureAuthSecrets             bool
 }
 
 type Option func(*Server)
@@ -73,6 +75,12 @@ func WithTLSConfig(tlsConfig *tls.Config, httpsListenAddr string) Option {
 		s.setRouter(httpsRouter)
 
 		s.httpsServer = &http.Server{Addr: httpsListenAddr, Handler: httpsRouter, ReadHeaderTimeout: 90 * time.Second, TLSConfig: tlsConfig}
+	}
+}
+
+func WithInsecureAuthSecrets() Option {
+	return func(s *Server) {
+		s.allowInsecureAuthSecrets = true
 	}
 }
 
@@ -119,6 +127,11 @@ func NewServer(log logr.Logger, allocator allocation.Allocator, listenAddr strin
 
 	for _, opt := range options {
 		opt(s)
+	}
+
+	if s.allowInsecureAuthSecrets {
+		slog.New(logr.ToSlogHandler(s.logger)).Warn("allowInsecureAuthSecrets is enabled - auth secret values will be served over plain HTTP. " +
+			"Only use this when the target allocator endpoint is secured by a service mesh or equivalent transport-level security.")
 	}
 
 	return s, nil
@@ -241,7 +254,7 @@ func (s *Server) ScrapeConfigsHandler(c *gin.Context) {
 	}
 	s.mtx.RLock()
 	result := s.scrapeConfigResponse
-	if c.Request.TLS != nil {
+	if c.Request.TLS != nil || s.allowInsecureAuthSecrets {
 		result = s.ScrapeConfigMarshalledSecretResponse
 	}
 	s.mtx.RUnlock()

--- a/cmd/otel-allocator/internal/server/server.go
+++ b/cmd/otel-allocator/internal/server/server.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"net/http/pprof"
 	"net/url"
@@ -130,7 +129,8 @@ func NewServer(log logr.Logger, allocator allocation.Allocator, listenAddr strin
 	}
 
 	if s.allowInsecureAuthSecrets {
-		slog.New(logr.ToSlogHandler(s.logger)).Warn("allowInsecureAuthSecrets is enabled - auth secret values will be served over plain HTTP. " +
+		// TODO: Change to Warn level after migrating away from logr.
+		s.logger.Info("allowInsecureAuthSecrets is enabled - auth secret values will be served over plain HTTP. " +
 			"Only use this when the target allocator endpoint is secured by a service mesh or equivalent transport-level security.")
 	}
 

--- a/cmd/otel-allocator/internal/server/server_test.go
+++ b/cmd/otel-allocator/internal/server/server_test.go
@@ -485,6 +485,30 @@ func TestServer_ScrapeConfigsHandler(t *testing.T) {
 			},
 			expectedCode: http.StatusOK,
 		},
+		{
+			description: "http with allow-insecure-auth-secrets serves real secret values",
+			scrapeConfigs: map[string]*promconfig.ScrapeConfig{
+				"serviceMonitor/testapp/testapp3/0": {
+					JobName:         "serviceMonitor/testapp/testapp3/0",
+					HonorTimestamps: true,
+					ScrapeInterval:  model.Duration(30 * time.Second),
+					ScrapeTimeout:   model.Duration(30 * time.Second),
+					MetricsPath:     "/metrics",
+					Scheme:          "http",
+					HTTPClientConfig: config.HTTPClientConfig{
+						FollowRedirects: true,
+						BasicAuth: &config.BasicAuth{
+							Username: "test",
+							Password: "P@$$w0rd1!?",
+						},
+					},
+				},
+			},
+			expectedCode: http.StatusOK,
+			serverOptions: []Option{
+				WithInsecureAuthSecrets(),
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
@@ -514,14 +538,15 @@ func TestServer_ScrapeConfigsHandler(t *testing.T) {
 			err = yaml.Unmarshal(bodyBytes, scrapeConfigs)
 			require.NoError(t, err)
 
+			serveSecrets := s.httpsServer != nil || s.allowInsecureAuthSecrets
 			for _, c := range scrapeConfigs {
-				if s.httpsServer == nil && c.HTTPClientConfig.BasicAuth != nil {
+				if !serveSecrets && c.HTTPClientConfig.BasicAuth != nil {
 					assert.Equal(t, c.HTTPClientConfig.BasicAuth.Password, config.Secret("<secret>"))
 				}
 			}
 
 			for _, c := range tc.scrapeConfigs {
-				if s.httpsServer == nil && c.HTTPClientConfig.BasicAuth != nil {
+				if !serveSecrets && c.HTTPClientConfig.BasicAuth != nil {
 					c.HTTPClientConfig.BasicAuth.Password = "<secret>"
 				}
 			}

--- a/cmd/otel-allocator/main.go
+++ b/cmd/otel-allocator/main.go
@@ -106,6 +106,9 @@ func main() {
 		}
 		httpOptions = append(httpOptions, server.WithTLSConfig(tlsConfig, cfg.HTTPS.ListenAddr))
 	}
+	if cfg.AllowInsecureAuthSecrets {
+		httpOptions = append(httpOptions, server.WithInsecureAuthSecrets())
+	}
 	srv, serverErr := server.NewServer(log, allocator, cfg.ListenAddr, httpOptions...)
 	if serverErr != nil {
 		panic(serverErr)

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -8073,6 +8073,8 @@ spec:
                     - consistent-hashing
                     - per-node
                     type: string
+                  allowInsecureAuthSecrets:
+                    type: boolean
                   collectorNotReadyGracePeriod:
                     default: 30s
                     format: duration

--- a/config/crd/bases/opentelemetry.io_targetallocators.yaml
+++ b/config/crd/bases/opentelemetry.io_targetallocators.yaml
@@ -1205,6 +1205,8 @@ spec:
                 - consistent-hashing
                 - per-node
                 type: string
+              allowInsecureAuthSecrets:
+                type: boolean
               args:
                 additionalProperties:
                   type: string

--- a/docs/api/opentelemetrycollectors.md
+++ b/docs/api/opentelemetrycollectors.md
@@ -32210,6 +32210,15 @@ WARNING: The per-node strategy currently ignores targets without a Node, like co
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>allowInsecureAuthSecrets</b></td>
+        <td>boolean</td>
+        <td>
+          AllowInsecureAuthSecrets controls whether auth secret values (e.g. basicAuth passwords)
+are served over plain HTTP without requiring mTLS. Only enable this when the target allocator
+endpoint is secured by a service mesh or equivalent transport-level security.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>collectorNotReadyGracePeriod</b></td>
         <td>string</td>
         <td>

--- a/docs/api/targetallocators.md
+++ b/docs/api/targetallocators.md
@@ -120,6 +120,15 @@ WARNING: The per-node strategy currently ignores targets without a Node, like co
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>allowInsecureAuthSecrets</b></td>
+        <td>boolean</td>
+        <td>
+          AllowInsecureAuthSecrets controls whether auth secret values (e.g. basicAuth passwords)
+are served over plain HTTP without requiring mTLS. Only enable this when the target allocator
+endpoint is secured by a service mesh or equivalent transport-level security.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>args</b></td>
         <td>map[string]string</td>
         <td>

--- a/internal/manifests/collector/targetallocator.go
+++ b/internal/manifests/collector/targetallocator.go
@@ -58,6 +58,7 @@ func TargetAllocator(params manifests.Params) (*v1alpha1.TargetAllocator, error)
 			FilterStrategy:               taSpec.FilterStrategy,
 			PrometheusCR:                 taSpec.PrometheusCR,
 			Observability:                taSpec.Observability,
+			AllowInsecureAuthSecrets:     taSpec.AllowInsecureAuthSecrets,
 			CollectorNotReadyGracePeriod: taSpec.CollectorNotReadyGracePeriod,
 		},
 	}, nil

--- a/internal/manifests/collector/targetallocator_test.go
+++ b/internal/manifests/collector/targetallocator_test.go
@@ -173,6 +173,7 @@ func TestTargetAllocator(t *testing.T) {
 								EnableMetrics: true,
 							},
 						},
+						AllowInsecureAuthSecrets: true,
 						PodDisruptionBudget: &v1beta1.PodDisruptionBudgetSpec{
 							MaxUnavailable: &intstr.IntOrString{
 								Type:   intstr.Int,
@@ -280,6 +281,7 @@ func TestTargetAllocator(t *testing.T) {
 							EnableMetrics: true,
 						},
 					},
+					AllowInsecureAuthSecrets: true,
 				},
 			},
 		},

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -146,6 +146,10 @@ func ConfigMap(params Params) (*corev1.ConfigMap, error) {
 		}
 	}
 
+	if taSpec.AllowInsecureAuthSecrets {
+		taConfig["allow_insecure_auth_secrets"] = true
+	}
+
 	if taSpec.CollectorNotReadyGracePeriod.Size() > 0 {
 		taConfig["collector_not_ready_grace_period"] = taSpec.CollectorNotReadyGracePeriod.Duration
 	}

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -922,7 +922,6 @@ filter_strategy: relabel-config
 		assert.Equal(t, "my-instance-targetallocator", actual.Name)
 		assert.Equal(t, expectedData[targetAllocatorFilename], actual.Data[targetAllocatorFilename])
 	})
-
 }
 
 func TestDesiredConfigMapAllowInsecureAuthSecrets(t *testing.T) {

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -922,6 +922,46 @@ filter_strategy: relabel-config
 		assert.Equal(t, "my-instance-targetallocator", actual.Name)
 		assert.Equal(t, expectedData[targetAllocatorFilename], actual.Data[targetAllocatorFilename])
 	})
+
+}
+
+func TestDesiredConfigMapAllowInsecureAuthSecrets(t *testing.T) {
+	flgs := featuregate.Flags(colfg.GlobalRegistry())
+	_ = flgs.Parse([]string{"--feature-gates=operator.targetallocator.fallbackstrategy"})
+
+	expectedData := map[string]string{
+		targetAllocatorFilename: `allocation_fallback_strategy: consistent-hashing
+allocation_strategy: consistent-hashing
+allow_insecure_auth_secrets: true
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: default.my-instance
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  matchexpressions: []
+config:
+  scrape_configs:
+  - job_name: otel-collector
+    scrape_interval: 10s
+    static_configs:
+    - targets:
+      - 0.0.0.0:8888
+      - 0.0.0.0:9999
+filter_strategy: relabel-config
+`,
+	}
+	ta := targetAllocatorInstance()
+	ta.Spec.AllowInsecureAuthSecrets = true
+	testParams := Params{
+		Collector:       collectorInstance(),
+		TargetAllocator: ta,
+	}
+	actual, err := ConfigMap(testParams)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-instance-targetallocator", actual.Name)
+	assert.Equal(t, expectedData[targetAllocatorFilename], actual.Data[targetAllocatorFilename])
 }
 
 func TestDesiredConfigMapWithDenyFSAccessThroughSMs(t *testing.T) {

--- a/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/00-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/00-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: insecure-auth-collector
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insecure-auth-targetallocator
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: insecure-auth-targetallocator

--- a/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/00-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/00-install.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  name: collector
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: (join('-', ['collector-insecure-auth', $namespace]))
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/metrics
+  - services
+  - endpoints
+  - namespaces
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - watch
+  - list
+- nonResourceURLs:
+  - /metrics
+  - /metrics/cadvisor
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: (join('-', ['collector-insecure-auth', $namespace]))
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: (join('-', ['collector-insecure-auth', $namespace]))
+subjects:
+- kind: ServiceAccount
+  name: collector
+  namespace: ($namespace)
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: insecure-auth
+spec:
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs: []
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [debug]
+  mode: statefulset
+  serviceAccount: collector
+  targetAllocator:
+    enabled: true
+    allowInsecureAuthSecrets: true
+    prometheusCR:
+      enabled: true
+      scrapeInterval: 1s
+      secretNamespaces:
+      - ($namespace)
+      serviceMonitorSelector: {}
+      podMonitorSelector: {}
+    serviceAccount: ta

--- a/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/01-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/01-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-app-secret
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-app
+status:
+  availableReplicas: 1
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: metrics-servicemonitor

--- a/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/01-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/01-install.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-app-secret
+type: Opaque
+stringData:
+  username: user
+  password: t0p$ecreT
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-app
+  labels:
+    app: metrics-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metrics-app
+  template:
+    metadata:
+      labels:
+        app: metrics-app
+    spec:
+      containers:
+      - name: metrics-app
+        image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-metrics-basic-auth:main
+        ports:
+        - containerPort: 9123
+        env:
+        - name: BASIC_AUTH_USERNAME
+          value: user
+        - name: BASIC_AUTH_PASSWORD
+          value: t0p$ecreT
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-service
+  labels:
+    app: metrics-app
+spec:
+  ports:
+  - name: metrics
+    port: 9123
+    targetPort: 9123
+    protocol: TCP
+  selector:
+    app: metrics-app
+  type: ClusterIP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: metrics-servicemonitor
+  labels:
+    app: metrics-app
+spec:
+  selector:
+    matchLabels:
+      app: metrics-app
+  endpoints:
+  - port: metrics
+    interval: 10s
+    basicAuth:
+      username:
+        name: metrics-app-secret
+        key: username
+      password:
+        name: metrics-app-secret
+        key: password

--- a/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/02-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/02-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-secret-served-over-http
+status:
+  succeeded: 1

--- a/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/02-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/02-install.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-secret-served-over-http
+spec:
+  template:
+    metadata:
+      labels:
+        checker: "true"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: check-secret
+        image: mirror.gcr.io/curlimages/curl:latest
+        args:
+        - /bin/sh
+        - -c
+        - |
+          for i in $(seq 30); do
+            CONFIG=$(curl -s http://insecure-auth-targetallocator/scrape_configs)
+            if echo "$CONFIG" | grep -q "t0p"; then
+              echo "SUCCESS: Real secret value found in scrape_configs over plain HTTP"
+              echo "$CONFIG"
+              exit 0
+            fi
+            echo "Attempt $i: waiting for secret to appear..."
+            sleep 5
+          done
+          echo "FAIL: Secret value not found in scrape_configs"
+          curl -s http://insecure-auth-targetallocator/scrape_configs
+          exit 1

--- a/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/chainsaw-test.yaml
+++ b/tests/e2e-targetallocator/targetallocator-insecure-auth-secrets/chainsaw-test.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: targetallocator-insecure-auth-secrets
+spec:
+  steps:
+  - name: Setup Target Allocator RBAC
+    use:
+      template: ../../step-templates/target-allocator-rbac-comprehensive.yaml
+      with:
+        bindings:
+        - name: clusterRoleName
+          value: targetallocator-insecure-auth-secrets
+        - name: clusterRoleBindingName
+          value: (join('-', ['ta', $namespace]))
+  - name: step-00-deploy-collector-with-insecure-auth
+    try:
+    - apply:
+        template: true
+        file: 00-install.yaml
+    - assert:
+        file: 00-assert.yaml
+    catch:
+    - podLogs:
+        selector: app.kubernetes.io/managed-by=opentelemetry-operator
+  - name: step-01-create-secret-and-servicemonitor
+    try:
+    - apply:
+        file: 01-install.yaml
+    - assert:
+        file: 01-assert.yaml
+    catch:
+    - podLogs:
+        selector: app.kubernetes.io/managed-by=opentelemetry-operator
+  - name: step-02-verify-secret-values-over-http
+    try:
+    - apply:
+        file: 02-install.yaml
+    - assert:
+        file: 02-assert.yaml
+    catch:
+    - podLogs:
+        selector: app.kubernetes.io/managed-by=opentelemetry-operator


### PR DESCRIPTION
**Description:** 
Currently the TA can only serve discovered auth data, eg. Kubernetes Secrets from a ServiceMonitor with basicauth, over mtls. This great feature would overcomplicate setups for teams who have existing service mesh which already handles the mtls auth between the services or high maintenance for teams who can't use the operator / crds and also for dev setups. 
Its configurable bool via config file, CLI flag (`--allow-insecure-auth-secrets`), or environment variable (`ALLOW_INSECURE_AUTH_SECRETS`) - allowing the most flexibility so the operator crds can cover this setting and also the standalone helm chart from the targetAllocator.
-> When enabled, a "warn" log will be written at startup that secret are exposed via plaintext. 
Defaults to `false` to maintain backwards compatibility.

A next feature could be that also https can be configured so no "heavy" mtls is needed, but at least the transport is secured.


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

- Resolves: #3746

**Testing:**
Expanded the tests for the new feature in the config, flags and the server files.
All tests, precommits and lints were successful.

**Documentation:** 
Added the new config parameter to the targetAllocator and a short description how it can be used, for which environments it should be used and which problem it can solve.
