### PR TITLE
Unskip instrumentation-python-oldest e2e test and bump to 3.10

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-python/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/01-assert.yaml
@@ -64,7 +64,7 @@ spec:
         ( contains(@, concat('k8s.namespace.name=', $namespace)) ): true
         ( contains(@, 'k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME)') ): true
         ( contains(@, join('', ['service.instance.id=', $namespace, '.$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME).myapp'])  ) ): true
-        ( contains(@, 'service.version=main') || contains(@, 'service.version=main-3.9') ): true
+        ( contains(@, 'service.version=main') || contains(@, 'service.version=main-3.10') ): true
     ports:
     - containerPort: 8080
       protocol: TCP

--- a/tests/e2e-instrumentation/instrumentation-python/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/chainsaw-test.yaml
@@ -68,7 +68,6 @@ kind: Test
 metadata:
   name: instrumentation-python-oldest
 spec:
-  skip: true # https://github.com/open-telemetry/opentelemetry-operator/issues/5072
   bindings:
     - name: podLabelSelector
       value: app=my-python
@@ -109,7 +108,7 @@ spec:
         - apply:
             bindings:
               - name: APP_IMAGE_TAG
-                value: main-3.9
+                value: main-3.10
               - name: APP_IMAGE
                 value: (join(':', ['ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-python', $APP_IMAGE_TAG]))
             file: 01-install-app.yaml


### PR DESCRIPTION
Python 3.9 hits a runtime error in the upstream Python instrumentation because the requests dependency uses PEP 604 union syntax (str | bytes) which is only available from 3.10. Now that the e2e test image is built against 3.10, the oldest-supported test can be reactivated.

Fixes https://github.com/open-telemetry/opentelemetry-operator/issues/5072