### PR TITLE
Add resourcedetection processor to ClusterObservability agent logs pipeline

### DIFF
--- a/internal/manifests/clusterobservability/config/loader.go
+++ b/internal/manifests/clusterobservability/config/loader.go
@@ -273,7 +273,7 @@ func (*ConfigLoader) buildPipelinesWithExporters(collectorType CollectorType) ma
 		}
 		pipelines["logs"] = PipelineConfig{
 			Receivers:  []string{"filelog"},
-			Processors: []string{"k8sattributes", "batch"},
+			Processors: []string{"resourcedetection", "k8sattributes", "batch"},
 			Exporters:  []string{exporterName},
 		}
 		pipelines["traces"] = PipelineConfig{


### PR DESCRIPTION
## Summary
- The agent collector's logs pipeline was missing the `resourcedetection` processor, unlike the metrics and traces pipelines which already had it.
- This meant resource attributes like `host.name` were not set on log data collected via the `filelog` receiver.

## Test plan
- [x] Run `make test` to verify no regressions
- [x] Deploy to a cluster and verify `host.name` is present on log resource attributes