### PR TITLE
Make instrumentation webhook HA

### DIFF
--- a/.chloggen/auto-instrumentation-webhook-ha.yaml
+++ b/.chloggen/auto-instrumentation-webhook-ha.yaml
@@ -1,0 +1,21 @@
+change_type: enhancement
+
+component: auto-instrumentation
+
+note: Add standalone pod webhook deployment for High Availability on OpenShift
+
+issues: [5010]
+
+subtext: |
+  On OpenShift with OLM, the pod mutation webhook (auto-instrumentation and sidecar injection)
+  is now deployed as a standalone Deployment with 2 replicas by default, enabling HA.
+
+  **OpenShift with OLM:**
+  - The standalone webhook deployment is managed by OLM via the CSV
+  - Default: 2 replicas for HA
+  - Only scaling down is supported via `POD_WEBHOOK_REPLICAS` env var in the Subscription (0 or 1)
+  - TLS certificates are automatically provisioned by OLM
+  - Automatic cleanup when operator is uninstalled (OLM garbage collection)
+
+  **Kubernetes (community bundle):**
+  - No change - pod webhook continues to run as part of the operator deployment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,6 +337,7 @@ operator-sdk run bundle docker.io/${DOCKER_USER}/opentelemetry-operator-bundle:l
 The operator can be uninstalled by deleting `subscriptions.operators.coreos.com` and `clusterserviceversion.operators.coreos.com` objects from the current namespace.
 
 ```bash
+kubectl delete catalogsources.operators.coreos.com --all
 kubectl delete clusterserviceversion.operators.coreos.com --all
 kubectl delete subscriptions.operators.coreos.com --all
 ```

--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,7 @@ uninstall: manifests kustomize
 .PHONY: set-image-controller
 set-image-controller: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/overlays/openshift && $(KUSTOMIZE) edit set image controller=${IMG}
 
 # Add a custom argument to the operator deployment
 .PHONY: add-operator-arg
@@ -929,6 +930,10 @@ generate-bundle: kustomize operator-sdk manifests set-image-controller api-docs
 bundle:
 	BUNDLE_VARIANT=community VERSION=$(VERSION) $(MAKE) generate-bundle
 	BUNDLE_VARIANT=openshift VERSION=$(VERSION) $(MAKE) generate-bundle
+	# Patch OpenShift CSV: update mpod.kb.io webhook to use pod-webhook deployment for HA
+	MPOD_LINE=$$(grep -n "generateName: mpod.kb.io" bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml | cut -d: -f1) && \
+	DEPLOY_LINE=$$(head -n "$$MPOD_LINE" bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml | grep -n "deploymentName:" | tail -1 | cut -d: -f1) && \
+	sed -i "$${DEPLOY_LINE}s/opentelemetry-operator-controller-manager/opentelemetry-operator-pod-webhook/" bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
 
 
 # Reset bundle configuration to defaults
@@ -950,7 +955,12 @@ reset: kustomize operator-sdk manifests
 	$(OPERATOR_SDK) bundle validate ./bundle/community
 	$(OPERATOR_SDK) bundle validate ./bundle/openshift
 	rm bundle.Dockerfile
+	# Patch OpenShift CSV: update mpod.kb.io webhook to use pod-webhook deployment for HA
+	MPOD_LINE=$$(grep -n "generateName: mpod.kb.io" bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml | cut -d: -f1) && \
+	DEPLOY_LINE=$$(head -n "$$MPOD_LINE" bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml | grep -n "deploymentName:" | tail -1 | cut -d: -f1) && \
+	sed -i "$${DEPLOY_LINE}s/opentelemetry-operator-controller-manager/opentelemetry-operator-pod-webhook/" bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
 	git checkout config/manager/kustomization.yaml
+	git checkout config/overlays/openshift/kustomization.yaml
 	./hack/ignore-createdAt-bundle.sh
 
 # Build the bundle image, used only for local dev purposes

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-06-23T13:07:10Z"
+    createdAt: "2026-06-25T13:47:28Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/openshift/manifests/opentelemetry-operator-pod-webhook_policy_v1_poddisruptionbudget.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator-pod-webhook_policy_v1_poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: pod-webhook
+    app.kubernetes.io/name: opentelemetry-operator
+  name: opentelemetry-operator-pod-webhook
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pod-webhook
+      app.kubernetes.io/name: opentelemetry-operator

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-06-23T13:07:11Z"
+    createdAt: "2026-06-25T13:47:28Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -634,6 +634,74 @@ spec:
                 secret:
                   defaultMode: 420
                   secretName: opentelemetry-operator-controller-manager-service-cert
+      - label:
+          app.kubernetes.io/component: pod-webhook
+          app.kubernetes.io/name: opentelemetry-operator
+        name: opentelemetry-operator-pod-webhook
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: pod-webhook
+              app.kubernetes.io/name: opentelemetry-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: pod-webhook
+                app.kubernetes.io/name: opentelemetry-operator
+            spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchLabels:
+                          app.kubernetes.io/component: pod-webhook
+                          app.kubernetes.io/name: opentelemetry-operator
+                      topologyKey: kubernetes.io/hostname
+                    weight: 100
+              containers:
+              - args:
+                - auto-instrumentation
+                - --zap-log-level=info
+                - --zap-time-encoding=rfc3339nano
+                env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ENABLE_NGINX_AUTO_INSTRUMENTATION
+                  value: "true"
+                - name: ENABLE_GO_AUTO_INSTRUMENTATION
+                  value: "true"
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.153.0
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: webhook
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources: {}
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: opentelemetry-operator-controller-manager
       permissions:
       - rules:
         - apiGroups:
@@ -760,7 +828,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: opentelemetry-operator-controller-manager
+    deploymentName: opentelemetry-operator-pod-webhook
     failurePolicy: Ignore
     generateName: mpod.kb.io
     rules:

--- a/config/overlays/openshift/kustomization.yaml
+++ b/config/overlays/openshift/kustomization.yaml
@@ -1,5 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - ../../default
+- pod-webhook-deployment.yaml
+- pod-webhook-pdb.yaml
 
 patches:
 - path: manager-patch.yaml
@@ -11,6 +16,3 @@ patches:
 - path: metrics_service_tls_patch.yaml
 - path: manager_auth_proxy_tls_patch.yaml
 - path: remove-cert-manager-annotations.yaml
-
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization

--- a/config/overlays/openshift/pod-webhook-deployment.yaml
+++ b/config/overlays/openshift/pod-webhook-deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-operator-pod-webhook
+  namespace: system
+  labels:
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/component: pod-webhook
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-operator
+      app.kubernetes.io/component: pod-webhook
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: opentelemetry-operator
+        app.kubernetes.io/component: pod-webhook
+    spec:
+      containers:
+      - name: webhook
+        image: controller
+        args:
+        - auto-instrumentation
+        - --zap-log-level=info
+        - --zap-time-encoding=rfc3339nano
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ENABLE_NGINX_AUTO_INSTRUMENTATION
+          value: "true"
+        - name: ENABLE_GO_AUTO_INSTRUMENTATION
+          value: "true"
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: opentelemetry-operator
+                  app.kubernetes.io/component: pod-webhook
+              topologyKey: kubernetes.io/hostname
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: opentelemetry-operator-controller-manager

--- a/config/overlays/openshift/pod-webhook-pdb.yaml
+++ b/config/overlays/openshift/pod-webhook-pdb.yaml
@@ -1,0 +1,14 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: opentelemetry-operator-pod-webhook
+  namespace: system
+  labels:
+    app.kubernetes.io/name: opentelemetry-operator
+    app.kubernetes.io/component: pod-webhook
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-operator
+      app.kubernetes.io/component: pod-webhook

