### PR TITLE
[chore] Remove unused nolint:exhaustive directive

### DIFF
--- a/internal/status/collector/collector.go
+++ b/internal/status/collector/collector.go
@@ -54,7 +54,7 @@ func updateCollectorStatus(ctx context.Context, cli client.Client, changed *v1be
 	var statusReplicas string
 	var statusImage string
 
-	switch mode { //nolint:exhaustive
+	switch mode {
 	case v1beta1.ModeDeployment:
 		obj := &appsv1.Deployment{}
 		if err := cli.Get(ctx, objKey, obj); err != nil {
@@ -84,6 +84,8 @@ func updateCollectorStatus(ctx context.Context, cli client.Client, changed *v1be
 		readyReplicas = obj.Status.NumberReady
 		statusReplicas = strconv.Itoa(int(readyReplicas)) + "/" + strconv.Itoa(int(replicas))
 		statusImage = obj.Spec.Template.Spec.Containers[0].Image
+
+	case v1beta1.ModeSidecar:
 	}
 
 	changed.Status.Scale.Replicas = replicas


### PR DESCRIPTION
## Summary
- Removes an unused `//nolint:exhaustive` directive in `internal/status/collector/collector.go` that causes the `nolintlint` linter to fail CI.

## Test plan
- [ ] CI lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)