### PR TITLE
[chore] Make GHCR image references in publish workflows owner-relative

### DIFF
--- a/.github/workflows/publish-autoinstrumentation-apache-httpd.yaml
+++ b/.github/workflows/publish-autoinstrumentation-apache-httpd.yaml
@@ -38,7 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
-          images: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-apache-httpd
+          images: ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-apache-httpd
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
 

--- a/.github/workflows/publish-autoinstrumentation-dotnet.yaml
+++ b/.github/workflows/publish-autoinstrumentation-dotnet.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           images: |
             otel/autoinstrumentation-dotnet
-            ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet
+            ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-dotnet
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
 

--- a/.github/workflows/publish-autoinstrumentation-java.yaml
+++ b/.github/workflows/publish-autoinstrumentation-java.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           images: |
             otel/autoinstrumentation-java
-            ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java
+            ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-java
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
             type=semver,pattern={{major}},value=v${{ env.VERSION }}

--- a/.github/workflows/publish-autoinstrumentation-nodejs.yaml
+++ b/.github/workflows/publish-autoinstrumentation-nodejs.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           images: |
             otel/autoinstrumentation-nodejs
-            ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs
+            ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-nodejs
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
 

--- a/.github/workflows/publish-autoinstrumentation-php.yaml
+++ b/.github/workflows/publish-autoinstrumentation-php.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-php
+            ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-php
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
 

--- a/.github/workflows/publish-autoinstrumentation-python.yaml
+++ b/.github/workflows/publish-autoinstrumentation-python.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           images: |
             otel/autoinstrumentation-python
-            ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python
+            ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-python
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
 

--- a/.github/workflows/publish-must-gather.yaml
+++ b/.github/workflows/publish-must-gather.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            ghcr.io/open-telemetry/opentelemetry-operator/must-gather
+            ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/must-gather
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/publish-operator-bundle.yaml
+++ b/.github/workflows/publish-operator-bundle.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           images: |
             otel/opentelemetry-operator-bundle
-            ghcr.io/open-telemetry/opentelemetry-operator/operator-bundle
+            ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/operator-bundle
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/publish-operator-opamp-bridge.yaml
+++ b/.github/workflows/publish-operator-opamp-bridge.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           images: |
             otel/operator-opamp-bridge
-            ghcr.io/open-telemetry/opentelemetry-operator/operator-opamp-bridge
+            ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/operator-opamp-bridge
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/publish-target-allocator.yaml
+++ b/.github/workflows/publish-target-allocator.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           images: |
             otel/target-allocator
-            ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
+            ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/target-allocator
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
Use github.repository_owner instead of a hardcoded open-telemetry namespace so forks publish to their own GHCR. No behavior change in this repo, where repository_owner resolves to open-telemetry.

This is just a CI tweak to make forks easier to run.