### PR TITLE
fix(opamp-bridge): exclude terminating collectors from EffectiveConfig

### DIFF
--- a/.chloggen/fix-opamp-deleted-effective.yaml
+++ b/.chloggen/fix-opamp-deleted-effective.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: opamp
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Skip OpenTelemetryCollector instances with a non-nil DeletionTimestamp when building EffectiveConfig
+
+# One or more tracking issues related to the change
+issues: [5170]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  ListInstances returns objects with DeletionTimestamp set until finalizers complete.
+  Reporting them as effective races with the bridge's own Delete calls in applyRemoteConfig.

--- a/cmd/operator-opamp-bridge/internal/agent/agent.go
+++ b/cmd/operator-opamp-bridge/internal/agent/agent.go
@@ -348,6 +348,10 @@ func (agent *Agent) getEffectiveConfig(context.Context) (*protobufs.EffectiveCon
 	}
 	instanceMap := map[string]*protobufs.AgentConfigFile{}
 	for _, instance := range instances {
+		// Skip collectors pending deletion
+		if deletionTimestamp := instance.GetDeletionTimestamp(); deletionTimestamp != nil {
+			continue
+		}
 		col := instance
 		marshaled, err := yaml.Marshal(&col)
 		if err != nil {

--- a/cmd/operator-opamp-bridge/internal/agent/agent.go
+++ b/cmd/operator-opamp-bridge/internal/agent/agent.go
@@ -349,7 +349,7 @@ func (agent *Agent) getEffectiveConfig(context.Context) (*protobufs.EffectiveCon
 	instanceMap := map[string]*protobufs.AgentConfigFile{}
 	for _, instance := range instances {
 		// Skip collectors pending deletion
-		if deletionTimestamp := instance.GetDeletionTimestamp(); deletionTimestamp != nil {
+		if instance.GetDeletionTimestamp() != nil {
 			continue
 		}
 		col := instance

--- a/cmd/operator-opamp-bridge/internal/agent/agent_test.go
+++ b/cmd/operator-opamp-bridge/internal/agent/agent_test.go
@@ -580,6 +580,55 @@ func TestAgent_getHealth(t *testing.T) {
 	}
 }
 
+func TestAgent_getEffectiveConfig(t *testing.T) {
+	t.Run("skip terminating", func(t *testing.T) {
+		mockClient := &mockOpampClient{}
+		conf := config.NewConfig(logr.Discard())
+		loadErr := config.LoadFromFile(conf, agentTestFileName)
+		require.NoError(t, loadErr, "should be able to load config")
+
+		now := metav1.Now()
+		aliveCollector := v1beta1.OpenTelemetryCollector{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testCollectorName,
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					operator.ManagedLabelKey: "true",
+				},
+			},
+		}
+		terminatingCollector := v1beta1.OpenTelemetryCollector{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      otherCollectorName,
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					operator.ManagedLabelKey: "true",
+				},
+				// Required at least one finalizer when DeletionTimestamp is set
+				Finalizers:        []string{"opentelemetrycollector.opentelemetry.io/finalizer-test"},
+				DeletionTimestamp: &now,
+			},
+		}
+		collectorList := &v1beta1.OpenTelemetryCollectorList{
+			Items: []v1beta1.OpenTelemetryCollector{aliveCollector, terminatingCollector},
+		}
+
+		applier := getFakeApplier(t, conf, collectorList)
+		mp := newMockProxy(nil, nil, nil)
+		agent := NewAgent(l, applier, conf, mockClient, mp)
+		err := agent.Start()
+		defer agent.Shutdown()
+		require.NoError(t, err, "should be able to start agent")
+
+		effectiveConfig, err := agent.getEffectiveConfig(context.Background())
+		require.NoError(t, err, "should be able to get effective config")
+
+		cfgMap := effectiveConfig.GetConfigMap().GetConfigMap()
+		assert.Contains(t, cfgMap, testCollectorKey, "alive collector must be reported as effective")
+		assert.NotContains(t, cfgMap, otherCollectorKey, "terminating collector must not be reported as effective")
+	})
+}
+
 func TestAgent_onMessage(t *testing.T) {
 	mockInstanceId := uuid.New()
 	type fields struct {

--- a/cmd/operator-opamp-bridge/internal/agent/agent_test.go
+++ b/cmd/operator-opamp-bridge/internal/agent/agent_test.go
@@ -620,7 +620,7 @@ func TestAgent_getEffectiveConfig(t *testing.T) {
 		defer agent.Shutdown()
 		require.NoError(t, err, "should be able to start agent")
 
-		effectiveConfig, err := agent.getEffectiveConfig(context.Background())
+		effectiveConfig, err := agent.getEffectiveConfig(t.Context())
 		require.NoError(t, err, "should be able to get effective config")
 
 		cfgMap := effectiveConfig.GetConfigMap().GetConfigMap()


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

`applyRemoteConfig` calls `applier.Delete` on collectors that are no longer in the config. Delete is asynchronous in k8s, sets deletionTimestamp and leaves the actual cleanup to finalizer. `UpdateEffectiveConfig` call that fires right after still sees those terminating collectors, so the bridge ends up reporting collectors that are on their way out as part of the effective config.

This patch filters out any OpenTelemetryCollector with a non-nil deletionTimestamp.

**Testing:** <Describe what testing was performed and which tests were added.>

- Added `TestAgent_getEffectiveConfig/skip_terminating`