### PR TITLE
[chore] Read proxy env vars at startup and store them in config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/goccy/go-yaml"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
@@ -144,6 +145,10 @@ type Config struct {
 	Instrumentation v1alpha1.Instrumentation `yaml:"instrumentations"`
 	// EnableInstrumentationCRDs enables looking for instrumentation CRDs.
 	EnableInstrumentationCRDs bool `yaml:"enable-instrumentation-crds"`
+	// ProxyEnvVars holds the proxy environment variables (HTTP_PROXY, HTTPS_PROXY,
+	// NO_PROXY — upper and lower case) captured from the operator's environment at
+	// startup and propagated to all managed containers.
+	ProxyEnvVars []corev1.EnvVar `yaml:"-"`
 }
 
 // Internal contains configuration that is propagated and cannot be accessed from the operator configuration.

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/operator-framework/operator-lib/proxy"
 )
 
 func ApplyEnvVars(cfg *Config) {
@@ -143,4 +145,5 @@ func ApplyEnvVars(cfg *Config) {
 	if v, ok := os.LookupEnv("WATCH_NAMESPACE"); ok {
 		cfg.WatchNamespace = v
 	}
+	cfg.ProxyEnvVars = proxy.ReadProxyVarsFromEnv()
 }

--- a/internal/manifests/collector/container.go
+++ b/internal/manifests/collector/container.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"github.com/operator-framework/operator-lib/proxy"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 
@@ -120,7 +119,7 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1beta1.OpenTeleme
 		Ports:           ports,
 		VolumeMounts:    volumeMounts,
 		Args:            args,
-		Env:             getContainerEnvVars(otelcol, logger),
+		Env:             getContainerEnvVars(cfg, otelcol, logger),
 		EnvFrom:         otelcol.Spec.EnvFrom,
 		Resources:       otelcol.Spec.Resources,
 		SecurityContext: otelcol.Spec.SecurityContext,
@@ -300,8 +299,8 @@ func getSpecPorts(ports []v1beta1.PortsSpec, logger logr.Logger) []corev1.Contai
 // getContainerEnvVars returns the environment variables for the collector container.
 // It combines user-defined environment variables from the OpenTelemetryCollector spec
 // with automatically inferred environment variables, giving precedence to user-defined ones.
-func getContainerEnvVars(otelcol v1beta1.OpenTelemetryCollector, logger logr.Logger) []corev1.EnvVar {
-	inferredEnvVars := getInferredContainerEnvVars(otelcol, logger)
+func getContainerEnvVars(cfg config.Config, otelcol v1beta1.OpenTelemetryCollector, logger logr.Logger) []corev1.EnvVar {
+	inferredEnvVars := getInferredContainerEnvVars(cfg, otelcol, logger)
 
 	envVars := []corev1.EnvVar{}
 	envVars = append(envVars, otelcol.Spec.Env...)
@@ -323,7 +322,7 @@ func getContainerEnvVars(otelcol v1beta1.OpenTelemetryCollector, logger logr.Log
 
 // getInferredContainerEnvVars returns environment variables that are automatically added to the collector container.
 // Those include parsing the collector config and adding the env vars derived from it.
-func getInferredContainerEnvVars(otelcol v1beta1.OpenTelemetryCollector, logger logr.Logger) []corev1.EnvVar {
+func getInferredContainerEnvVars(cfg config.Config, otelcol v1beta1.OpenTelemetryCollector, logger logr.Logger) []corev1.EnvVar {
 	envVars := []corev1.EnvVar{}
 
 	envVars = append(envVars, corev1.EnvVar{
@@ -364,5 +363,5 @@ func getInferredContainerEnvVars(otelcol v1beta1.OpenTelemetryCollector, logger 
 		envVars = append(envVars, configEnvVars...)
 	}
 
-	return append(envVars, proxy.ReadProxyVarsFromEnv()...)
+	return append(envVars, cfg.ProxyEnvVars...)
 }

--- a/internal/manifests/collector/container_test.go
+++ b/internal/manifests/collector/container_test.go
@@ -537,12 +537,15 @@ func TestContainerDefaultEnvVars(t *testing.T) {
 }
 
 func TestContainerProxyEnvVars(t *testing.T) {
-	t.Setenv("NO_PROXY", "localhost")
 	otelcol := v1beta1.OpenTelemetryCollector{
 		Spec: v1beta1.OpenTelemetryCollectorSpec{},
 	}
 
 	cfg := config.New()
+	cfg.ProxyEnvVars = []corev1.EnvVar{
+		{Name: "NO_PROXY", Value: "localhost"},
+		{Name: "no_proxy", Value: "localhost"},
+	}
 
 	// test
 	c := Container(cfg, testLogger, otelcol, true)
@@ -927,9 +930,9 @@ func TestGetEnvironmentVariables(t *testing.T) {
 	tests := []struct {
 		name                 string
 		otelcol              v1beta1.OpenTelemetryCollector
+		cfg                  config.Config
 		enableSetGolangFlags bool
 		expectedEnvVars      []corev1.EnvVar
-		before               func(t *testing.T)
 	}{
 		{
 			name: "default environment variables",
@@ -1114,9 +1117,13 @@ func TestGetEnvironmentVariables(t *testing.T) {
 				{Name: "NO_PROXY", Value: "localhost"},
 				{Name: "no_proxy", Value: "localhost"},
 			},
-			before: func(t *testing.T) {
-				t.Setenv("HTTP_PROXY", "http://proxy.example.com")
-				t.Setenv("NO_PROXY", "localhost")
+			cfg: config.Config{
+				ProxyEnvVars: []corev1.EnvVar{
+					{Name: "HTTP_PROXY", Value: "http://proxy.example.com"},
+					{Name: "http_proxy", Value: "http://proxy.example.com"},
+					{Name: "NO_PROXY", Value: "localhost"},
+					{Name: "no_proxy", Value: "localhost"},
+				},
 			},
 		},
 		{
@@ -1253,11 +1260,7 @@ service:
 				})
 			}
 
-			if test.before != nil {
-				test.before(t)
-			}
-
-			envVars := getContainerEnvVars(test.otelcol, testLogger)
+			envVars := getContainerEnvVars(test.cfg, test.otelcol, testLogger)
 			assert.ElementsMatch(t, test.expectedEnvVars, envVars)
 		})
 	}

--- a/internal/manifests/opampbridge/container.go
+++ b/internal/manifests/opampbridge/container.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 
 	"github.com/go-logr/logr"
-	"github.com/operator-framework/operator-lib/proxy"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
@@ -76,7 +75,7 @@ func Container(cfg config.Config, _ logr.Logger, opampBridge v1alpha1.OpAMPBridg
 		)
 	}
 
-	envVars = append(envVars, proxy.ReadProxyVarsFromEnv()...)
+	envVars = append(envVars, cfg.ProxyEnvVars...)
 
 	return corev1.Container{
 		Name:            naming.OpAMPBridgeContainer(),

--- a/internal/manifests/targetallocator/container.go
+++ b/internal/manifests/targetallocator/container.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 
 	"github.com/go-logr/logr"
-	"github.com/operator-framework/operator-lib/proxy"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -139,7 +138,7 @@ func Container(cfg config.Config, _ logr.Logger, instance v1alpha1.TargetAllocat
 		})
 	}
 
-	envVars = append(envVars, proxy.ReadProxyVarsFromEnv()...)
+	envVars = append(envVars, cfg.ProxyEnvVars...)
 	return corev1.Container{
 		Name:            naming.TAContainer(),
 		Image:           image,

--- a/internal/manifests/targetallocator/container_test.go
+++ b/internal/manifests/targetallocator/container_test.go
@@ -232,8 +232,6 @@ func TestContainerHasEnvVars(t *testing.T) {
 }
 
 func TestContainerHasProxyEnvVars(t *testing.T) {
-	t.Setenv("NO_PROXY", "localhost")
-
 	// prepare
 	targetAllocator := v1alpha1.TargetAllocator{
 		Spec: v1alpha1.TargetAllocatorSpec{
@@ -249,6 +247,10 @@ func TestContainerHasProxyEnvVars(t *testing.T) {
 	}
 	cfg := config.Config{
 		TargetAllocatorImage: "default-image",
+		ProxyEnvVars: []corev1.EnvVar{
+			{Name: "NO_PROXY", Value: "localhost"},
+			{Name: "no_proxy", Value: "localhost"},
+		},
 	}
 
 	// test


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Instead of calling `proxy.ReadProxyVarsFromEnv()` inside each container manifest builder at reconcile time, read the proxy variables once during operator startup in `ApplyEnvVars` and store them in `config.Config.ProxyEnvVars`.

The manifest builders (collector, targetallocator, opampbridge) now read from `cfg.ProxyEnvVars` instead of calling `os.LookupEnv` out-of-band. This eliminates an antipattern where reconcile-time code had hidden dependencies on the process environment, and makes the values easy to control in tests by setting `cfg.ProxyEnvVars` directly rather than via `t.Setenv`.

A particular environment this fixes is a coding agent sandbox, where all external connections go through a proxy. Tests would fail there because of environment variables. This change isolates them.

