### PR TITLE
[chore] Use container log parser in ClusterObservability agent

### DIFF
--- a/internal/manifests/clusterobservability/config/configs/agent-collector-base.yaml
+++ b/internal/manifests/clusterobservability/config/configs/agent-collector-base.yaml
@@ -25,15 +25,8 @@ receivers:
     include_file_path: true
     include_file_name: false
     operators:
-      - type: router
-        id: get-format
-        routes:
-          - output: parser-docker
-            expr: 'body matches "^\\{"'
-          - output: parser-crio  
-            expr: 'body matches "^[^ Z]+ "'
-          - output: parser-containerd
-            expr: 'body matches "^[^ Z]+Z"'
+      - type: container
+        id: container-parser
 
 processors:
   batch: {}

--- a/internal/manifests/clusterobservability/config/configs/distros/openshift/agent-collector-overrides.yaml
+++ b/internal/manifests/clusterobservability/config/configs/distros/openshift/agent-collector-overrides.yaml
@@ -15,36 +15,20 @@ receivers:
     extra_metadata_labels:
       - container.id
     
-  # OpenShift uses CRI-O container runtime  
   filelog:
     include:
       - "/var/log/pods/*/*/*.log"
       - "/var/log/containers/*.log"
     exclude:
-      - "/var/log/pods/openshift-*/*/*.log"  # Skip OpenShift system logs
-      - "/var/log/pods/kube-*/*/*.log"       # Skip kube-system logs
+      - "/var/log/pods/openshift-*/*/*.log"
+      - "/var/log/pods/kube-*/*/*.log"
       - "/var/log/pods/*/otc-container/*.log"
     start_at: end
     include_file_path: true
     include_file_name: false
     operators:
-      - type: router
-        id: get-format
-        routes:
-          - output: parser-crio
-            expr: 'body matches "^[^ Z]+ "'
-          - output: parser-docker
-            expr: 'body matches "^\\{"'
-      - type: json_parser
-        id: parser-docker
-        if: 'attributes["log_type"] == "docker"'
-      - type: regex_parser
-        id: parser-crio
-        if: 'attributes["log_type"] == "crio"'
-        regex: '^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) (?P<message>.*)$'
-        timestamp:
-          parse_from: attributes.time
-          layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+      - type: container
+        id: container-parser
 
 processors:
   resourcedetection:


### PR DESCRIPTION
## Summary
- Replace manual router + regex/json parser chain with the built-in `container` operator in the filelog receiver config
- Applied to both the base agent config and the OpenShift distro override

## Why
The filelog receiver config defined a router with routes to `parser-docker`, `parser-crio`, and `parser-containerd` operators, but the parser operators were not fully defined, causing the collector to crash with `operator parser-docker does not exist`.

The built-in [`container` operator](https://opentelemetry.io/blog/2024/otel-collector-container-log-parser/) auto-detects the log format at runtime and handles all three formats plus partial log recombination for CRI-O.
