### PR TITLE
[chore] Address zizmor CI security findings

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/ci-markdown-link.yml
+++ b/.github/workflows/ci-markdown-link.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # equivalent cli: linkspector check
       - name: Run linkspector

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -47,6 +49,8 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -82,6 +86,8 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -105,6 +111,8 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/create-release-issue.yaml
+++ b/.github/workflows/create-release-issue.yaml
@@ -21,9 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Create release issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          hack/create-release-issue.sh ${{ inputs.version && format('--version {0}', inputs.version) || '' }}
+          if [ -n "$INPUT_VERSION" ]; then
+            hack/create-release-issue.sh --version "$INPUT_VERSION"
+          else
+            hack/create-release-issue.sh
+          fi

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,5 +18,7 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/e2e-junit-report.yml
+++ b/.github/workflows/e2e-junit-report.yml
@@ -1,6 +1,6 @@
 name: E2E Junit Report
 on:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers] only reads artifacts and event metadata from the triggering run, never executes untrusted code
     workflows: [ "End-to-end tests" ]
     types: [ completed ]
   workflow_dispatch:

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   run-e2e-tests:
@@ -28,13 +27,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: [run-e2e-tests, retry-on-failure]
     if: always() && (needs.run-e2e-tests.result == 'failure' && needs.retry-on-failure.result == 'failure')
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      
-      
+        with:
+          persist-credentials: false
+
+
       - name: Create issue on test failure
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
         with:
           script: |
             // Get team members
@@ -49,17 +60,17 @@ jobs:
               console.log('Could not fetch team members:', error.message);
               approvers = ['@open-telemetry/operator-approvers'];
             }
