### PR TITLE
feat: add support for arb sm toggle

### DIFF
--- a/.chloggen/add-support-for-arb-sm-toggle.yaml
+++ b/.chloggen/add-support-for-arb-sm-toggle.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support for disabling service and pod monitor credential reading"
+
+# One or more tracking issues related to the change
+issues: [5104]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/add-support-for-arb-sm-toggle.yaml
+++ b/.chloggen/add-support-for-arb-sm-toggle.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: target allocator
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Add support for disabling service and pod monitor credential reading"
+note: "Add support for dropping ServiceMonitor/PodMonitor endpoints that reference arbitrary files"
 
 # One or more tracking issues related to the change
 issues: [5104]

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -411,6 +411,15 @@ type OpenTelemetryTargetAllocatorPrometheusCR struct {
 	// Empty or nil map matches all service monitors.
 	// +optional
 	ServiceMonitorSelector map[string]string `json:"serviceMonitorSelector,omitempty"`
+	// DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
+	// that reference arbitrary files on the file system. When enabled, endpoints with
+	// bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
+	// will be rejected. This prevents tenants from stealing the Collector's
+	// service account token via ServiceMonitor bearerTokenFile references.
+	// This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
+	// Prometheus Operator.
+	// +optional
+	DenyFSAccessThroughSMs bool `json:"denyFSAccessThroughSMs,omitempty"`
 }
 
 // ScaleSubresourceStatus defines the observed state of the OpenTelemetryCollector's

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -411,13 +411,14 @@ type OpenTelemetryTargetAllocatorPrometheusCR struct {
 	// Empty or nil map matches all service monitors.
 	// +optional
 	ServiceMonitorSelector map[string]string `json:"serviceMonitorSelector,omitempty"`
-	// DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
-	// that reference arbitrary files on the file system. When enabled, endpoints with
-	// bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
-	// will be rejected. This prevents tenants from stealing the Collector's
-	// service account token via ServiceMonitor bearerTokenFile references.
-	// This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
-	// Prometheus Operator.
+	// DenyFSAccessThroughSMs causes the Target Allocator to drop ServiceMonitor and
+	// PodMonitor endpoints that reference arbitrary files on the file system. When
+	// enabled, endpoints with bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile,
+	// or tlsConfig.keyFile are dropped from the produced scrape configuration while
+	// the remaining endpoints are kept. This prevents tenants from stealing the
+	// Collector's service account token via ServiceMonitor bearerTokenFile
+	// references. This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from
+	// the Prometheus Operator.
 	// +optional
 	DenyFSAccessThroughSMs bool `json:"denyFSAccessThroughSMs,omitempty"`
 }

