### PR TITLE
fix(collector): reconcile Service trafficDistribution and related fields

### DIFF
--- a/internal/manifests/mutate.go
+++ b/internal/manifests/mutate.go
@@ -301,6 +301,10 @@ func mutateTargetAllocator(existing, desired *v1alpha1.TargetAllocator) {
 func mutateService(existing, desired *corev1.Service) {
 	existing.Spec.Ports = desired.Spec.Ports
 	existing.Spec.Selector = desired.Spec.Selector
+	existing.Spec.InternalTrafficPolicy = desired.Spec.InternalTrafficPolicy
+	existing.Spec.IPFamilies = desired.Spec.IPFamilies
+	existing.Spec.IPFamilyPolicy = desired.Spec.IPFamilyPolicy
+	existing.Spec.TrafficDistribution = desired.Spec.TrafficDistribution
 }
 
 func mutateDaemonset(existing, desired *appsv1.DaemonSet) error {

--- a/internal/manifests/mutate_test.go
+++ b/internal/manifests/mutate_test.go
@@ -40,6 +40,127 @@ func TestMutateServiceAccount(t *testing.T) {
 	}, existing)
 }
 
+func TestMutateService(t *testing.T) {
+	trafficLocal := corev1.ServiceInternalTrafficPolicyLocal
+	trafficCluster := corev1.ServiceInternalTrafficPolicyCluster
+	ipFamilyPolicySingleStack := corev1.IPFamilyPolicySingleStack
+	ipFamilyPolicyDualStack := corev1.IPFamilyPolicyRequireDualStack
+	preferClose := "PreferClose"
+	preferSameZone := "PreferSameZone"
+
+	tests := []struct {
+		name     string
+		existing corev1.Service
+		desired  corev1.Service
+	}{
+		{
+			name: "update trafficDistribution",
+			existing: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports:               []corev1.ServicePort{{Name: "otlp", Port: 4317}},
+					Selector:            map[string]string{"app": "collector"},
+					TrafficDistribution: &preferClose,
+				},
+			},
+			desired: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports:               []corev1.ServicePort{{Name: "otlp", Port: 4317}},
+					Selector:            map[string]string{"app": "collector"},
+					TrafficDistribution: &preferSameZone,
+				},
+			},
+		},
+		{
+			name: "update internalTrafficPolicy",
+			existing: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports:                 []corev1.ServicePort{{Name: "otlp", Port: 4317}},
+					Selector:              map[string]string{"app": "collector"},
+					InternalTrafficPolicy: &trafficCluster,
+				},
+			},
+			desired: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports:                 []corev1.ServicePort{{Name: "otlp", Port: 4317}},
+					Selector:              map[string]string{"app": "collector"},
+					InternalTrafficPolicy: &trafficLocal,
+				},
+			},
+		},
+		{
+			name: "update ipFamilies and ipFamilyPolicy",
+			existing: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports:          []corev1.ServicePort{{Name: "otlp", Port: 4317}},
+					Selector:       map[string]string{"app": "collector"},
+					IPFamilies:     []corev1.IPFamily{corev1.IPv4Protocol},
+					IPFamilyPolicy: &ipFamilyPolicySingleStack,
+				},
+			},
+			desired: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports:          []corev1.ServicePort{{Name: "otlp", Port: 4317}},
+					Selector:       map[string]string{"app": "collector"},
+					IPFamilies:     []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+					IPFamilyPolicy: &ipFamilyPolicyDualStack,
+				},
+			},
+		},
+		{
+			name: "update all service fields",
+			existing: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports:                 []corev1.ServicePort{{Name: "otlp", Port: 4317}},
+					Selector:              map[string]string{"app": "collector"},
+					InternalTrafficPolicy: &trafficCluster,
+					IPFamilies:            []corev1.IPFamily{corev1.IPv4Protocol},
+					IPFamilyPolicy:        &ipFamilyPolicySingleStack,
+					TrafficDistribution:   &preferClose,
+				},
+			},
+			desired: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports:                 []corev1.ServicePort{{Name: "otlp", Port: 4317}, {Name: "metrics", Port: 8888}},
+					Selector:              map[string]string{"app": "collector", "version": "v2"},
+					InternalTrafficPolicy: &trafficLocal,
+					IPFamilies:            []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+					IPFamilyPolicy:        &ipFamilyPolicyDualStack,
+					TrafficDistribution:   &preferSameZone,
+				},
+			},
+		},
+		{
+			name: "remove trafficDistribution",
+			existing: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports:               []corev1.ServicePort{{Name: "otlp", Port: 4317}},
+					Selector:            map[string]string{"app": "collector"},
+					TrafficDistribution: &preferClose,
+				},
+			},
+			desired: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports:    []corev1.ServicePort{{Name: "otlp", Port: 4317}},
+					Selector: map[string]string{"app": "collector"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			err := mutateFn()
+			require.NoError(t, err)
+			assert.Equal(t, tt.desired.Spec.Ports, tt.existing.Spec.Ports)
+			assert.Equal(t, tt.desired.Spec.Selector, tt.existing.Spec.Selector)
+			assert.Equal(t, tt.desired.Spec.InternalTrafficPolicy, tt.existing.Spec.InternalTrafficPolicy)
+			assert.Equal(t, tt.desired.Spec.IPFamilies, tt.existing.Spec.IPFamilies)
+			assert.Equal(t, tt.desired.Spec.IPFamilyPolicy, tt.existing.Spec.IPFamilyPolicy)
+			assert.Equal(t, tt.desired.Spec.TrafficDistribution, tt.existing.Spec.TrafficDistribution)
+		})
+	}
+}
+
 func TestMutateDaemonsetAdditionalContainers(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/tests/e2e/traffic-distribution-change/00-assert.yaml
+++ b/tests/e2e/traffic-distribution-change/00-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: traffic-dist-collector
+status:
+  readyReplicas: 1

--- a/tests/e2e/traffic-distribution-change/00-install.yaml
+++ b/tests/e2e/traffic-distribution-change/00-install.yaml
@@ -1,0 +1,19 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: traffic-dist
+spec:
+  mode: deployment
+  trafficDistribution: PreferClose
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+    exporters:
+      debug: {}
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]