--- a/docs/rfcs/pod-mutation-high-availability.md
+++ b/docs/rfcs/pod-mutation-high-availability.md
@@ -1,0 +1,302 @@
+# Pod Mutation High Availability
+
+## Summary
+
+This RFC proposes enabling high availability (HA) for the pod mutation webhook on OpenShift by including it as a separate OLM-managed deployment in the CSV. This allows independent scaling of the webhook without affecting the operator's leader election.
+
+## Motivation
+
+The OpenTelemetry Operator includes a pod mutation webhook (`/mutate-v1-pod`) that handles:
+- Auto-instrumentation injection
+- Sidecar collector injection
+
+In production environments, this webhook is critical infrastructure - if it's unavailable or slow, pod creation across the cluster is impacted. Currently, the webhook runs as part of the operator deployment, which has limitations:
+
+1. **Single replica by default**: The operator uses leader election, and while the webhook doesn't require it, they share the same deployment.
+
+2. **OLM scaling limitations**: On OpenShift with OLM, users cannot scale CSV-managed deployments UP - OLM continuously reconciles replicas back to the CSV-defined count. However, OLM allows scaling DOWN (including to 0 for maintenance).
+
+3. **Coupled lifecycle**: Scaling the webhook means scaling the entire operator, which is wasteful since controllers only need one active instance.
+
+### Goals
+
+- Enable HA for the pod mutation webhook on OpenShift (OLM)
+- Support scaling down for maintenance/debugging
+- Maintain backward compatibility for vanilla Kubernetes deployments
+- Ensure proper cleanup when the operator is uninstalled
+- Handle TLS certificate provisioning automatically
+
+### Non-Goals
+
+- Changing how CR validation/mutation webhooks work (they remain in the operator)
+- Supporting webhook HA on vanilla Kubernetes (no change to community bundle)
+- Horizontal Pod Autoscaler (HPA) integration
+
+## Design
+
+### Architecture
+
+On OpenShift with OLM, the CSV includes two deployments:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    opentelemetry-operator-system                │
+│                                                                 │
+│  ┌──────────────────────────┐    ┌──────────────────────────┐  │
+│  │ opentelemetry-operator-  │    │ opentelemetry-operator-  │  │
+│  │ controller-manager       │    │ pod-webhook              │  │
+│  │ (1 replica, leader       │    │ (2 replicas, no leader   │  │
+│  │  election)               │    │  election)               │  │
+│  │                          │    │                          │  │
+│  │ - CR controllers         │    │ - /mutate-v1-pod         │  │
+│  │ - CR webhooks            │    │   (instrumentation +     │  │
+│  │                          │    │    sidecar injection)    │  │
+│  └──────────────────────────┘    └──────────────────────────┘  │
+│                                                                 │
+│  Both deployments managed by OLM via CSV                        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+On vanilla Kubernetes (community bundle), everything remains in a single deployment (no change).
+
+### How It Works
+
+#### OpenShift with OLM
+
+1. **Kustomize overlay** adds a second deployment definition via `config/overlays/openshift/pod-webhook-deployment.yaml`. This becomes part of the CSV during `make bundle`.
+2. **Bundle generation** patches the `mpod.kb.io` webhookdefinition to point to the pod-webhook deployment instead of the controller-manager.
+3. **OLM manages both deployments** - creation, TLS certificates, and cleanup. The operator does NOT create the pod-webhook deployment at runtime — OLM does, based on the CSV.
+4. **Replica controller** (`PodWebhookReconciler`) only adjusts replicas on the OLM-created deployment when `POD_WEBHOOK_REPLICAS` env var is set. It does not create or delete the deployment.
+5. **Default: 2 replicas** for HA, with PodDisruptionBudget (`maxUnavailable: 1`) and pod anti-affinity across nodes.
+6. **Users can scale DOWN** (including to 0) via `POD_WEBHOOK_REPLICAS` but not UP beyond CSV default.
+
+#### Vanilla Kubernetes
+
+No change - the pod webhook runs as part of the operator deployment, same as before.
+
+### Certificate Management
+
+#### OpenShift (OLM-managed)
+
+OLM handles certificate provisioning for both deployments automatically:
+- Creates TLS secrets for webhook servers
+- Injects CA bundles into MutatingWebhookConfiguration
+- Rotates certificates automatically
+
+#### Vanilla Kubernetes
+
+Uses cert-manager annotations on the MutatingWebhookConfiguration (existing behavior).
+
+### Garbage Collection
+
+#### OpenShift with OLM
+
+All resources are managed by OLM via the CSV:
+- When the operator is uninstalled, OLM deletes the CSV
+- All CSV-managed resources (both deployments, services, webhooks) are automatically cleaned up
+- No manual cleanup required
+
+#### Vanilla Kubernetes
+
+Standard Kubernetes garbage collection via owner references (existing behavior).
+
+### Scaling Behavior
+
+Due to OLM's design:
+- **Scale UP**: Usually reverted (OLM sees deployment as unhealthy during pod startup and reinstalls from CSV)
+- **Scale DOWN**: Usually sticks (deployment stays healthy, so OLM doesn't trigger reinstall)
+- **Upgrades reset replicas**: Manual scaling does NOT survive operator upgrades. OLM resets deployments to CSV-defined replicas during upgrade.
+
+This means:
+- Default 2 replicas provides HA out-of-the-box
+- Users can scale to 1 or 0 for debugging/maintenance
+- Users needing more than 2 replicas must wait for a CSV update
+
+#### Why OLM Reverts Scale-Up But Not Scale-Down
+
+OLM does not have explicit scale-enforcement logic. The asymmetry is a side effect of how
+OLM's health check interacts with Kubernetes deployment rollout behavior.
+
+**The reconciliation loop** ([deployment.go], [operator.go]):
+
+1. OLM watches deployments owned by a CSV via an informer. Any change to the deployment
+   requeues the owning CSV for reconciliation.
+2. When the CSV is in the [`Succeeded` phase][succeeded-phase], OLM calls [`CheckInstalled()`][check-installed] which runs two checks:
+   - **Spec-hash check**: compares a SHA256 hash stored in the [`olm.deployment-spec-hash`][hash-label]
+     label on the deployment against a [hash computed from the CSV spec][hash-compute]. Since
+     `kubectl scale` only changes `.spec.replicas` and does not modify labels, the hashes
+     always match. This check never triggers a revert on its own.
+   - **Availability check** ([`DeploymentStatus()`][deployment-status]): verifies that the
+     deployment's `Available` condition is `True`.
+
+**Scaling UP (e.g. 1 → 5) — reverted:**
+
+When new pods are added, the Kubernetes deployment controller must schedule and start them.
+During this window the deployment's `Available` condition becomes `False`
+(`Deployment does not have minimum availability`). OLM sees this and triggers the cascade:
+
+```
+Succeeded → Failed (ComponentUnhealthy) → Pending (NeedsReinstall) → InstallReady → Install()
+```
+
+The [`Install()`][install] call executes [`CreateOrUpdateDeployment()`][create-or-update] which
+performs a full `Update()` on the deployment object using the spec from the CSV — overwriting
+`.spec.replicas` back to the CSV-defined value.
+
+Note: this is timing-dependent. If all new pods become ready before OLM's next reconciliation
+tick, OLM will see a healthy deployment with matching hashes and will not revert. In practice,
+the informer-triggered reconciliation is fast enough that OLM almost always catches the
+deployment in an unavailable state.
+
+**Scaling DOWN (e.g. 2 → 0) — respected:**
+
+When pods are removed, the Kubernetes deployment controller terminates excess pods while the
+remaining pods (if any) continue running. The deployment's `Available` condition stays `True`
+throughout the scale-down because the remaining replicas still satisfy the availability
+requirement. Even scaling to 0 converges almost instantly from the API's perspective
+(`status.replicas=0`, `updatedReplicas=0`, no outdated replicas).
+
+Since `DeploymentStatus()` returns `ready=true` and the hash check passes, `CheckInstalled()`
+reports the deployment as healthy. OLM keeps the CSV in `Succeeded` and does not trigger a
+reinstall.
+
+[deployment.go]: https://github.com/operator-framework/operator-lifecycle-manager/blob/v0.42.0/pkg/controller/install/deployment.go
+[operator.go]: https://github.com/operator-framework/operator-lifecycle-manager/blob/v0.42.0/pkg/controller/operators/olm/operator.go
+[succeeded-phase]: https://github.com/operator-framework/operator-lifecycle-manager/blob/v0.42.0/pkg/controller/operators/olm/operator.go#L2369
+[check-installed]: https://github.com/operator-framework/operator-lifecycle-manager/blob/v0.42.0/pkg/controller/install/deployment.go#L218
+[hash-label]: https://github.com/operator-framework/operator-lifecycle-manager/blob/v0.42.0/pkg/controller/install/deployment.go#L21
+[hash-compute]: https://github.com/operator-framework/operator-lifecycle-manager/blob/v0.42.0/pkg/controller/install/deployment.go#L183-L187
+[deployment-status]: https://github.com/operator-framework/operator-lifecycle-manager/blob/v0.42.0/pkg/controller/install/status_viewer.go#L13
+[install]: https://github.com/operator-framework/operator-lifecycle-manager/blob/v0.42.0/pkg/controller/install/deployment.go#L93
+[create-or-update]: https://github.com/operator-framework/operator-lifecycle-manager/blob/v0.42.0/pkg/api/wrappers/deployment_install_client.go#L112-L125
+
+**Summary:**
+
+| Action | Deployment Available | OLM response |
+|---|---|---|
+| Scale up (pods starting) | `False` (temporarily) | Reinstall from CSV spec (reverts replicas) |
+| Scale up (pods ready before OLM reconciles) | `True` | No action (replicas stick) |
+| Scale down | `True` (always) | No action (replicas stick) |
+
+#### Scaling Down
+
+Only scaling down is supported. To reduce the pod-webhook replicas, set the `POD_WEBHOOK_REPLICAS` environment variable in the Subscription (0 or 1). Scale-up beyond CSV default (2) is ignored to avoid race conditions with OLM.
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: opentelemetry-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  config:
+    env:
+    - name: POD_WEBHOOK_REPLICAS
+      value: "1"
+```
+
+The operator includes a controller that watches the pod-webhook deployment and scales it down to the configured value. After an upgrade (when OLM resets replicas to the CSV default of 2), the operator automatically scales it back down to the configured value (0 or 1).
+
+### Pod Disruption Budget
+
+A `PodDisruptionBudget` with `maxUnavailable: 1` is included in the OpenShift overlay. This ensures that during voluntary disruptions (node drains, cluster upgrades), Kubernetes evicts only one pod at a time and waits for the replacement to become Ready before evicting the next.
+
+`maxUnavailable: 1` is preferred over `minAvailable: 1` because it works correctly at any replica count. With `minAvailable: 1` and a single replica, node drains would be blocked since evicting the only pod would drop available below the minimum. With `maxUnavailable: 1`, a single-replica deployment can still be drained.
+
+Note: PDB only gates the eviction API (voluntary disruptions). Direct scaling via the controller or `kubectl scale` bypasses PDB entirely.
+
+### Pod Anti-Affinity
+
+The pod-webhook deployment uses `preferredDuringSchedulingIgnoredDuringExecution` pod anti-affinity on `kubernetes.io/hostname`. This tells the scheduler to prefer placing the 2 webhook pods on different nodes, ensuring a single node failure doesn't take down both webhook replicas.
+
+`preferred` (soft) anti-affinity is used instead of `required` (hard) so that scheduling is not blocked on single-node or resource-constrained clusters (e.g., development environments).
+
+## Implementation
+
+### Bundle Generation
+
+1. **Kustomize overlay** (`config/overlays/openshift/pod-webhook-deployment.yaml`):
+   - Defines the `opentelemetry-operator-pod-webhook` deployment
+   - Sets 2 replicas by default
+
+2. **Makefile bundle target**:
+   - Uses kustomize to include the pod-webhook deployment
+   - Patches the `mpod.kb.io` webhookdefinition to reference the pod-webhook deployment
+
+### Pod Webhook Replica Controller
+
+The `internal/controllers/podwebhook_controller.go` watches the pod-webhook deployment and scales it down to the configured replica count (from `POD_WEBHOOK_REPLICAS` env var). Only scale-down is supported (0 or 1). Scale-up beyond CSV default is ignored.
+
+### Files Modified
+
+- `config/overlays/openshift/pod-webhook-deployment.yaml` - Pod webhook deployment for OpenShift (includes pod anti-affinity)
+- `config/overlays/openshift/pod-webhook-pdb.yaml` - PodDisruptionBudget for the pod webhook
+- `config/overlays/openshift/kustomization.yaml` - Includes pod-webhook deployment and PDB
+- `Makefile` - Patches webhookdefinition after bundle generation
+- `internal/controllers/podwebhook_controller.go` - Replica controller for upgrade survival
+- `internal/config/env.go` - Reads `POD_WEBHOOK_REPLICAS` env var
+
+### RBAC
+
+The operator already has RBAC permissions for Deployments (used by other controllers), so no additional RBAC is needed for this feature. The pod-webhook replica controller reuses existing permissions.
+
+## Deployment Scenarios
+
+### OpenShift with OLM (Recommended for HA)
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: opentelemetry-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+```
+
+The standalone webhook deployment is automatically created with 2 replicas.
+
+To scale down for maintenance:
+```bash
+kubectl scale deployment opentelemetry-operator-pod-webhook --replicas=0
+```
+
+### Vanilla Kubernetes
+
+No change - install via Helm chart or kustomize as before. The pod webhook runs in the operator deployment.
+
+## Alternatives Considered
+
+### 1. Operator-managed webhook deployment
+
+**Approach**: Operator creates/manages the webhook deployment at runtime based on env vars.
+
+**Why rejected**: 
+- Complex garbage collection (cross-scope owner references don't work reliably)
+- Required additional RBAC for MutatingWebhookConfiguration
+- More code to maintain
+
+### 2. OLM Deployment Scaling
+
+**Approach**: Use OLM's `Subscription.spec.config.replicas` to scale the operator.
+
+**Why rejected**: OLM doesn't support `replicas` in subscription config. OLM actively reconciles deployments back to CSV-defined replicas (for scaling UP).
+
+### 3. HPA on Operator Deployment
+
+**Approach**: Users add HPA targeting the operator deployment.
+
+**Why rejected**: OLM fights with HPA over replica count for scaling UP. Also scales controllers unnecessarily.
+
+## References
+
+- [GitHub Issue #5010](https://github.com/open-telemetry/opentelemetry-operator/issues/5010)
+- [OLM Webhook Documentation](https://olm.operatorframework.io/docs/advanced-tasks/adding-admission-and-conversion-webhooks/)
+- [OLM Deployment Management](https://olm.operatorframework.io/docs/tasks/creating-operator-manifests/)

--- a/internal/config/cli.go
+++ b/internal/config/cli.go
@@ -62,6 +62,7 @@ func CreateCLIParser(cfg Config) *pflag.FlagSet {
 	f.String("zap-level-format", "uppercase", "The level format to be used in the customized Log Encoder")
 	f.Bool("enable-webhooks", cfg.EnableWebhooks, "Enable webhooks for the controllers")
 	f.String("watch-namespace", cfg.WatchNamespace, "Comma-separated list of namespaces the operator should watch for CustomResources. Empty means watch all namespaces.")
+	f.Int32("pod-webhook-replicas", cfg.PodWebhookReplicas, "Desired replica count for the standalone pod webhook deployment (default: 2). Only scale-down is supported (0 or 1). Scale-up beyond CSV default is ignored.")
 
 	return f
 }
@@ -169,6 +170,8 @@ func ApplyCLI(cfg *Config) error {
 				} else {
 					cfg.CreateRBACPermissions = autoRBAC.NotAvailable
 				}
+			case "pod-webhook-replicas":
+				cfg.PodWebhookReplicas, _ = f.GetInt32("pod-webhook-replicas")
 			}
 		}
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,9 @@ const (
 	defaultCollectorConfigMapEntry           = "collector.yaml"
 	defaultTargetAllocatorConfigMapEntry     = "targetallocator.yaml"
 	defaultOperatorOpAMPBridgeConfigMapEntry = "remoteconfiguration.yaml"
+	// defaultPodWebhookReplicas is the default replica count for the standalone pod webhook deployment.
+	// This matches the value defined in the OpenShift CSV.
+	defaultPodWebhookReplicas = 2
 )
 
 type ZapConfig struct {
@@ -139,6 +142,10 @@ type Config struct {
 	// FeatureGates is a comma-separated list of feature gates to enable/disable.
 	// Format: "gate1,gate2,-gate3" where - prefix disables the gate.
 	FeatureGates string `yaml:"feature-gates"`
+	// PodWebhookReplicas is the desired number of replicas for the standalone pod webhook deployment.
+	// Only scale-down is supported (0 or 1). Scale-up beyond CSV default (2) is ignored.
+	// Default is 2 (matching the CSV default). Set via --pod-webhook-replicas flag or POD_WEBHOOK_REPLICAS env var.
+	PodWebhookReplicas int32 `yaml:"pod-webhook-replicas"`
 	// Internal contains configuration that is propagated and cannot be accessed from the operator configuration.
 	Internal Internal `yaml:"-"`
 	// Instrumentation is the set of instrumentations to use if CRDs are not present
@@ -221,7 +228,8 @@ func New() Config {
 			LevelKey:    "level",
 			LevelFormat: "uppercase",
 		},
-		EnableWebhooks: true,
+		EnableWebhooks:     true,
+		PodWebhookReplicas: defaultPodWebhookReplicas,
 		Internal: Internal{
 			NativeSidecarSupport: false,
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -56,6 +56,7 @@ func TestToStringMap(t *testing.T) {
 		"openshift-create-dashboard":              "false",
 		"operator-op-amp-bridge-configmap-entry":  "foo.yaml",
 		"operatoropampbridge-image":               "",
+		"pod-webhook-replicas":                    "0",
 		"pprof-addr":                              "",
 		"health-probe-addr":                       "",
 		"prometheus-cr-availability":              "0",

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -145,5 +145,10 @@ func ApplyEnvVars(cfg *Config) {
 	if v, ok := os.LookupEnv("WATCH_NAMESPACE"); ok {
 		cfg.WatchNamespace = v
 	}
+	if v, ok := os.LookupEnv("POD_WEBHOOK_REPLICAS"); ok {
+		if replicas, err := strconv.ParseInt(v, 10, 32); err == nil && replicas >= 0 {
+			cfg.PodWebhookReplicas = int32(replicas)
+		}
+	}
 	cfg.ProxyEnvVars = proxy.ReadProxyVarsFromEnv()
 }

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -51,3 +51,4 @@ zap:
   level-format: uppercase
 enable-webhooks: true
 enable-instrumentation-crds: true
+pod-webhook-replicas: 2

--- a/internal/controllers/podwebhook_controller.go
+++ b/internal/controllers/podwebhook_controller.go
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// podWebhookDeploymentName is the name of the standalone pod webhook deployment managed by OLM.
+	podWebhookDeploymentName = "opentelemetry-operator-pod-webhook"
+	// csvDefaultReplicas is the default replica count defined in the CSV.
+	csvDefaultReplicas = 2
+)
+
+// PodWebhookReconciler reconciles the standalone pod webhook deployment replicas.
+// On OpenShift with OLM, the pod-webhook deployment is managed by OLM via CSV.
+// This controller scales the deployment to the desired replica count (up or down)
+// but refuses to scale beyond the CSV default to avoid race conditions with OLM.
+type PodWebhookReconciler struct {
+	client.Client
+	Namespace       string
+	DesiredReplicas int32
+}
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
+
+func (r *PodWebhookReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Only reconcile the pod-webhook deployment in our namespace
+	if req.Name != podWebhookDeploymentName || req.Namespace != r.Namespace {
+		return reconcile.Result{}, nil
+	}
+
+	deployment := &appsv1.Deployment{}
+	err := r.Get(ctx, types.NamespacedName{Name: podWebhookDeploymentName, Namespace: r.Namespace}, deployment)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Deployment doesn't exist (not on OpenShift or not installed via OLM)
+			return reconcile.Result{}, nil
+		}
+		logger.Error(err, "Failed to get pod-webhook deployment")
+		return reconcile.Result{}, err
+	}
+
+	// Check current replicas
+	currentReplicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		currentReplicas = *deployment.Spec.Replicas
+	}
+
+	// Refuse to scale beyond the CSV default to avoid race conditions with OLM.
+	if r.DesiredReplicas > csvDefaultReplicas {
+		logger.Info("Ignoring scale request beyond CSV default",
+			"requested", r.DesiredReplicas,
+			"csvDefault", csvDefaultReplicas)
+		return reconcile.Result{}, nil
+	}
+
+	if currentReplicas != r.DesiredReplicas {
+		logger.Info("Scaling pod-webhook deployment",
+			"from", currentReplicas,
+			"to", r.DesiredReplicas)
+
+		deployment.Spec.Replicas = &r.DesiredReplicas
+		if err := r.Update(ctx, deployment); err != nil {
+			logger.Error(err, "Failed to scale pod-webhook deployment")
+			return reconcile.Result{}, err
+		}
+		logger.Info("Successfully scaled pod-webhook deployment", "replicas", r.DesiredReplicas)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *PodWebhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.Deployment{}).
+		Complete(r)
+}

--- a/internal/controllers/podwebhook_controller_test.go
+++ b/internal/controllers/podwebhook_controller_test.go
@@ -1,0 +1,228 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func newPodWebhookDeployment(replicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podWebhookDeploymentName,
+			Namespace: "test-ns",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "pod-webhook"},
+			},
+		},
+	}
+}
+
+func TestPodWebhookReconciler_ScaleDown(t *testing.T) {
+	ns := "test-ns"
+	dep := newPodWebhookDeployment(2)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dep).Build()
+
+	r := &PodWebhookReconciler{
+		Client:          cl,
+		Namespace:       ns,
+		DesiredReplicas: 1,
+	}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns}, updated))
+	assert.Equal(t, int32(1), *updated.Spec.Replicas)
+}
+
+func TestPodWebhookReconciler_ScaleUp(t *testing.T) {
+	ns := "test-ns"
+	dep := newPodWebhookDeployment(1)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dep).Build()
+
+	r := &PodWebhookReconciler{
+		Client:          cl,
+		Namespace:       ns,
+		DesiredReplicas: 2,
+	}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns}, updated))
+	assert.Equal(t, int32(2), *updated.Spec.Replicas)
+}
+
+func TestPodWebhookReconciler_NoChangeWhenAlreadyAtDesired(t *testing.T) {
+	ns := "test-ns"
+	dep := newPodWebhookDeployment(2)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dep).Build()
+
+	r := &PodWebhookReconciler{
+		Client:          cl,
+		Namespace:       ns,
+		DesiredReplicas: 2,
+	}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns}, updated))
+	assert.Equal(t, int32(2), *updated.Spec.Replicas)
+}
+
+func TestPodWebhookReconciler_IgnoreScaleBeyondCSVDefault(t *testing.T) {
+	ns := "test-ns"
+	dep := newPodWebhookDeployment(2)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dep).Build()
+
+	r := &PodWebhookReconciler{
+		Client:          cl,
+		Namespace:       ns,
+		DesiredReplicas: 5,
+	}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns}, updated))
+	assert.Equal(t, int32(2), *updated.Spec.Replicas)
+}
+
+func TestPodWebhookReconciler_IgnoreOtherDeployments(t *testing.T) {
+	ns := "test-ns"
+	dep := newPodWebhookDeployment(2)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dep).Build()
+
+	r := &PodWebhookReconciler{
+		Client:          cl,
+		Namespace:       ns,
+		DesiredReplicas: 1,
+	}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: "some-other-deployment", Namespace: ns},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns}, updated))
+	assert.Equal(t, int32(2), *updated.Spec.Replicas)
+}
+
+func TestPodWebhookReconciler_IgnoreWrongNamespace(t *testing.T) {
+	ns := "test-ns"
+	dep := newPodWebhookDeployment(2)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dep).Build()
+
+	r := &PodWebhookReconciler{
+		Client:          cl,
+		Namespace:       ns,
+		DesiredReplicas: 1,
+	}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: podWebhookDeploymentName, Namespace: "other-ns"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns}, updated))
+	assert.Equal(t, int32(2), *updated.Spec.Replicas)
+}
+
+func TestPodWebhookReconciler_DeploymentNotFound(t *testing.T) {
+	ns := "test-ns"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := &PodWebhookReconciler{
+		Client:          cl,
+		Namespace:       ns,
+		DesiredReplicas: 1,
+	}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+}
+
+func TestPodWebhookReconciler_ScaleToZero(t *testing.T) {
+	ns := "test-ns"
+	dep := newPodWebhookDeployment(2)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dep).Build()
+
+	r := &PodWebhookReconciler{
+		Client:          cl,
+		Namespace:       ns,
+		DesiredReplicas: 0,
+	}
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: podWebhookDeploymentName, Namespace: ns}, updated))
+	assert.Equal(t, int32(0), *updated.Spec.Replicas)
+}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/spf13/cobra"
 	colfeaturegate "go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap/zapcore"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -89,11 +91,10 @@ func init() {
 }
 
 func main() {
+	// Create config and flags for the root command (operator mode)
 	cfg := config.New()
-
 	cliFlags := config.CreateCLIParser(cfg)
 
-	// registers any flags that underlying libraries might use
 	opts := zap.Options{}
 	var zapFlagSet flag.FlagSet
 	opts.BindFlags(&zapFlagSet)
@@ -104,30 +105,62 @@ func main() {
 
 	var configFile string
 	cliFlags.StringVar(&configFile, "config-file", "", "Path to config file")
-	if err := cliFlags.Parse(os.Args[1:]); err != nil {
-		panic(err)
+
+	rootCmd := &cobra.Command{
+		Use:   "operator",
+		Short: "OpenTelemetry Operator",
+		Long:  "OpenTelemetry Operator manages OpenTelemetry Collectors, auto-instrumentation, and the Target Allocator",
+		Run: func(_ *cobra.Command, _ []string) {
+			runOperator(cfg, configFile, opts, featureGates)
+		},
 	}
 
-	err := cfg.Apply(configFile)
-	if err != nil {
-		fmt.Printf("configuration error: %v\n", err)
+	// Add flags to root command so cobra can parse them
+	rootCmd.Flags().AddFlagSet(cliFlags)
+
+	// Create the auto-instrumentation sub-command with its own flag set
+	autoInstrumentationCmd := newAutoInstrumentationCmd()
+
+	rootCmd.AddCommand(autoInstrumentationCmd)
+
+	// Disable Cobra's default completion command
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
 
-	opts.EncoderConfigOptions = append(opts.EncoderConfigOptions, func(ec *zapcore.EncoderConfig) {
-		ec.MessageKey = cfg.Zap.MessageKey
-		ec.LevelKey = cfg.Zap.LevelKey
-		ec.TimeKey = cfg.Zap.TimeKey
-		if cfg.Zap.LevelFormat == "lowercase" {
-			ec.EncodeLevel = zapcore.LowercaseLevelEncoder
-		} else {
-			ec.EncodeLevel = zapcore.CapitalLevelEncoder
-		}
-	})
+func newAutoInstrumentationCmd() *cobra.Command {
+	cfg := config.New()
+	cliFlags := config.CreateCLIParser(cfg)
 
-	logger := zap.New(zap.UseFlagOptions(&opts))
-	ctrl.SetLogger(logger)
+	opts := zap.Options{}
+	var zapFlagSet flag.FlagSet
+	opts.BindFlags(&zapFlagSet)
+	cliFlags.AddGoFlagSet(&zapFlagSet)
 
+	var configFile string
+	cliFlags.StringVar(&configFile, "config-file", "", "Path to config file")
+
+	cmd := &cobra.Command{
+		Use:   "pod-webhook",
+		Short: "Run only the pod mutation webhook",
+		Long: `Run only the pod mutation webhook without the controllers.
+The pod mutation webhook is responsible for mutating pods to add sidecar containers and auto-instrumentation.`,
+		Run: func(_ *cobra.Command, _ []string) {
+			runAutoInstrumentationWebhook(cfg, configFile, opts)
+		},
+	}
+
+	cmd.Flags().AddFlagSet(cliFlags)
+
+	return cmd
+}
+
+func runOperator(cfg config.Config, configFile string, opts zap.Options, featureGates *flag.FlagSet) {
+	applyConfigAndSetupLogger(&cfg, configFile, opts)
+	logger := ctrl.Log
 	configLog := ctrl.Log.WithName("config")
 
 	v := version.Get()
@@ -144,56 +177,14 @@ func main() {
 
 	restConfig := ctrl.GetConfigOrDie()
 
-	var namespaces map[string]cache.Config
-	if cfg.WatchNamespace != "" {
-		setupLog.Info("watching namespace(s)", "namespaces", cfg.WatchNamespace)
-		namespaces = map[string]cache.Config{}
-		for ns := range strings.SplitSeq(cfg.WatchNamespace, ",") {
-			namespaces[ns] = cache.Config{}
-		}
-	} else {
-		setupLog.Info("watching all namespaces")
-	}
+	namespaces := parseWatchNamespaces(cfg.WatchNamespace)
 
 	// see https://github.com/openshift/library-go/blob/4362aa519714a4b62b00ab8318197ba2bba51cb7/pkg/config/leaderelection/leaderelection.go#L104
 	leaseDuration := time.Second * 137
 	renewDeadline := time.Second * 107
 	retryPeriod := time.Second * 26
 
-	optionsTlSOptsFuncs := []func(*tls.Config){
-		func(config *tls.Config) {
-			if err = cfg.TLS.ApplyTLSConfig(config); err != nil {
-				setupLog.Error(err, "error setting up TLS")
-			}
-		},
-	}
-	var initialTLSProfileSpec configv1.TLSProfileSpec
-	// Fetch TLS profile from the cluster if enabled
-	if cfg.TLS.UseClusterProfile {
-		// Create a temporary client for TLS profile fetch (before the manager is created).
-		// The TLS profile should be set before the manager starts.
-		tempClient, errClient := client.New(restConfig, client.Options{Scheme: scheme})
-		if errClient != nil {
-			setupLog.Error(errClient, "unable to create temporary client for TLS profile fetch")
-			os.Exit(1)
-		}
-
-		// Fetch initial TLS profile using controller-runtime-common
-		initialTLSProfileSpec, err = openshifttls.FetchAPIServerTLSProfile(context.Background(), tempClient)
-		if err != nil {
-			setupLog.Error(err, "unable to get TLS profile from cluster")
-			os.Exit(1)
-		}
-
-		// Convert to TLS options function for operator's own TLS (webhooks, metrics)
-		tlsConfigFunc, unsupportedCiphers := openshifttls.NewTLSConfigFromProfile(initialTLSProfileSpec)
-		if len(unsupportedCiphers) > 0 {
-			setupLog.Info("some TLS ciphers from cluster profile are not supported by Go", "unsupportedCiphers", unsupportedCiphers)
-		}
-
-		// Add cluster profile to the TLS funcs, it will override the statically provided config.
-		optionsTlSOptsFuncs = append(optionsTlSOptsFuncs, tlsConfigFunc)
-	}
+	optionsTlSOptsFuncs, initialTLSProfileSpec := buildTLSOptions(cfg, restConfig)
 	if cfg.TLS.ConfigureOperands {
 		tlsCfg := &tls.Config{}
 		for _, t := range optionsTlSOptsFuncs {
@@ -202,20 +193,7 @@ func main() {
 		cfg.Internal.OperandTLSProfile = components.NewStaticTLSProfile(tlsCfg.MinVersion, tlsCfg.CipherSuites)
 	}
 
-	// Configure metrics server options
-	metricsOptions := metricsserver.Options{
-		BindAddress: cfg.MetricsAddr,
-	}
-	if cfg.MetricsSecure {
-		metricsOptions.SecureServing = true
-		metricsOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
-		metricsOptions.TLSOpts = optionsTlSOptsFuncs
-		if cfg.MetricsTLSCertFile != "" && cfg.MetricsTLSKeyFile != "" {
-			metricsOptions.CertDir = filepath.Dir(cfg.MetricsTLSCertFile)
-			metricsOptions.CertName = filepath.Base(cfg.MetricsTLSCertFile)
-			metricsOptions.KeyName = filepath.Base(cfg.MetricsTLSKeyFile)
-		}
-	}
+	metricsOptions := buildMetricsOptions(cfg, optionsTlSOptsFuncs)
 
 	mgrOptions := ctrl.Options{
 		Scheme:                        scheme,
@@ -348,23 +326,7 @@ func main() {
 
 	setupLog.Info("Native sidecar", "enabled", cfg.Internal.NativeSidecarSupport)
 
-	if cfg.AnnotationsFilter != nil {
-		for _, basePattern := range cfg.AnnotationsFilter {
-			_, compileErr := regexp.Compile(basePattern)
-			if compileErr != nil {
-				setupLog.Error(compileErr, "could not compile the regexp pattern for Annotations filter")
-			}
-		}
-	}
-
-	if cfg.LabelsFilter != nil {
-		for _, basePattern := range cfg.LabelsFilter {
-			_, compileErr := regexp.Compile(basePattern)
-			if compileErr != nil {
-				setupLog.Error(compileErr, "could not compile the regexp pattern for Labels filter")
-			}
-		}
-	}
+	validateFilterPatterns(cfg)
 
 	if cfg.EnableInstrumentationCRDs {
 		err = addInstrumentationUpgrader(ctx, mgr, cfg)
@@ -442,6 +404,27 @@ func main() {
 		err = mgr.Add(operatorMetrics)
 		if err != nil {
 			setupLog.Error(err, "Failed to add the operator metrics SM")
+		}
+	}
+
+	// Setup pod-webhook replica controller to maintain desired replica count.
+	// On OpenShift with OLM, this ensures replicas survive upgrades (OLM resets to CSV default).
+	// On vanilla Kubernetes, the controller is a no-op (pod-webhook deployment doesn't exist).
+	{
+		namespace := os.Getenv("NAMESPACE")
+		if namespace == "" {
+			namespace = "opentelemetry-operator-system"
+		}
+		setupLog.Info("Setting up pod-webhook replica controller",
+			"namespace", namespace,
+			"desiredReplicas", cfg.PodWebhookReplicas)
+		if err = (&controllers.PodWebhookReconciler{
+			Client:          mgr.GetClient(),
+			Namespace:       namespace,
+			DesiredReplicas: cfg.PodWebhookReplicas,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "PodWebhook")
+			os.Exit(1)
 		}
 	}
 
@@ -523,20 +506,7 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
-	}
-	if cfg.EnableWebhooks {
-		if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
-			setupLog.Error(err, "unable to set up webhook ready check")
-			os.Exit(1)
-		}
-	}
+	addHealthChecks(mgr, cfg.EnableWebhooks)
 
 	setupLog.Info("starting manager")
 	// NOTE: We enable LeaderElectionReleaseOnCancel, and to be safe we need to exit right after the manager does
@@ -674,4 +644,259 @@ func parseFipsFlag(fipsFlag string) (receivers, exporters, processors, extension
 		}
 	}
 	return receivers, exporters, processors, extensions
+}
+
+func applyConfigAndSetupLogger(cfg *config.Config, configFile string, opts zap.Options) {
+	err := cfg.Apply(configFile)
+	if err != nil {
+		fmt.Printf("configuration error: %v\n", err)
+		os.Exit(1)
+	}
+
+	opts.EncoderConfigOptions = append(opts.EncoderConfigOptions, func(ec *zapcore.EncoderConfig) {
+		ec.MessageKey = cfg.Zap.MessageKey
+		ec.LevelKey = cfg.Zap.LevelKey
+		ec.TimeKey = cfg.Zap.TimeKey
+		if cfg.Zap.LevelFormat == "lowercase" {
+			ec.EncodeLevel = zapcore.LowercaseLevelEncoder
+		} else {
+			ec.EncodeLevel = zapcore.CapitalLevelEncoder
+		}
+	})
+
+	logger := zap.New(zap.UseFlagOptions(&opts))
+	ctrl.SetLogger(logger)
+}
+
+func parseWatchNamespaces(watchNamespace string) map[string]cache.Config {
+	if watchNamespace != "" {
+		setupLog.Info("watching namespace(s)", "namespaces", watchNamespace)
+		namespaces := map[string]cache.Config{}
+		for ns := range strings.SplitSeq(watchNamespace, ",") {
+			namespaces[ns] = cache.Config{}
+		}
+		return namespaces
+	}
+	setupLog.Info("watching all namespaces")
+	return nil
+}
+
+func buildTLSOptions(cfg config.Config, restCfg *rest.Config) ([]func(*tls.Config), configv1.TLSProfileSpec) {
+	optionsTlSOptsFuncs := []func(*tls.Config){
+		func(c *tls.Config) {
+			if tlsErr := cfg.TLS.ApplyTLSConfig(c); tlsErr != nil {
+				setupLog.Error(tlsErr, "error setting up TLS")
+			}
+		},
+	}
+
+	var initialTLSProfileSpec configv1.TLSProfileSpec
+	if cfg.TLS.UseClusterProfile {
+		tempClient, errClient := client.New(restCfg, client.Options{Scheme: scheme})
+		if errClient != nil {
+			setupLog.Error(errClient, "unable to create temporary client for TLS profile fetch")
+			os.Exit(1)
+		}
+
+		var err error
+		initialTLSProfileSpec, err = openshifttls.FetchAPIServerTLSProfile(context.Background(), tempClient)
+		if err != nil {
+			setupLog.Error(err, "unable to get TLS profile from cluster")
+			os.Exit(1)
+		}
+
+		tlsConfigFunc, unsupportedCiphers := openshifttls.NewTLSConfigFromProfile(initialTLSProfileSpec)
+		if len(unsupportedCiphers) > 0 {
+			setupLog.Info("some TLS ciphers from cluster profile are not supported by Go", "unsupportedCiphers", unsupportedCiphers)
+		}
+
+		optionsTlSOptsFuncs = append(optionsTlSOptsFuncs, tlsConfigFunc)
+	}
+
+	return optionsTlSOptsFuncs, initialTLSProfileSpec
+}
+
+func buildMetricsOptions(cfg config.Config, tlsOpts []func(*tls.Config)) metricsserver.Options {
+	metricsOptions := metricsserver.Options{
+		BindAddress: cfg.MetricsAddr,
+	}
+	if cfg.MetricsSecure {
+		metricsOptions.SecureServing = true
+		metricsOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
+		metricsOptions.TLSOpts = tlsOpts
+		if cfg.MetricsTLSCertFile != "" && cfg.MetricsTLSKeyFile != "" {
+			metricsOptions.CertDir = filepath.Dir(cfg.MetricsTLSCertFile)
+			metricsOptions.CertName = filepath.Base(cfg.MetricsTLSCertFile)
+			metricsOptions.KeyName = filepath.Base(cfg.MetricsTLSKeyFile)
+		}
+	}
+	return metricsOptions
+}
+
+func validateFilterPatterns(cfg config.Config) {
+	if cfg.AnnotationsFilter != nil {
+		for _, basePattern := range cfg.AnnotationsFilter {
+			_, compileErr := regexp.Compile(basePattern)
+			if compileErr != nil {
+				setupLog.Error(compileErr, "could not compile the regexp pattern for Annotations filter")
+			}
+		}
+	}
+	if cfg.LabelsFilter != nil {
+		for _, basePattern := range cfg.LabelsFilter {
+			_, compileErr := regexp.Compile(basePattern)
+			if compileErr != nil {
+				setupLog.Error(compileErr, "could not compile the regexp pattern for Labels filter")
+			}
+		}
+	}
+}
+
+func addHealthChecks(mgr ctrl.Manager, includeWebhook bool) {
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+	if includeWebhook {
+		if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
+			setupLog.Error(err, "unable to set up webhook ready check")
+			os.Exit(1)
+		}
+	}
+}
+
+// runAutoInstrumentationWebhook runs only the auto-instrumentation webhook without the controllers.
+// This enables High Availability (HA) deployment where the webhook can be scaled independently.
+func runAutoInstrumentationWebhook(cfg config.Config, configFile string, opts zap.Options) {
+	applyConfigAndSetupLogger(&cfg, configFile, opts)
+	logger := ctrl.Log
+
+	configLog := ctrl.Log.WithName("config")
+
+	v := version.Get()
+
+	logger.Info("Starting the OpenTelemetry Auto-Instrumentation Webhook",
+		"opentelemetry-operator", v.Operator,
+		"build-date", v.BuildDate,
+		"go-version", v.Go,
+		"go-arch", runtime.GOARCH,
+		"go-os", runtime.GOOS,
+		"config", cfg.ToStringMap(),
+	)
+
+	restConfig := ctrl.GetConfigOrDie()
+
+	namespaces := parseWatchNamespaces(cfg.WatchNamespace)
+	optionsTlSOptsFuncs, _ := buildTLSOptions(cfg, restConfig)
+	metricsOptions := buildMetricsOptions(cfg, optionsTlSOptsFuncs)
+
+	// Webhooks do not require leader election - multiple instances can serve webhook requests
+	mgrOptions := ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsOptions,
+		HealthProbeBindAddress: cfg.ProbeAddr,
+		LeaderElection:         false, // Webhooks can run without leader election
+		PprofBindAddress:       cfg.PprofAddr,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Port:    cfg.WebhookPort,
+			TLSOpts: optionsTlSOptsFuncs,
+		}),
+		Cache: cache.Options{
+			DefaultNamespaces: namespaces,
+		},
+	}
+
+	mgr, err := ctrl.NewManager(restConfig, mgrOptions)
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		setupLog.Error(err, "failed to create kubernetes clientset")
+	}
+
+	reviewer := rbac.NewReviewer(clientset)
+
+	// Autodetect configuration
+	ad, err := autodetect.New(restConfig, reviewer)
+	if err != nil {
+		setupLog.Error(err, "failed to setup auto-detect routine")
+		os.Exit(1)
+	}
+
+	if err = autodetect.ApplyAutoDetect(ad, &cfg, configLog); err != nil {
+		setupLog.Error(err, "failed to autodetect config variables")
+	}
+
+	setupLog.Info("Native sidecar", "enabled", cfg.Internal.NativeSidecarSupport)
+
+	validateFilterPatterns(cfg)
+
+	// Register the Instrumentation webhook for validation
+	if err = wh.SetupInstrumentationWebhook(mgr, cfg); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "Instrumentation")
+		os.Exit(1)
+	}
+
+	// Register the pod mutation webhook with only the instrumentation mutator
+	decoder := admission.NewDecoder(mgr.GetScheme())
+
+	podMutators := []podmutation.PodMutator{
+		sidecar.NewMutator(logger, cfg, mgr.GetClient()),
+		instrumentation.NewMutator(logger, mgr.GetClient(), mgr.GetEventRecorder("opentelemetry-operator"), cfg),
+	}
+
+	mgr.GetWebhookServer().Register("/mutate-v1-pod", &webhook.Admission{
+		Handler: podmutation.NewWebhookHandler(cfg, ctrl.Log.WithName("pod-webhook"), decoder, mgr.GetClient(), podMutators),
+	})
+
+	addHealthChecks(mgr, true)
+
+	// Create a cancellable context for graceful shutdown on TLS profile change
+	signalCtx := ctrl.SetupSignalHandler()
+	ctx, cancel := context.WithCancel(signalCtx)
+	defer cancel()
+
+	// Setup TLS profile watcher for graceful restart on TLS profile change (OpenShift only).
+	// When the cluster's TLS security profile changes, the watcher detects this and
+	// cancels the context, triggering a graceful shutdown. The webhook pod will restart
+	// and apply the new TLS settings.
+	if cfg.TLS.UseClusterProfile {
+		tempClient, errClient := client.New(restConfig, client.Options{Scheme: scheme})
+		if errClient != nil {
+			setupLog.Error(errClient, "unable to create temporary client for TLS profile fetch")
+			os.Exit(1)
+		}
+
+		initialTLSProfileSpec, err := openshifttls.FetchAPIServerTLSProfile(context.Background(), tempClient)
+		if err != nil {
+			setupLog.Error(err, "unable to get initial TLS profile from cluster")
+			os.Exit(1)
+		}
+
+		watcher := &openshifttls.SecurityProfileWatcher{
+			Client:                mgr.GetClient(),
+			InitialTLSProfileSpec: initialTLSProfileSpec,
+			OnProfileChange: func(_ context.Context, _, _ configv1.TLSProfileSpec) {
+				setupLog.Info("TLS security profile changed, triggering graceful restart")
+				cancel()
+			},
+		}
+		if err = watcher.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to setup TLS profile watcher")
+			os.Exit(1)
+		}
+	}
+
+	setupLog.Info("starting auto-instrumentation webhook")
+	if err := mgr.Start(ctx); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
 }

