### PR TITLE
Restrict automatic RBAC creation from users without permissions

### DIFF
--- a/.chloggen/rbac-privilege-escalation-check.yaml
+++ b/.chloggen/rbac-privilege-escalation-check.yaml
@@ -1,0 +1,22 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Restrict automatic RBAC from users without the necessary permissions
+
+# One or more tracking issues related to the change
+issues: [5105]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  If the operator has permission to create ClusterRoles and ClusterRoleBindings, it sets up RBAC
+  for collectors automatically based on their configuration.
+  If a user tries to create an OpenTelemetryCollector whose permissions would be automatically
+  generated this way, and the user doesn't have the permissions themselves, it will be rejected.
+  If the collector tries to use an existing ServiceAccount, only the permissions missing from
+  that ServiceAccount are checked this way.

--- a/internal/rbac/access.go
+++ b/internal/rbac/access.go
@@ -87,6 +87,60 @@ func (r *Reviewer) CanAccess(ctx context.Context, serviceAccount, serviceAccount
 	return r.client.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 }
 
+// CheckPolicyRulesForUser is a convenience function that checks whether a user (identified by
+// username and group membership) holds all the permissions described by the given PolicyRules.
+func (r *Reviewer) CheckPolicyRulesForUser(ctx context.Context, username string, groups []string, rules ...*rbacv1.PolicyRule) ([]*v1.SubjectAccessReview, error) {
+	var subjectAccessReviews []*v1.SubjectAccessReview
+	var errs []error
+	for _, rule := range rules {
+		if rule == nil {
+			continue
+		}
+		resourceAttributes := policyRuleToResourceAttributes(rule)
+		nonResourceAttributes := policyRuleToNonResourceAttributes(rule)
+		for _, res := range resourceAttributes {
+			sar, err := r.CanAccessAsUser(ctx, username, groups, res, nil)
+			subjectAccessReviews = append(subjectAccessReviews, sar)
+			errs = append(errs, err)
+		}
+		for _, nonResourceAttribute := range nonResourceAttributes {
+			sar, err := r.CanAccessAsUser(ctx, username, groups, nil, nonResourceAttribute)
+			subjectAccessReviews = append(subjectAccessReviews, sar)
+			errs = append(errs, err)
+		}
+	}
+	return subjectAccessReviews, errors.Join(errs...)
+}
+
+// CheckSARsForUser re-checks the resource attributes described by the given SubjectAccessReviews
+// against a user identity. It is used to check whether a user holds the same permissions that
+// a ServiceAccount was found to be missing: the caller runs CheckPolicyRules for the SA, collects
+// the denied results, and passes them here to see whether the requesting user holds those
+// permissions themselves.
+func (r *Reviewer) CheckSARsForUser(ctx context.Context, username string, groups []string, sars []*v1.SubjectAccessReview) ([]*v1.SubjectAccessReview, error) {
+	var result []*v1.SubjectAccessReview
+	var errs []error
+	for _, sar := range sars {
+		userSAR, err := r.CanAccessAsUser(ctx, username, groups, sar.Spec.ResourceAttributes, sar.Spec.NonResourceAttributes)
+		result = append(result, userSAR)
+		errs = append(errs, err)
+	}
+	return result, errors.Join(errs...)
+}
+
+// CanAccessAsUser checks whether a user is able to access a single requested resource attribute.
+func (r *Reviewer) CanAccessAsUser(ctx context.Context, username string, groups []string, res *v1.ResourceAttributes, nonResourceAttributes *v1.NonResourceAttributes) (*v1.SubjectAccessReview, error) {
+	sar := &v1.SubjectAccessReview{
+		Spec: v1.SubjectAccessReviewSpec{
+			ResourceAttributes:    res,
+			NonResourceAttributes: nonResourceAttributes,
+			User:                  username,
+			Groups:                groups,
+		},
+	}
+	return r.client.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
+}
+
 // policyRuleToResourceAttributes converts a single policy rule in to a list of resource attribute requests.
 // policyRules have lists of resources, verbs, groups, etc. whereas resource attributes do not work on lists. This
 // requires us to iterate over each list and flatten.

--- a/internal/rbac/access_test.go
+++ b/internal/rbac/access_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/authorization/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,6 +17,26 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	kubeTesting "k8s.io/client-go/testing"
 )
