### PR TITLE
[chore] Consolidate envtest setup in tests and ensure it runs in sandboxes

### DIFF
--- a/cmd/gather/cluster/write_test.go
+++ b/cmd/gather/cluster/write_test.go
@@ -173,7 +173,7 @@ func (m *MockRequest) Stream(ctx context.Context) (io.ReadCloser, error) {
 }
 
 func TestCreateOTELFolder(t *testing.T) {
-	collectionDir := "/tmp/test-dir"
+	collectionDir := t.TempDir()
 	otelCol := &v1beta1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-namespace",
@@ -186,16 +186,12 @@ func TestCreateOTELFolder(t *testing.T) {
 	expectedDir := filepath.Join(collectionDir, "namespaces", otelCol.Namespace, otelCol.Name)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedDir, outputDir)
-
-	// Clean up after the test
-	os.RemoveAll(collectionDir)
 }
 
 func TestCreateFile(t *testing.T) {
-	outputDir := "/tmp/test-dir"
+	outputDir := t.TempDir()
 	err := os.MkdirAll(outputDir, os.ModePerm)
 	assert.NoError(t, err)
-	defer os.RemoveAll(outputDir)
 
 	mockObj := &MockObject{}
 	mockObj.On("GetObjectKind").Return(schema.EmptyObjectKind)

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -177,18 +177,26 @@ func TestMain(m *testing.M) {
 	utilruntime.Must(v1beta1.AddToScheme(testScheme))
 	utilruntime.Must(gatewayv1.Install(testScheme))
 
-	tenv := testenv.Start(&ctrlenvtest.Environment{
+	tenv, err := testenv.Start(&ctrlenvtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		CRDs:              []*apiextensionsv1.CustomResourceDefinition{testdata.OpenShiftRouteCRD, testdata.ServiceMonitorCRD, testdata.PodMonitorCRD, testdata.HTTPRouteCRD},
 		WebhookInstallOptions: ctrlenvtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
 		},
 	}, testScheme)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	testEnv = tenv.Env
 	restCfg = tenv.Config
 	k8sClient = tenv.Client
 
-	mgr := testenv.NewWebhookManager(restCfg, testScheme, &testEnv.WebhookInstallOptions)
+	mgr, err := testenv.NewWebhookManager(restCfg, testScheme, &testEnv.WebhookInstallOptions)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	clientset, clientErr := kubernetes.NewForConfig(restCfg)
 	if clientErr != nil {
@@ -216,10 +224,16 @@ func TestMain(m *testing.M) {
 	ctx, cancel = context.WithCancel(context.TODO())
 	defer cancel()
 
-	testenv.RunWebhookServer(ctx, mgr, &testEnv.WebhookInstallOptions)
+	if err := testenv.RunWebhookServer(ctx, mgr, &testEnv.WebhookInstallOptions); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	code := m.Run()
-	tenv.Stop()
+
+	if err := tenv.Stop(); err != nil {
+		fmt.Println(err)
+	}
 	os.Exit(code)
 }
 

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -5,15 +5,11 @@ package controllers_test
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
-	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -29,19 +25,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	ctrlenvtest "sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml"
 
@@ -61,12 +53,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector/testdata"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 	"github.com/open-telemetry/opentelemetry-operator/internal/rbac"
+	"github.com/open-telemetry/opentelemetry-operator/internal/testenv"
 	wh "github.com/open-telemetry/opentelemetry-operator/internal/webhook"
 )
 
 var (
 	k8sClient  client.Client
-	testEnv    *envtest.Environment
+	testEnv    *ctrlenvtest.Environment
 	testScheme *runtime.Scheme = scheme.Scheme
 	ctx        context.Context
 	cancel     context.CancelFunc
@@ -182,54 +175,21 @@ func TestMain(m *testing.M) {
 	utilruntime.Must(routev1.AddToScheme(testScheme))
 	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
 	utilruntime.Must(v1beta1.AddToScheme(testScheme))
-
 	utilruntime.Must(gatewayv1.Install(testScheme))
 
-	var binaryAssetsDir string
-	binaryAssetsDir, err = envtest.SetupEnvtestDefaultBinaryAssetsDirectory()
-	if err != nil {
-		fmt.Printf("failed to find setup-envtest assets directory, using a temporary one: %v", err)
-	}
-
-	testEnv = &envtest.Environment{
+	tenv := testenv.Start(&ctrlenvtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		CRDs:              []*apiextensionsv1.CustomResourceDefinition{testdata.OpenShiftRouteCRD, testdata.ServiceMonitorCRD, testdata.PodMonitorCRD, testdata.HTTPRouteCRD},
-		WebhookInstallOptions: envtest.WebhookInstallOptions{
+		WebhookInstallOptions: ctrlenvtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
 		},
-		DownloadBinaryAssets:  true,
-		BinaryAssetsDirectory: binaryAssetsDir,
-	}
-	restCfg, err = testEnv.Start()
-	if err != nil {
-		fmt.Printf("failed to start testEnv: %v", err)
-		os.Exit(1)
-	}
+	}, testScheme)
+	testEnv = tenv.Env
+	restCfg = tenv.Config
+	k8sClient = tenv.Client
 
-	k8sClient, err = client.New(restCfg, client.Options{Scheme: testScheme})
-	if err != nil {
-		fmt.Printf("failed to setup a Kubernetes client: %v", err)
-		os.Exit(1)
-	}
+	mgr := testenv.NewWebhookManager(restCfg, testScheme, &testEnv.WebhookInstallOptions)
 
-	// start webhook server using Manager
-	webhookInstallOptions := &testEnv.WebhookInstallOptions
-	mgr, mgrErr := ctrl.NewManager(restCfg, ctrl.Options{
-		Scheme:         testScheme,
-		LeaderElection: false,
-		WebhookServer: webhook.NewServer(webhook.Options{
-			Host:    webhookInstallOptions.LocalServingHost,
-			Port:    webhookInstallOptions.LocalServingPort,
-			CertDir: webhookInstallOptions.LocalServingCertDir,
-		}),
-		Metrics: metricsserver.Options{
-			BindAddress: "0",
-		},
-	})
-	if mgrErr != nil {
-		fmt.Printf("failed to start webhook server: %v", mgrErr)
-		os.Exit(1)
-	}
 	clientset, clientErr := kubernetes.NewForConfig(restCfg)
 	if clientErr != nil {
 		fmt.Printf("failed to setup kubernetes clientset %v", clientErr)
@@ -244,12 +204,10 @@ func TestMain(m *testing.M) {
 		fmt.Printf("failed to SetupWebhookWithManager: %v", err)
 		os.Exit(1)
 	}
-
 	if err = wh.SetupTargetAllocatorWebhook(mgr, config.New(), reviewer); err != nil {
 		fmt.Printf("failed to SetupWebhookWithManager: %v", err)
 		os.Exit(1)
 	}
-
 	if err = wh.SetupOpAMPBridgeWebhook(mgr, config.New()); err != nil {
 		fmt.Printf("failed to SetupWebhookWithManager: %v", err)
 		os.Exit(1)
@@ -257,54 +215,11 @@ func TestMain(m *testing.M) {
 
 	ctx, cancel = context.WithCancel(context.TODO())
 	defer cancel()
-	go func() {
-		if err = mgr.Start(ctx); err != nil {
-			fmt.Printf("failed to start manager: %v", err)
-			os.Exit(1)
-		}
-	}()
 
-	// wait for the webhook server to get ready
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	dialer := &net.Dialer{Timeout: time.Second}
-	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
-	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
-		if err = retry.OnError(wait.Backoff{
-			Steps:    20,
-			Duration: 10 * time.Millisecond,
-			Factor:   1.5,
-			Jitter:   0.1,
-			Cap:      time.Second * 30,
-		}, func(error) bool {
-			return true
-		}, func() error {
-			tlsDialer := &tls.Dialer{
-				NetDialer: dialer,
-				Config:    &tls.Config{InsecureSkipVerify: true},
-			}
-			conn, tlsErr := tlsDialer.DialContext(ctx, "tcp", addrPort)
-			if tlsErr != nil {
-				return tlsErr
-			}
-			_ = conn.Close()
-			return nil
-		}); err != nil {
-			fmt.Printf("failed to wait for webhook server to be ready: %v", err)
-			os.Exit(1)
-		}
-	}(wg)
-	wg.Wait()
+	testenv.RunWebhookServer(ctx, mgr, &testEnv.WebhookInstallOptions)
 
 	code := m.Run()
-
-	err = testEnv.Stop()
-	if err != nil {
-		fmt.Printf("failed to stop testEnv: %v", err)
-		os.Exit(1)
-	}
-
+	tenv.Stop()
 	os.Exit(code)
 }
 

--- a/internal/instrumentation/instrumentation_suite_test.go
+++ b/internal/instrumentation/instrumentation_suite_test.go
@@ -4,7 +4,6 @@
 package instrumentation
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,53 +12,30 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	ctrlenvtest "sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/testenv"
 )
 
 var (
 	k8sClient  client.Client
-	testEnv    *envtest.Environment
+	testEnv    *ctrlenvtest.Environment
 	testScheme = scheme.Scheme
-	err        error
 	cfg        *rest.Config
 )
 
 func TestMain(m *testing.M) {
-	var binaryAssetsDir string
-	binaryAssetsDir, err = envtest.SetupEnvtestDefaultBinaryAssetsDirectory()
-	if err != nil {
-		fmt.Printf("failed to find setup-envtest assets directory, using a temporary one: %v", err)
-	}
-
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		DownloadBinaryAssets:  true,
-		BinaryAssetsDirectory: binaryAssetsDir,
-	}
-
-	cfg, err = testEnv.Start()
-	if err != nil {
-		fmt.Printf("failed to start testEnv: %v", err)
-		os.Exit(1)
-	}
-
 	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
-	if err != nil {
-		fmt.Printf("failed to setup a Kubernetes client: %v", err)
-		os.Exit(1)
-	}
+	tenv := testenv.Start(&ctrlenvtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}, testScheme)
+	testEnv = tenv.Env
+	cfg = tenv.Config
+	k8sClient = tenv.Client
 
 	code := m.Run()
-
-	err = testEnv.Stop()
-	if err != nil {
-		fmt.Printf("failed to stop testEnv: %v", err)
-		os.Exit(1)
-	}
-
+	tenv.Stop()
 	os.Exit(code)
 }

--- a/internal/instrumentation/instrumentation_suite_test.go
+++ b/internal/instrumentation/instrumentation_suite_test.go
@@ -4,6 +4,7 @@
 package instrumentation
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,14 +29,21 @@ var (
 func TestMain(m *testing.M) {
 	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
 
-	tenv := testenv.Start(&ctrlenvtest.Environment{
+	tenv, err := testenv.Start(&ctrlenvtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
 	}, testScheme)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	testEnv = tenv.Env
 	cfg = tenv.Config
 	k8sClient = tenv.Client
 
 	code := m.Run()
-	tenv.Stop()
+
+	if err := tenv.Stop(); err != nil {
+		fmt.Println(err)
+	}
 	os.Exit(code)
 }

--- a/internal/instrumentation/upgrade/upgrade_suite_test.go
+++ b/internal/instrumentation/upgrade/upgrade_suite_test.go
@@ -4,6 +4,7 @@
 package upgrade
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,16 +29,23 @@ var (
 func TestMain(m *testing.M) {
 	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
 
-	tenv := testenv.Start(&ctrlenvtest.Environment{
+	tenv, err := testenv.Start(&ctrlenvtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "config", "crd", "bases"),
 		},
 	}, testScheme)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	testEnv = tenv.Env
 	cfg = tenv.Config
 	k8sClient = tenv.Client
 
 	code := m.Run()
-	tenv.Stop()
+
+	if err := tenv.Stop(); err != nil {
+		fmt.Println(err)
+	}
 	os.Exit(code)
 }

--- a/internal/instrumentation/upgrade/upgrade_suite_test.go
+++ b/internal/instrumentation/upgrade/upgrade_suite_test.go
@@ -4,7 +4,6 @@
 package upgrade
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,55 +12,32 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	ctrlenvtest "sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/testenv"
 )
 
 var (
 	k8sClient  client.Client
-	testEnv    *envtest.Environment
+	testEnv    *ctrlenvtest.Environment
 	testScheme = scheme.Scheme
-	err        error
 	cfg        *rest.Config
 )
 
 func TestMain(m *testing.M) {
-	var binaryAssetsDir string
-	binaryAssetsDir, err = envtest.SetupEnvtestDefaultBinaryAssetsDirectory()
-	if err != nil {
-		fmt.Printf("failed to find setup-envtest assets directory, using a temporary one: %v", err)
-	}
+	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
 
-	testEnv = &envtest.Environment{
+	tenv := testenv.Start(&ctrlenvtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "config", "crd", "bases"),
 		},
-		DownloadBinaryAssets:  true,
-		BinaryAssetsDirectory: binaryAssetsDir,
-	}
-
-	cfg, err = testEnv.Start()
-	if err != nil {
-		fmt.Printf("failed to start testEnv: %v", err)
-		os.Exit(1)
-	}
-
-	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
-	if err != nil {
-		fmt.Printf("failed to setup a Kubernetes client: %v", err)
-		os.Exit(1)
-	}
+	}, testScheme)
+	testEnv = tenv.Env
+	cfg = tenv.Config
+	k8sClient = tenv.Client
 
 	code := m.Run()
