### PR TITLE
[chore] Skip dockerhub publish for PHP autoinstrumentation image

### DIFF
--- a/.github/workflows/publish-autoinstrumentation-php.yaml
+++ b/.github/workflows/publish-autoinstrumentation-php.yaml
@@ -39,7 +39,6 @@ jobs:
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: |
-            otel/autoinstrumentation-php
             ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-php
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
@@ -54,13 +53,6 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-
-      - name: Log into Docker.io
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        if: ${{ github.event_name == 'push' }}
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Package Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The image this publishes to doesn't exist. It probably shouldn't be published until PHP autoinstrumentation support is at least in alpha. Skip it to stop the workflow from failing.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/5082