+
+// captureReactor is a reactor that records which SubjectAccessReview specs were submitted.
+type captureReactor struct {
+	status   v1.SubjectAccessReviewStatus
+	mockErr  error
+	captured []*v1.SubjectAccessReview
+}
+
+func (cr *captureReactor) react(action kubeTesting.Action) (handled bool, ret runtime.Object, err error) {
+	if !action.Matches(createVerb, sarResource) {
+		return false, nil, errors.New("must be a create for a SAR")
+	}
+	sar, ok := action.(kubeTesting.CreateAction).GetObject().DeepCopyObject().(*v1.SubjectAccessReview)
+	if !ok || sar == nil {
+		return false, nil, errors.New("bad object")
+	}
+	cr.captured = append(cr.captured, sar.DeepCopy())
+	sar.Status = cr.status
+	return true, sar, cr.mockErr
+}
 
 const (
 	createVerb  = "create"
@@ -220,6 +241,217 @@ func TestReviewer_CheckPolicyRules(t *testing.T) {
 			assert.Equal(t, tt.want, ok)
 			if !ok {
 				assert.Equal(t, tt.numFailedReviews, len(deniedReviews))
+			}
+		})
+	}
+}
+
+func TestReviewer_CanAccessAsUser(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    v1.SubjectAccessReviewStatus
+		mockErr   error
+		username  string
+		groups    []string
+		res       *v1.ResourceAttributes
+		wantAllow bool
+		wantErr   bool
+	}{
+		{
+			name:     "user can access",
+			status:   v1.SubjectAccessReviewStatus{Allowed: true},
+			username: "alice",
+			groups:   []string{"devs"},
+			res: &v1.ResourceAttributes{
+				Verb:     "list",
+				Resource: "nodes",
+			},
+			wantAllow: true,
+		},
+		{
+			name:     "user cannot access",
+			status:   v1.SubjectAccessReviewStatus{Denied: true},
+			username: "bob",
+			groups:   []string{"viewers"},
+			res: &v1.ResourceAttributes{
+				Verb:     "list",
+				Resource: "nodes",
+			},
+			wantAllow: false,
+		},
+		{
+			name:    "handles error",
+			mockErr: errors.New("api unavailable"),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cr := &captureReactor{status: tt.status, mockErr: tt.mockErr}
+			c := fake.NewClientset()
+			c.PrependReactor(createVerb, sarResource, cr.react)
+			r := NewReviewer(c)
+
+			got, err := r.CanAccessAsUser(context.Background(), tt.username, tt.groups, tt.res, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CanAccessAsUser() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			assert.Equal(t, tt.wantAllow, got.Status.Allowed)
+
+			// Verify the SAR was submitted with the correct user fields (not the SA form).
+			require.Len(t, cr.captured, 1)
+			assert.Equal(t, tt.username, cr.captured[0].Spec.User)
+			assert.Equal(t, tt.groups, cr.captured[0].Spec.Groups)
+			// The SA format "system:serviceaccount:..." must NOT appear.
+			assert.NotContains(t, cr.captured[0].Spec.User, "system:serviceaccount")
+		})
+	}
+}
+
+func TestReviewer_CheckSARsForUser(t *testing.T) {
+	// Build two "denied SA SARs" with known resource attributes — these simulate the output
+	// of CheckPolicyRules when the SA is missing permissions.
+	deniedSARs := []*v1.SubjectAccessReview{
+		{Spec: v1.SubjectAccessReviewSpec{ResourceAttributes: &v1.ResourceAttributes{Verb: "get", Resource: "events"}}},
+		{Spec: v1.SubjectAccessReviewSpec{ResourceAttributes: &v1.ResourceAttributes{Verb: "list", Resource: "events"}}},
+	}
+
+	tests := []struct {
+		name      string
+		status    v1.SubjectAccessReviewStatus
+		mockErr   error
+		username  string
+		groups    []string
+		wantAllow bool
+		wantErr   bool
+	}{
+		{
+			name:      "user holds the delta permissions — allowed",
+			status:    v1.SubjectAccessReviewStatus{Allowed: true},
+			username:  "alice",
+			groups:    []string{"platform"},
+			wantAllow: true,
+		},
+		{
+			name:      "user lacks the delta permissions — denied",
+			status:    v1.SubjectAccessReviewStatus{Denied: true},
+			username:  "bob",
+			groups:    []string{"readonly"},
+			wantAllow: false,
+		},
+		{
+			name:    "api error propagates",
+			mockErr: errors.New("api unavailable"),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cr := &captureReactor{status: tt.status, mockErr: tt.mockErr}
+			c := fake.NewClientset()
+			c.PrependReactor(createVerb, sarResource, cr.react)
+			r := NewReviewer(c)
+
+			got, err := r.CheckSARsForUser(context.Background(), tt.username, tt.groups, deniedSARs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckSARsForUser() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			ok, _ := AllSubjectAccessReviewsAllowed(got)
+			assert.Equal(t, tt.wantAllow, ok)
+			assert.Len(t, got, len(deniedSARs), "should produce one result SAR per input SAR")
+
+			// Verify the re-issued SARs carry the user identity and the same resource attributes.
+			require.Len(t, cr.captured, len(deniedSARs))
+			for i, sar := range cr.captured {
+				assert.Equal(t, tt.username, sar.Spec.User)
+				assert.Equal(t, tt.groups, sar.Spec.Groups)
+				assert.Equal(t, deniedSARs[i].Spec.ResourceAttributes, sar.Spec.ResourceAttributes)
+			}
+		})
+	}
+}
+
+func TestReviewer_CheckPolicyRulesForUser(t *testing.T) {
+	policyRules := []*rbacv1.PolicyRule{
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{""},
+			Resources: []string{"nodes", "services"},
+		},
+		{
+			Verbs:           []string{"get"},
+			NonResourceURLs: []string{"/metrics"},
+		},
+	}
+	// 2 resources × 3 verbs = 6 resource SARs + 1 non-resource SAR = 7 total.
+	const totalSARs = 7
+
+	tests := []struct {
+		name             string
+		status           v1.SubjectAccessReviewStatus
+		mockErr          error
+		username         string
+		groups           []string
+		wantAllow        bool
+		wantErr          bool
+		numDeniedReviews int
+	}{
+		{
+			name:      "all rules allowed",
+			status:    v1.SubjectAccessReviewStatus{Allowed: true},
+			username:  "alice",
+			groups:    []string{"platform"},
+			wantAllow: true,
+		},
+		{
+			name:             "all rules denied",
+			status:           v1.SubjectAccessReviewStatus{Denied: true},
+			username:         "bob",
+			groups:           []string{"readonly"},
+			wantAllow:        false,
+			numDeniedReviews: totalSARs,
+		},
+		{
+			name:             "api error propagates",
+			mockErr:          errors.New("api unavailable"),
+			username:         "alice",
+			wantErr:          true,
+			numDeniedReviews: totalSARs,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cr := &captureReactor{status: tt.status, mockErr: tt.mockErr}
+			c := fake.NewClientset()
+			c.PrependReactor(createVerb, sarResource, cr.react)
+			r := NewReviewer(c)
+
+			got, err := r.CheckPolicyRulesForUser(context.Background(), tt.username, tt.groups, policyRules...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckPolicyRulesForUser() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			ok, deniedReviews := AllSubjectAccessReviewsAllowed(got)
+			assert.Equal(t, tt.wantAllow, ok)
+			if !ok {
+				assert.Equal(t, tt.numDeniedReviews, len(deniedReviews))
+			}
+
+			// All captured SARs should carry the user identity, not the SA form.
+			for _, sar := range cr.captured {
+				assert.Equal(t, tt.username, sar.Spec.User)
+				assert.Equal(t, tt.groups, sar.Spec.Groups)
 			}
 		})
 	}

