### PR TITLE
feat(clusterobservability): enable TargetAllocator support for cluster collectors

### DIFF
--- a/internal/manifests/clusterobservability/clusterobservability.go
+++ b/internal/manifests/clusterobservability/clusterobservability.go
@@ -16,6 +16,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/clusterobservability/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
+	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 )
 
 const (
@@ -64,7 +66,7 @@ func Build(params manifests.Params) ([]client.Object, error) {
 		resourceManifests = append(resourceManifests, agentCollector)
 	}
 
-	// Build cluster-level collector (Deployment)
+	// Build cluster-level collector (StatefulSet)
 	clusterCollector, err := buildClusterCollector(params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build cluster collector: %w", err)
@@ -333,6 +335,7 @@ func buildClusterCollector(params manifests.Params) (*v1beta1.OpenTelemetryColle
 	clusterLabels := manifestutils.Labels(co.ObjectMeta, clusterCollectorName, params.Config.CollectorImage, ComponentClusterObservability, params.Config.LabelsFilter)
 	clusterLabels["app.kubernetes.io/managed-by"] = "opentelemetry-operator"
 	clusterLabels["app.kubernetes.io/component"] = ComponentClusterObservability
+	clusterLabels[constants.LabelTargetAllocator] = naming.TargetAllocator(co.Name)
 
 	clusterCollector := &v1beta1.OpenTelemetryCollector{
 		ObjectMeta: metav1.ObjectMeta{
@@ -351,7 +354,7 @@ func buildClusterCollector(params manifests.Params) (*v1beta1.OpenTelemetryColle
 			},
 		},
 		Spec: v1beta1.OpenTelemetryCollectorSpec{
-			Mode:   v1beta1.ModeDeployment,
+			Mode:   v1beta1.ModeStatefulSet,
 			Config: collectorConfig,
 			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
 				Image:    getCollectorImage(params.Config.CollectorImage),

--- a/internal/manifests/clusterobservability/config/configs/cluster-collector-base.yaml
+++ b/internal/manifests/clusterobservability/config/configs/cluster-collector-base.yaml
@@ -6,9 +6,13 @@ receivers:
     collection_interval: 30s
     node_conditions_to_report: ["Ready", "MemoryPressure", "DiskPressure", "PIDPressure"]
     allocatable_types_to_report: ["cpu", "memory", "storage", "pods"]
-    
+
   k8s_events:
     auth_type: serviceAccount
+
+  prometheus:
+    config:
+      scrape_configs: []
 
 processors:
   batch: {}

--- a/internal/manifests/clusterobservability/config/loader.go
+++ b/internal/manifests/clusterobservability/config/loader.go
@@ -288,6 +288,11 @@ func (*ConfigLoader) buildPipelinesWithExporters(collectorType CollectorType) ma
 			Processors: []string{"resourcedetection", "batch"},
 			Exporters:  []string{exporterName},
 		}
+		pipelines["metrics/prometheus"] = PipelineConfig{
+			Receivers:  []string{"prometheus"},
+			Processors: []string{"batch"},
+			Exporters:  []string{exporterName},
+		}
 		pipelines["logs"] = PipelineConfig{
 			Receivers:  []string{"k8s_events"},
 			Processors: []string{"batch"},


### PR DESCRIPTION
## Summary

- Adds a noop `prometheus` receiver with empty `scrape_configs` to the cluster collector base config
- Adds a `metrics/prometheus` pipeline to wire the prometheus receiver into the cluster collector's service
- Sets the `opentelemetry.io/target-allocator` label on the generated `*-cluster` OpenTelemetryCollector CR using `naming.TargetAllocator(co.Name)`

This enables a standalone TargetAllocator CR to discover the cluster collector via the existing label-based mechanism and inject scrape target configuration automatically.

- Closes #5138

## Example

```yaml
apiVersion: opentelemetry.io/v1alpha1
kind: TargetAllocator
metadata:
  name: gateway
  namespace: observability
spec:
  allocationStrategy: consistent-hashing
  filterStrategy: relabel-config
  prometheusCR:
    enabled: true
    scrapeInterval: 30s
    serviceMonitorSelector: {}
    serviceMonitorNamespaceSelector: {}
    podMonitorSelector: {}
    podMonitorNamespaceSelector: {}
---
apiVersion: opentelemetry.io/v1alpha1
kind: ClusterObservability
metadata:
  name: gateway
  namespace: observability
spec:
  exporter:
    endpoint: "http://backend.observability.svc.cluster.local:4318"
```

```
gateway-agent-collector-27ljc                   1/1     Running   0              4m9s
gateway-agent-collector-5jm7m                   1/1     Running   0              4m9s
gateway-agent-collector-752nm                   1/1     Running   0              4m9s
gateway-agent-collector-844t8                   1/1     Running   0              4m9s
gateway-agent-collector-hsnfg                   1/1     Running   1 (4m6s ago)   4m9s
gateway-agent-collector-qnh4t                   1/1     Running   0              4m9s
gateway-agent-collector-xkxnw                   1/1     Running   0              4m9s
gateway-cluster-collector-0                     1/1     Running   0              4m8s
gateway-targetallocator-7f4986548d-rwp26        1/1     Running   0              4m9s
opentelemetry-operator-5dccfbd4c5-tzz9x         1/1     Running   0              4m21s
```