### PR TITLE
[chore] Gate Docker Hub publishing on secret presence

### DIFF
--- a/.github/workflows/publish-autoinstrumentation-dotnet.yaml
+++ b/.github/workflows/publish-autoinstrumentation-dotnet.yaml
@@ -27,6 +27,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +41,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/autoinstrumentation-dotnet
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/autoinstrumentation-dotnet' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-dotnet
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
@@ -52,7 +54,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-autoinstrumentation-java.yaml
+++ b/.github/workflows/publish-autoinstrumentation-java.yaml
@@ -27,6 +27,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +41,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/autoinstrumentation-java
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/autoinstrumentation-java' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-java
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
@@ -53,7 +55,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-autoinstrumentation-nodejs.yaml
+++ b/.github/workflows/publish-autoinstrumentation-nodejs.yaml
@@ -27,6 +27,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +41,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/autoinstrumentation-nodejs
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/autoinstrumentation-nodejs' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-nodejs
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
@@ -52,7 +54,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-autoinstrumentation-python.yaml
+++ b/.github/workflows/publish-autoinstrumentation-python.yaml
@@ -27,6 +27,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,7 +41,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/autoinstrumentation-python
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/autoinstrumentation-python' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/autoinstrumentation-python
           tags: |
             type=match,pattern=v(.*),group=1,value=v${{ env.VERSION }}
@@ -52,7 +54,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -26,6 +26,8 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
       image: ${{ steps.release-image.outputs.image }}
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -72,7 +74,7 @@ jobs:
         with:
           images: |
             ${{ env.GHCR_IMAGE }}
-            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ secrets.DOCKER_USERNAME != '' && env.DOCKERHUB_IMAGE || '' }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -91,7 +93,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -124,4 +126,6 @@ jobs:
           UPLOAD: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || 'false' }}
         run: |
           make cosign-sign IMAGE="${GHCR_IMAGE}" DIGEST="${DIGEST}" UPLOAD="${UPLOAD}"
-          make cosign-sign IMAGE="${DOCKERHUB_IMAGE}" DIGEST="${DIGEST}" UPLOAD="${UPLOAD}"
+          if [ -n "${DOCKER_USERNAME}" ]; then
+            make cosign-sign IMAGE="${DOCKERHUB_IMAGE}" DIGEST="${DIGEST}" UPLOAD="${UPLOAD}"
+          fi

--- a/.github/workflows/publish-must-gather.yaml
+++ b/.github/workflows/publish-must-gather.yaml
@@ -21,6 +21,8 @@ jobs:
       id-token: write
     name: Publish must-gather container image
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -59,7 +61,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-operator-bundle.yaml
+++ b/.github/workflows/publish-operator-bundle.yaml
@@ -21,6 +21,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -30,7 +32,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/opentelemetry-operator-bundle
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/opentelemetry-operator-bundle' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/operator-bundle
           tags: |
             type=semver,pattern={{version}}
@@ -46,7 +48,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-operator-opamp-bridge.yaml
+++ b/.github/workflows/publish-operator-opamp-bridge.yaml
@@ -24,6 +24,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,7 +47,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/operator-opamp-bridge
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/operator-opamp-bridge' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/operator-opamp-bridge
           tags: |
             type=semver,pattern={{version}}
@@ -61,7 +63,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-target-allocator.yaml
+++ b/.github/workflows/publish-target-allocator.yaml
@@ -24,6 +24,8 @@ jobs:
       attestations: write
       id-token: write
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -45,7 +47,7 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
-            otel/target-allocator
+            ${{ secrets.DOCKER_USERNAME != '' && 'otel/target-allocator' || '' }}
             ghcr.io/${{ github.repository_owner }}/opentelemetry-operator/target-allocator
           tags: |
             type=semver,pattern={{version}}
@@ -61,7 +63,7 @@ jobs:
 
       - name: Log into Docker.io
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.DOCKER_USERNAME != '' }}
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Make the Docker Hub image, login, and signing steps conditional on DOCKER_USERNAME being set so the publish workflows succeed in forks without Docker Hub credentials. The otel/* image is dropped from the metadata image list when the secret is absent, the Docker.io login step is skipped, and the Docker Hub cosign-sign call is guarded.

Behavior in this repo is unchanged: with the secret set the otel/* image, login, and signing all run exactly as before.