--- a/internal/webhook/collector_webhook.go
+++ b/internal/webhook/collector_webhook.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-logr/logr"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/events"
@@ -18,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/fips"
 	ta "github.com/open-telemetry/opentelemetry-operator/internal/manifests/targetallocator/adapters"
@@ -302,6 +304,13 @@ func (c CollectorWebhook) Validate(ctx context.Context, r *v1beta1.OpenTelemetry
 		}
 	}
 
+	// validate that the requesting user holds every permission the operator would auto-grant
+	if c.reviewer != nil {
+		if err := c.validateRBACPrivilegeEscalation(ctx, r); err != nil {
+			return warnings, err
+		}
+	}
+
 	return warnings, nil
 }
 
@@ -349,6 +358,87 @@ func (c CollectorWebhook) validateTargetAllocatorConfig(ctx context.Context, r *
 	}
 
 	return nil, nil
+}
+
+// validateRBACPrivilegeEscalation checks that the requesting user holds every permission
+// that the operator would newly grant to the collector's ServiceAccount via auto-RBAC.
+//
+// Without this check a user who has CREATE on OpenTelemetryCollector but no direct RBAC write
+// access could craft a collector config that causes the operator to grant the collector's
+// ServiceAccount permissions the requesting user does not themselves hold — a privilege
+// escalation path equivalent to the one Kubernetes guards against with the "escalate" verb.
+//
+// The check uses a delta approach to avoid false rejections:
+//  1. Determine what RBAC rules the collector config requires.
+//  2. Check what the collector's ServiceAccount already holds.
+//  3. Compute the delta — rules the SA does not yet hold and that reconciliation would grant.
+//  4. Check the requesting user against the delta only.
+//
+// If the SA already holds all required permissions (delta is empty), no new grants will
+// occur and the check passes regardless of the requesting user's permissions.
+//
+// The check is skipped when:
+//   - CreateRBACPermissions is not Available (the auto-RBAC feature is disabled), or
+//   - the collector config requires no extra RBAC rules, or
+//   - no admission.Request is present in the context (direct calls from tests / internal code).
+func (c CollectorWebhook) validateRBACPrivilegeEscalation(ctx context.Context, r *v1beta1.OpenTelemetryCollector) error {
+	if c.cfg.CreateRBACPermissions != autoRBAC.Available {
+		return nil
+	}
+
+	rules, err := otelconfig.GetAllRbacRules(&r.Spec.Config, c.logger)
+	if err != nil {
+		return fmt.Errorf("unable to determine RBAC rules for collector config: %w", err)
+	}
+	if len(rules) == 0 {
+		return nil
+	}
+
+	req, err := admission.RequestFromContext(ctx)
+	if err != nil {
+		// No admission request in context (e.g. called directly in unit tests or internal
+		// reconciliation); skip the check rather than blocking legitimate uses.
+		return nil
+	}
+
+	rulePtrs := make([]*rbacv1.PolicyRule, len(rules))
+	for i := range rules {
+		rulePtrs[i] = &rules[i]
+	}
+
+	// Determine the ServiceAccount name the operator will manage RBAC for.
+	saName := r.Spec.ServiceAccount
+	if saName == "" {
+		saName = naming.ServiceAccount(r.Name)
+	}
+
+	// Step 2: check what the SA already holds.
+	saSARs, err := c.reviewer.CheckPolicyRules(ctx, saName, r.Namespace, rulePtrs...)
+	if err != nil {
+		return fmt.Errorf("unable to check existing SA RBAC permissions: %w", err)
+	}
+
+	// Step 3: compute the delta — permissions the SA does not yet hold.
+	_, delta := rbac.AllSubjectAccessReviewsAllowed(saSARs)
+	if len(delta) == 0 {
+		// SA already holds all required permissions; reconciliation won't grant anything new.
+		return nil
+	}
+
+	// Step 4: check the requesting user against the delta only.
+	username := req.UserInfo.Username
+	groups := req.UserInfo.Groups
+
+	userSARs, err := c.reviewer.CheckSARsForUser(ctx, username, groups, delta)
+	if err != nil {
+		return fmt.Errorf("unable to check RBAC privilege escalation for user %q: %w", username, err)
+	}
+
+	if allowed, denied := rbac.AllSubjectAccessReviewsAllowed(userSARs); !allowed {
+		missing := strings.Join(rbac.WarningsGroupedByResource(denied), "; ")
+		return fmt.Errorf("user %q is not allowed to create a collector whose config would grant permissions they do not hold: %s", username, missing)
+	}
+	return nil
 }
 
 func ValidatePorts(ports []v1beta1.PortsSpec) error {

--- a/internal/webhook/collector_webhook_test.go
+++ b/internal/webhook/collector_webhook_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -16,7 +17,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	authv1 "k8s.io/api/authorization/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
@@ -31,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	collectorManifests "github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
@@ -1787,4 +1791,158 @@ func getReviewer(shouldFailSAR bool) *rbac.Reviewer {
 		return true, sar, nil
 	})
 	return rbac.NewReviewer(c)