--- a/tests/e2e/traffic-distribution-change/01-assert.yaml
+++ b/tests/e2e/traffic-distribution-change/01-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: traffic-dist-collector
+status:
+  readyReplicas: 1

--- a/tests/e2e/traffic-distribution-change/01-install.yaml
+++ b/tests/e2e/traffic-distribution-change/01-install.yaml
@@ -1,0 +1,19 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: traffic-dist
+spec:
+  mode: deployment
+  trafficDistribution: PreferSameZone
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+    exporters:
+      debug: {}
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]

--- a/tests/e2e/traffic-distribution-change/chainsaw-test.yaml
+++ b/tests/e2e/traffic-distribution-change/chainsaw-test.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: traffic-distribution-change
+spec:
+  bindings:
+    - name: version
+      value: (x_k8s_server_version($config))
+    - name: minorVersion
+      value: (to_number($version.minor))
+  steps:
+    - name: step-00
+      description: deploy collector with trafficDistribution PreferClose
+      try:
+        - apply:
+            file: 00-install.yaml
+        - assert:
+            file: 00-assert.yaml
+        - script:
+            content: kubectl get svc traffic-dist-collector -n $NAMESPACE -o jsonpath='{.spec.trafficDistribution}' || echo ""
+            outputs:
+              - name: trafficDistribution
+                value: ($stdout)
+        - assert:
+            resource:
+              (($minorVersion >= `31` && $trafficDistribution == 'PreferClose') || ($minorVersion < `31` && $trafficDistribution == '')): true
+    - name: step-01
+      description: update collector trafficDistribution to PreferSameZone
+      try:
+        - update:
+            file: 01-install.yaml
+        - assert:
+            file: 01-assert.yaml
+        - script:
+            content: kubectl get svc traffic-dist-collector -n $NAMESPACE -o jsonpath='{.spec.trafficDistribution}' || echo ""
+            outputs:
+              - name: trafficDistribution
+                value: ($stdout)
+        - assert:
+            resource:
+              (($minorVersion >= `31` && $trafficDistribution == 'PreferSameZone') || ($minorVersion < `31` && $trafficDistribution == '')): true


### PR DESCRIPTION
## Summary
- Fix `mutateService()` to propagate `TrafficDistribution`, `InternalTrafficPolicy`, `IPFamilies`, and `IPFamilyPolicy` from desired to existing Service during reconciliation
- These fields were set on initial Service creation but never synced on updates, causing CR changes to be silently ignored
- Add unit tests for all mutated Service fields
- Add e2e chainsaw test verifying `trafficDistribution` changes propagate to Services

Fixes #5141

## Test plan
- [x] Unit test `TestMutateService` with 5 sub-tests (update each field, update all, remove)
- [x] E2e test `traffic-distribution-change` deploys with `PreferClose`, updates to `PreferSameZone`, verifies Service reflects the change
- [x] `go test ./internal/manifests/...` passes
- [x] `golangci-lint` passes