### PR TITLE
[chore] Fix flaky privilege-escalation-check e2e test

### DIFF
--- a/tests/e2e-automatic-rbac/privilege-escalation-check/chainsaw-test.yaml
+++ b/tests/e2e-automatic-rbac/privilege-escalation-check/chainsaw-test.yaml
@@ -23,6 +23,19 @@ spec:
     try:
     - apply:
         file: 01-install.yaml
+  - name: wait-for-rbac-propagation
+    try:
+    - script:
+        timeout: 60s
+        content: |
+          for i in $(seq 1 30); do
+            if kubectl auth can-i get events --as=permitted-user -A 2>/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "RBAC propagation timed out"
+          exit 1
   - name: limited-user-request-is-rejected
     try:
     - script:


### PR DESCRIPTION
## Summary
- The `privilege-escalation-check` e2e test in `e2e-automatic-rbac` fails intermittently because the `ClusterRoleBinding` for `permitted-user` hasn't fully propagated by the time the webhook fires a `SubjectAccessReview`.
- Adds a `wait-for-rbac-propagation` step that polls `kubectl auth can-i` until the RBAC binding is effective before running the assertions.

Noticed it already a few times failing e.g.:
- https://github.com/open-telemetry/opentelemetry-operator/actions/runs/26443751767/job/77848333037?pr=5139

## Test plan
- [x] CI should pass the `e2e-automatic-rbac` suite consistently