+}
+
+// getReviewerDelta returns a Reviewer whose fake client responds differently to SA SARs
+// (identifiable by a "system:serviceaccount:" user prefix) vs user SARs. This is used
+// to test the delta logic in validateRBACPrivilegeEscalation: saAllowed controls whether
+// the SA is considered to already hold the permissions, and userAllowed controls whether
+// the requesting user holds those permissions.
+func getReviewerDelta(saAllowed, userAllowed bool) *rbac.Reviewer {
+	c := fake.NewClientset()
+	c.PrependReactor("create", "subjectaccessreviews", func(action kubeTesting.Action) (handled bool, ret runtime.Object, err error) {
+		if !action.Matches("create", "subjectaccessreviews") {
+			return false, nil, errors.New("must be a create for a SAR")
+		}
+		sar, ok := action.(kubeTesting.CreateAction).GetObject().DeepCopyObject().(*authv1.SubjectAccessReview)
+		if !ok || sar == nil {
+			return false, nil, errors.New("bad object")
+		}
+		isSA := strings.HasPrefix(sar.Spec.User, "system:serviceaccount:")
+		allowed := userAllowed
+		if isSA {
+			allowed = saAllowed
+		}
+		sar.Status = authv1.SubjectAccessReviewStatus{
+			Allowed: allowed,
+			Denied:  !allowed,
+		}
+		return true, sar, nil
+	})
+	return rbac.NewReviewer(c)
+}
+
+// requestContext injects an admission.Request carrying the given username and groups into ctx.
+func requestContext(ctx context.Context, username string, groups []string) context.Context {
+	return admission.NewContextWithRequest(ctx, admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UserInfo: authenticationv1.UserInfo{
+				Username: username,
+				Groups:   groups,
+			},
+		},
+	})
+}
+
+// k8seventsCollector returns a minimal collector whose config contains the k8s_events
+// receiver — a receiver that requires RBAC rules (get/list/watch on events).
+func k8seventsCollector() v1beta1.OpenTelemetryCollector {
+	const cfgYAML = `
+receivers:
+  k8s_events: {}
+exporters:
+  debug: {}
+service:
+  pipelines:
+    logs:
+      receivers: [k8s_events]
+      exporters: [debug]
+`
+	var cfg v1beta1.Config
+	if err := go_yaml.Unmarshal([]byte(cfgYAML), &cfg); err != nil {
+		panic(err)
+	}
+	return v1beta1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-col", Namespace: "default"},
+		Spec:       v1beta1.OpenTelemetryCollectorSpec{Config: cfg},
+	}
+}
+
+func TestValidateRBACPrivilegeEscalation(t *testing.T) {
+	// A config that produces RBAC rules (k8s_events receiver requires get/list/watch on events).
+	col := k8seventsCollector()
+
+	tests := []struct {
+		name             string
+		createRBACPerms  autoRBAC.Availability
+		reviewer         *rbac.Reviewer
+		injectRequest    bool
+		username         string
+		groups           []string
+		expectedWarnings []string
+		expectedErr      string
+	}{
+		{
+			name:            "feature disabled — no check performed",
+			createRBACPerms: autoRBAC.NotAvailable,
+			reviewer:        getReviewerDelta(false, false), // would deny everything but never called
+			injectRequest:   true,
+			username:        "alice",
+		},
+		{
+			name:            "no admission request in context — check skipped",
+			createRBACPerms: autoRBAC.Available,
+			reviewer:        getReviewerDelta(false, false), // would deny everything but never called
+			injectRequest:   false,
+		},
+		{
+			name:            "SA already holds all required permissions — allowed regardless of user",
+			createRBACPerms: autoRBAC.Available,
+			reviewer:        getReviewerDelta(true, false), // SA allowed, user would be denied but delta is empty
+			injectRequest:   true,
+			username:        "alice",
+			groups:          []string{"platform"},
+		},
+		{
+			name:            "SA lacks permissions, user holds them — allowed",
+			createRBACPerms: autoRBAC.Available,
+			reviewer:        getReviewerDelta(false, true), // SA denied → delta = all rules; user allowed
+			injectRequest:   true,
+			username:        "alice",
+			groups:          []string{"platform"},
+		},
+		{
+			name:            "SA lacks permissions, user also lacks them — request rejected",
+			createRBACPerms: autoRBAC.Available,
+			reviewer:        getReviewerDelta(false, false), // SA denied → delta = all rules; user also denied
+			injectRequest:   true,
+			username:        "bob",
+			groups:          []string{"readonly"},
+			// k8s_events receiver requires get/list/watch on events (core group).
+			expectedErr: `user "bob" is not allowed to create a collector whose config would grant permissions they do not hold`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{
+				CollectorImage:        "default-collector",
+				TargetAllocatorImage:  "default-ta-allocator",
+				CreateRBACPermissions: tt.createRBACPerms,
+			}
+			cvw := webhook.NewCollectorWebhook(
+				logr.Discard(),
+				testScheme,
+				cfg,
+				tt.reviewer,
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+
+			ctx := context.Background()
+			if tt.injectRequest {
+				ctx = requestContext(ctx, tt.username, tt.groups)
+			}
+
+			warnings, err := cvw.ValidateCreate(ctx, col.DeepCopy())
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedWarnings, warnings)
+		})
+	}
 }