-            
+
             const title = `Nightly e2e tests failed with contrib-dev collector`;
             const body = `
             ## Summary
             The nightly end-to-end tests using the latest \`otel/opentelemetry-collector-contrib-dev\` image have failed.
-            
+
             ## Details
-            - **Workflow run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            - **Triggered on**: ${{ github.event_name }}
-            - **Branch**: ${{ github.ref_name }}
-            - **Commit**: ${{ github.sha }}
+            - **Workflow run**: ${process.env.SERVER_URL}/${process.env.REPOSITORY}/actions/runs/${process.env.RUN_ID}
+            - **Triggered on**: ${process.env.EVENT_NAME}
+            - **Branch**: ${process.env.REF_NAME}
+            - **Commit**: ${process.env.SHA}
             - **Collector image**: otel/opentelemetry-collector-contrib-dev:latest
             
             ## Action Required

--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       id: setup-go
@@ -109,6 +111,8 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       id: setup-go

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
         with:

--- a/.github/workflows/publish-autoinstrumentation-apache-httpd.yaml
+++ b/.github/workflows/publish-autoinstrumentation-apache-httpd.yaml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Read version
         run: echo "VERSION=$(cat autoinstrumentation/apache-httpd/version.txt)" >> $GITHUB_ENV

--- a/.github/workflows/publish-autoinstrumentation-dotnet.yaml
+++ b/.github/workflows/publish-autoinstrumentation-dotnet.yaml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Read version
         run: echo "VERSION=$(cat autoinstrumentation/dotnet/version.txt)" >> $GITHUB_ENV

--- a/.github/workflows/publish-autoinstrumentation-java.yaml
+++ b/.github/workflows/publish-autoinstrumentation-java.yaml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Read version
         run: echo "VERSION=$(cat autoinstrumentation/java/version.txt)" >> $GITHUB_ENV

--- a/.github/workflows/publish-autoinstrumentation-nodejs.yaml
+++ b/.github/workflows/publish-autoinstrumentation-nodejs.yaml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Read version
         run: echo VERSION=$(cat autoinstrumentation/nodejs/package.json | jq -r '.dependencies."@opentelemetry/auto-instrumentations-node"') >> $GITHUB_ENV

--- a/.github/workflows/publish-autoinstrumentation-php.yaml
+++ b/.github/workflows/publish-autoinstrumentation-php.yaml
@@ -30,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Read version
         run: echo "VERSION=$(cat autoinstrumentation/php/version.txt)" >> $GITHUB_ENV
@@ -55,7 +57,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare files for docker image
-        run: pushd ./autoinstrumentation/php ; ./prepare_files_for_docker_image.sh --ext-ver ${{ env.VERSION }} --dest-dir ${PWD}/files_for_docker_image ; popd
+        run: pushd ./autoinstrumentation/php ; ./prepare_files_for_docker_image.sh --ext-ver $VERSION --dest-dir ${PWD}/files_for_docker_image ; popd
 
       - name: Build and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0

--- a/.github/workflows/publish-autoinstrumentation-python.yaml
+++ b/.github/workflows/publish-autoinstrumentation-python.yaml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Read version
         run: echo VERSION=$(head -n 1 autoinstrumentation/python/requirements.txt | cut -d '=' -f3) >> $GITHUB_ENV

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -30,10 +30,13 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "~1.26.3"
+          cache: false
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/publish-must-gather.yaml
+++ b/.github/workflows/publish-must-gather.yaml
@@ -25,10 +25,13 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "~1.26.3"
+          cache: false
 
       - name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/publish-operator-bundle.yaml
+++ b/.github/workflows/publish-operator-bundle.yaml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Docker meta
         id: docker_meta

--- a/.github/workflows/publish-operator-opamp-bridge.yaml
+++ b/.github/workflows/publish-operator-opamp-bridge.yaml
@@ -29,10 +29,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "~1.26.3"
+          cache: false
 
       - name: Build the binary for each supported architecture
         run: |

--- a/.github/workflows/publish-target-allocator.yaml
+++ b/.github/workflows/publish-target-allocator.yaml
@@ -29,10 +29,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "~1.26.3"
+          cache: false
 
       - name: Build the binary for each supported architecture
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: "Get versions from versions.txt"
         id: get-versions
         run: |
@@ -37,11 +38,14 @@ jobs:
       DESIRED_VERSION: ${{ needs.get-versions.outputs.desired_version }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: "~1.26.3"
+        cache: false
 
     - name: "generate release resources"
       run: make release-artifacts IMG_PREFIX="ghcr.io/open-telemetry/opentelemetry-operator" VERSION=${DESIRED_VERSION}

--- a/.github/workflows/reusable-operator-hub-release.yaml
+++ b/.github/workflows/reusable-operator-hub-release.yaml
@@ -36,12 +36,14 @@ jobs:
       - name: Sync fork
         env:
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          INPUT_REPO: ${{ inputs.repo }}
+          INPUT_ORG: ${{ inputs.org }}
         run: |
           # synchronizing the fork is fast, and avoids the need to fetch the full upstream repo
           # (fetching the upstream repo with "--depth 1" would lead to "shallow update not allowed"
           #  error when pushing back to the origin repo)
-          gh repo sync opentelemetrybot/${{ inputs.repo }} \
-              --source ${{ inputs.org }}/${{ inputs.repo }} \
+          gh repo sync "opentelemetrybot/${INPUT_REPO}" \
+              --source "${INPUT_ORG}/${INPUT_REPO}" \
               --force
 
       - name: Checkout operatorhub repo
@@ -56,13 +58,15 @@ jobs:
           repository: open-telemetry/opentelemetry-operator
           token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
           path: tmp/
+          persist-credentials: false
 
       - name: Update version
         env:
           VERSION: ${{ env.version }}
+          INPUT_FOLDER: ${{ inputs.folder }}
         run: |
           mkdir operators/opentelemetry-operator/${VERSION}
-          cp -R ./tmp/bundle/${{ inputs.folder }}/* operators/opentelemetry-operator/${VERSION}
+          cp -R ./tmp/bundle/${INPUT_FOLDER}/* operators/opentelemetry-operator/${VERSION}
           rm -rf ./tmp
 
       - name: Use CLA approved github bot
@@ -74,6 +78,8 @@ jobs:
         env:
           VERSION: ${{ env.version }}
           GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          INPUT_ORG: ${{ inputs.org }}
+          INPUT_REPO: ${{ inputs.repo }}
         run: |
           message="Update the opentelemetry to $VERSION"
           body="Release opentelemetry-operator \`$VERSION\`.
@@ -92,5 +98,5 @@ jobs:
           git push -f --set-upstream origin $branch
           gh pr create --title "$message" \
                        --body "$body" \
-                       --repo ${{ inputs.org }}/${{ inputs.repo }} \
+                       --repo "${INPUT_ORG}/${INPUT_REPO}" \
                        --base main

--- a/.github/workflows/reusable-operator-hub-release.yaml
+++ b/.github/workflows/reusable-operator-hub-release.yaml
@@ -47,7 +47,7 @@ jobs:
               --force
 
       - name: Checkout operatorhub repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] credentials must persist for the git push later in this job
         with:
           repository: opentelemetrybot/${{ inputs.repo }}
           token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}

--- a/.github/workflows/reusable-publish-test-e2e-images.yaml
+++ b/.github/workflows/reusable-publish-test-e2e-images.yaml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Cache tools
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -16,6 +16,8 @@ jobs:
       SHELLCHECK_VERSION: v0.10.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: shellcheck ci scripts
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         env:


### PR DESCRIPTION
**Description:**

Resolves findings from a local zizmor scan (https://github.com/open-telemetry/sig-security/issues/268).

- artipacked: add `persist-credentials: false` to all `actions/checkout` steps that do not require credentials for subsequent git operations (26 call sites across 24 workflows). The one exception is the first checkout in reusable-operator-hub-release.yaml, which must retain credentials to authenticate the git push that follows.

- cache-poisoning: add `cache: false` to `actions/setup-go` in the five publishing workflows (publish-images, publish-must-gather, publish-operator-opamp-bridge, publish-target-allocator, release). These workflows run on push/tag and produce release artifacts, so a poisoned Go module cache could influence the published output.

- template-injection: move workflow/input context expressions out of `run:` blocks and into step-level `env:` maps, then reference them as shell variables. Affected: create-release-issue.yaml (inputs.version), e2e-nightly.yaml (github.* context in github-script body), reusable-operator-hub-release.yaml (inputs.repo / inputs.org / inputs.folder in three separate steps), publish-autoinstrumentation-php (env.VERSION already available as a shell variable).

- excessive-permissions: scope `issues: write` in e2e-nightly.yaml from the workflow level down to the single job that actually creates issues (create-issue-on-failure).

I think we'll eventually want to re-enable caching for builds on `main` after we move them to a separate repository, but I think it's fine to remove them for now.

This leaves two reports unfixed:

```
error[dangerous-triggers]: use of fundamentally insecure workflow trigger
  --> ./.github/workflows/e2e-junit-report.yml:2:1
   |
 2 | / on:
 3 | |   workflow_run:
 4 | |     workflows: [ "End-to-end tests" ]
 5 | |     types: [ completed ]
...  |
 9 | |         description: "Workflow ID"
10 | |         required: true
   | |______________________^ workflow_run is almost always used insecurely
   |
   = note: audit confidence → Medium

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/reusable-operator-hub-release.yaml:49:9
   |
49 |         - name: Checkout operatorhub repo
   |  _________^
50 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
51 | |         with:
52 | |           repository: opentelemetrybot/${{ inputs.repo }}
53 | |           token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
   | |_____________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix
```

Because these are intentional and will require exceptions or a more involved change. I ignored these via inline comments for now.

**Link to tracking Issue(s):**

- Relates https://github.com/open-telemetry/sig-security/issues/268
- Relates https://github.com/open-telemetry/admin/pull/687

