### PR TITLE
feat(targetallocator): auto-create RBAC for standalone TargetAllocator

### DIFF
--- a/.chloggen/targetallocator-auto-rbac.yaml
+++ b/.chloggen/targetallocator-auto-rbac.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Auto-create ClusterRole and ClusterRoleBinding for standalone TargetAllocator CRs when --create-rbac-permissions is enabled.
+
+# One or more tracking issues related to the change
+issues: [5148]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, standalone TargetAllocator CRs required manually creating RBAC resources
+  for Prometheus CR discovery (namespaces, nodes, servicemonitors, etc.). The operator now
+  generates these automatically, matching the behavior of collector-embedded TargetAllocators.

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-05-25T14:37:22Z"
+    createdAt: "2026-05-26T18:39:20Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -488,6 +488,19 @@ spec:
           - policy
           resources:
           - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
           verbs:
           - create
           - delete

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-05-25T14:37:22Z"
+    createdAt: "2026-05-26T18:39:21Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -488,6 +488,19 @@ spec:
           - policy
           resources:
           - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
           verbs:
           - create
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -205,6 +205,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/internal/controllers/targetallocator_controller.go
+++ b/internal/controllers/targetallocator_controller.go
@@ -145,6 +145,7 @@ func NewTargetAllocatorReconciler(
 // +kubebuilder:rbac:groups=opentelemetry.io,resources=opentelemetrycollectors,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=opentelemetry.io,resources=targetallocators,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=opentelemetry.io,resources=targetallocators/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile the current state of a TargetAllocator resource with the desired state.
 func (r *TargetAllocatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/manifests/targetallocator/rbac.go
+++ b/internal/manifests/targetallocator/rbac.go
@@ -1,0 +1,78 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package targetallocator
+
+import (
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
+	"github.com/open-telemetry/opentelemetry-operator/internal/naming"
+)
+
+func ClusterRole(params Params) *rbacv1.ClusterRole {
+	ta := params.TargetAllocator
+	name := naming.TAClusterRole(ta.Name, ta.Namespace)
+	labels := manifestutils.Labels(ta.ObjectMeta, name, ta.Spec.Image, ComponentOpenTelemetryTargetAllocator, nil)
+
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: ta.Annotations,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"namespaces", "nodes", "nodes/metrics", "services", "endpoints", "pods", "configmaps"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"monitoring.coreos.com"},
+				Resources: []string{"servicemonitors", "podmonitors", "probes", "scrapeconfigs"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"discovery.k8s.io"},
+				Resources: []string{"endpointslices"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"ingresses"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				NonResourceURLs: []string{"/metrics"},
+				Verbs:           []string{"get"},
+			},
+		},
+	}
+}
+
+func ClusterRoleBinding(params Params) *rbacv1.ClusterRoleBinding {
+	ta := params.TargetAllocator
+	name := naming.TAClusterRoleBinding(ta.Name, ta.Namespace)
+	labels := manifestutils.Labels(ta.ObjectMeta, name, ta.Spec.Image, ComponentOpenTelemetryTargetAllocator, nil)
+
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: ta.Annotations,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      ServiceAccountName(ta),
+				Namespace: ta.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     naming.TAClusterRole(ta.Name, ta.Namespace),
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+}

--- a/internal/manifests/targetallocator/targetallocator.go
+++ b/internal/manifests/targetallocator/targetallocator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
+	autoRBAC "github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
@@ -35,6 +36,13 @@ func Build(params Params) ([]client.Object, error) {
 
 	if params.TargetAllocator.Spec.Observability.Metrics.EnableMetrics {
 		resourceFactories = append(resourceFactories, manifests.FactoryWithoutError(ServiceMonitor))
+	}
+
+	if params.Config.CreateRBACPermissions == autoRBAC.Available {
+		resourceFactories = append(resourceFactories,
+			manifests.FactoryWithoutError(ClusterRole),
+			manifests.FactoryWithoutError(ClusterRoleBinding),
+		)
 	}
 
 	if params.Config.CertManagerAvailability == certmanager.Available && featuregate.EnableTargetAllocatorMTLS.IsEnabled() {

--- a/internal/naming/main.go
+++ b/internal/naming/main.go
@@ -150,6 +150,16 @@ func ClusterRoleBinding(otelcol, namespace string) string {
 	return DNSName(Truncate("%s-%s-collector", 63, otelcol, namespace))
 }
 
+// TAClusterRole builds the cluster role name for a TargetAllocator instance.
+func TAClusterRole(taName, namespace string) string {
+	return DNSName(Truncate("%s-%s-targetallocator", 63, taName, namespace))
+}
+
+// TAClusterRoleBinding builds the cluster role binding name for a TargetAllocator instance.
+func TAClusterRoleBinding(taName, namespace string) string {
+	return DNSName(Truncate("%s-%s-targetallocator", 63, taName, namespace))
+}
+
 // TAService returns the name to use for the TargetAllocator service.
 func TAService(taName string) string {
 	return DNSName(Truncate("%s-targetallocator", 63, taName))


### PR DESCRIPTION
## Summary
- When `--create-rbac-permissions` is enabled, the operator now generates a `ClusterRole` and `ClusterRoleBinding` for standalone `TargetAllocator` CRs
- Grants the TA service account the permissions needed for Prometheus CR discovery (namespaces, nodes, servicemonitors, podmonitors, etc.)
- Previously this RBAC had to be created manually, unlike collector-embedded TargetAllocators

🤖 Generated with [Claude Code](https://claude.com/claude-code)