### PR TITLE
Upload operator image signature only for tags

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -129,6 +129,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
+          UPLOAD: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
         run: |
-          make cosign-sign IMAGE="${GHCR_IMAGE}" DIGEST="${DIGEST}"
-          make cosign-sign IMAGE="${DOCKERHUB_IMAGE}" DIGEST="${DIGEST}"
+          make cosign-sign IMAGE="${GHCR_IMAGE}" DIGEST="${DIGEST}" UPLOAD="${UPLOAD}"
+          make cosign-sign IMAGE="${DOCKERHUB_IMAGE}" DIGEST="${DIGEST}" UPLOAD="${UPLOAD}"

--- a/Makefile
+++ b/Makefile
@@ -995,6 +995,7 @@ catalog-push: ## Push a catalog image.
 # renovate: datasource=github-releases depName=sigstore/cosign
 COSIGN_VERSION ?= v2.6.3
 COSIGN ?= $(LOCALBIN)/cosign
+UPLOAD ?= true
 
 
 # Download cosign locally if necessary
@@ -1019,7 +1020,7 @@ endif
 ifndef DIGEST
 	$(error DIGEST is not set. Usage: make cosign-sign IMAGE=<image> DIGEST=<digest>)
 endif
-	$(COSIGN) sign --yes "$(IMAGE)@$(DIGEST)"
+	$(COSIGN) sign --yes --upload=$(UPLOAD) "$(IMAGE)@$(DIGEST)"
 
 ##@ Release
 


### PR DESCRIPTION
We currently upload the signatures for dev builds as well. They show up as named tags in the list on GHCR, which makes it less readable. See https://github.com/open-telemetry/opentelemetry-operator/issues/5009 for further discussion.

This PR removes signature upload from builds on `main`. We can reenable them once we've migrated the dev builds to a different repository.