--- a/tests/e2e-openshift/env-config/02-assert-pod-webhook-scaled.yaml
+++ b/tests/e2e-openshift/env-config/02-assert-pod-webhook-scaled.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-operator-pod-webhook
+  namespace: ($OTEL_NAMESPACE)
+spec:
+  replicas: 1

--- a/tests/e2e-openshift/env-config/03-assert-pod-webhook-default.yaml
+++ b/tests/e2e-openshift/env-config/03-assert-pod-webhook-default.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-operator-pod-webhook
+  namespace: ($OTEL_NAMESPACE)
+spec:
+  replicas: 2

--- a/tests/e2e-openshift/env-config/chainsaw-test.yaml
+++ b/tests/e2e-openshift/env-config/chainsaw-test.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   # Running serially as this patches the operator Subscription causing a restart
   concurrent: false
+  bindings:
+  - name: OTEL_NAMESPACE
+    value: opentelemetry-operator-system
   steps:
   - name: Patch operator Subscription with LABELS_FILTER env var
     try:
@@ -126,3 +129,92 @@ spec:
           kubectl rollout status deployment/opentelemetry-operator-controller-manager \
             -n "$OTEL_NAMESPACE" --timeout=120s || true
           echo "Cleanup complete"
+
+  - name: Patch operator Subscription with POD_WEBHOOK_REPLICAS env var
+    try:
+    - script:
+        env:
+        - name: OTEL_NAMESPACE
+          value: opentelemetry-operator-system
+        timeout: 180s
+        content: |
+          #!/bin/bash
+          set -e
+
+          # Check if pod-webhook deployment exists (OpenShift with OLM only)
+          if ! kubectl get deployment opentelemetry-operator-pod-webhook -n "$OTEL_NAMESPACE" &>/dev/null; then
+            echo "SKIP: pod-webhook deployment not found"
+            exit 0
+          fi
+
+          # Find the OpenTelemetry operator Subscription
+          SUB_NAME=$(kubectl get subscription.operators.coreos.com -n "$OTEL_NAMESPACE" \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+            | grep -i opentelemetry | head -1)
+
+          if [ -z "$SUB_NAME" ]; then
+            echo "SKIP: No Subscription found"
+            exit 0
+          fi
+
+          echo "Patching Subscription $SUB_NAME with POD_WEBHOOK_REPLICAS=1"
+
+          # Check if spec.config.env already exists
+          ENV_EXISTS=$(kubectl get subscription.operators.coreos.com "$SUB_NAME" -n "$OTEL_NAMESPACE" \
+            -o jsonpath='{.spec.config.env}' 2>/dev/null || true)
+
+          if [ -n "$ENV_EXISTS" ] && [ "$ENV_EXISTS" != "null" ] && [ "$ENV_EXISTS" != "[]" ]; then
+            kubectl patch subscription.operators.coreos.com "$SUB_NAME" -n "$OTEL_NAMESPACE" --type=json \
+              -p '[{"op":"add","path":"/spec/config/env/-","value":{"name":"POD_WEBHOOK_REPLICAS","value":"1"}}]'
+          else
+            kubectl patch subscription.operators.coreos.com "$SUB_NAME" -n "$OTEL_NAMESPACE" --type=merge \
+              -p '{"spec":{"config":{"env":[{"name":"POD_WEBHOOK_REPLICAS","value":"1"}]}}}'
+          fi
+
+          kubectl rollout status deployment/opentelemetry-operator-controller-manager \
+            -n "$OTEL_NAMESPACE" --timeout=120s
+    - sleep:
+        duration: 10s
+    - assert:
+        file: 02-assert-pod-webhook-scaled.yaml
+
+  - name: Remove POD_WEBHOOK_REPLICAS and verify default restored
+    try:
+    - script:
+        env:
+        - name: OTEL_NAMESPACE
+          value: opentelemetry-operator-system
+        timeout: 180s
+        content: |
+          #!/bin/bash
+          set -e
+
+          # Check if pod-webhook deployment exists
+          if ! kubectl get deployment opentelemetry-operator-pod-webhook -n "$OTEL_NAMESPACE" &>/dev/null; then
+            echo "SKIP: pod-webhook deployment not found"
+            exit 0
+          fi
+
+          # Find the OpenTelemetry operator Subscription
+          SUB_NAME=$(kubectl get subscription.operators.coreos.com -n "$OTEL_NAMESPACE" \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+            | grep -i opentelemetry | head -1 || true)
+
+          if [ -n "$SUB_NAME" ]; then
+            echo "Removing POD_WEBHOOK_REPLICAS from Subscription: $SUB_NAME"
+            ENV_INDEX=$(kubectl get subscription.operators.coreos.com "$SUB_NAME" -n "$OTEL_NAMESPACE" \
+              -o jsonpath='{range .spec.config.env[*]}{.name}{"\n"}{end}' 2>/dev/null \
+              | grep -n "^POD_WEBHOOK_REPLICAS$" | cut -d: -f1 || true)
+            if [ -n "$ENV_INDEX" ]; then
+              IDX=$((ENV_INDEX - 1))
+              kubectl patch subscription.operators.coreos.com "$SUB_NAME" -n "$OTEL_NAMESPACE" --type=json \
+                -p "[{\"op\":\"remove\",\"path\":\"/spec/config/env/$IDX\"}]"
+            fi
+          fi
+
+          kubectl rollout status deployment/opentelemetry-operator-controller-manager \
+            -n "$OTEL_NAMESPACE" --timeout=120s
+    - sleep:
+        duration: 10s
+    - assert:
+        file: 03-assert-pod-webhook-default.yaml


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #5010 