--- a/apis/v1beta1/targetallocator_types.go
+++ b/apis/v1beta1/targetallocator_types.go
@@ -22,13 +22,14 @@ type TargetAllocatorPrometheusCR struct {
 	// If not configured, defaults to the target allocator's own namespace.
 	// +optional
 	SecretNamespaces []string `json:"secretNamespaces,omitempty"`
-	// DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
-	// that reference arbitrary files on the file system. When enabled, endpoints with
-	// bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
-	// will be rejected. This prevents tenants from stealing the Collector's
-	// service account token via ServiceMonitor bearerTokenFile references.
-	// This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
-	// Prometheus Operator.
+	// DenyFSAccessThroughSMs causes the Target Allocator to drop ServiceMonitor and
+	// PodMonitor endpoints that reference arbitrary files on the file system. When
+	// enabled, endpoints with bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile,
+	// or tlsConfig.keyFile are dropped from the produced scrape configuration while
+	// the remaining endpoints are kept. This prevents tenants from stealing the
+	// Collector's service account token via ServiceMonitor bearerTokenFile
+	// references. This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from
+	// the Prometheus Operator.
 	// +optional
 	DenyFSAccessThroughSMs bool `json:"denyFSAccessThroughSMs,omitempty"`
 	// Default interval between consecutive scrapes. Intervals set in ServiceMonitors and PodMonitors override it.

--- a/apis/v1beta1/targetallocator_types.go
+++ b/apis/v1beta1/targetallocator_types.go
@@ -22,6 +22,15 @@ type TargetAllocatorPrometheusCR struct {
 	// If not configured, defaults to the target allocator's own namespace.
 	// +optional
 	SecretNamespaces []string `json:"secretNamespaces,omitempty"`
+	// DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
+	// that reference arbitrary files on the file system. When enabled, endpoints with
+	// bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
+	// will be rejected. This prevents tenants from stealing the Collector's
+	// service account token via ServiceMonitor bearerTokenFile references.
+	// This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
+	// Prometheus Operator.
+	// +optional
+	DenyFSAccessThroughSMs bool `json:"denyFSAccessThroughSMs,omitempty"`
 	// Default interval between consecutive scrapes. Intervals set in ServiceMonitors and PodMonitors override it.
 	//
 	// Default: "30s"

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-05-19T17:37:02Z"
+    createdAt: "2026-05-19T18:40:17Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -573,7 +573,7 @@ spec:
                   value: "true"
                 - name: ENABLE_NGINX_AUTO_INSTRUMENTATION
                   value: "true"
-                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0-314-g54249c77
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-05-08T09:28:09Z"
+    createdAt: "2026-05-19T17:37:02Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -573,7 +573,7 @@ spec:
                   value: "true"
                 - name: ENABLE_NGINX_AUTO_INSTRUMENTATION
                   value: "true"
-                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0-314-g54249c77
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -3363,6 +3363,8 @@ spec:
                     type: object
                   prometheusCR:
                     properties:
+                      denyFSAccessThroughSMs:
+                        type: boolean
                       enabled:
                         type: boolean
                       podMonitorSelector:
@@ -8302,6 +8304,8 @@ spec:
                         items:
                           type: string
                         type: array
+                      denyFSAccessThroughSMs:
+                        type: boolean
                       denyNamespaces:
                         items:
                           type: string

--- a/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
@@ -2480,6 +2480,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  denyFSAccessThroughSMs:
+                    type: boolean
                   denyNamespaces:
                     items:
                       type: string

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-05-08T09:28:09Z"
+    createdAt: "2026-05-19T17:37:09Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -591,7 +591,7 @@ spec:
                   value: "true"
                 - name: TLS_CONFIGURE_OPERANDS
                   value: "true"
-                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0-314-g54249c77
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-05-19T17:37:09Z"
+    createdAt: "2026-05-19T18:40:17Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -591,7 +591,7 @@ spec:
                   value: "true"
                 - name: TLS_CONFIGURE_OPERANDS
                   value: "true"
-                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.144.0-314-g54249c77
+                image: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator:0.151.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -3362,6 +3362,8 @@ spec:
                     type: object
                   prometheusCR:
                     properties:
+                      denyFSAccessThroughSMs:
+                        type: boolean
                       enabled:
                         type: boolean
                       podMonitorSelector:
@@ -8301,6 +8303,8 @@ spec:
                         items:
                           type: string
                         type: array
+                      denyFSAccessThroughSMs:
+                        type: boolean
                       denyNamespaces:
                         items:
                           type: string

--- a/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
@@ -2480,6 +2480,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  denyFSAccessThroughSMs:
+                    type: boolean
                   denyNamespaces:
                     items:
                       type: string

--- a/cmd/otel-allocator/internal/config/config.go
+++ b/cmd/otel-allocator/internal/config/config.go
@@ -91,6 +91,15 @@ type PrometheusCRConfig struct {
 	EvaluationInterval              model.Duration                `yaml:"evaluation_interval,omitempty"`
 	ScrapeProtocols                 []monitoringv1.ScrapeProtocol `yaml:"scrape_protocols,omitempty"`
 	ScrapeClasses                   []monitoringv1.ScrapeClass    `yaml:"scrape_classes,omitempty"`
+	// DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
+	// that reference arbitrary files on the file system. When true, endpoints with
+	// bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
+	// referencing paths outside an operator-owned mount will be rejected.
+	// This prevents tenants from stealing the Collector's service account token.
+	// This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
+	// Prometheus Operator.
+	// +optional
+	DenyFSAccessThroughSMs bool `yaml:"deny_fs_access_through_sms,omitempty"`
 }
 
 type HTTPSServerConfig struct {

--- a/cmd/otel-allocator/internal/config/config.go
+++ b/cmd/otel-allocator/internal/config/config.go
@@ -91,12 +91,13 @@ type PrometheusCRConfig struct {
 	EvaluationInterval              model.Duration                `yaml:"evaluation_interval,omitempty"`
 	ScrapeProtocols                 []monitoringv1.ScrapeProtocol `yaml:"scrape_protocols,omitempty"`
 	ScrapeClasses                   []monitoringv1.ScrapeClass    `yaml:"scrape_classes,omitempty"`
-	// DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
-	// that reference arbitrary files on the file system. When true, endpoints with
-	// bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
-	// referencing paths outside an operator-owned mount will be rejected.
-	// This prevents tenants from stealing the Collector's service account token.
-	// This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
+	// DenyFSAccessThroughSMs causes the Target Allocator to drop ServiceMonitor and
+	// PodMonitor endpoints that reference arbitrary files on the file system. When
+	// true, endpoints with bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or
+	// tlsConfig.keyFile referencing paths outside an operator-owned mount are
+	// dropped from the produced scrape configuration while the remaining endpoints
+	// are kept. This prevents tenants from stealing the Collector's service account
+	// token. This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
 	// Prometheus Operator.
 	// +optional
 	DenyFSAccessThroughSMs bool `yaml:"deny_fs_access_through_sms,omitempty"`

--- a/cmd/otel-allocator/internal/watcher/promOperator.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator.go
@@ -687,6 +687,9 @@ func (w *PrometheusCRWatcher) LoadConfig(ctx context.Context) (*promconfig.Confi
 // references (caFile, certFile, keyFile). This is the equivalent guard from
 // ArbitraryFSAccessThroughSMs.Deny in the Prometheus Operator.
 func (w *PrometheusCRWatcher) validateAndFilterScrapeConfigs(promCfg *promconfig.Config) error {
+	if !w.denyFSAccessThroughSMs {
+		return nil
+	}
 	for _, sc := range promCfg.ScrapeConfigs {
 		// Check the HTTPClientConfig.Authorization.CredentialsFile
 		auth := sc.HTTPClientConfig.Authorization

--- a/cmd/otel-allocator/internal/watcher/promOperator.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator.go
@@ -651,15 +651,11 @@ func (w *PrometheusCRWatcher) LoadConfig(ctx context.Context) (*promconfig.Confi
 			return nil, unmarshalErr
 		}
 
-		// If denyFSAccessThroughSMs is enabled, validate and reject scrape configs
-		// that reference arbitrary files on the file system. This prevents
-		// tenants from stealing the Collector's service account token.
+		// If denyFSAccessThroughSMs is enabled, drop scrape configs that reference
+		// arbitrary files on the file system. This prevents tenants from stealing
+		// the Collector's service account token.
 		if w.denyFSAccessThroughSMs {
-			if err := w.validateAndFilterScrapeConfigs(promCfg); err != nil {
-				w.logger.Error("Rejected scrape configuration due to denied file path access", "error", err)
-				// Return the config without the rejected scrape configs
-				promCfg.ScrapeConfigs = nil
-			}
+			w.filterScrapeConfigs(promCfg)
 		}
 
 		// set kubeconfig path to service discovery configs, else kubernetes_sd will always attempt in-cluster
@@ -678,48 +674,45 @@ func (w *PrometheusCRWatcher) LoadConfig(ctx context.Context) (*promconfig.Confi
 	return promCfg, nil
 }
 
-// validateAndFilterScrapeConfigs validates scrape configs and returns an error if
-// any config references arbitrary files on the file system. This prevents
-// tenants from stealing the Collector's service account token via ServiceMonitor
-// bearerTokenFile (via authorization.credentials_file) or tlsConfig file
-// references (caFile, certFile, keyFile). This is the equivalent guard from
+// filterScrapeConfigs drops scrape configs that reference arbitrary files on
+// the file system. This prevents tenants from stealing the Collector's service
+// account token via ServiceMonitor bearerTokenFile (via
+// authorization.credentials_file) or tlsConfig file references (caFile,
+// certFile, keyFile). This is the equivalent guard from
 // ArbitraryFSAccessThroughSMs.Deny in the Prometheus Operator.
-func (w *PrometheusCRWatcher) validateAndFilterScrapeConfigs(promCfg *promconfig.Config) error {
+func (w *PrometheusCRWatcher) filterScrapeConfigs(promCfg *promconfig.Config) {
 	if !w.denyFSAccessThroughSMs {
-		return nil
+		return
 	}
+	filtered := promCfg.ScrapeConfigs[:0]
 	for _, sc := range promCfg.ScrapeConfigs {
-		// Check the HTTPClientConfig.Authorization.CredentialsFile
-		auth := sc.HTTPClientConfig.Authorization
-		if auth != nil && auth.CredentialsFile != "" {
-			return fmt.Errorf(
-				"service monitor denied: endpoint references arbitrary file via authorization.credentials_file: %s",
-				auth.CredentialsFile,
-			)
+		if reason := deniedFSAccessReason(sc); reason != "" {
+			w.logger.Warn("dropping scrape config that references arbitrary file path", "job", sc.JobName, "reason", reason)
+			continue
 		}
-
-		// Check TLS config file paths
-		tls := &sc.HTTPClientConfig.TLSConfig
-		if tls.CAFile != "" {
-			return fmt.Errorf(
-				"service monitor denied: endpoint references arbitrary file via tls_config.ca_file: %s",
-				tls.CAFile,
-			)
-		}
-		if tls.CertFile != "" {
-			return fmt.Errorf(
-				"service monitor denied: endpoint references arbitrary file via tls_config.cert_file: %s",
-				tls.CertFile,
-			)
-		}
-		if tls.KeyFile != "" {
-			return fmt.Errorf(
-				"service monitor denied: endpoint references arbitrary file via tls_config.key_file: %s",
-				tls.KeyFile,
-			)
-		}
+		filtered = append(filtered, sc)
 	}
-	return nil
+	promCfg.ScrapeConfigs = filtered
+}
+
+// deniedFSAccessReason returns a non-empty reason if the scrape config
+// references arbitrary files via authorization or TLS config, or "" if the
+// config is allowed.
+func deniedFSAccessReason(sc *promconfig.ScrapeConfig) string {
+	if auth := sc.HTTPClientConfig.Authorization; auth != nil && auth.CredentialsFile != "" {
+		return fmt.Sprintf("authorization.credentials_file: %s", auth.CredentialsFile)
+	}
+	tls := &sc.HTTPClientConfig.TLSConfig
+	if tls.CAFile != "" {
+		return fmt.Sprintf("tls_config.ca_file: %s", tls.CAFile)
+	}
+	if tls.CertFile != "" {
+		return fmt.Sprintf("tls_config.cert_file: %s", tls.CertFile)
+	}
+	if tls.KeyFile != "" {
+		return fmt.Sprintf("tls_config.key_file: %s", tls.KeyFile)
+	}
+	return ""
 }
 
 // WaitForNamedCacheSync adds a timeout to the informer's wait for the cache to be ready.

--- a/cmd/otel-allocator/internal/watcher/promOperator.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator.go
@@ -171,9 +171,7 @@ type PrometheusCRWatcher struct {
 	resourceSelector                *prometheus.ResourceSelector
 	store                           *assets.StoreBuilder
 	prometheusCR                    *monitoringv1.Prometheus
-	// denyFSAccessThroughSMs indicates whether to reject ServiceMonitors and
-	// PodMonitors that reference arbitrary files on the file system.
-	denyFSAccessThroughSMs bool
+	denyFSAccessThroughSMs          bool
 }
 
 func getNamespaceInformer(ctx context.Context, allowList, denyList map[string]struct{}, promOperatorLogger *slog.Logger, clientset kubernetes.Interface, operatorMetrics *operator.Metrics) (cache.SharedIndexInformer, error) {

--- a/cmd/otel-allocator/internal/watcher/promOperator.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator.go
@@ -150,6 +150,7 @@ func NewPrometheusCRWatcher(
 		resourceSelector:                resourceSelector,
 		store:                           store,
 		prometheusCR:                    prom,
+		denyFSAccessThroughSMs:          cfg.PrometheusCR.DenyFSAccessThroughSMs,
 	}, nil
 }
 
@@ -170,6 +171,9 @@ type PrometheusCRWatcher struct {
 	resourceSelector                *prometheus.ResourceSelector
 	store                           *assets.StoreBuilder
 	prometheusCR                    *monitoringv1.Prometheus
+	// denyFSAccessThroughSMs indicates whether to reject ServiceMonitors and
+	// PodMonitors that reference arbitrary files on the file system.
+	denyFSAccessThroughSMs bool
 }
 
 func getNamespaceInformer(ctx context.Context, allowList, denyList map[string]struct{}, promOperatorLogger *slog.Logger, clientset kubernetes.Interface, operatorMetrics *operator.Metrics) (cache.SharedIndexInformer, error) {
@@ -649,6 +653,17 @@ func (w *PrometheusCRWatcher) LoadConfig(ctx context.Context) (*promconfig.Confi
 			return nil, unmarshalErr
 		}
 
+		// If denyFSAccessThroughSMs is enabled, validate and reject scrape configs
+		// that reference arbitrary files on the file system. This prevents
+		// tenants from stealing the Collector's service account token.
+		if w.denyFSAccessThroughSMs {
+			if err := w.validateAndFilterScrapeConfigs(promCfg); err != nil {
+				w.logger.Error("Rejected scrape configuration due to denied file path access", "error", err)
+				// Return the config without the rejected scrape configs
+				promCfg.ScrapeConfigs = nil
+			}
+		}
+
 		// set kubeconfig path to service discovery configs, else kubernetes_sd will always attempt in-cluster
 		// authentication even if running with a detected kubeconfig
 		for _, scrapeConfig := range promCfg.ScrapeConfigs {
@@ -663,6 +678,47 @@ func (w *PrometheusCRWatcher) LoadConfig(ctx context.Context) (*promconfig.Confi
 	}
 	w.logger.Info("Unable to load config since resource selector is nil, returning empty prometheus config")
 	return promCfg, nil
+}
+
+// validateAndFilterScrapeConfigs validates scrape configs and returns an error if
+// any config references arbitrary files on the file system. This prevents
+// tenants from stealing the Collector's service account token via ServiceMonitor
+// bearerTokenFile (via authorization.credentials_file) or tlsConfig file
+// references (caFile, certFile, keyFile). This is the equivalent guard from
+// ArbitraryFSAccessThroughSMs.Deny in the Prometheus Operator.
+func (w *PrometheusCRWatcher) validateAndFilterScrapeConfigs(promCfg *promconfig.Config) error {
+	for _, sc := range promCfg.ScrapeConfigs {
+		// Check the HTTPClientConfig.Authorization.CredentialsFile
+		auth := sc.HTTPClientConfig.Authorization
+		if auth != nil && auth.CredentialsFile != "" {
+			return fmt.Errorf(
+				"service monitor denied: endpoint references arbitrary file via authorization.credentials_file: %s",
+				auth.CredentialsFile,
+			)
+		}
+
+		// Check TLS config file paths
+		tls := &sc.HTTPClientConfig.TLSConfig
+		if tls.CAFile != "" {
+			return fmt.Errorf(
+				"service monitor denied: endpoint references arbitrary file via tls_config.ca_file: %s",
+				tls.CAFile,
+			)
+		}
+		if tls.CertFile != "" {
+			return fmt.Errorf(
+				"service monitor denied: endpoint references arbitrary file via tls_config.cert_file: %s",
+				tls.CertFile,
+			)
+		}
+		if tls.KeyFile != "" {
+			return fmt.Errorf(
+				"service monitor denied: endpoint references arbitrary file via tls_config.key_file: %s",
+				tls.KeyFile,
+			)
+		}
+	}
+	return nil
 }
 
 // WaitForNamedCacheSync adds a timeout to the informer's wait for the cache to be ready.

--- a/cmd/otel-allocator/internal/watcher/promOperator.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator.go
@@ -681,9 +681,6 @@ func (w *PrometheusCRWatcher) LoadConfig(ctx context.Context) (*promconfig.Confi
 // certFile, keyFile). This is the equivalent guard from
 // ArbitraryFSAccessThroughSMs.Deny in the Prometheus Operator.
 func (w *PrometheusCRWatcher) filterScrapeConfigs(promCfg *promconfig.Config) {
-	if !w.denyFSAccessThroughSMs {
-		return
-	}
 	filtered := promCfg.ScrapeConfigs[:0]
 	for _, sc := range promCfg.ScrapeConfigs {
 		if reason := deniedFSAccessReason(sc); reason != "" {

--- a/cmd/otel-allocator/internal/watcher/promOperator_denyfs_test.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator_denyfs_test.go
@@ -4,7 +4,7 @@
 package watcher
 
 import (
-	"strings"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -14,17 +14,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestValidateAndFilterScrapeConfigsWithCredentialsFile verifies that the guard
-// rejects scrape configs with authorization.credentials_file.
-func TestValidateAndFilterScrapeConfigsWithCredentialsFile(t *testing.T) {
-	tw := &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: true,
+func newDenyFSWatcher(deny bool) *PrometheusCRWatcher {
+	return &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: deny,
+		logger:                 slog.Default(),
 	}
+}
 
-	got := &promconfig.Config{
+// TestFilterScrapeConfigsDropsCredentialsFile verifies that a scrape config
+// with authorization.credentials_file is dropped.
+func TestFilterScrapeConfigsDropsCredentialsFile(t *testing.T) {
+	tw := newDenyFSWatcher(true)
+
+	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{
 			{
-				JobName: "test",
+				JobName: "unsafe",
 				HTTPClientConfig: config.HTTPClientConfig{
 					Authorization: &config.Authorization{
 						Type:            "Bearer",
@@ -35,22 +40,19 @@ func TestValidateAndFilterScrapeConfigsWithCredentialsFile(t *testing.T) {
 		},
 	}
 
-	err := tw.validateAndFilterScrapeConfigs(got)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "credentials_file")
+	tw.filterScrapeConfigs(cfg)
+	assert.Empty(t, cfg.ScrapeConfigs)
 }
 
-// TestValidateAndFilterScrapeConfigsDisabled verifies that when the guard is
-// disabled, it does not reject scrape configs.
-func TestValidateAndFilterScrapeConfigsDisabled(t *testing.T) {
-	tw := &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: false,
-	}
+// TestFilterScrapeConfigsDisabled verifies that when the guard is disabled, no
+// scrape configs are dropped.
+func TestFilterScrapeConfigsDisabled(t *testing.T) {
+	tw := newDenyFSWatcher(false)
 
-	got := &promconfig.Config{
+	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{
 			{
-				JobName: "test",
+				JobName: "unsafe",
 				HTTPClientConfig: config.HTTPClientConfig{
 					Authorization: &config.Authorization{
 						Type:            "Bearer",
@@ -61,113 +63,63 @@ func TestValidateAndFilterScrapeConfigsDisabled(t *testing.T) {
 		},
 	}
 
-	err := tw.validateAndFilterScrapeConfigs(got)
-	assert.NoError(t, err)
+	tw.filterScrapeConfigs(cfg)
+	assert.Len(t, cfg.ScrapeConfigs, 1)
 }
 
-// TestValidateAndFilterScrapeConfigsWithTLSFiles verifies the guard also
-// rejects tlsConfig.caFile, certFile, and keyFile.
-func TestValidateAndFilterScrapeConfigsWithTLSFiles(t *testing.T) {
-	tw := &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: true,
-	}
+// TestFilterScrapeConfigsDropsTLSFiles verifies the guard drops scrape configs
+// that set tlsConfig.caFile / certFile / keyFile.
+func TestFilterScrapeConfigsDropsTLSFiles(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tls  config.TLSConfig
+	}{
+		{name: "ca_file", tls: config.TLSConfig{CAFile: "/path/to/ca.crt"}},
+		{name: "cert_file", tls: config.TLSConfig{CertFile: "/path/to/cert.crt"}},
+		{name: "key_file", tls: config.TLSConfig{KeyFile: "/path/to/key.key"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tw := newDenyFSWatcher(true)
 
-	got := &promconfig.Config{
-		ScrapeConfigs: []*promconfig.ScrapeConfig{
-			{
-				JobName: "test",
-				HTTPClientConfig: config.HTTPClientConfig{
-					TLSConfig: config.TLSConfig{
-						CAFile:   "/path/to/ca.crt",
-						CertFile: "/path/to/cert.crt",
-						KeyFile:  "/path/to/key.key",
+			cfg := &promconfig.Config{
+				ScrapeConfigs: []*promconfig.ScrapeConfig{
+					{
+						JobName: "tls-" + tc.name,
+						HTTPClientConfig: config.HTTPClientConfig{
+							TLSConfig: tc.tls,
+						},
 					},
 				},
-			},
-		},
-	}
+			}
 
-	err := tw.validateAndFilterScrapeConfigs(got)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "ca_file")
+			tw.filterScrapeConfigs(cfg)
+			assert.Empty(t, cfg.ScrapeConfigs)
+		})
+	}
 }
 
-// TestValidateAndFilterScrapeConfigsWithTLSFilesCert verifies cert_file is
-// detected.
-func TestValidateAndFilterScrapeConfigsWithTLSFilesCert(t *testing.T) {
-	tw := &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: true,
-	}
+// TestFilterScrapeConfigsEmpty verifies that an empty scrape config list is a
+// no-op.
+func TestFilterScrapeConfigsEmpty(t *testing.T) {
+	tw := newDenyFSWatcher(true)
 
-	got := &promconfig.Config{
-		ScrapeConfigs: []*promconfig.ScrapeConfig{
-			{
-				JobName: "test",
-				HTTPClientConfig: config.HTTPClientConfig{
-					TLSConfig: config.TLSConfig{
-						CertFile: "/path/to/cert.crt",
-					},
-				},
-			},
-		},
-	}
-
-	err := tw.validateAndFilterScrapeConfigs(got)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cert_file")
-}
-
-// TestValidateAndFilterScrapeConfigsWithTLSFilesKey verifies key_file is
-// detected.
-func TestValidateAndFilterScrapeConfigsWithTLSFilesKey(t *testing.T) {
-	tw := &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: true,
-	}
-
-	got := &promconfig.Config{
-		ScrapeConfigs: []*promconfig.ScrapeConfig{
-			{
-				JobName: "test",
-				HTTPClientConfig: config.HTTPClientConfig{
-					TLSConfig: config.TLSConfig{
-						KeyFile: "/path/to/key.key",
-					},
-				},
-			},
-		},
-	}
-
-	err := tw.validateAndFilterScrapeConfigs(got)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "key_file")
-}
-
-// TestValidateAndFilterScrapeConfigsWithEmptyScrapeConfigs verifies that
-// empty scrape configs do not cause errors.
-func TestValidateAndFilterScrapeConfigsWithEmptyScrapeConfigs(t *testing.T) {
-	tw := &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: true,
-	}
-
-	got := &promconfig.Config{
+	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{},
 	}
 
-	err := tw.validateAndFilterScrapeConfigs(got)
-	assert.NoError(t, err)
+	tw.filterScrapeConfigs(cfg)
+	assert.Empty(t, cfg.ScrapeConfigs)
 }
 
-// TestValidateAndFilterScrapeConfigsWithNormalPrometheusConfig verifies
-// that normal scrape configs without file references are allowed through.
-func TestValidateAndFilterScrapeConfigsWithNormalPrometheusConfig(t *testing.T) {
-	tw := &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: true,
-	}
+// TestFilterScrapeConfigsKeepsSafeConfigs verifies that scrape configs without
+// file references are kept.
+func TestFilterScrapeConfigsKeepsSafeConfigs(t *testing.T) {
+	tw := newDenyFSWatcher(true)
 
-	got := &promconfig.Config{
+	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{
 			{
-				JobName:           "test",
+				JobName:           "safe",
 				MetricsPath:       "/metrics",
 				ScrapeInterval:    model.Duration(30 * time.Second),
 				EnableCompression: true,
@@ -181,53 +133,20 @@ func TestValidateAndFilterScrapeConfigsWithNormalPrometheusConfig(t *testing.T) 
 		},
 	}
 
-	err := tw.validateAndFilterScrapeConfigs(got)
-	assert.NoError(t, err)
+	tw.filterScrapeConfigs(cfg)
+	assert.Len(t, cfg.ScrapeConfigs, 1)
+	assert.Equal(t, "safe", cfg.ScrapeConfigs[0].JobName)
 }
 
-// TestValidateAndFilterScrapeConfigsWithBearerTokenFileRejection tests the
-// exact attack scenario: bearerTokenFile pointing to the Collector's service
-// account token should be rejected.
-func TestValidateAndFilterScrapeConfigsWithBearerTokenFileRejection(t *testing.T) {
-	tw := &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: true,
-	}
+// TestFilterScrapeConfigsKeepsSafeDropsUnsafe verifies that in a mixed list,
+// only the unsafe scrape configs are dropped.
+func TestFilterScrapeConfigsKeepsSafeDropsUnsafe(t *testing.T) {
+	tw := newDenyFSWatcher(true)
 
-	got := &promconfig.Config{
+	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{
 			{
-				JobName: "test",
-				HTTPClientConfig: config.HTTPClientConfig{
-					Authorization: &config.Authorization{
-						Type:            "Bearer",
-						CredentialsFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
-					},
-				},
-			},
-		},
-	}
-
-	err := tw.validateAndFilterScrapeConfigs(got)
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "credentials_file"),
-		"expected error to mention credentials_file")
-	assert.True(t, strings.Contains(err.Error(),
-		"/var/run/secrets/kubernetes.io/serviceaccount/token"),
-		"expected error to mention the token path")
-}
-
-// TestValidateAndFilterScrapeConfigsMultipleScrapeConfigs verifies that
-// the guard checks all scrape configs in a list.
-func TestValidateAndFilterScrapeConfigsMultipleScrapeConfigs(t *testing.T) {
-	tw := &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: true,
-	}
-
-	got := &promconfig.Config{
-		ScrapeConfigs: []*promconfig.ScrapeConfig{
-			{
-				JobName:           "safe-config",
-				EnableCompression: true,
+				JobName: "safe",
 				HTTPClientConfig: config.HTTPClientConfig{
 					BasicAuth: &config.BasicAuth{
 						Username: "user",
@@ -236,8 +155,7 @@ func TestValidateAndFilterScrapeConfigsMultipleScrapeConfigs(t *testing.T) {
 				},
 			},
 			{
-				JobName:           "unsafe-config",
-				EnableCompression: true,
+				JobName: "unsafe-credentials",
 				HTTPClientConfig: config.HTTPClientConfig{
 					Authorization: &config.Authorization{
 						Type:            "Bearer",
@@ -245,26 +163,29 @@ func TestValidateAndFilterScrapeConfigsMultipleScrapeConfigs(t *testing.T) {
 					},
 				},
 			},
+			{
+				JobName: "unsafe-tls",
+				HTTPClientConfig: config.HTTPClientConfig{
+					TLSConfig: config.TLSConfig{KeyFile: "/path/to/key.key"},
+				},
+			},
 		},
 	}
 
-	err := tw.validateAndFilterScrapeConfigs(got)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "credentials_file")
+	tw.filterScrapeConfigs(cfg)
+	assert.Len(t, cfg.ScrapeConfigs, 1)
+	assert.Equal(t, "safe", cfg.ScrapeConfigs[0].JobName)
 }
 
-// TestValidateAndFilterScrapeConfigsWithNilAuthorization verifies that nil
-// Authorization fields do not cause panics.
-func TestValidateAndFilterScrapeConfigsWithNilAuthorization(t *testing.T) {
-	tw := &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: true,
-	}
+// TestFilterScrapeConfigsNilAuthorization verifies nil Authorization fields do
+// not cause panics or unintended drops.
+func TestFilterScrapeConfigsNilAuthorization(t *testing.T) {
+	tw := newDenyFSWatcher(true)
 
-	got := &promconfig.Config{
+	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{
 			{
-				JobName:           "test",
-				EnableCompression: true,
+				JobName: "no-auth",
 				HTTPClientConfig: config.HTTPClientConfig{
 					Authorization: nil,
 				},
@@ -272,22 +193,19 @@ func TestValidateAndFilterScrapeConfigsWithNilAuthorization(t *testing.T) {
 		},
 	}
 
-	err := tw.validateAndFilterScrapeConfigs(got)
-	assert.NoError(t, err)
+	tw.filterScrapeConfigs(cfg)
+	assert.Len(t, cfg.ScrapeConfigs, 1)
 }
 
-// TestValidateAndFilterScrapeConfigsWithNilTLSConfig verifies that nil
-// TLSConfig fields do not cause panics.
-func TestValidateAndFilterScrapeConfigsWithNilTLSConfig(t *testing.T) {
-	tw := &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: true,
-	}
+// TestFilterScrapeConfigsEmptyTLSConfig verifies an empty TLSConfig keeps the
+// scrape config.
+func TestFilterScrapeConfigsEmptyTLSConfig(t *testing.T) {
+	tw := newDenyFSWatcher(true)
 
-	got := &promconfig.Config{
+	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{
 			{
-				JobName:           "test",
-				EnableCompression: true,
+				JobName: "empty-tls",
 				HTTPClientConfig: config.HTTPClientConfig{
 					TLSConfig: config.TLSConfig{},
 				},
@@ -295,6 +213,6 @@ func TestValidateAndFilterScrapeConfigsWithNilTLSConfig(t *testing.T) {
 		},
 	}
 
-	err := tw.validateAndFilterScrapeConfigs(got)
-	assert.NoError(t, err)
+	tw.filterScrapeConfigs(cfg)
+	assert.Len(t, cfg.ScrapeConfigs, 1)
 }

--- a/cmd/otel-allocator/internal/watcher/promOperator_denyfs_test.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator_denyfs_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newDenyFSWatcher(deny bool) *PrometheusCRWatcher {
+func newDenyFSWatcher() *PrometheusCRWatcher {
 	return &PrometheusCRWatcher{
-		denyFSAccessThroughSMs: deny,
+		denyFSAccessThroughSMs: true,
 		logger:                 slog.Default(),
 	}
 }
@@ -24,7 +24,7 @@ func newDenyFSWatcher(deny bool) *PrometheusCRWatcher {
 // TestFilterScrapeConfigsDropsCredentialsFile verifies that a scrape config
 // with authorization.credentials_file is dropped.
 func TestFilterScrapeConfigsDropsCredentialsFile(t *testing.T) {
-	tw := newDenyFSWatcher(true)
+	tw := newDenyFSWatcher()
 
 	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{
@@ -44,29 +44,6 @@ func TestFilterScrapeConfigsDropsCredentialsFile(t *testing.T) {
 	assert.Empty(t, cfg.ScrapeConfigs)
 }
 
-// TestFilterScrapeConfigsDisabled verifies that when the guard is disabled, no
-// scrape configs are dropped.
-func TestFilterScrapeConfigsDisabled(t *testing.T) {
-	tw := newDenyFSWatcher(false)
-
-	cfg := &promconfig.Config{
-		ScrapeConfigs: []*promconfig.ScrapeConfig{
-			{
-				JobName: "unsafe",
-				HTTPClientConfig: config.HTTPClientConfig{
-					Authorization: &config.Authorization{
-						Type:            "Bearer",
-						CredentialsFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
-					},
-				},
-			},
-		},
-	}
-
-	tw.filterScrapeConfigs(cfg)
-	assert.Len(t, cfg.ScrapeConfigs, 1)
-}
-
 // TestFilterScrapeConfigsDropsTLSFiles verifies the guard drops scrape configs
 // that set tlsConfig.caFile / certFile / keyFile.
 func TestFilterScrapeConfigsDropsTLSFiles(t *testing.T) {
@@ -79,7 +56,7 @@ func TestFilterScrapeConfigsDropsTLSFiles(t *testing.T) {
 		{name: "key_file", tls: config.TLSConfig{KeyFile: "/path/to/key.key"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			tw := newDenyFSWatcher(true)
+			tw := newDenyFSWatcher()
 
 			cfg := &promconfig.Config{
 				ScrapeConfigs: []*promconfig.ScrapeConfig{
@@ -101,7 +78,7 @@ func TestFilterScrapeConfigsDropsTLSFiles(t *testing.T) {
 // TestFilterScrapeConfigsEmpty verifies that an empty scrape config list is a
 // no-op.
 func TestFilterScrapeConfigsEmpty(t *testing.T) {
-	tw := newDenyFSWatcher(true)
+	tw := newDenyFSWatcher()
 
 	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{},
@@ -114,7 +91,7 @@ func TestFilterScrapeConfigsEmpty(t *testing.T) {
 // TestFilterScrapeConfigsKeepsSafeConfigs verifies that scrape configs without
 // file references are kept.
 func TestFilterScrapeConfigsKeepsSafeConfigs(t *testing.T) {
-	tw := newDenyFSWatcher(true)
+	tw := newDenyFSWatcher()
 
 	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{
@@ -141,7 +118,7 @@ func TestFilterScrapeConfigsKeepsSafeConfigs(t *testing.T) {
 // TestFilterScrapeConfigsKeepsSafeDropsUnsafe verifies that in a mixed list,
 // only the unsafe scrape configs are dropped.
 func TestFilterScrapeConfigsKeepsSafeDropsUnsafe(t *testing.T) {
-	tw := newDenyFSWatcher(true)
+	tw := newDenyFSWatcher()
 
 	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{
@@ -180,7 +157,7 @@ func TestFilterScrapeConfigsKeepsSafeDropsUnsafe(t *testing.T) {
 // TestFilterScrapeConfigsNilAuthorization verifies nil Authorization fields do
 // not cause panics or unintended drops.
 func TestFilterScrapeConfigsNilAuthorization(t *testing.T) {
-	tw := newDenyFSWatcher(true)
+	tw := newDenyFSWatcher()
 
 	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{
@@ -200,7 +177,7 @@ func TestFilterScrapeConfigsNilAuthorization(t *testing.T) {
 // TestFilterScrapeConfigsEmptyTLSConfig verifies an empty TLSConfig keeps the
 // scrape config.
 func TestFilterScrapeConfigsEmptyTLSConfig(t *testing.T) {
-	tw := newDenyFSWatcher(true)
+	tw := newDenyFSWatcher()
 
 	cfg := &promconfig.Config{
 		ScrapeConfigs: []*promconfig.ScrapeConfig{

--- a/cmd/otel-allocator/internal/watcher/promOperator_denyfs_test.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator_denyfs_test.go
@@ -4,397 +4,297 @@
 package watcher
 
 import (
-	"context"
-	"log/slog"
-	"os"
+	"strings"
 	"testing"
-	"testing/synctest"
 	"time"
 
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	promv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
-	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
-	"github.com/prometheus-operator/prometheus-operator/pkg/informers"
-	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
-	"github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
-	prometheusgoclient "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	promconfig "github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/kubernetes/fake"
-	metadatafake "k8s.io/client-go/metadata/fake"
-	"k8s.io/client-go/tools/cache"
-	fcache "k8s.io/client-go/tools/cache/testing"
-
-	allocatorconfig "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/config"
 )
 
-// TestDenyFSAccessThroughSMsBasic verifies that when DenyFSAccessThroughSMs
-// is enabled, ServiceMonitors with authorization.credentials_file are rejected
-// and the resulting scrape configs are cleared.
-func TestDenyFSAccessThroughSMsBasic(t *testing.T) {
-	namespace := "test"
-	portName := "web"
-
-	sm := &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "attacker-sm",
-			Namespace: namespace,
-		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			JobLabel: "test",
-			Endpoints: []monitoringv1.Endpoint{
-				{
-					Port: portName,
-					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
-						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
-							HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
-								Authorization: &monitoringv1.SafeAuthorization{
-									Type: "Bearer",
-									CredentialsFile: func() *string {
-										s := "/var/run/secrets/kubernetes.io/serviceaccount/token"
-										return &s
-									}(),
-								},
-							},
-						},
-					},
-				},
-			},
-			Selector: metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": "attacker"},
-			},
-		},
+// TestValidateAndFilterScrapeConfigsWithCredentialsFile verifies that the guard
+// rejects scrape configs with authorization.credentials_file.
+func TestValidateAndFilterScrapeConfigsWithCredentialsFile(t *testing.T) {
+	tw := &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: true,
 	}
 
-	cfg := allocatorconfig.Config{
-		PrometheusCR: allocatorconfig.PrometheusCRConfig{
-			ServiceMonitorSelector: &metav1.LabelSelector{},
-			DenyFSAccessThroughSMs: true,
-		},
-	}
-
-	synctest.Test(t, func(t *testing.T) {
-		tw := newTestWatcherWithDenyFlag(t, cfg)
-		tw.ServiceMonitorSource.Add(sm)
-		defer tw.Close()
-
-		time.Sleep(watchSyncDuration)
-		synctest.Wait()
-
-		got, err := tw.LoadConfig(context.Background())
-		require.NoError(t, err)
-
-		assert.Empty(t, got.ScrapeConfigs,
-			"expected no scrape configs when DenyFSAccessThroughSMs rejects credentials_file")
-	})
-}
-
-// TestDenyFSAccessThroughSMsDisabled verifies that when DenyFSAccessThroughSMs
-// is NOT enabled, ServiceMonitors without file references are allowed through.
-func TestDenyFSAccessThroughSMsDisabled(t *testing.T) {
-	namespace := "test"
-	portName := "web"
-
-	sm := &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "simple-sm",
-			Namespace: namespace,
-		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			JobLabel: "test",
-			Endpoints: []monitoringv1.Endpoint{
-				{Port: portName},
-			},
-		},
-	}
-
-	cfg := allocatorconfig.Config{
-		PrometheusCR: allocatorconfig.PrometheusCRConfig{
-			ServiceMonitorSelector: &metav1.LabelSelector{},
-			DenyFSAccessThroughSMs: false,
-		},
-	}
-
-	synctest.Test(t, func(t *testing.T) {
-		tw := newTestWatcherWithDenyFlag(t, cfg)
-		tw.ServiceMonitorSource.Add(sm)
-		defer tw.Close()
-
-		time.Sleep(watchSyncDuration)
-		synctest.Wait()
-
-		got, err := tw.LoadConfig(context.Background())
-		require.NoError(t, err)
-
-		assert.NotEmpty(t, got.ScrapeConfigs,
-			"expected scrape configs when DenyFSAccessThroughSMs is disabled")
-	})
-}
-
-// TestDenyFSAccessThroughSMsWithBearerTokenFile verifies the exact attack
-// scenario: a tenant sets bearerTokenFile to the Collector's service account
-// token path, and the guard should reject it.
-func TestDenyFSAccessThroughSMsWithBearerTokenFile(t *testing.T) {
-	namespace := "test"
-
-	sm := &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "attacker-bearer-sm",
-			Namespace: namespace,
-		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			JobLabel: "test",
-			Endpoints: []monitoringv1.Endpoint{
-				{
-					Port: "web",
-					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
-						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
-							HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
-								Authorization: &monitoringv1.SafeAuthorization{
-									Type: "Bearer",
-									CredentialsFile: func() *string {
-										s := "/var/run/secrets/kubernetes.io/serviceaccount/token"
-										return &s
-									}(),
-								},
-							},
-						},
+	got := &promconfig.Config{
+		ScrapeConfigs: []*promconfig.ScrapeConfig{
+			{
+				JobName: "test",
+				HTTPClientConfig: config.HTTPClientConfig{
+					Authorization: &config.Authorization{
+						Type:            "Bearer",
+						CredentialsFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 					},
 				},
 			},
 		},
 	}
 
-	cfg := allocatorconfig.Config{
-		PrometheusCR: allocatorconfig.PrometheusCRConfig{
-			ServiceMonitorSelector: &metav1.LabelSelector{},
-			DenyFSAccessThroughSMs: true,
-		},
-	}
-
-	synctest.Test(t, func(t *testing.T) {
-		tw := newTestWatcherWithDenyFlag(t, cfg)
-		tw.ServiceMonitorSource.Add(sm)
-		defer tw.Close()
-
-		time.Sleep(watchSyncDuration)
-		synctest.Wait()
-
-		got, err := tw.LoadConfig(context.Background())
-		require.NoError(t, err)
-
-		assert.Empty(t, got.ScrapeConfigs,
-			"expected no scrape configs when credentials_file points to SA token")
-	})
+	err := tw.validateAndFilterScrapeConfigs(got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "credentials_file")
 }
 
-// TestDenyFSAccessThroughSMsNormalSMsWithoutFileReferences verifies that
-// ServiceMonitors without file references (credentials_file, caFile, etc.)
-// are allowed through even when DenyFSAccessThroughSMs is enabled.
-func TestDenyFSAccessThroughSMsNormalSMsWithoutFileReferences(t *testing.T) {
-	namespace := "test"
+// TestValidateAndFilterScrapeConfigsDisabled verifies that when the guard is
+// disabled, it does not reject scrape configs.
+func TestValidateAndFilterScrapeConfigsDisabled(t *testing.T) {
+	tw := &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: false,
+	}
 
-	sm := &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "normal-sm",
-			Namespace: namespace,
-		},
-		Spec: monitoringv1.ServiceMonitorSpec{
-			JobLabel: "test",
-			Endpoints: []monitoringv1.Endpoint{
-				{
-					Port: "web",
-					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
-						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
-							HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
-								BasicAuth: &monitoringv1.BasicAuth{
-									Username: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
-										Key:                  "user",
-									},
-									Password: &v1.SecretKeySelector{
-										LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
-										Key:                  "pass",
-									},
-								},
-							},
-						},
+	got := &promconfig.Config{
+		ScrapeConfigs: []*promconfig.ScrapeConfig{
+			{
+				JobName: "test",
+				HTTPClientConfig: config.HTTPClientConfig{
+					Authorization: &config.Authorization{
+						Type:            "Bearer",
+						CredentialsFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 					},
 				},
 			},
 		},
 	}
 
-	cfg := allocatorconfig.Config{
-		PrometheusCR: allocatorconfig.PrometheusCRConfig{
-			ServiceMonitorSelector: &metav1.LabelSelector{},
-			DenyFSAccessThroughSMs: true,
-		},
-	}
-
-	synctest.Test(t, func(t *testing.T) {
-		tw := newTestWatcherWithDenyFlag(t, cfg)
-		tw.ServiceMonitorSource.Add(sm)
-		defer tw.Close()
-
-		time.Sleep(watchSyncDuration)
-		synctest.Wait()
-
-		got, err := tw.LoadConfig(context.Background())
-		require.NoError(t, err)
-
-		assert.NotEmpty(t, got.ScrapeConfigs,
-			"expected scrape configs for ServiceMonitor without file references")
-	})
+	err := tw.validateAndFilterScrapeConfigs(got)
+	assert.NoError(t, err)
 }
 
-// newTestWatcherWithDenyFlag creates a testWatcher with the deny flag set
-// to match cfg.PrometheusCR.DenyFSAccessThroughSMs.
-func newTestWatcherWithDenyFlag(t *testing.T, cfg allocatorconfig.Config) *testWatcher {
-	t.Helper()
-
-	k8sClient := fake.NewClientset()
-
-	newSource := func() *fcache.FakeControllerSource {
-		s := fcache.NewFakeControllerSource()
-		t.Cleanup(func() { s.Broadcaster.Shutdown() })
-		return s
+// TestValidateAndFilterScrapeConfigsWithTLSFiles verifies the guard also
+// rejects tlsConfig.caFile, certFile, and keyFile.
+func TestValidateAndFilterScrapeConfigsWithTLSFiles(t *testing.T) {
+	tw := &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: true,
 	}
 
-	smSource := newSource()
-	pmSource := newSource()
-	probeSource := newSource()
-	scSource := newSource()
-	nsSource := newSource()
-
-	type gvrInfo struct {
-		gvr      schema.GroupVersionResource
-		source   *fcache.FakeControllerSource
-		exemplar runtime.Object
-	}
-	resources := []gvrInfo{
-		{monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName), smSource, &monitoringv1.ServiceMonitor{}},
-		{monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName), pmSource, &monitoringv1.PodMonitor{}},
-		{monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ProbeName), probeSource, &monitoringv1.Probe{}},
-		{promv1alpha1.SchemeGroupVersion.WithResource(promv1alpha1.ScrapeConfigName), scSource, &promv1alpha1.ScrapeConfig{}},
-	}
-
-	sources := make(map[schema.GroupVersionResource]*fcache.FakeControllerSource, len(resources))
-	exemplars := make(map[schema.GroupVersionResource]runtime.Object, len(resources))
-	for _, r := range resources {
-		sources[r.gvr] = r.source
-		exemplars[r.gvr] = r.exemplar
-	}
-
-	fakeFactory := &fakeFactoriesForNamespaces{
-		sources:    sources,
-		exemplars:  exemplars,
-		namespaces: sets.New[string](v1.NamespaceAll),
-	}
-
-	mdScheme := metadatafake.NewTestScheme()
-	_ = metav1.AddMetaToScheme(mdScheme)
-	mdClient := metadatafake.NewSimpleMetadataClient(mdScheme)
-	metadataFactory := informers.NewMetadataInformerFactory(
-		map[string]struct{}{v1.NamespaceAll: {}},
-		map[string]struct{}{},
-		mdClient, 1*time.Second, nil,
-	)
-
-	informerDefs := map[string]schema.GroupVersionResource{
-		monitoringv1.ServiceMonitorName: monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName),
-		monitoringv1.PodMonitorName:     monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName),
-		monitoringv1.ProbeName:          monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ProbeName),
-		promv1alpha1.ScrapeConfigName:   promv1alpha1.SchemeGroupVersion.WithResource(promv1alpha1.ScrapeConfigName),
-	}
-	informersMap := make(map[string]*informers.ForResource, len(informerDefs)+1)
-	for name, gvr := range informerDefs {
-		inf, infErr := informers.NewInformersForResource(fakeFactory, gvr)
-		require.NoError(t, infErr)
-		if inf != nil {
-			informersMap[name] = inf
-		}
-	}
-	secretInformer, err := informers.NewInformersForResourceWithTransform(
-		metadataFactory,
-		v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
-		informers.PartialObjectMetadataStrip(operator.SecretGVK()),
-	)
-	require.NoError(t, err)
-	if secretInformer != nil {
-		informersMap[string(v1.ResourceSecrets)] = secretInformer
-	}
-
-	serviceDiscoveryRole := monitoringv1.ServiceDiscoveryRole("EndpointSlice")
-
-	prom := &monitoringv1.Prometheus{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "test",
-		},
-		Spec: monitoringv1.PrometheusSpec{
-			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
-				ServiceMonitorSelector:          cfg.PrometheusCR.ServiceMonitorSelector,
-				PodMonitorSelector:              cfg.PrometheusCR.PodMonitorSelector,
-				ServiceMonitorNamespaceSelector: cfg.PrometheusCR.ServiceMonitorNamespaceSelector,
-				PodMonitorNamespaceSelector:     cfg.PrometheusCR.PodMonitorNamespaceSelector,
-				ScrapeConfigSelector:            cfg.PrometheusCR.ScrapeConfigSelector,
-				ScrapeConfigNamespaceSelector:   cfg.PrometheusCR.ScrapeConfigNamespaceSelector,
-				ProbeSelector:                   cfg.PrometheusCR.ProbeSelector,
-				ProbeNamespaceSelector:          cfg.PrometheusCR.ProbeNamespaceSelector,
-				ScrapeClasses:                   cfg.PrometheusCR.ScrapeClasses,
-				ServiceDiscoveryRole:            &serviceDiscoveryRole,
+	got := &promconfig.Config{
+		ScrapeConfigs: []*promconfig.ScrapeConfig{
+			{
+				JobName: "test",
+				HTTPClientConfig: config.HTTPClientConfig{
+					TLSConfig: config.TLSConfig{
+						CAFile:   "/path/to/ca.crt",
+						CertFile: "/path/to/cert.crt",
+						KeyFile:  "/path/to/key.key",
+					},
+				},
 			},
-			EvaluationInterval: monitoringv1.Duration(cfg.PrometheusCR.EvaluationInterval.String()),
 		},
 	}
 
-	promOperatorLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	err := tw.validateAndFilterScrapeConfigs(got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ca_file")
+}
 
-	generator, err := prometheus.NewConfigGenerator(promOperatorLogger, prom,
-		prometheus.WithEndpointSliceSupport(),
-		prometheus.WithInlineTLSConfig())
-	require.NoError(t, err)
-
-	store := assets.NewStoreBuilder(k8sClient.CoreV1(), k8sClient.CoreV1())
-	promRegisterer := prometheusgoclient.NewRegistry()
-	operatorMetrics := operator.NewMetrics(promRegisterer)
-	eventRecorder := operator.NewFakeRecorder(10, prom)
-
-	nsSource.Add(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}})
-
-	nsMonInf := cache.NewSharedInformer(nsSource, &v1.Namespace{}, 1*time.Second).(cache.SharedIndexInformer)
-
-	resourceSelector, err := prometheus.NewResourceSelector(
-		promOperatorLogger, prom, store, nsMonInf, operatorMetrics, eventRecorder)
-	require.NoError(t, err)
-
-	return &testWatcher{
-		PrometheusCRWatcher: &PrometheusCRWatcher{
-			logger:                          slog.Default(),
-			k8sClient:                       k8sClient,
-			informers:                       informersMap,
-			nsInformer:                      nsMonInf,
-			stopChannel:                     make(chan struct{}),
-			configGenerator:                 generator,
-			podMonitorNamespaceSelector:     cfg.PrometheusCR.PodMonitorNamespaceSelector,
-			serviceMonitorNamespaceSelector: cfg.PrometheusCR.ServiceMonitorNamespaceSelector,
-			probeNamespaceSelector:          cfg.PrometheusCR.ProbeNamespaceSelector,
-			scrapeConfigNamespaceSelector:   cfg.PrometheusCR.ScrapeConfigNamespaceSelector,
-			resourceSelector:                resourceSelector,
-			store:                           store,
-			prometheusCR:                    prom,
-			denyFSAccessThroughSMs:          cfg.PrometheusCR.DenyFSAccessThroughSMs,
-		},
-		NamespaceSource:      nsSource,
-		ServiceMonitorSource: smSource,
-		PodMonitorSource:     pmSource,
-		ProbeSource:          probeSource,
-		ScrapeConfigSource:   scSource,
-		MetadataClient:       mdClient,
+// TestValidateAndFilterScrapeConfigsWithTLSFilesCert verifies cert_file is
+// detected.
+func TestValidateAndFilterScrapeConfigsWithTLSFilesCert(t *testing.T) {
+	tw := &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: true,
 	}
+
+	got := &promconfig.Config{
+		ScrapeConfigs: []*promconfig.ScrapeConfig{
+			{
+				JobName: "test",
+				HTTPClientConfig: config.HTTPClientConfig{
+					TLSConfig: config.TLSConfig{
+						CertFile: "/path/to/cert.crt",
+					},
+				},
+			},
+		},
+	}
+
+	err := tw.validateAndFilterScrapeConfigs(got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "cert_file")
+}
+
+// TestValidateAndFilterScrapeConfigsWithTLSFilesKey verifies key_file is
+// detected.
+func TestValidateAndFilterScrapeConfigsWithTLSFilesKey(t *testing.T) {
+	tw := &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: true,
+	}
+
+	got := &promconfig.Config{
+		ScrapeConfigs: []*promconfig.ScrapeConfig{
+			{
+				JobName: "test",
+				HTTPClientConfig: config.HTTPClientConfig{
+					TLSConfig: config.TLSConfig{
+						KeyFile: "/path/to/key.key",
+					},
+				},
+			},
+		},
+	}
+
+	err := tw.validateAndFilterScrapeConfigs(got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "key_file")
+}
+
+// TestValidateAndFilterScrapeConfigsWithEmptyScrapeConfigs verifies that
+// empty scrape configs do not cause errors.
+func TestValidateAndFilterScrapeConfigsWithEmptyScrapeConfigs(t *testing.T) {
+	tw := &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: true,
+	}
+
+	got := &promconfig.Config{
+		ScrapeConfigs: []*promconfig.ScrapeConfig{},
+	}
+
+	err := tw.validateAndFilterScrapeConfigs(got)
+	assert.NoError(t, err)
+}
+
+// TestValidateAndFilterScrapeConfigsWithNormalPrometheusConfig verifies
+// that normal scrape configs without file references are allowed through.
+func TestValidateAndFilterScrapeConfigsWithNormalPrometheusConfig(t *testing.T) {
+	tw := &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: true,
+	}
+
+	got := &promconfig.Config{
+		ScrapeConfigs: []*promconfig.ScrapeConfig{
+			{
+				JobName:           "test",
+				MetricsPath:       "/metrics",
+				ScrapeInterval:    model.Duration(30 * time.Second),
+				EnableCompression: true,
+				HTTPClientConfig: config.HTTPClientConfig{
+					BasicAuth: &config.BasicAuth{
+						Username: "user",
+						Password: "password",
+					},
+				},
+			},
+		},
+	}
+
+	err := tw.validateAndFilterScrapeConfigs(got)
+	assert.NoError(t, err)
+}
+
+// TestValidateAndFilterScrapeConfigsWithBearerTokenFileRejection tests the
+// exact attack scenario: bearerTokenFile pointing to the Collector's service
+// account token should be rejected.
+func TestValidateAndFilterScrapeConfigsWithBearerTokenFileRejection(t *testing.T) {
+	tw := &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: true,
+	}
+
+	got := &promconfig.Config{
+		ScrapeConfigs: []*promconfig.ScrapeConfig{
+			{
+				JobName: "test",
+				HTTPClientConfig: config.HTTPClientConfig{
+					Authorization: &config.Authorization{
+						Type:            "Bearer",
+						CredentialsFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+					},
+				},
+			},
+		},
+	}
+
+	err := tw.validateAndFilterScrapeConfigs(got)
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "credentials_file"),
+		"expected error to mention credentials_file")
+	assert.True(t, strings.Contains(err.Error(),
+		"/var/run/secrets/kubernetes.io/serviceaccount/token"),
+		"expected error to mention the token path")
+}
+
+// TestValidateAndFilterScrapeConfigsMultipleScrapeConfigs verifies that
+// the guard checks all scrape configs in a list.
+func TestValidateAndFilterScrapeConfigsMultipleScrapeConfigs(t *testing.T) {
+	tw := &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: true,
+	}
+
+	got := &promconfig.Config{
+		ScrapeConfigs: []*promconfig.ScrapeConfig{
+			{
+				JobName:           "safe-config",
+				EnableCompression: true,
+				HTTPClientConfig: config.HTTPClientConfig{
+					BasicAuth: &config.BasicAuth{
+						Username: "user",
+						Password: "pass",
+					},
+				},
+			},
+			{
+				JobName:           "unsafe-config",
+				EnableCompression: true,
+				HTTPClientConfig: config.HTTPClientConfig{
+					Authorization: &config.Authorization{
+						Type:            "Bearer",
+						CredentialsFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+					},
+				},
+			},
+		},
+	}
+
+	err := tw.validateAndFilterScrapeConfigs(got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "credentials_file")
+}
+
+// TestValidateAndFilterScrapeConfigsWithNilAuthorization verifies that nil
+// Authorization fields do not cause panics.
+func TestValidateAndFilterScrapeConfigsWithNilAuthorization(t *testing.T) {
+	tw := &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: true,
+	}
+
+	got := &promconfig.Config{
+		ScrapeConfigs: []*promconfig.ScrapeConfig{
+			{
+				JobName:           "test",
+				EnableCompression: true,
+				HTTPClientConfig: config.HTTPClientConfig{
+					Authorization: nil,
+				},
+			},
+		},
+	}
+
+	err := tw.validateAndFilterScrapeConfigs(got)
+	assert.NoError(t, err)
+}
+
+// TestValidateAndFilterScrapeConfigsWithNilTLSConfig verifies that nil
+// TLSConfig fields do not cause panics.
+func TestValidateAndFilterScrapeConfigsWithNilTLSConfig(t *testing.T) {
+	tw := &PrometheusCRWatcher{
+		denyFSAccessThroughSMs: true,
+	}
+
+	got := &promconfig.Config{
+		ScrapeConfigs: []*promconfig.ScrapeConfig{
+			{
+				JobName:           "test",
+				EnableCompression: true,
+				HTTPClientConfig: config.HTTPClientConfig{
+					TLSConfig: config.TLSConfig{},
+				},
+			},
+		},
+	}
+
+	err := tw.validateAndFilterScrapeConfigs(got)
+	assert.NoError(t, err)
 }

--- a/cmd/otel-allocator/internal/watcher/promOperator_denyfs_test.go
+++ b/cmd/otel-allocator/internal/watcher/promOperator_denyfs_test.go
@@ -1,0 +1,400 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	promv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
+	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
+	"github.com/prometheus-operator/prometheus-operator/pkg/informers"
+	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+	"github.com/prometheus-operator/prometheus-operator/pkg/prometheus"
+	prometheusgoclient "github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes/fake"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	"k8s.io/client-go/tools/cache"
+	fcache "k8s.io/client-go/tools/cache/testing"
+
+	allocatorconfig "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/config"
+)
+
+// TestDenyFSAccessThroughSMsBasic verifies that when DenyFSAccessThroughSMs
+// is enabled, ServiceMonitors with authorization.credentials_file are rejected
+// and the resulting scrape configs are cleared.
+func TestDenyFSAccessThroughSMsBasic(t *testing.T) {
+	namespace := "test"
+	portName := "web"
+
+	sm := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "attacker-sm",
+			Namespace: namespace,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			JobLabel: "test",
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port: portName,
+					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
+						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
+							HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
+								Authorization: &monitoringv1.SafeAuthorization{
+									Type: "Bearer",
+									CredentialsFile: func() *string {
+										s := "/var/run/secrets/kubernetes.io/serviceaccount/token"
+										return &s
+									}(),
+								},
+							},
+						},
+					},
+				},
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "attacker"},
+			},
+		},
+	}
+
+	cfg := allocatorconfig.Config{
+		PrometheusCR: allocatorconfig.PrometheusCRConfig{
+			ServiceMonitorSelector: &metav1.LabelSelector{},
+			DenyFSAccessThroughSMs: true,
+		},
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		tw := newTestWatcherWithDenyFlag(t, cfg)
+		tw.ServiceMonitorSource.Add(sm)
+		defer tw.Close()
+
+		time.Sleep(watchSyncDuration)
+		synctest.Wait()
+
+		got, err := tw.LoadConfig(context.Background())
+		require.NoError(t, err)
+
+		assert.Empty(t, got.ScrapeConfigs,
+			"expected no scrape configs when DenyFSAccessThroughSMs rejects credentials_file")
+	})
+}
+
+// TestDenyFSAccessThroughSMsDisabled verifies that when DenyFSAccessThroughSMs
+// is NOT enabled, ServiceMonitors without file references are allowed through.
+func TestDenyFSAccessThroughSMsDisabled(t *testing.T) {
+	namespace := "test"
+	portName := "web"
+
+	sm := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "simple-sm",
+			Namespace: namespace,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			JobLabel: "test",
+			Endpoints: []monitoringv1.Endpoint{
+				{Port: portName},
+			},
+		},
+	}
+
+	cfg := allocatorconfig.Config{
+		PrometheusCR: allocatorconfig.PrometheusCRConfig{
+			ServiceMonitorSelector: &metav1.LabelSelector{},
+			DenyFSAccessThroughSMs: false,
+		},
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		tw := newTestWatcherWithDenyFlag(t, cfg)
+		tw.ServiceMonitorSource.Add(sm)
+		defer tw.Close()
+
+		time.Sleep(watchSyncDuration)
+		synctest.Wait()
+
+		got, err := tw.LoadConfig(context.Background())
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, got.ScrapeConfigs,
+			"expected scrape configs when DenyFSAccessThroughSMs is disabled")
+	})
+}
+
+// TestDenyFSAccessThroughSMsWithBearerTokenFile verifies the exact attack
+// scenario: a tenant sets bearerTokenFile to the Collector's service account
+// token path, and the guard should reject it.
+func TestDenyFSAccessThroughSMsWithBearerTokenFile(t *testing.T) {
+	namespace := "test"
+
+	sm := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "attacker-bearer-sm",
+			Namespace: namespace,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			JobLabel: "test",
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port: "web",
+					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
+						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
+							HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
+								Authorization: &monitoringv1.SafeAuthorization{
+									Type: "Bearer",
+									CredentialsFile: func() *string {
+										s := "/var/run/secrets/kubernetes.io/serviceaccount/token"
+										return &s
+									}(),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := allocatorconfig.Config{
+		PrometheusCR: allocatorconfig.PrometheusCRConfig{
+			ServiceMonitorSelector: &metav1.LabelSelector{},
+			DenyFSAccessThroughSMs: true,
+		},
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		tw := newTestWatcherWithDenyFlag(t, cfg)
+		tw.ServiceMonitorSource.Add(sm)
+		defer tw.Close()
+
+		time.Sleep(watchSyncDuration)
+		synctest.Wait()
+
+		got, err := tw.LoadConfig(context.Background())
+		require.NoError(t, err)
+
+		assert.Empty(t, got.ScrapeConfigs,
+			"expected no scrape configs when credentials_file points to SA token")
+	})
+}
+
+// TestDenyFSAccessThroughSMsNormalSMsWithoutFileReferences verifies that
+// ServiceMonitors without file references (credentials_file, caFile, etc.)
+// are allowed through even when DenyFSAccessThroughSMs is enabled.
+func TestDenyFSAccessThroughSMsNormalSMsWithoutFileReferences(t *testing.T) {
+	namespace := "test"
+
+	sm := &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "normal-sm",
+			Namespace: namespace,
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			JobLabel: "test",
+			Endpoints: []monitoringv1.Endpoint{
+				{
+					Port: "web",
+					HTTPConfigWithProxyAndTLSFiles: monitoringv1.HTTPConfigWithProxyAndTLSFiles{
+						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
+							HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
+								BasicAuth: &monitoringv1.BasicAuth{
+									Username: &v1.SecretKeySelector{
+										LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+										Key:                  "user",
+									},
+									Password: &v1.SecretKeySelector{
+										LocalObjectReference: v1.LocalObjectReference{Name: "secret"},
+										Key:                  "pass",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := allocatorconfig.Config{
+		PrometheusCR: allocatorconfig.PrometheusCRConfig{
+			ServiceMonitorSelector: &metav1.LabelSelector{},
+			DenyFSAccessThroughSMs: true,
+		},
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		tw := newTestWatcherWithDenyFlag(t, cfg)
+		tw.ServiceMonitorSource.Add(sm)
+		defer tw.Close()
+
+		time.Sleep(watchSyncDuration)
+		synctest.Wait()
+
+		got, err := tw.LoadConfig(context.Background())
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, got.ScrapeConfigs,
+			"expected scrape configs for ServiceMonitor without file references")
+	})
+}
+
+// newTestWatcherWithDenyFlag creates a testWatcher with the deny flag set
+// to match cfg.PrometheusCR.DenyFSAccessThroughSMs.
+func newTestWatcherWithDenyFlag(t *testing.T, cfg allocatorconfig.Config) *testWatcher {
+	t.Helper()
+
+	k8sClient := fake.NewClientset()
+
+	newSource := func() *fcache.FakeControllerSource {
+		s := fcache.NewFakeControllerSource()
+		t.Cleanup(func() { s.Broadcaster.Shutdown() })
+		return s
+	}
+
+	smSource := newSource()
+	pmSource := newSource()
+	probeSource := newSource()
+	scSource := newSource()
+	nsSource := newSource()
+
+	type gvrInfo struct {
+		gvr      schema.GroupVersionResource
+		source   *fcache.FakeControllerSource
+		exemplar runtime.Object
+	}
+	resources := []gvrInfo{
+		{monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName), smSource, &monitoringv1.ServiceMonitor{}},
+		{monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName), pmSource, &monitoringv1.PodMonitor{}},
+		{monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ProbeName), probeSource, &monitoringv1.Probe{}},
+		{promv1alpha1.SchemeGroupVersion.WithResource(promv1alpha1.ScrapeConfigName), scSource, &promv1alpha1.ScrapeConfig{}},
+	}
+
+	sources := make(map[schema.GroupVersionResource]*fcache.FakeControllerSource, len(resources))
+	exemplars := make(map[schema.GroupVersionResource]runtime.Object, len(resources))
+	for _, r := range resources {
+		sources[r.gvr] = r.source
+		exemplars[r.gvr] = r.exemplar
+	}
+
+	fakeFactory := &fakeFactoriesForNamespaces{
+		sources:    sources,
+		exemplars:  exemplars,
+		namespaces: sets.New[string](v1.NamespaceAll),
+	}
+
+	mdScheme := metadatafake.NewTestScheme()
+	_ = metav1.AddMetaToScheme(mdScheme)
+	mdClient := metadatafake.NewSimpleMetadataClient(mdScheme)
+	metadataFactory := informers.NewMetadataInformerFactory(
+		map[string]struct{}{v1.NamespaceAll: {}},
+		map[string]struct{}{},
+		mdClient, 1*time.Second, nil,
+	)
+
+	informerDefs := map[string]schema.GroupVersionResource{
+		monitoringv1.ServiceMonitorName: monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName),
+		monitoringv1.PodMonitorName:     monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName),
+		monitoringv1.ProbeName:          monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ProbeName),
+		promv1alpha1.ScrapeConfigName:   promv1alpha1.SchemeGroupVersion.WithResource(promv1alpha1.ScrapeConfigName),
+	}
+	informersMap := make(map[string]*informers.ForResource, len(informerDefs)+1)
+	for name, gvr := range informerDefs {
+		inf, infErr := informers.NewInformersForResource(fakeFactory, gvr)
+		require.NoError(t, infErr)
+		if inf != nil {
+			informersMap[name] = inf
+		}
+	}
+	secretInformer, err := informers.NewInformersForResourceWithTransform(
+		metadataFactory,
+		v1.SchemeGroupVersion.WithResource(string(v1.ResourceSecrets)),
+		informers.PartialObjectMetadataStrip(operator.SecretGVK()),
+	)
+	require.NoError(t, err)
+	if secretInformer != nil {
+		informersMap[string(v1.ResourceSecrets)] = secretInformer
+	}
+
+	serviceDiscoveryRole := monitoringv1.ServiceDiscoveryRole("EndpointSlice")
+
+	prom := &monitoringv1.Prometheus{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+		},
+		Spec: monitoringv1.PrometheusSpec{
+			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
+				ServiceMonitorSelector:          cfg.PrometheusCR.ServiceMonitorSelector,
+				PodMonitorSelector:              cfg.PrometheusCR.PodMonitorSelector,
+				ServiceMonitorNamespaceSelector: cfg.PrometheusCR.ServiceMonitorNamespaceSelector,
+				PodMonitorNamespaceSelector:     cfg.PrometheusCR.PodMonitorNamespaceSelector,
+				ScrapeConfigSelector:            cfg.PrometheusCR.ScrapeConfigSelector,
+				ScrapeConfigNamespaceSelector:   cfg.PrometheusCR.ScrapeConfigNamespaceSelector,
+				ProbeSelector:                   cfg.PrometheusCR.ProbeSelector,
+				ProbeNamespaceSelector:          cfg.PrometheusCR.ProbeNamespaceSelector,
+				ScrapeClasses:                   cfg.PrometheusCR.ScrapeClasses,
+				ServiceDiscoveryRole:            &serviceDiscoveryRole,
+			},
+			EvaluationInterval: monitoringv1.Duration(cfg.PrometheusCR.EvaluationInterval.String()),
+		},
+	}
+
+	promOperatorLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	generator, err := prometheus.NewConfigGenerator(promOperatorLogger, prom,
+		prometheus.WithEndpointSliceSupport(),
+		prometheus.WithInlineTLSConfig())
+	require.NoError(t, err)
+
+	store := assets.NewStoreBuilder(k8sClient.CoreV1(), k8sClient.CoreV1())
+	promRegisterer := prometheusgoclient.NewRegistry()
+	operatorMetrics := operator.NewMetrics(promRegisterer)
+	eventRecorder := operator.NewFakeRecorder(10, prom)
+
+	nsSource.Add(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test"}})
+
+	nsMonInf := cache.NewSharedInformer(nsSource, &v1.Namespace{}, 1*time.Second).(cache.SharedIndexInformer)
+
+	resourceSelector, err := prometheus.NewResourceSelector(
+		promOperatorLogger, prom, store, nsMonInf, operatorMetrics, eventRecorder)
+	require.NoError(t, err)
+
+	return &testWatcher{
+		PrometheusCRWatcher: &PrometheusCRWatcher{
+			logger:                          slog.Default(),
+			k8sClient:                       k8sClient,
+			informers:                       informersMap,
+			nsInformer:                      nsMonInf,
+			stopChannel:                     make(chan struct{}),
+			configGenerator:                 generator,
+			podMonitorNamespaceSelector:     cfg.PrometheusCR.PodMonitorNamespaceSelector,
+			serviceMonitorNamespaceSelector: cfg.PrometheusCR.ServiceMonitorNamespaceSelector,
+			probeNamespaceSelector:          cfg.PrometheusCR.ProbeNamespaceSelector,
+			scrapeConfigNamespaceSelector:   cfg.PrometheusCR.ScrapeConfigNamespaceSelector,
+			resourceSelector:                resourceSelector,
+			store:                           store,
+			prometheusCR:                    prom,
+			denyFSAccessThroughSMs:          cfg.PrometheusCR.DenyFSAccessThroughSMs,
+		},
+		NamespaceSource:      nsSource,
+		ServiceMonitorSource: smSource,
+		PodMonitorSource:     pmSource,
+		ProbeSource:          probeSource,
+		ScrapeConfigSource:   scSource,
+		MetadataClient:       mdClient,
+	}
+}

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -3349,6 +3349,8 @@ spec:
                     type: object
                   prometheusCR:
                     properties:
+                      denyFSAccessThroughSMs:
+                        type: boolean
                       enabled:
                         type: boolean
                       podMonitorSelector:
@@ -8288,6 +8290,8 @@ spec:
                         items:
                           type: string
                         type: array
+                      denyFSAccessThroughSMs:
+                        type: boolean
                       denyNamespaces:
                         items:
                           type: string

--- a/config/crd/bases/opentelemetry.io_targetallocators.yaml
+++ b/config/crd/bases/opentelemetry.io_targetallocators.yaml
@@ -2478,6 +2478,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  denyFSAccessThroughSMs:
+                    type: boolean
                   denyNamespaces:
                     items:
                       type: string

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
+  newTag: 0.144.0-314-g54249c77

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,2 @@
 resources:
 - manager.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-images:
-- name: controller
-  newName: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-  newTag: 0.144.0-314-g54249c77

--- a/docs/api/opentelemetrycollectors.md
+++ b/docs/api/opentelemetrycollectors.md
@@ -13979,6 +13979,19 @@ All CR instances which the ServiceAccount has access to will be retrieved. This 
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>denyFSAccessThroughSMs</b></td>
+        <td>boolean</td>
+        <td>
+          DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
+that reference arbitrary files on the file system. When enabled, endpoints with
+bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
+will be rejected. This prevents tenants from stealing the Collector's
+service account token via ServiceMonitor bearerTokenFile references.
+This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
+Prometheus Operator.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>enabled</b></td>
         <td>boolean</td>
         <td>
@@ -34857,6 +34870,19 @@ All CR instances which the ServiceAccount has access to will be retrieved. This 
         <td>[]string</td>
         <td>
           AllowNamespaces Namespaces to scope the interaction of the Target Allocator and the apiserver (allow list). This is mutually exclusive with DenyNamespaces.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>denyFSAccessThroughSMs</b></td>
+        <td>boolean</td>
+        <td>
+          DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
+that reference arbitrary files on the file system. When enabled, endpoints with
+bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
+will be rejected. This prevents tenants from stealing the Collector's
+service account token via ServiceMonitor bearerTokenFile references.
+This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
+Prometheus Operator.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/api/opentelemetrycollectors.md
+++ b/docs/api/opentelemetrycollectors.md
@@ -13982,13 +13982,14 @@ All CR instances which the ServiceAccount has access to will be retrieved. This 
         <td><b>denyFSAccessThroughSMs</b></td>
         <td>boolean</td>
         <td>
-          DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
-that reference arbitrary files on the file system. When enabled, endpoints with
-bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
-will be rejected. This prevents tenants from stealing the Collector's
-service account token via ServiceMonitor bearerTokenFile references.
-This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
-Prometheus Operator.<br/>
+          DenyFSAccessThroughSMs causes the Target Allocator to drop ServiceMonitor and
+PodMonitor endpoints that reference arbitrary files on the file system. When
+enabled, endpoints with bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile,
+or tlsConfig.keyFile are dropped from the produced scrape configuration while
+the remaining endpoints are kept. This prevents tenants from stealing the
+Collector's service account token via ServiceMonitor bearerTokenFile
+references. This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from
+the Prometheus Operator.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -34876,13 +34877,14 @@ All CR instances which the ServiceAccount has access to will be retrieved. This 
         <td><b>denyFSAccessThroughSMs</b></td>
         <td>boolean</td>
         <td>
-          DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
-that reference arbitrary files on the file system. When enabled, endpoints with
-bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
-will be rejected. This prevents tenants from stealing the Collector's
-service account token via ServiceMonitor bearerTokenFile references.
-This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
-Prometheus Operator.<br/>
+          DenyFSAccessThroughSMs causes the Target Allocator to drop ServiceMonitor and
+PodMonitor endpoints that reference arbitrary files on the file system. When
+enabled, endpoints with bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile,
+or tlsConfig.keyFile are dropped from the produced scrape configuration while
+the remaining endpoints are kept. This prevents tenants from stealing the
+Collector's service account token via ServiceMonitor bearerTokenFile
+references. This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from
+the Prometheus Operator.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/api/targetallocators.md
+++ b/docs/api/targetallocators.md
@@ -10365,6 +10365,19 @@ PrometheusCR defines the configuration for the retrieval of PrometheusOperator C
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>denyFSAccessThroughSMs</b></td>
+        <td>boolean</td>
+        <td>
+          DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
+that reference arbitrary files on the file system. When enabled, endpoints with
+bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
+will be rejected. This prevents tenants from stealing the Collector's
+service account token via ServiceMonitor bearerTokenFile references.
+This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
+Prometheus Operator.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>denyNamespaces</b></td>
         <td>[]string</td>
         <td>

--- a/docs/api/targetallocators.md
+++ b/docs/api/targetallocators.md
@@ -10368,13 +10368,14 @@ PrometheusCR defines the configuration for the retrieval of PrometheusOperator C
         <td><b>denyFSAccessThroughSMs</b></td>
         <td>boolean</td>
         <td>
-          DenyFSAccessThroughSMs enables rejection of ServiceMonitor and PodMonitor endpoints
-that reference arbitrary files on the file system. When enabled, endpoints with
-bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile, or tlsConfig.keyFile
-will be rejected. This prevents tenants from stealing the Collector's
-service account token via ServiceMonitor bearerTokenFile references.
-This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from the
-Prometheus Operator.<br/>
+          DenyFSAccessThroughSMs causes the Target Allocator to drop ServiceMonitor and
+PodMonitor endpoints that reference arbitrary files on the file system. When
+enabled, endpoints with bearerTokenFile, tlsConfig.caFile, tlsConfig.certFile,
+or tlsConfig.keyFile are dropped from the produced scrape configuration while
+the remaining endpoints are kept. This prevents tenants from stealing the
+Collector's service account token via ServiceMonitor bearerTokenFile
+references. This is the equivalent of ArbitraryFSAccessThroughSMs.Deny from
+the Prometheus Operator.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -117,6 +117,10 @@ func ConfigMap(params Params) (*corev1.ConfigMap, error) {
 			prometheusCRConfig["secret_namespaces"] = taSpec.PrometheusCR.SecretNamespaces
 		}
 
+		if taSpec.PrometheusCR.DenyFSAccessThroughSMs {
+			prometheusCRConfig["deny_fs_access_through_sms"] = true
+		}
+
 		prometheusCRConfig["service_monitor_namespace_selector"] = taSpec.PrometheusCR.ServiceMonitorNamespaceSelector
 		prometheusCRConfig["service_monitor_selector"] = taSpec.PrometheusCR.ServiceMonitorSelector
 

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -925,40 +925,56 @@ filter_strategy: relabel-config
 }
 
 func TestDesiredConfigMapWithDenyFSAccessThroughSMs(t *testing.T) {
-	collector := collectorInstance()
-	targetAllocator := targetAllocatorInstance()
-	targetAllocator.Spec.PrometheusCR.DenyFSAccessThroughSMs = true
+	t.Run("should return expected target allocator config map with denyFSAccessThroughSMs", func(t *testing.T) {
+		require.NoError(t, colfg.GlobalRegistry().Set("operator.targetallocator.fallbackstrategy", true))
+		t.Cleanup(func() {
+			require.NoError(t, colfg.GlobalRegistry().Set("operator.targetallocator.fallbackstrategy", false))
+		})
 
-	expectedData := map[string]string{
-		targetAllocatorFilename: `allocation_strategy: consistent-hashing
-	collector_selector:
-	  matchlabels:
-	    app.kubernetes.io/component: opentelemetry-collector
-	    app.kubernetes.io/instance: default.my-instance
-	    app.kubernetes.io/managed-by: opentelemetry-operator
-	    app.kubernetes.io/part-of: opentelemetry
-	  matchexpressions: []
-	config:
-	  scrape_configs:
-	  - job_name: otel-collector
-	    scrape_interval: 10s
-	    static_configs:
-	     - targets:
-	       - 0.0.0.0:8888
-	       - 0.0.0.0:9999
-	filter_strategy: relabel-config
-	prometheus_cr:
-	  deny_fs_access_through_sms: true
-	  enabled: true
-	`,
-	}
+		expectedData := map[string]string{
+			targetAllocatorFilename: `allocation_fallback_strategy: consistent-hashing
+allocation_strategy: consistent-hashing
+collector_selector:
+  matchlabels:
+    app.kubernetes.io/component: opentelemetry-collector
+    app.kubernetes.io/instance: default.my-instance
+    app.kubernetes.io/managed-by: opentelemetry-operator
+    app.kubernetes.io/part-of: opentelemetry
+  matchexpressions: []
+config:
+  scrape_configs:
+  - job_name: otel-collector
+    scrape_interval: 10s
+    static_configs:
+    - targets:
+      - 0.0.0.0:8888
+      - 0.0.0.0:9999
+filter_strategy: relabel-config
+prometheus_cr:
+  deny_fs_access_through_sms: true
+  enabled: true
+  pod_monitor_namespace_selector: null
+  pod_monitor_selector: null
+  probe_namespace_selector: null
+  probe_selector: null
+  scrape_config_namespace_selector: null
+  scrape_config_selector: null
+  service_monitor_namespace_selector: null
+  service_monitor_selector: null
+`,
+		}
 
-	actual, err := ConfigMap(Params{
-		Collector:       collector,
-		TargetAllocator: targetAllocator,
+		targetAllocator := targetAllocatorInstance()
+		targetAllocator.Spec.PrometheusCR.Enabled = true
+		targetAllocator.Spec.PrometheusCR.DenyFSAccessThroughSMs = true
+		testParams := Params{
+			Collector:       collectorInstance(),
+			TargetAllocator: targetAllocator,
+		}
+		actual, err := ConfigMap(testParams)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "my-instance-targetallocator", actual.Name)
+		assert.Equal(t, expectedData, actual.Data)
 	})
-	require.NoError(t, err)
-
-	assert.Equal(t, "my-instance-targetallocator", actual.Name)
-	assert.Equal(t, expectedData[targetAllocatorFilename], actual.Data[targetAllocatorFilename])
 }

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -923,3 +923,42 @@ filter_strategy: relabel-config
 		assert.Equal(t, expectedData[targetAllocatorFilename], actual.Data[targetAllocatorFilename])
 	})
 }
+
+func TestDesiredConfigMapWithDenyFSAccessThroughSMs(t *testing.T) {
+	collector := collectorInstance()
+	targetAllocator := targetAllocatorInstance()
+	targetAllocator.Spec.PrometheusCR.DenyFSAccessThroughSMs = true
+
+	expectedData := map[string]string{
+		targetAllocatorFilename: `allocation_strategy: consistent-hashing
+	collector_selector:
+	  matchlabels:
+	    app.kubernetes.io/component: opentelemetry-collector
+	    app.kubernetes.io/instance: default.my-instance
+	    app.kubernetes.io/managed-by: opentelemetry-operator
+	    app.kubernetes.io/part-of: opentelemetry
+	  matchexpressions: []
+	config:
+	  scrape_configs:
+	  - job_name: otel-collector
+	    scrape_interval: 10s
+	    static_configs:
+	     - targets:
+	       - 0.0.0.0:8888
+	       - 0.0.0.0:9999
+	filter_strategy: relabel-config
+	prometheus_cr:
+	  deny_fs_access_through_sms: true
+	  enabled: true
+	`,
+	}
+
+	actual, err := ConfigMap(Params{
+		Collector:       collector,
+		TargetAllocator: targetAllocator,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-instance-targetallocator", actual.Name)
+	assert.Equal(t, expectedData[targetAllocatorFilename], actual.Data[targetAllocatorFilename])
+}

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/00-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/00-assert.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: prometheus-cr-denyfs-collector
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-cr-denyfs-targetallocator
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-cr-denyfs-targetallocator

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/00-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/00-install.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  name: collector
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: collector-prometheuscr-denyfs
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/metrics
+  - services
+  - endpoints
+  - namespaces
+  verbs:
+  - get
+  - watch
+  - list
+- nonResourceURLs:
+  - /metrics
+  - /metrics/cadvisor
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: (join('-', ['collector', $namespace]))
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: collector-prometheuscr-denyfs
+subjects:
+- kind: ServiceAccount
+  name: collector
+  namespace: ($namespace)
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: prometheus-cr-denyfs
+spec:
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs: []
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [debug]
+  mode: statefulset
+  serviceAccount: collector
+  targetAllocator:
+    enabled: true
+    prometheusCR:
+      enabled: true
+      scrapeInterval: 1s
+      denyFSAccessThroughSMs: true
+      serviceMonitorSelector: {}
+      podMonitorSelector: {}
+    serviceAccount: ta

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/01-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/01-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-app
+status:
+  availableReplicas: 1
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: metrics-servicemonitor
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-denyfs-filtering
+status:
+  succeeded: 1

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/01-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/01-install.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-app
+  labels:
+    app: metrics-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metrics-app
+  template:
+    metadata:
+      labels:
+        app: metrics-app
+    spec:
+      containers:
+      - name: metrics-app
+        image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-metrics-basic-auth:main
+        ports:
+        - containerPort: 9123
+        env:
+        - name: BASIC_AUTH_USERNAME
+          value: user
+        - name: BASIC_AUTH_PASSWORD
+          value: pass
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-service
+  labels:
+    app: metrics-app
+spec:
+  ports:
+  - name: metrics
+    port: 9123
+    targetPort: 9123
+    protocol: TCP
+  - name: safe-metrics
+    port: 9124
+    targetPort: 9123
+    protocol: TCP
+  selector:
+    app: metrics-app
+  type: ClusterIP
+---
+# A ServiceMonitor with one unsafe endpoint (bearerTokenFile, references the
+# Collector's mounted service account token) and one safe endpoint (no file
+# references). With denyFSAccessThroughSMs enabled, only the safe endpoint
+# should appear in the Target Allocator's scrape configs.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: metrics-servicemonitor
+  labels:
+    app: metrics-app
+spec:
+  selector:
+    matchLabels:
+      app: metrics-app
+  endpoints:
+  - port: metrics
+    interval: 10s
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  - port: safe-metrics
+    interval: 10s
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-denyfs-filtering
+spec:
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        checker: "true"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: check-config
+          image: mirror.gcr.io/curlimages/curl:latest
+          args:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              CONFIG=$(curl -fs http://prometheus-cr-denyfs-targetallocator/scrape_configs)
+              echo "$CONFIG"
+              # The safe endpoint (port safe-metrics) must remain.
+              echo "$CONFIG" | grep -q "safe-metrics"
+              # The unsafe endpoint (bearerTokenFile) must be dropped: neither
+              # the credentials_file path nor the unsafe port should be present.
+              if echo "$CONFIG" | grep -q "credentials_file"; then
+                echo "credentials_file should have been dropped"
+                exit 1
+              fi
+              if echo "$CONFIG" | grep -q "/var/run/secrets/kubernetes.io/serviceaccount/token"; then
+                echo "service account token path should have been dropped"
+                exit 1
+              fi

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/chainsaw-test.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/chainsaw-test.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: targetallocator-prometheuscr-denyfs
+spec:
+  steps:
+  - name: Setup Target Allocator RBAC
+    use:
+      template: ../../step-templates/target-allocator-rbac-comprehensive.yaml
+      with:
+        bindings:
+        - name: clusterRoleName
+          value: targetallocator-prometheuscr-denyfs
+        - name: clusterRoleBindingName
+          value: (join('-', ['ta', $namespace]))
+  - name: step-00-install-collector-with-deny
+    try:
+    - apply:
+        template: true
+        file: 00-install.yaml
+    - assert:
+        file: 00-assert.yaml
+    catch:
+    - podLogs:
+        selector: app.kubernetes.io/managed-by=opentelemetry-operator
+  - name: step-01-verify-unsafe-dropped-safe-kept
+    try:
+    - apply:
+        file: 01-install.yaml
+    - assert:
+        file: 01-assert.yaml
+    catch:
+    - podLogs:
+        selector: app.kubernetes.io/component=opentelemetry-targetallocator


### PR DESCRIPTION
**Description:**
Add support to disable service and podmonitor endpoints that read arbitrary files. The current behavior is to keep this disabled to continue previous expectations. Users may want to enable this feature and manually mount secrets themselves in the future.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #issue-number

**Testing:** unit

**Documentation:** crd