--- a/tests/e2e-automatic-rbac/privilege-escalation-check/01-install.yaml
+++ b/tests/e2e-automatic-rbac/privilege-escalation-check/01-install.yaml
@@ -1,0 +1,67 @@
+# limited-user: has permission to create OpenTelemetryCollectors but does NOT hold the
+# cluster-level get/list/watch on events that the k8s_events receiver requires.
+# permitted-user: has permission to create OpenTelemetryCollectors AND already holds the
+# cluster-level permissions that k8s_events requires.
+#
+# Users are not Kubernetes objects; RBAC bindings reference them by name directly.
+---
+# Namespace-scoped role that allows managing OpenTelemetryCollectors.
+# Both test subjects share this role via separate RoleBindings.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: otc-creator
+rules:
+- apiGroups: ["opentelemetry.io"]
+  resources: ["opentelemetrycollectors"]
+  verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: limited-user-otc-creator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: otc-creator
+subjects:
+- kind: User
+  name: limited-user
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: permitted-user-otc-creator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: otc-creator
+subjects:
+- kind: User
+  name: permitted-user
+  apiGroup: rbac.authorization.k8s.io
+---
+# Cluster-level events permissions that the k8s_events receiver requires.
+# Granted ONLY to permitted-user so that limited-user triggers the escalation check.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ($namespace)-events-reader
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ($namespace)-permitted-user-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ($namespace)-events-reader
+subjects:
+- kind: User
+  name: permitted-user
+  apiGroup: rbac.authorization.k8s.io

