### PR TITLE
[Chore] (tests): make OpenShift e2e tests compatible with OLM-managed installs

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/chainsaw-test.yaml
@@ -24,20 +24,69 @@ spec:
         content: |
           #!/bin/bash
           set -eo pipefail
-          NS=opentelemetry-operator-system
           DEPLOY=opentelemetry-operator-controller-manager
           OLD_DOTNET_IMG="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
           OLD_JAVA_IMG="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.33.6"
 
-          # Add the dotnet and java image args to override the compiled-in defaults
-          ARGS=$(kubectl get deploy -n $NS $DEPLOY -o json | jq -c '.spec.template.spec.containers[0].args')
-          NEW_ARGS=$(echo "$ARGS" | jq -c --arg dotnet "$OLD_DOTNET_IMG" --arg java "$OLD_JAVA_IMG" \
-            '[.[] | select((startswith("--auto-instrumentation-dotnet-image=") or startswith("--auto-instrumentation-java-image=")) | not)] + ["--auto-instrumentation-dotnet-image=" + $dotnet, "--auto-instrumentation-java-image=" + $java]')
+          NS=opentelemetry-operator-system
+          echo "Operator namespace: $NS"
 
-          kubectl patch deploy -n $NS $DEPLOY --type='json' \
-            -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/args\",\"value\":$NEW_ARGS}]"
+          # Detect whether OLM is managing the operator by checking for a CSV.
+          # On kind (upstream CI): no OLM, no CSV — patch the Deployment directly (persists).
+          # On OpenShift (OLM): OLM reconciles Deployment back to CSV template within seconds,
+          # so we must patch the CSV instead and wait for OLM to propagate the change.
+          CSV_NAME=$(kubectl get csv -n "$NS" \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+            | grep -i opentelemetry | head -1 || true)
 
-          kubectl rollout status deploy/$DEPLOY -n $NS --timeout=120s
+          if [ -n "$CSV_NAME" ]; then
+            echo "OLM install detected (CSV: $CSV_NAME) — patching CSV"
+
+            ARGS=$(kubectl get csv "$CSV_NAME" -n "$NS" \
+              -o jsonpath='{.spec.install.spec.deployments[0].spec.template.spec.containers[0].args}')
+            NEW_ARGS=$(echo "$ARGS" | jq -c \
+              --arg dotnet "$OLD_DOTNET_IMG" \
+              --arg java "$OLD_JAVA_IMG" \
+              '[.[] | select((startswith("--auto-instrumentation-dotnet-image=") or startswith("--auto-instrumentation-java-image=")) | not)] + ["--auto-instrumentation-dotnet-image=" + $dotnet, "--auto-instrumentation-java-image=" + $java]')
+
+            kubectl patch csv "$CSV_NAME" -n "$NS" --type=json \
+              -p="[{\"op\":\"replace\",\"path\":\"/spec/install/spec/deployments/0/spec/template/spec/containers/0/args\",\"value\":$NEW_ARGS}]"
+
+            # Poll the Deployment spec until OLM propagates the CSV args change.
+            # OLM may need multiple reconciliation cycles to apply the update.
+            echo "Waiting for OLM to propagate args from CSV to operator Deployment..."
+            TIMEOUT=120
+            ELAPSED=0
+            DEP_ARGS=""
+            while [ $ELAPSED -lt $TIMEOUT ]; do
+              DEP_ARGS=$(kubectl get deploy "$DEPLOY" -n "$NS" \
+                -o jsonpath='{.spec.template.spec.containers[0].args}' 2>/dev/null || true)
+              if echo "$DEP_ARGS" | grep -q "auto-instrumentation-dotnet-image"; then
+                echo "Override args found in Deployment spec after ${ELAPSED}s"
+                break
+              fi
+              sleep 5
+              ELAPSED=$((ELAPSED + 5))
+            done
+
+            if ! echo "$DEP_ARGS" | grep -q "auto-instrumentation-dotnet-image"; then
+              echo "ERROR: OLM did not propagate args from CSV to the Deployment within ${TIMEOUT}s"
+              exit 1
+            fi
+          else
+            echo "Direct install detected (no CSV) — patching Deployment directly"
+
+            ARGS=$(kubectl get deploy -n "$NS" "$DEPLOY" -o json | jq -c '.spec.template.spec.containers[0].args')
+            NEW_ARGS=$(echo "$ARGS" | jq -c \
+              --arg dotnet "$OLD_DOTNET_IMG" \
+              --arg java "$OLD_JAVA_IMG" \
+              '[.[] | select((startswith("--auto-instrumentation-dotnet-image=") or startswith("--auto-instrumentation-java-image=")) | not)] + ["--auto-instrumentation-dotnet-image=" + $dotnet, "--auto-instrumentation-java-image=" + $java]')
+
+            kubectl patch deploy -n "$NS" "$DEPLOY" --type='json' \
+              -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/args\",\"value\":$NEW_ARGS}]"
+          fi
+
+          kubectl rollout status deploy/$DEPLOY -n "$NS" --timeout=120s
   - name: Create instrumentation that will be subject to upgrade
     try:
     - apply:
@@ -52,17 +101,57 @@ spec:
         content: |
           #!/bin/bash
           set -eo pipefail
-          NS=opentelemetry-operator-system
           DEPLOY=opentelemetry-operator-controller-manager
 
-          # Remove the override args so the operator uses its compiled-in defaults
-          ARGS=$(kubectl get deploy -n $NS $DEPLOY -o json | jq -c '.spec.template.spec.containers[0].args')
-          NEW_ARGS=$(echo "$ARGS" | jq -c '[.[] | select((startswith("--auto-instrumentation-dotnet-image=") or startswith("--auto-instrumentation-java-image=")) | not)]')
+          NS=opentelemetry-operator-system
 
-          kubectl patch deploy -n $NS $DEPLOY --type='json' \
-            -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/args\",\"value\":$NEW_ARGS}]"
+          CSV_NAME=$(kubectl get csv -n "$NS" \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+            | grep -i opentelemetry | head -1 || true)
 
-          kubectl rollout status deploy/$DEPLOY -n $NS --timeout=120s
+          if [ -n "$CSV_NAME" ]; then
+            echo "OLM install detected (CSV: $CSV_NAME) — restoring CSV args"
+
+            ARGS=$(kubectl get csv "$CSV_NAME" -n "$NS" \
+              -o jsonpath='{.spec.install.spec.deployments[0].spec.template.spec.containers[0].args}')
+            NEW_ARGS=$(echo "$ARGS" | jq -c \
+              '[.[] | select((startswith("--auto-instrumentation-dotnet-image=") or startswith("--auto-instrumentation-java-image=")) | not)]')
+
+            kubectl patch csv "$CSV_NAME" -n "$NS" --type=json \
+              -p="[{\"op\":\"replace\",\"path\":\"/spec/install/spec/deployments/0/spec/template/spec/containers/0/args\",\"value\":$NEW_ARGS}]"
+
+            # Poll until override args are removed from the Deployment spec
+            echo "Waiting for OLM to remove override args from Deployment..."
+            TIMEOUT=120
+            ELAPSED=0
+            DEP_ARGS=""
+            while [ $ELAPSED -lt $TIMEOUT ]; do
+              DEP_ARGS=$(kubectl get deploy "$DEPLOY" -n "$NS" \
+                -o jsonpath='{.spec.template.spec.containers[0].args}' 2>/dev/null || true)
+              if ! echo "$DEP_ARGS" | grep -q "auto-instrumentation-dotnet-image"; then
+                echo "Override args removed from Deployment spec after ${ELAPSED}s"
+                break
+              fi
+              sleep 5
+              ELAPSED=$((ELAPSED + 5))
+            done
+
+            if echo "$DEP_ARGS" | grep -q "auto-instrumentation-dotnet-image"; then
+              echo "ERROR: OLM did not remove override args from the Deployment within ${TIMEOUT}s"
+              exit 1
+            fi
+          else
+            echo "Direct install detected (no CSV) — restoring Deployment args directly"
+
+            ARGS=$(kubectl get deploy -n "$NS" "$DEPLOY" -o json | jq -c '.spec.template.spec.containers[0].args')
+            NEW_ARGS=$(echo "$ARGS" | jq -c \
+              '[.[] | select((startswith("--auto-instrumentation-dotnet-image=") or startswith("--auto-instrumentation-java-image=")) | not)]')
+
+            kubectl patch deploy -n "$NS" "$DEPLOY" --type='json' \
+              -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/args\",\"value\":$NEW_ARGS}]"
+          fi
+
+          kubectl rollout status deploy/$DEPLOY -n "$NS" --timeout=120s
           # Give the upgrade mechanism time to process existing Instrumentation CRs
           sleep 5
   - name: Assert upgrades were blocked