## Summary

 Split the pod mutation webhook (`/mutate-v1-pod`) into a standalone deployment on OpenShift to enable high availability (HA). The webhook handles auto-instrumentation and sidecar injection.

  - Add a separate `opentelemetry-operator-pod-webhook` deployment to the OpenShift CSV with 2 replicas by default
  - Add a `PodWebhookReconciler` controller that reconciles the pod-webhook deployment replica count based on the `POD_WEBHOOK_REPLICAS` env var (scales up and down, capped at CSV default)
  - Split `main.go` into subcommands: `operator` (full operator) and `auto-instrumentation` (webhook-only mode for the standalone deployment)
  - Add `POD_WEBHOOK_REPLICAS` to the operator config (`internal/config/`) with a default of 2
  - Add kustomize overlay resources for the pod-webhook deployment (`config/overlays/openshift/`)
  - Add e2e tests verifying:
    - `LABELS_FILTER` env var propagation via OLM Subscription
    - Scaling pod-webhook down via `POD_WEBHOOK_REPLICAS=1`
    - Scaling pod-webhook back to default (2) when env var is removed

## Design 

  See `docs/rfcs/pod-mutation-high-availability.md` included in this PR.


## Notes

```
 # Build and push the operator image
 IMG=ghcr.io/pavolloffay/opentelemetry-operator:latest make bundle container container-push

 # Build and push the OpenShift bundle
BUNDLE_VARIANT=openshift IMG=ghcr.io/pavolloffay/opentelemetry-operator:latest BUNDLE_IMG=ghcr.io/pavolloffay/opentelemetry-operator-bundle:latest make bundle-build bundle-push

 # Deploy via OLM
 ./bin/operator-sdk run bundle ghcr.io/pavolloffay/opentelemetry-operator-bundle:latest

Cleanup
kubectl delete catalogsources.operators.coreos.com --all
kubectl delete clusterserviceversion.operators.coreos.com --all
kubectl delete subscriptions.operators.coreos.com --all

Upgrade
OPERATOR_VERSION=0.150.1 IMG=ghcr.io/pavolloffay/opentelemetry-operator:latest BUNDLE_IMG=ghcr.io/pavolloffay/opentelemetry-operator-bundle:latest make bundle bundle-build bundle-push
operator-sdk run bundle-upgrade ghcr.io/pavolloffay/opentelemetry-operator-bundle:latest --timeout 5m
```

TODOS:
- [x] when webhook replicas is removed from subscription the scaled up replicas are not reverted to the value from CSV

**Testing:** <Describe what testing was performed and which tests were added.>

* unit  tests
* e2e openshift test

**Documentation:** <Describe the documentation added.>
