### PR TITLE
Add hostmetrics receiver to ClusterObservability agent

### DIFF
--- a/internal/manifests/clusterobservability/config/configs/agent-collector-base.yaml
+++ b/internal/manifests/clusterobservability/config/configs/agent-collector-base.yaml
@@ -1,6 +1,17 @@
 # Base configuration for agent collectors (DaemonSet) 
 # Collects kubelet stats, container logs, and OTLP data from auto-instrumentation
 receivers:
+  hostmetrics:
+    root_path: /hostfs
+    collection_interval: 30s
+    scrapers:
+      cpu: {}
+      memory: {}
+      disk: {}
+      filesystem: {}
+      load: {}
+      network: {}
+      paging: {}
   otlp:
     protocols:
       grpc:

--- a/internal/manifests/clusterobservability/config/loader.go
+++ b/internal/manifests/clusterobservability/config/loader.go
@@ -267,7 +267,7 @@ func (*ConfigLoader) buildPipelinesWithExporters(collectorType CollectorType) ma
 	case AgentCollectorType:
 		// Agent collector: metrics, logs, traces
 		pipelines["metrics"] = PipelineConfig{
-			Receivers:  []string{"otlp", "kubeletstats"},
+			Receivers:  []string{"otlp", "hostmetrics", "kubeletstats"},
 			Processors: []string{"resourcedetection", "k8sattributes", "batch"},
 			Exporters:  []string{exporterName},
 		}


### PR DESCRIPTION
## Summary
- Adds the `hostmetrics` receiver to the ClusterObservability agent (DaemonSet) base configuration, collecting CPU, memory, disk, filesystem, load, network, and paging metrics from the host via `/hostfs`.
- Wires `hostmetrics` into the agent metrics pipeline alongside `otlp` and `kubeletstats`.

## Test plan
- [ ] Verify `make test` passes
- [ ] Verify `make ensure-update-is-noop` passes
- [ ] Deploy to a cluster and confirm hostmetrics data flows through the agent pipeline