-
-	err = testEnv.Stop()
-	if err != nil {
-		fmt.Printf("failed to stop testEnv: %v", err)
-		os.Exit(1)
-	}
-
+	tenv.Stop()
 	os.Exit(code)
 }

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -1,0 +1,152 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package testenv provides utilities for envtest-based integration tests,
+// reducing boilerplate in TestMain functions across the operator test suites.
+package testenv
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlenvtest "sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// Environment holds the running envtest.Environment together with the REST
+// configuration and a ready-to-use Kubernetes client.
+type Environment struct {
+	// Env is the underlying controller-runtime envtest.Environment.
+	// Use it to access WebhookInstallOptions after starting.
+	Env *ctrlenvtest.Environment
+	// Config is the REST configuration for the running test cluster.
+	Config *rest.Config
+	// Client is a Kubernetes client connected to the test cluster.
+	Client client.Client
+}
+
+// Start configures env with standard defaults, starts it, and returns an
+// Environment with a Kubernetes client created using scheme.
+//
+// The following defaults are applied to env before starting:
+//   - DownloadBinaryAssets is set to true.
+//   - BinaryAssetsDirectory is populated from SetupEnvtestDefaultBinaryAssetsDirectory.
+//   - The kube-apiserver advertise-address is set to 127.0.0.1 so that sandbox
+//     environments without a default network route work correctly.
+//
+// On any failure Start prints a message and calls os.Exit(1), matching
+// TestMain conventions.
+func Start(env *ctrlenvtest.Environment, scheme *runtime.Scheme) *Environment {
+	binaryAssetsDir, err := ctrlenvtest.SetupEnvtestDefaultBinaryAssetsDirectory()
+	if err != nil {
+		fmt.Printf("failed to find setup-envtest assets directory, using a temporary one: %v\n", err)
+	}
+	env.DownloadBinaryAssets = true
+	env.BinaryAssetsDirectory = binaryAssetsDir
+	// In sandbox environments the network namespace has no default route, so
+	// kube-apiserver cannot auto-detect its advertise address. Set it explicitly.
+	env.ControlPlane.GetAPIServer().Configure().Set("advertise-address", "127.0.0.1")
+
+	cfg, err := env.Start()
+	if err != nil {
+		fmt.Printf("failed to start testEnv: %v\n", err)
+		os.Exit(1)
+	}
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		fmt.Printf("failed to setup a Kubernetes client: %v\n", err)
+		os.Exit(1)
+	}
+
+	return &Environment{
+		Env:    env,
+		Config: cfg,
+		Client: k8sClient,
+	}
+}
+
+// Stop stops the test environment. On failure it prints a message and calls
+// os.Exit(1), matching TestMain conventions.
+func (e *Environment) Stop() {
+	if err := e.Env.Stop(); err != nil {
+		fmt.Printf("failed to stop testEnv: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// NewWebhookManager creates a controller-runtime Manager configured to serve
+// the webhook server described by opts. Metrics are disabled (BindAddress "0")
+// and leader election is turned off, which is appropriate for test environments.
+//
+// On failure it prints a message and calls os.Exit(1).
+func NewWebhookManager(cfg *rest.Config, scheme *runtime.Scheme, opts *ctrlenvtest.WebhookInstallOptions) ctrl.Manager {
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:         scheme,
+		LeaderElection: false,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    opts.LocalServingHost,
+			Port:    opts.LocalServingPort,
+			CertDir: opts.LocalServingCertDir,
+		}),
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	if err != nil {
+		fmt.Printf("failed to create webhook manager: %v\n", err)
+		os.Exit(1)
+	}
+	return mgr
+}
+
+// RunWebhookServer starts mgr in a background goroutine and blocks until the
+// embedded webhook server is ready to accept TLS connections.
+// On any failure it prints a message and calls os.Exit(1).
+func RunWebhookServer(ctx context.Context, mgr ctrl.Manager, opts *ctrlenvtest.WebhookInstallOptions) {
+	go func() {
+		if err := mgr.Start(ctx); err != nil {
+			fmt.Printf("failed to start manager: %v\n", err)
+			os.Exit(1)
+		}
+	}()
+
+	addrPort := fmt.Sprintf("%s:%d", opts.LocalServingHost, opts.LocalServingPort)
+	dialer := &net.Dialer{Timeout: time.Second}
+
+	err := retry.OnError(wait.Backoff{
+		Steps:    20,
+		Duration: 10 * time.Millisecond,
+		Factor:   1.5,
+		Jitter:   0.1,
+		Cap:      30 * time.Second,
+	}, func(error) bool {
+		return true
+	}, func() error {
+		tlsDialer := &tls.Dialer{
+			NetDialer: dialer,
+			Config:    &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		}
+		conn, tlsErr := tlsDialer.DialContext(ctx, "tcp", addrPort)
+		if tlsErr != nil {
+			return tlsErr
+		}
+		_ = conn.Close()
+		return nil
+	})
+	if err != nil {
+		fmt.Printf("failed to wait for webhook server to be ready: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/testenv/testenv.go
+++ b/internal/testenv/testenv.go
@@ -10,7 +10,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"os"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,10 +43,7 @@ type Environment struct {
 //   - BinaryAssetsDirectory is populated from SetupEnvtestDefaultBinaryAssetsDirectory.
 //   - The kube-apiserver advertise-address is set to 127.0.0.1 so that sandbox
 //     environments without a default network route work correctly.
-//
-// On any failure Start prints a message and calls os.Exit(1), matching
-// TestMain conventions.
-func Start(env *ctrlenvtest.Environment, scheme *runtime.Scheme) *Environment {
+func Start(env *ctrlenvtest.Environment, scheme *runtime.Scheme) (*Environment, error) {
 	binaryAssetsDir, err := ctrlenvtest.SetupEnvtestDefaultBinaryAssetsDirectory()
 	if err != nil {
 		fmt.Printf("failed to find setup-envtest assets directory, using a temporary one: %v\n", err)
@@ -60,38 +56,33 @@ func Start(env *ctrlenvtest.Environment, scheme *runtime.Scheme) *Environment {
 
 	cfg, err := env.Start()
 	if err != nil {
-		fmt.Printf("failed to start testEnv: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to start testEnv: %w", err)
 	}
 
 	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
-		fmt.Printf("failed to setup a Kubernetes client: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to setup a Kubernetes client: %w", err)
 	}
 
 	return &Environment{
 		Env:    env,
 		Config: cfg,
 		Client: k8sClient,
-	}
+	}, nil
 }
 
-// Stop stops the test environment. On failure it prints a message and calls
-// os.Exit(1), matching TestMain conventions.
-func (e *Environment) Stop() {
+// Stop stops the test environment and returns any error.
+func (e *Environment) Stop() error {
 	if err := e.Env.Stop(); err != nil {
-		fmt.Printf("failed to stop testEnv: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to stop testEnv: %w", err)
 	}
+	return nil
 }
 
 // NewWebhookManager creates a controller-runtime Manager configured to serve
 // the webhook server described by opts. Metrics are disabled (BindAddress "0")
 // and leader election is turned off, which is appropriate for test environments.
-//
-// On failure it prints a message and calls os.Exit(1).
-func NewWebhookManager(cfg *rest.Config, scheme *runtime.Scheme, opts *ctrlenvtest.WebhookInstallOptions) ctrl.Manager {
+func NewWebhookManager(cfg *rest.Config, scheme *runtime.Scheme, opts *ctrlenvtest.WebhookInstallOptions) (ctrl.Manager, error) {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:         scheme,
 		LeaderElection: false,
@@ -105,27 +96,24 @@ func NewWebhookManager(cfg *rest.Config, scheme *runtime.Scheme, opts *ctrlenvte
 		},
 	})
 	if err != nil {
-		fmt.Printf("failed to create webhook manager: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to create webhook manager: %w", err)
 	}
-	return mgr
+	return mgr, nil
 }
 
 // RunWebhookServer starts mgr in a background goroutine and blocks until the
 // embedded webhook server is ready to accept TLS connections.
-// On any failure it prints a message and calls os.Exit(1).
-func RunWebhookServer(ctx context.Context, mgr ctrl.Manager, opts *ctrlenvtest.WebhookInstallOptions) {
+func RunWebhookServer(ctx context.Context, mgr ctrl.Manager, opts *ctrlenvtest.WebhookInstallOptions) error {
 	go func() {
 		if err := mgr.Start(ctx); err != nil {
 			fmt.Printf("failed to start manager: %v\n", err)
-			os.Exit(1)
 		}
 	}()
 
 	addrPort := fmt.Sprintf("%s:%d", opts.LocalServingHost, opts.LocalServingPort)
 	dialer := &net.Dialer{Timeout: time.Second}
 
-	err := retry.OnError(wait.Backoff{
+	return retry.OnError(wait.Backoff{
 		Steps:    20,
 		Duration: 10 * time.Millisecond,
 		Factor:   1.5,
@@ -145,8 +133,4 @@ func RunWebhookServer(ctx context.Context, mgr ctrl.Manager, opts *ctrlenvtest.W
 		_ = conn.Close()
 		return nil
 	})
-	if err != nil {
-		fmt.Printf("failed to wait for webhook server to be ready: %v\n", err)
-		os.Exit(1)
-	}
 }

--- a/internal/webhook/main_test.go
+++ b/internal/webhook/main_test.go
@@ -5,6 +5,7 @@ package webhook_test
 
 import (
 	"context"
+	"fmt"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
@@ -30,13 +31,20 @@ func TestMain(m *testing.M) {
 	utilruntime.Must(clientgoscheme.AddToScheme(sch))
 	utilruntime.Must(v1beta1.AddToScheme(sch))
 
-	tenv := testenv.Start(&ctrlenvtest.Environment{
+	tenv, err := testenv.Start(&ctrlenvtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
 	}, sch)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	k8sClient = tenv.Client
 
 	code := m.Run()
-	tenv.Stop()
+
+	if err := tenv.Stop(); err != nil {
+		fmt.Println(err)
+	}
 	os.Exit(code)
 }
 

--- a/internal/webhook/main_test.go
+++ b/internal/webhook/main_test.go
@@ -5,7 +5,6 @@ package webhook_test
 
 import (
 	"context"
-	"fmt"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
@@ -18,9 +17,10 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	ctrlenvtest "sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/testenv"
 )
 
 var k8sClient client.Client
@@ -30,34 +30,13 @@ func TestMain(m *testing.M) {
 	utilruntime.Must(clientgoscheme.AddToScheme(sch))
 	utilruntime.Must(v1beta1.AddToScheme(sch))
 
-	binaryAssetsDir, err := envtest.SetupEnvtestDefaultBinaryAssetsDirectory()
-	if err != nil {
-		fmt.Printf("failed to find setup-envtest assets directory, using a temporary one: %v", err)
-	}
-
-	testEnv := &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		DownloadBinaryAssets:  true,
-		BinaryAssetsDirectory: binaryAssetsDir,
-	}
-
-	cfg, err := testEnv.Start()
-	if err != nil {
-		fmt.Printf("failed to start test environment: %v", err)
-		os.Exit(1)
-	}
-	k8sClient, err = client.New(cfg, client.Options{Scheme: sch})
-	if err != nil {
-		fmt.Printf("failed to setup a Kubernetes client: %v", err)
-		os.Exit(1)
-	}
+	tenv := testenv.Start(&ctrlenvtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}, sch)
+	k8sClient = tenv.Client
 
 	code := m.Run()
-
-	if err := testEnv.Stop(); err != nil {
-		fmt.Printf("failed to stop test environment: %v", err)
-		os.Exit(1)
-	}
+	tenv.Stop()
 	os.Exit(code)
 }
 

--- a/internal/webhook/podmutation/webhookhandler_suite_test.go
+++ b/internal/webhook/podmutation/webhookhandler_suite_test.go
@@ -5,38 +5,30 @@ package podmutation_test
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/util/retry"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	ctrlenvtest "sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/rbac"
+	"github.com/open-telemetry/opentelemetry-operator/internal/testenv"
 	wh "github.com/open-telemetry/opentelemetry-operator/internal/webhook"
 )
 
 var (
 	k8sClient  client.Client
-	testEnv    *envtest.Environment
+	testEnv    *ctrlenvtest.Environment
 	testScheme *runtime.Scheme = scheme.Scheme
 	ctx        context.Context
 	cancel     context.CancelFunc
@@ -50,55 +42,20 @@ func TestMain(m *testing.M) {
 	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
 	utilruntime.Must(v1beta1.AddToScheme(testScheme))
 
-	var binaryAssetsDir string
-	binaryAssetsDir, err = envtest.SetupEnvtestDefaultBinaryAssetsDirectory()
-	if err != nil {
-		fmt.Printf("failed to find setup-envtest assets directory, using a temporary one: %v", err)
-	}
-
-	testEnv = &envtest.Environment{
+	tenv := testenv.Start(&ctrlenvtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		WebhookInstallOptions: envtest.WebhookInstallOptions{
+		WebhookInstallOptions: ctrlenvtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
 		},
-		DownloadBinaryAssets:  true,
-		BinaryAssetsDirectory: binaryAssetsDir,
-	}
-	cfg, err = testEnv.Start()
-	if err != nil {
-		fmt.Printf("failed to start testEnv: %v", err)
-		os.Exit(1)
-	}
+	}, testScheme)
+	testEnv = tenv.Env
+	cfg = tenv.Config
+	k8sClient = tenv.Client
 
-	// +kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
-	if err != nil {
-		fmt.Printf("failed to setup a Kubernetes client: %v", err)
-		os.Exit(1)
-	}
-
-	// start webhook server using Manager
-	webhookInstallOptions := &testEnv.WebhookInstallOptions
-	mgr, mgrErr := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:         testScheme,
-		LeaderElection: false,
-		WebhookServer: webhook.NewServer(webhook.Options{
-			Host:    webhookInstallOptions.LocalServingHost,
-			Port:    webhookInstallOptions.LocalServingPort,
-			CertDir: webhookInstallOptions.LocalServingCertDir,
-		}),
-		Metrics: metricsserver.Options{
-			BindAddress: "0",
-		},
-	})
-	if mgrErr != nil {
-		fmt.Printf("failed to start webhook server: %v", mgrErr)
-		os.Exit(1)
-	}
+	mgr := testenv.NewWebhookManager(cfg, testScheme, &testEnv.WebhookInstallOptions)
 
 	clientset, clientErr := kubernetes.NewForConfig(cfg)
-	if err != nil {
+	if clientErr != nil {
 		fmt.Printf("failed to setup kubernetes clientset %v", clientErr)
 	}
 	reviewer := rbac.NewReviewer(clientset)
@@ -110,53 +67,10 @@ func TestMain(m *testing.M) {
 
 	ctx, cancel = context.WithCancel(context.TODO())
 	defer cancel()
-	go func() {
-		if err = mgr.Start(ctx); err != nil {
-			fmt.Printf("failed to start manager: %v", err)
-			os.Exit(1)
-		}
-	}()
 
-	// wait for the webhook server to get ready
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	dialer := &net.Dialer{Timeout: time.Second}
-	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
-	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
-		if err = retry.OnError(wait.Backoff{
-			Steps:    20,
-			Duration: 10 * time.Millisecond,
-			Factor:   1.5,
-			Jitter:   0.1,
-			Cap:      time.Second * 30,
-		}, func(error) bool {
-			return true
-		}, func() error {
-			tlsDialer := &tls.Dialer{
-				NetDialer: dialer,
-				Config:    &tls.Config{InsecureSkipVerify: true},
-			}
-			conn, tlsErr := tlsDialer.DialContext(ctx, "tcp", addrPort)
-			if tlsErr != nil {
-				return tlsErr
-			}
-			_ = conn.Close()
-			return nil
-		}); err != nil {
-			fmt.Printf("failed to wait for webhook server to be ready: %v", err)
-			os.Exit(1)
-		}
-	}(wg)
-	wg.Wait()
+	testenv.RunWebhookServer(ctx, mgr, &testEnv.WebhookInstallOptions)
 
 	code := m.Run()
-
-	err = testEnv.Stop()
-	if err != nil {
-		fmt.Printf("failed to stop testEnv: %v", err)
-		os.Exit(1)
-	}
-
+	tenv.Stop()
 	os.Exit(code)
 }

--- a/internal/webhook/podmutation/webhookhandler_suite_test.go
+++ b/internal/webhook/podmutation/webhookhandler_suite_test.go
@@ -32,7 +32,6 @@ var (
 	testScheme *runtime.Scheme = scheme.Scheme
 	ctx        context.Context
 	cancel     context.CancelFunc
-	err        error
 	cfg        *rest.Config
 )
 
@@ -42,17 +41,25 @@ func TestMain(m *testing.M) {
 	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
 	utilruntime.Must(v1beta1.AddToScheme(testScheme))
 
-	tenv := testenv.Start(&ctrlenvtest.Environment{
+	tenv, err := testenv.Start(&ctrlenvtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 		WebhookInstallOptions: ctrlenvtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
 		},
 	}, testScheme)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	testEnv = tenv.Env
 	cfg = tenv.Config
 	k8sClient = tenv.Client
 
-	mgr := testenv.NewWebhookManager(cfg, testScheme, &testEnv.WebhookInstallOptions)
+	mgr, err := testenv.NewWebhookManager(cfg, testScheme, &testEnv.WebhookInstallOptions)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	clientset, clientErr := kubernetes.NewForConfig(cfg)
 	if clientErr != nil {
@@ -68,9 +75,15 @@ func TestMain(m *testing.M) {
 	ctx, cancel = context.WithCancel(context.TODO())
 	defer cancel()
 
-	testenv.RunWebhookServer(ctx, mgr, &testEnv.WebhookInstallOptions)
+	if err := testenv.RunWebhookServer(ctx, mgr, &testEnv.WebhookInstallOptions); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	code := m.Run()
-	tenv.Stop()
+
+	if err := tenv.Stop(); err != nil {
+		fmt.Println(err)
+	}
 	os.Exit(code)
 }

--- a/pkg/collector/upgrade/suite_test.go
+++ b/pkg/collector/upgrade/suite_test.go
@@ -33,7 +33,6 @@ var (
 	testScheme *runtime.Scheme = scheme.Scheme
 	ctx        context.Context
 	cancel     context.CancelFunc
-	err        error
 	cfg        *rest.Config
 )
 
@@ -43,17 +42,25 @@ func TestMain(m *testing.M) {
 	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
 	utilruntime.Must(v1beta1.AddToScheme(testScheme))
 
-	tenv := testenv.Start(&ctrlenvtest.Environment{
+	tenv, err := testenv.Start(&ctrlenvtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 		WebhookInstallOptions: ctrlenvtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
 		},
 	}, testScheme)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	testEnv = tenv.Env
 	cfg = tenv.Config
 	k8sClient = tenv.Client
 
-	mgr := testenv.NewWebhookManager(cfg, testScheme, &testEnv.WebhookInstallOptions)
+	mgr, err := testenv.NewWebhookManager(cfg, testScheme, &testEnv.WebhookInstallOptions)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	clientset, clientErr := kubernetes.NewForConfig(cfg)
 	if clientErr != nil {
@@ -68,10 +75,16 @@ func TestMain(m *testing.M) {
 
 	//+kubebuilder:scaffold:webhook
 
-	testenv.RunWebhookServer(ctx, mgr, &testEnv.WebhookInstallOptions)
+	if err := testenv.RunWebhookServer(ctx, mgr, &testEnv.WebhookInstallOptions); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	code := m.Run()
-	tenv.Stop()
+
+	if err := tenv.Stop(); err != nil {
+		fmt.Println(err)
+	}
 	os.Exit(code)
 }
 

--- a/pkg/collector/upgrade/suite_test.go
+++ b/pkg/collector/upgrade/suite_test.go
@@ -5,39 +5,31 @@ package upgrade_test
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/util/retry"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	ctrlenvtest "sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/rbac"
+	"github.com/open-telemetry/opentelemetry-operator/internal/testenv"
 	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 	wh "github.com/open-telemetry/opentelemetry-operator/internal/webhook"
 )
 
 var (
 	k8sClient  client.Client
-	testEnv    *envtest.Environment
+	testEnv    *ctrlenvtest.Environment
 	testScheme *runtime.Scheme = scheme.Scheme
 	ctx        context.Context
 	cancel     context.CancelFunc
@@ -51,55 +43,20 @@ func TestMain(m *testing.M) {
 	utilruntime.Must(v1alpha1.AddToScheme(testScheme))
 	utilruntime.Must(v1beta1.AddToScheme(testScheme))
 
-	var binaryAssetsDir string
-	binaryAssetsDir, err = envtest.SetupEnvtestDefaultBinaryAssetsDirectory()
-	if err != nil {
-		fmt.Printf("failed to find setup-envtest assets directory, using a temporary one: %v", err)
-	}
-
-	testEnv = &envtest.Environment{
+	tenv := testenv.Start(&ctrlenvtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		WebhookInstallOptions: envtest.WebhookInstallOptions{
+		WebhookInstallOptions: ctrlenvtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
 		},
-		DownloadBinaryAssets:  true,
-		BinaryAssetsDirectory: binaryAssetsDir,
-	}
+	}, testScheme)
+	testEnv = tenv.Env
+	cfg = tenv.Config
+	k8sClient = tenv.Client
 
-	cfg, err = testEnv.Start()
-	if err != nil {
-		fmt.Printf("failed to start testEnv: %v", err)
-		os.Exit(1)
-	}
-	// +kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
-	if err != nil {
-		fmt.Printf("failed to setup a Kubernetes client: %v", err)
-		os.Exit(1)
-	}
-
-	// start webhook server using Manager
-	webhookInstallOptions := &testEnv.WebhookInstallOptions
-	mgr, mgrErr := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:         testScheme,
-		LeaderElection: false,
-		WebhookServer: webhook.NewServer(webhook.Options{
-			Host:    webhookInstallOptions.LocalServingHost,
-			Port:    webhookInstallOptions.LocalServingPort,
-			CertDir: webhookInstallOptions.LocalServingCertDir,
-		}),
-		Metrics: metricsserver.Options{
-			BindAddress: "0",
-		},
-	})
-	if mgrErr != nil {
-		fmt.Printf("failed to start webhook server: %v", mgrErr)
-		os.Exit(1)
-	}
+	mgr := testenv.NewWebhookManager(cfg, testScheme, &testEnv.WebhookInstallOptions)
 
 	clientset, clientErr := kubernetes.NewForConfig(cfg)
-	if err != nil {
+	if clientErr != nil {
 		fmt.Printf("failed to setup kubernetes clientset %v", clientErr)
 	}
 	reviewer := rbac.NewReviewer(clientset)
@@ -111,54 +68,10 @@ func TestMain(m *testing.M) {
 
 	//+kubebuilder:scaffold:webhook
 
-	go func() {
-		if err = mgr.Start(ctx); err != nil {
-			fmt.Printf("failed to start manager: %v", err)
-			os.Exit(1)
-		}
-	}()
-
-	// wait for the webhook server to get ready
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	dialer := &net.Dialer{Timeout: time.Second}
-	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
-	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
-		if err = retry.OnError(wait.Backoff{
-			Steps:    20,
-			Duration: 10 * time.Millisecond,
-			Factor:   1.5,
-			Jitter:   0.1,
-			Cap:      time.Second * 30,
-		}, func(error) bool {
-			return true
-		}, func() error {
-			tlsDialer := &tls.Dialer{
-				NetDialer: dialer,
-				Config:    &tls.Config{InsecureSkipVerify: true},
-			}
-			conn, tlsErr := tlsDialer.DialContext(ctx, "tcp", addrPort)
-			if tlsErr != nil {
-				return tlsErr
-			}
-			_ = conn.Close()
-			return nil
-		}); err != nil {
-			fmt.Printf("failed to wait for webhook server to be ready: %v", err)
-			os.Exit(1)
-		}
-	}(wg)
-	wg.Wait()
+	testenv.RunWebhookServer(ctx, mgr, &testEnv.WebhookInstallOptions)
 
 	code := m.Run()
-
-	err = testEnv.Stop()
-	if err != nil {
-		fmt.Printf("failed to stop testEnv: %v", err)
-		os.Exit(1)
-	}
-
+	tenv.Stop()
 	os.Exit(code)
 }
 


### PR DESCRIPTION
Move the common envtest setup to a new `internal/testenv/` package. While at it, explicitly set the local apiserver address - otherwise, it inspects existing network routes, which might not exist in a restricted environment like a coding agent's sandbox.

Also fix two minor issues in must-gather tests.