### PR TITLE
[chore] Restrict org-specific workflows to the upstream repository

### DIFF
--- a/.github/workflows/create-release-issue.yaml
+++ b/.github/workflows/create-release-issue.yaml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   create-release-issue:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-operator' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   run-e2e-tests:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-operator' }}
     uses: ./.github/workflows/e2e-reusable.yaml
     with:
       collector-image: "otel/opentelemetry-collector-contrib-dev:latest"

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   fossa:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-operator' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: ${{ github.event_name != 'pull_request' }}
+          publish_results: ${{ github.event_name != 'pull_request' && github.repository == 'open-telemetry/opentelemetry-operator' }}
 
       # Upload the results as artifacts (optional). Commenting out will disable
       # uploads of run results in SARIF format to the repository Actions tab.
@@ -45,6 +45,7 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
+        if: ${{ github.repository == 'open-telemetry/opentelemetry-operator' }}
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/publish-operator-hub.yaml
+++ b/.github/workflows/publish-operator-hub.yaml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   operator-hub-prod-release:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-operator' }}
     permissions: # required by the reusable workflow
       contents: write
     uses: ./.github/workflows/reusable-operator-hub-release.yaml
@@ -19,6 +20,7 @@ jobs:
       OPENTELEMETRYBOT_GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
 
   operator-hub-community-release:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-operator' }}
     permissions: # required by the reusable workflow
       contents: write
     uses: ./.github/workflows/reusable-operator-hub-release.yaml

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   stale:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-operator' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0


### PR DESCRIPTION
Guards the housekeeping / org-credentialed workflows with a `github.repository == 'open-telemetry/opentelemetry-operator'` check so they no longer run (and fail or create noise) in forks. Upstream behavior is unchanged — the guard is always `true` there.

| Workflow | Change |
|---|---|
| `fossa.yml` | guard the `fossa` job (needs `FOSSA_API_KEY`) |
| `publish-operator-hub.yaml` | guard both release jobs (open PRs to external operator-hub repos, need `OPENTELEMETRYBOT_GITHUB_TOKEN`) |
| `stale.yaml` | guard the `stale` job (acts on the repo's own PRs) |
| `create-release-issue.yaml` | guard the cron job (creates release-tracking issues) |
| `e2e-nightly.yaml` | guard the entry `run-e2e-tests` job; dependent retry / issue-creation jobs then skip naturally |
| `ossf-scorecard.yml` | gate **only** result publishing (`publish_results`) and the code-scanning SARIF upload — the scan itself still runs on fork PRs |

Fork owners who actually want one of these can flip the guard in their own copy of the workflow.