--- a/tests/e2e-automatic-rbac/privilege-escalation-check/02-collector.yaml
+++ b/tests/e2e-automatic-rbac/privilege-escalation-check/02-collector.yaml
@@ -1,0 +1,15 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: privilege-test
+spec:
+  config:
+    receivers:
+      k8s_events: {}
+    exporters:
+      debug: {}
+    service:
+      pipelines:
+        logs:
+          receivers: [k8s_events]
+          exporters: [debug]

--- a/tests/e2e-automatic-rbac/privilege-escalation-check/chainsaw-test.yaml
+++ b/tests/e2e-automatic-rbac/privilege-escalation-check/chainsaw-test.yaml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: privilege-escalation-check
+spec:
+  # This test verifies that the OpenTelemetryCollector admission webhook rejects requests
+  # where the auto-RBAC feature would grant the collector's ServiceAccount permissions
+  # that the requesting user does not already hold themselves (privilege escalation
+  # prevention).
+  #
+  # Two scenarios are exercised using kubectl impersonation (--as):
+  #   1. limited-user  — can create OTCs but lacks the cluster-level events permissions
+  #                      that the k8s_events receiver requires.  Request must be rejected.
+  #   2. permitted-user — can create OTCs and already holds those events permissions.
+  #                       Request must be accepted.
+  #
+  # Both scenarios use --dry-run=server so the admission webhook fires without persisting
+  # the OTC.
+  steps:
+  - name: setup-test-subjects
+    try:
+    - apply:
+        file: 01-install.yaml
+  - name: limited-user-request-is-rejected
+    try:
+    - script:
+        content: |
+          kubectl apply \
+            --namespace $NAMESPACE \
+            --dry-run=server \
+            --as=limited-user \
+            -f 02-collector.yaml
+        check:
+          ($error != null): true
+          (contains($stderr, 'is not allowed to create a collector whose config would grant permissions they do not hold')): true
+  - name: permitted-user-request-is-accepted
+    try:
+    - script:
+        content: |
+          kubectl apply \
+            --namespace $NAMESPACE \
+            --dry-run=server \
+            --as=permitted-user \
+            -f 02-collector.yaml
+        check:
+          ($error != null): false