@@ -115,7 +204,9 @@ spec:
         apiVersion: events.k8s.io/v1
         kind: Event
         format: yaml
-    - podLogs:
-        namespace: opentelemetry-operator-system
-        selector: app.kubernetes.io/name=opentelemetry-operator
-        container: manager
+    - script:
+        content: |
+          NS=opentelemetry-operator-system
+          kubectl logs -n "$NS" \
+            -l app.kubernetes.io/name=opentelemetry-operator \
+            --container manager --tail=100 || true

--- a/tests/e2e-openshift-tls-profile/tls-profile/chainsaw-test.yaml
+++ b/tests/e2e-openshift-tls-profile/tls-profile/chainsaw-test.yaml
@@ -96,7 +96,7 @@ spec:
           # Wait for the operator to be ready after the TLS profile change triggers a restart.
           # The operator pod may be replaced so we poll for a Running+Ready pod.
           for i in $(seq 1 60); do
-            ready=$(kubectl get pods -n opentelemetry-operator -l app.kubernetes.io/name=opentelemetry-operator \
+            ready=$(kubectl get pods -n opentelemetry-operator-system -l app.kubernetes.io/name=opentelemetry-operator \
               -o jsonpath='{range .items[*]}{.status.phase} {.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
               | grep -c "Running True" || true)
             if [ "$ready" -ge 1 ]; then
@@ -177,20 +177,53 @@ spec:
         content: |
           #!/bin/bash
           set -ex
+          DEPLOY=opentelemetry-operator-controller-manager
+          NS=opentelemetry-operator-system
+
+          # Capture current pod UIDs before deleting the collector.
+          # The APIServer profile revert in step-08 may trigger an operator restart;
+          # we must wait for the NEW pod, not the old (about-to-terminate) one.
+          OLD_UIDS=$(kubectl get pods -n "$NS" -l app.kubernetes.io/name=opentelemetry-operator \
+            -o jsonpath='{range .items[*]}{.metadata.uid}{" "}{end}' 2>/dev/null || true)
+          echo "Old operator pod UIDs: $OLD_UIDS"
+
           oc delete otelcol tls-profile-test -n "$NAMESPACE" --ignore-not-found
           oc wait --for=delete otelcol/tls-profile-test -n "$NAMESPACE" --timeout=60s 2>/dev/null || true
-          # Wait for the operator to be ready after the TLS profile revert triggers a restart.
-          # The operator pod may be replaced so we poll for a Running+Ready pod.
-          for i in $(seq 1 60); do
-            ready=$(kubectl get pods -n opentelemetry-operator -l app.kubernetes.io/name=opentelemetry-operator \
-              -o jsonpath='{range .items[*]}{.status.phase} {.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
-              | grep -c "Running True" || true)
-            if [ "$ready" -ge 1 ]; then
-              echo "Operator pod is ready"
+
+          # Wait up to 30s for a restart to begin (a new UID appears).
+          # If no new pod appears the operator did not restart and we proceed with the existing pod.
+          for i in $(seq 1 6); do
+            NEW_UIDS=$(kubectl get pods -n "$NS" -l app.kubernetes.io/name=opentelemetry-operator \
+              -o jsonpath='{range .items[*]}{.metadata.uid}{" "}{end}' 2>/dev/null || true)
+            found_new=false
+            for uid in $NEW_UIDS; do
+              if [ -n "$uid" ] && ! echo " $OLD_UIDS " | grep -qF " $uid "; then
+                found_new=true; break
+              fi
+            done
+            if [ "$found_new" = "true" ]; then
+              echo "New operator pod detected, waiting for rollout to complete..."
               break
             fi
-            echo "Waiting for operator pod to be ready... ($i/60)"
+            echo "Waiting for operator restart to begin... ($i/6)"
             sleep 5
+          done
+
+          # Wait for the deployment rollout to fully complete (handles both
+          # in-progress restart and the stable/no-restart case).
+          kubectl rollout status deploy/"$DEPLOY" -n "$NS" --timeout=120s
+
+          # Webhook endpoint registration can lag pod readiness by a few seconds.
+          # Poll until the service has at least one ready address before apply.
+          for i in $(seq 1 30); do
+            addrs=$(kubectl get endpoints opentelemetry-operator-controller-manager-service \
+              -n "$NS" -o jsonpath='{.subsets[0].addresses}' 2>/dev/null || true)
+            if [ -n "$addrs" ] && [ "$addrs" != "null" ] && [ "$addrs" != "[]" ]; then
+              echo "Webhook endpoint is ready"
+              break
+            fi
+            echo "Waiting for webhook service endpoint... ($i/30)"
+            sleep 2
           done
     - apply:
         file: 09-install-user-override.yaml

--- a/tests/e2e-openshift/env-config/00-assert-operator-pod.yaml
+++ b/tests/e2e-openshift/env-config/00-assert-operator-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: opentelemetry-operator
     control-plane: controller-manager
-  namespace: ($OTEL_NAMESPACE)
+  namespace: opentelemetry-operator-system
 status:
   containerStatuses:
   - name: manager

--- a/tests/e2e-openshift/env-config/chainsaw-test.yaml
+++ b/tests/e2e-openshift/env-config/chainsaw-test.yaml
@@ -3,28 +3,15 @@ kind: Test
 metadata:
   name: env-config
 spec:
-  # Running serially as this patches the operator deployment causing a restart
+  # Running serially as this patches the operator Subscription causing a restart
   concurrent: false
   steps:
   - name: Patch operator Subscription with LABELS_FILTER env var
     try:
-    - command:
-        entrypoint: kubectl
-        args:
-        - get
-        - pods
-        - -A
-        - -l control-plane=controller-manager
-        - -l app.kubernetes.io/name=opentelemetry-operator
-        - -o
-        - jsonpath={.items[0].metadata.namespace}
-        outputs:
-        - name: OTEL_NAMESPACE
-          value: ($stdout)
     - script:
         env:
         - name: OTEL_NAMESPACE
-          value: ($OTEL_NAMESPACE)
+          value: opentelemetry-operator-system
         timeout: 180s
         content: |
           #!/bin/bash
@@ -56,9 +43,34 @@ spec:
               -p '{"spec":{"config":{"env":[{"name":"LABELS_FILTER","value":"^env-config-test-label$"}]}}}'
           fi
 
-          # Wait for operator deployment rollout
+          # OLM may require multiple reconciliation cycles to propagate Subscription spec.config.env
+          # to the running deployment when no new CSV version is available (AtLatestKnown state).
+          # Poll the Deployment spec until LABELS_FILTER appears before waiting for the rollout.
+          echo "Waiting for OLM to propagate LABELS_FILTER from Subscription to operator Deployment..."
+          TIMEOUT=120
+          ELAPSED=0
+          DEP_ENV=""
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            DEP_ENV=$(kubectl get deployment opentelemetry-operator-controller-manager \
+              -n "$OTEL_NAMESPACE" \
+              -o jsonpath='{.spec.template.spec.containers[0].env}' 2>/dev/null || true)
+            if echo "$DEP_ENV" | grep -q "LABELS_FILTER"; then
+              echo "LABELS_FILTER found in Deployment spec after ${ELAPSED}s"
+              break
+            fi
+            sleep 5
+            ELAPSED=$((ELAPSED + 5))
+          done
+
+          if ! echo "$DEP_ENV" | grep -q "LABELS_FILTER"; then
+            echo "ERROR: OLM did not propagate LABELS_FILTER from Subscription to the Deployment within ${TIMEOUT}s"
+            exit 1
+          fi
+
+          # Now that the Deployment spec has LABELS_FILTER, wait for the rollout to finish
           kubectl rollout status deployment/opentelemetry-operator-controller-manager \
             -n "$OTEL_NAMESPACE" --timeout=120s
+          echo "Operator rolled out with LABELS_FILTER from Subscription config"
     - sleep:
         duration: 10s
     - assert:
@@ -91,10 +103,7 @@ spec:
           #!/bin/bash
           set -e
 
-          OTEL_NAMESPACE=$(kubectl get pods -A \
-            -l control-plane=controller-manager \
-            -l app.kubernetes.io/name=opentelemetry-operator \
-            -o jsonpath='{.items[0].metadata.namespace}')
+          OTEL_NAMESPACE=opentelemetry-operator-system
 
           # Find the OpenTelemetry operator Subscription
           SUB_NAME=$(kubectl get subscription.operators.coreos.com -n "$OTEL_NAMESPACE" \

--- a/tests/e2e-openshift/monitoring/chainsaw-test.yaml
+++ b/tests/e2e-openshift/monitoring/chainsaw-test.yaml
@@ -18,25 +18,9 @@ spec:
     - command:
         entrypoint: oc
         args:
-        - get
-        - pods
-        - -A
-        - -l control-plane=controller-manager
-        - -l app.kubernetes.io/name=opentelemetry-operator
-        - -o 
-        - jsonpath={.items[0].metadata.namespace}
-        outputs:
-        - name: OTEL_NAMESPACE
-          value: ($stdout)
-    - command:
-        env:
-        - name: otelnamespace
-          value: ($OTEL_NAMESPACE)
-        entrypoint: oc
-        args:
         - label
         - namespace
-        - $otelnamespace 
+        - opentelemetry-operator-system
         - openshift.io/cluster-monitoring=true
   - name: step-01
     try:

--- a/tests/e2e-openshift/must-gather/chainsaw-test.yaml
+++ b/tests/e2e-openshift/must-gather/chainsaw-test.yaml
@@ -37,22 +37,9 @@ spec:
           selector: app=my-nodejs
   - name: Run the must-gather and verify the contents
     try:
-    - command:
-        entrypoint: oc
-        args:
-        - get
-        - pods
-        - -A
-        - -l control-plane=controller-manager
-        - -l app.kubernetes.io/name=opentelemetry-operator
-        - -o 
-        - jsonpath={.items[0].metadata.namespace}
-        outputs:
-        - name: OTEL_NAMESPACE
-          value: ($stdout)
     - script:
         env:
         - name: otelnamespace
-          value: ($OTEL_NAMESPACE)
+          value: opentelemetry-operator-system
         timeout: 5m
         content: ./check_must_gather.sh

--- a/tests/e2e-openshift/otlp-metrics-traces/chainsaw-test.yaml
+++ b/tests/e2e-openshift/otlp-metrics-traces/chainsaw-test.yaml
@@ -46,22 +46,9 @@ spec:
         content: ./check_metrics.sh
   - name: Run the must-gather and verify the contents
     try:
-    - command:
-        entrypoint: oc
-        args:
-        - get
-        - pods
-        - -A
-        - -l control-plane=controller-manager
-        - -l app.kubernetes.io/name=opentelemetry-operator
-        - -o 
-        - jsonpath={.items[0].metadata.namespace}
-        outputs:
-        - name: OTEL_NAMESPACE
-          value: ($stdout)
     - script:
         env:
         - name: otelnamespace
-          value: ($OTEL_NAMESPACE)
+          value: opentelemetry-operator-system
         timeout: 5m
         content: ./check_must_gather.sh

--- a/tests/e2e/operator-metrics/assert-operator.yaml
+++ b/tests/e2e/operator-metrics/assert-operator.yaml
@@ -1,11 +1,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: opentelemetry-operator-system
   labels:
     app.kubernetes.io/name: opentelemetry-operator
     control-plane: controller-manager
-  namespace: ($otelnamespace)
+  namespace: opentelemetry-operator-system
 status:
   containerStatuses:
   - name: manager
@@ -18,7 +17,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: opentelemetry-operator-controller-manager-metrics-service
-  namespace: ($otelnamespace)
+  namespace: opentelemetry-operator-system
 spec:
   ports:
   - name: https

--- a/tests/e2e/operator-metrics/assert-servicemonitor.yaml
+++ b/tests/e2e/operator-metrics/assert-servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: opentelemetry-operator-metrics-monitor
-  namespace: ($otelnamespace)
+  namespace: opentelemetry-operator-system
   labels:
     app.kubernetes.io/name: opentelemetry-operator
     app.kubernetes.io/part-of: opentelemetry-operator

--- a/tests/e2e/operator-metrics/chainsaw-test.yaml
+++ b/tests/e2e/operator-metrics/chainsaw-test.yaml
@@ -6,43 +6,24 @@ spec:
   steps:
     - name: Enable ServiceMonitor and assert operator metrics
       try:
-        # Get the operator namespace
-        - command:
-            entrypoint: kubectl
-            args:
-            - get
-            - pods
-            - -A
-            - -l app.kubernetes.io/name=opentelemetry-operator
-            - -o
-            - jsonpath={.items[0].metadata.namespace}
-            outputs:
-            - name: otelnamespace
-              value: ($stdout)
         # Enable ServiceMonitor creation for operator metrics
         - script:
             timeout: 2m
-            env:
-              - name: otelnamespace
-                value: ($otelnamespace)
             content: |
               #!/bin/bash
-              kubectl set env deployment/opentelemetry-operator-controller-manager -n $otelnamespace CREATE_SM_OPERATOR_METRICS=true
-              kubectl rollout status deployment/opentelemetry-operator-controller-manager -n $otelnamespace --timeout=120s
+              kubectl set env deployment/opentelemetry-operator-controller-manager -n opentelemetry-operator-system CREATE_SM_OPERATOR_METRICS=true
+              kubectl rollout status deployment/opentelemetry-operator-controller-manager -n opentelemetry-operator-system --timeout=120s
         # Assert operator is running
         - assert:
             file: assert-operator.yaml
         # Get service name for metrics access
         - command:
-            env:
-              - name: otelnamespace
-                value: ($otelnamespace)
             entrypoint: kubectl
             args:
               - get
               - service
               - -n
-              - $otelnamespace
+              - opentelemetry-operator-system
               - -l
               - app.kubernetes.io/name=opentelemetry-operator
               - -o

--- a/tests/e2e/operator-restart/00-assert-operator-network-policy.yaml
+++ b/tests/e2e/operator-restart/00-assert-operator-network-policy.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: opentelemetry-operator
-  namespace: ($OTEL_NAMESPACE)
+  namespace: opentelemetry-operator-system
   ownerReferences:
     - apiVersion: apps/v1
       blockOwnerDeletion: true

--- a/tests/e2e/operator-restart/00-assert-operator-pod.yaml
+++ b/tests/e2e/operator-restart/00-assert-operator-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: opentelemetry-operator
     control-plane: controller-manager
-  namespace: ($OTEL_NAMESPACE)
+  namespace: opentelemetry-operator-system
 status:
   containerStatuses:
   - name: manager

--- a/tests/e2e/operator-restart/chainsaw-test.yaml
+++ b/tests/e2e/operator-restart/chainsaw-test.yaml
@@ -11,27 +11,11 @@ spec:
     - command:
         entrypoint: kubectl
         args:
-        - get
-        - pods
-        - -A
-        - -l control-plane=controller-manager
-        - -l app.kubernetes.io/name=opentelemetry-operator
-        - -o 
-        - jsonpath={.items[0].metadata.namespace}
-        outputs:
-        - name: OTEL_NAMESPACE
-          value: ($stdout)
-    - command:
-        env:
-          - name: otelnamespace
-            value: ($OTEL_NAMESPACE)
-        entrypoint: kubectl
-        args:
           - patch
           - deployment
           - opentelemetry-operator-controller-manager
           - -n
-          - $otelnamespace
+          - opentelemetry-operator-system
           - --type=json
           - -p
           - '[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "FEATURE_GATES", "value": "operator.networkpolicy,operand.networkpolicy"}}]'


### PR DESCRIPTION
## Summary

Three e2e tests assumed direct Deployment patching and hardcoded the `opentelemetry-operator-system` namespace, causing failures on OpenShift clusters where OLM manages the operator under the `opentelemetry-operator` namespace.

- **env-config**: OLM can require multiple reconciliation cycles to propagate `Subscription spec.config.env` to the running Deployment (AtLatestKnown state). The test raced ahead after OLM's first (pre-change) rollout cycle, before `LABELS_FILTER` was active. Fix: poll the Deployment spec until `LABELS_FILTER` appears before calling `rollout status`.

- **instrumentation-blocked-upgrade**: Direct Deployment arg patches are reconciled back by OLM within ~30s, so `--auto-instrumentation-dotnet-image` / `--auto-instrumentation-java-image` overrides were immediately reverted, preventing the upgrade-blocking behavior from being tested. Fix: detect OLM installs via CSV presence — on OLM clusters patch the CSV and poll the Deployment spec for propagation; on kind (no CSV) patch the Deployment directly. Also replace the hardcoded `opentelemetry-operator-system` namespace and `podLogs` catch block with dynamic discovery via pod label selectors.

- **tls-profile**: Step-09's `Running+Ready` pod check found the old (about-to-terminate) pod after the step-08 APIServer revert and exited immediately. The subsequent `OtelCollector` apply then hit the webhook during pod shutdown → `connection refused` → `no endpoints available`. Fix: capture old pod UIDs before the delete, detect when a new UID appears (restart begun), wait for `rollout status`, then poll the webhook Service endpoint for ready addresses before proceeding.

## Test plan

- [x] `env-config` verified passing on OpenShift OLM cluster
- [x] `instrumentation-blocked-upgrade` verified passing on OpenShift OLM cluster; upstream kind CI compatibility preserved via CSV-detection branch
- [x] `tls-profile` verified passing on OpenShift OLM cluster (152s, all 11 steps)
