### PR TITLE
[chore] Fix flaky privilege-escalation e2e tests

### DIFF
--- a/tests/e2e-automatic-rbac/privilege-escalation-check/01-install.yaml
+++ b/tests/e2e-automatic-rbac/privilege-escalation-check/01-install.yaml
@@ -47,7 +47,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ($namespace)-events-reader
+  name: (join('-', [$namespace, 'events-reader']))
 rules:
 - apiGroups: [""]
   resources: ["events"]
@@ -56,11 +56,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ($namespace)-permitted-user-events
+  name: (join('-', [$namespace, 'permitted-user-events']))
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ($namespace)-events-reader
+  name: (join('-', [$namespace, 'events-reader']))
 subjects:
 - kind: User
   name: permitted-user

--- a/tests/e2e-automatic-rbac/privilege-escalation-delta/01-install.yaml
+++ b/tests/e2e-automatic-rbac/privilege-escalation-delta/01-install.yaml
@@ -33,7 +33,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ($namespace)-events-reader
+  name: (join('-', [$namespace, 'events-reader']))
 rules:
 - apiGroups: [""]
   resources: ["events"]
@@ -45,11 +45,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ($namespace)-sa-events
+  name: (join('-', [$namespace, 'sa-events']))
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ($namespace)-events-reader
+  name: (join('-', [$namespace, 'events-reader']))
 subjects:
 - kind: ServiceAccount
   name: privilege-delta-test-collector


### PR DESCRIPTION
Tale as old as time, another clusterrole name collision, this one from a misuse of chainsaw templating syntax. Fixes recent flaky failures of this test, including https://github.com/open-telemetry/opentelemetry-operator/issues/5154.