--- a/tests/e2e-automatic-rbac/privilege-escalation-delta/01-install.yaml
+++ b/tests/e2e-automatic-rbac/privilege-escalation-delta/01-install.yaml
@@ -1,0 +1,56 @@
+# limited-user: has permission to create OpenTelemetryCollectors but does NOT hold the
+# cluster-level get/list/watch on events that the k8s_events receiver requires.
+#
+# The collector's ServiceAccount (privilege-delta-test-collector, derived from
+# naming.ServiceAccount("privilege-delta-test")) is pre-bound to the events permissions,
+# simulating a binding that exists independently of the operator's auto-RBAC feature.
+# The SA object itself does not need to exist for RBAC bindings to take effect.
+---
+# Namespace-scoped role that allows managing OpenTelemetryCollectors.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: otc-creator
+rules:
+- apiGroups: ["opentelemetry.io"]
+  resources: ["opentelemetrycollectors"]
+  verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: limited-user-otc-creator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: otc-creator
+subjects:
+- kind: User
+  name: limited-user
+  apiGroup: rbac.authorization.k8s.io
+---
+# Cluster-level events permissions that the k8s_events receiver requires.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ($namespace)-events-reader
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+---
+# Pre-bind the collector's ServiceAccount to the events permissions.
+# This represents a binding that exists before the OTC is created — the operator would
+# not grant any new permissions, so the delta is empty and the request should be allowed.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ($namespace)-sa-events
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ($namespace)-events-reader
+subjects:
+- kind: ServiceAccount
+  name: privilege-delta-test-collector
+  namespace: ($namespace)

--- a/tests/e2e-automatic-rbac/privilege-escalation-delta/02-collector.yaml
+++ b/tests/e2e-automatic-rbac/privilege-escalation-delta/02-collector.yaml
@@ -1,0 +1,15 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: privilege-delta-test
+spec:
+  config:
+    receivers:
+      k8s_events: {}
+    exporters:
+      debug: {}
+    service:
+      pipelines:
+        logs:
+          receivers: [k8s_events]
+          exporters: [debug]

--- a/tests/e2e-automatic-rbac/privilege-escalation-delta/chainsaw-test.yaml
+++ b/tests/e2e-automatic-rbac/privilege-escalation-delta/chainsaw-test.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  creationTimestamp: null
+  name: privilege-escalation-delta
+spec:
+  # This test verifies the delta approach in the RBAC privilege escalation check:
+  # if the collector's ServiceAccount already holds the required permissions through
+  # a pre-existing binding, the webhook allows the request even when the requesting
+  # user does not hold those permissions themselves.
+  #
+  # The collector is named "privilege-delta-test", so the operator would manage RBAC
+  # for ServiceAccount "privilege-delta-test-collector" (naming.ServiceAccount derives
+  # this deterministically).  That SA is pre-bound to the events permissions before the
+  # OTC is submitted, making the delta empty — reconciliation would grant nothing new,
+  # so no privilege escalation can occur and the request must be accepted.
+  steps:
+  - name: setup-pre-existing-sa-binding
+    try:
+    - apply:
+        file: 01-install.yaml
+  - name: limited-user-request-accepted-because-sa-already-has-permissions
+    try:
+    - script:
+        content: |
+          kubectl apply \
+            --namespace $NAMESPACE \
+            --dry-run=server \
+            --as=limited-user \
+            -f 02-collector.yaml
+        check:
+          ($error != null): false


### PR DESCRIPTION
**Description:**

Ensure the auto-RBAC mechanism doesn't assign permissions the submitting user doesn't have. This happens at admission and is very similar to the mechanism that emits warnings during reconciliation. If the submitting user doesn't have permissions needed by the collector configuration that aren't covered by the existing ServiceAccount, then the submission is rejected.

**Testing:**

Added unit tests and e2e tests.
