### PR TITLE
Skip flaky instrumentation-no-crds e2e test

### DIFF
--- a/tests/e2e-no-crds/instrumentation-no-crds/chainsaw-test.yaml
+++ b/tests/e2e-no-crds/instrumentation-no-crds/chainsaw-test.yaml
@@ -4,6 +4,7 @@ kind: Test
 metadata:
   name: instrumentation-no-crds
 spec:
+  skip: true # https://github.com/open-telemetry/opentelemetry-operator/issues/5092
   steps:
   - name: step-00
     try:


### PR DESCRIPTION
Test has recently been flaky, skipping until that's resolved. Tracking in https://github.com/open-telemetry/opentelemetry-operator/issues/5092.