### PR TITLE
[Chore] fix OpenShift OLM e2e tests for must-gather, tls-profile, and instrumentation-blocked-upgrade

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/00-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/00-assert.yaml
@@ -2,8 +2,3 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   name: blocked-upgrade-test
-spec:
-  dotnet:
-    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
-  java:
-    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.33.6"

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/01-assert.yaml
@@ -2,8 +2,3 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   name: upgrade-test
-spec:
-  dotnet:
-    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
-  java:
-    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.33.6"

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/02-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/02-assert.yaml
@@ -2,11 +2,6 @@ apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:
   name: upgrade-test
-spec:
-  dotnet:
-    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
-  java:
-    image: "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.33.6"
 status:
   upgradeBlockedVersions:
     dotnet: "Automated upgrade blocked for dotnet: .NET instrumentation 1.3.0 contains breaking HTTP semantic convention changes. See https://opentelemetry.io/blog/2023/http-conventions-declared-stable/ for a general description of the changes. To upgrade, manually set the image on this Instrumentation resource to 1.3.0 or higher."

--- a/tests/e2e-instrumentation/instrumentation-blocked-upgrade/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-blocked-upgrade/chainsaw-test.yaml
@@ -9,9 +9,58 @@ spec:
   - name: Create instrumentation with blocked dotnet and java versions and verify webhook warnings
     try:
     - script:
-        timeout: 30s
+        timeout: 60s
+        shell: /bin/bash
         content: |
-          kubectl apply -n $NAMESPACE -f 00-install-instrumentation-blocked.yaml 2>&1
+          #!/bin/bash
+          set -eo pipefail
+
+          NS=opentelemetry-operator-system
+          DEPLOY=opentelemetry-operator-controller-manager
+
+          # Get the operator's effective default images (env var overrides compiled-in args).
+          DEFAULT_DOTNET=$(kubectl get deploy -n "$NS" "$DEPLOY" \
+            -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RELATED_IMAGE_AUTO_INSTRUMENTATION_DOTNET")].value}' 2>/dev/null || true)
+          DEFAULT_JAVA=$(kubectl get deploy -n "$NS" "$DEPLOY" \
+            -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RELATED_IMAGE_AUTO_INSTRUMENTATION_JAVA")].value}' 2>/dev/null || true)
+
+          # Fall back to the compiled-in upstream defaults when no env override is present (kind/direct install).
+          [ -z "$DEFAULT_DOTNET" ] && DEFAULT_DOTNET="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0"
+          [ -z "$DEFAULT_JAVA" ] && DEFAULT_JAVA="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.28.1"
+
+          DOTNET_REPO="${DEFAULT_DOTNET%:*}"
+          JAVA_REPO="${DEFAULT_JAVA%:*}"
+          DOTNET_DEFAULT_TAG="${DEFAULT_DOTNET##*:}"
+
+          # Choose test images based on whether the default tag is semver-parseable:
+          #   Semver default (e.g. 1.15.0): use a version BELOW the blocked threshold so the
+          #     range check (current < blocked <= target) fires.
+          #   Non-semver default (e.g. "latest"): use the EXACT blocked version so the
+          #     exact-match fallback in IsInstrumentationVersionUnupgradable fires.
+          if echo "$DOTNET_DEFAULT_TAG" | grep -qE '^v?[0-9]+\.[0-9]+'; then
+            BLOCKED_DOTNET_IMG="${DOTNET_REPO}:1.2.0"
+            BLOCKED_JAVA_IMG="${JAVA_REPO}:1.33.6"
+          else
+            BLOCKED_DOTNET_IMG="${DOTNET_REPO}:1.3.0"
+            BLOCKED_JAVA_IMG="${JAVA_REPO}:2.0.0"
+          fi
+          echo "Using blocked images: dotnet=$BLOCKED_DOTNET_IMG  java=$BLOCKED_JAVA_IMG"
+
+          kubectl apply -n "$NAMESPACE" -f - 2>&1 << EOF
+          apiVersion: opentelemetry.io/v1alpha1
+          kind: Instrumentation
+          metadata:
+            name: blocked-upgrade-test
+          spec:
+            exporter:
+              endpoint: http://localhost:4317
+            sampler:
+              type: always_on
+            dotnet:
+              image: "${BLOCKED_DOTNET_IMG}"
+            java:
+              image: "${BLOCKED_JAVA_IMG}"
+          EOF
         check:
           (contains($stdout, 'cannot be automatically upgraded')): true
     - assert:
@@ -24,12 +73,31 @@ spec:
         content: |
           #!/bin/bash
           set -eo pipefail
-          DEPLOY=opentelemetry-operator-controller-manager
-          OLD_DOTNET_IMG="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.2.0"
-          OLD_JAVA_IMG="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:1.33.6"
 
           NS=opentelemetry-operator-system
-          echo "Operator namespace: $NS"
+          DEPLOY=opentelemetry-operator-controller-manager
+
+          # Get the operator's effective default images
+          DEFAULT_DOTNET=$(kubectl get deploy -n "$NS" "$DEPLOY" \
+            -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RELATED_IMAGE_AUTO_INSTRUMENTATION_DOTNET")].value}' 2>/dev/null || true)
+          DEFAULT_JAVA=$(kubectl get deploy -n "$NS" "$DEPLOY" \
+            -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RELATED_IMAGE_AUTO_INSTRUMENTATION_JAVA")].value}' 2>/dev/null || true)
+          [ -z "$DEFAULT_DOTNET" ] && DEFAULT_DOTNET="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0"
+          [ -z "$DEFAULT_JAVA" ] && DEFAULT_JAVA="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.28.1"
+
+          DOTNET_REPO="${DEFAULT_DOTNET%:*}"
+          JAVA_REPO="${DEFAULT_JAVA%:*}"
+          DOTNET_DEFAULT_TAG="${DEFAULT_DOTNET##*:}"
+
+          # Use the same image selection logic as step 1
+          if echo "$DOTNET_DEFAULT_TAG" | grep -qE '^v?[0-9]+\.[0-9]+'; then
+            OLD_DOTNET_IMG="${DOTNET_REPO}:1.2.0"
+            OLD_JAVA_IMG="${JAVA_REPO}:1.33.6"
+          else
+            OLD_DOTNET_IMG="${DOTNET_REPO}:1.3.0"
+            OLD_JAVA_IMG="${JAVA_REPO}:2.0.0"
+          fi
+          echo "Using old images: dotnet=$OLD_DOTNET_IMG  java=$OLD_JAVA_IMG"
 
           # Detect whether OLM is managing the operator by checking for a CSV.
           # On kind (upstream CI): no OLM, no CSV — patch the Deployment directly (persists).
@@ -53,7 +121,6 @@ spec:
               -p="[{\"op\":\"replace\",\"path\":\"/spec/install/spec/deployments/0/spec/template/spec/containers/0/args\",\"value\":$NEW_ARGS}]"
 
             # Poll the Deployment spec until OLM propagates the CSV args change.
-            # OLM may need multiple reconciliation cycles to apply the update.
             echo "Waiting for OLM to propagate args from CSV to operator Deployment..."
             TIMEOUT=120
             ELAPSED=0
@@ -101,9 +168,9 @@ spec:
         content: |
           #!/bin/bash
           set -eo pipefail
-          DEPLOY=opentelemetry-operator-controller-manager
 
           NS=opentelemetry-operator-system
+          DEPLOY=opentelemetry-operator-controller-manager
 
           CSV_NAME=$(kubectl get csv -n "$NS" \
             -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
@@ -156,10 +223,8 @@ spec:
           sleep 5
   - name: Assert upgrades were blocked
     try:
-    # DotNet image should still be 1.2.0 and Java image should still be 1.33.6
-    # (neither upgraded to their respective compiled-in defaults), and the
-    # Instrumentation status should record the blocked upgrade reason for both
-    # languages.
+    # The Instrumentation status should record the blocked upgrade reason for both
+    # languages, regardless of which image registry or tag the operator uses.
     - assert:
         file: 02-assert.yaml
     # Verify both UpgradeBlocked events were emitted by the operator. We do
@@ -174,6 +239,38 @@ spec:
         content: |
           #!/bin/bash
           set -eo pipefail
+
+          NS=opentelemetry-operator-system
+          DEPLOY=opentelemetry-operator-controller-manager
+
+          # Compute the current (restored) operator defaults — the images upgrade-test must NOT have.
+          CURRENT_DOTNET=$(kubectl get deploy -n "$NS" "$DEPLOY" \
+            -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RELATED_IMAGE_AUTO_INSTRUMENTATION_DOTNET")].value}' 2>/dev/null || true)
+          CURRENT_JAVA=$(kubectl get deploy -n "$NS" "$DEPLOY" \
+            -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RELATED_IMAGE_AUTO_INSTRUMENTATION_JAVA")].value}' 2>/dev/null || true)
+          [ -z "$CURRENT_DOTNET" ] && CURRENT_DOTNET="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet:1.15.0"
+          [ -z "$CURRENT_JAVA" ] && CURRENT_JAVA="ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.28.1"
+
+          # Verify the images in upgrade-test were NOT auto-upgraded to the current defaults.
+          # This is the core proof that upgrade blocking worked: the images must still be at
+          # the old blocked version set in step 2, not at the restored current defaults.
+          ACTUAL_DOTNET=$(kubectl get instrumentation upgrade-test -n "$NAMESPACE" \
+            -o jsonpath='{.spec.dotnet.image}' 2>/dev/null || true)
+          ACTUAL_JAVA=$(kubectl get instrumentation upgrade-test -n "$NAMESPACE" \
+            -o jsonpath='{.spec.java.image}' 2>/dev/null || true)
+
+          if [ "$ACTUAL_DOTNET" = "$CURRENT_DOTNET" ]; then
+            echo "ERROR: dotnet image was auto-upgraded to current default '$CURRENT_DOTNET' — blocking failed" >&2
+            exit 1
+          fi
+          if [ "$ACTUAL_JAVA" = "$CURRENT_JAVA" ]; then
+            echo "ERROR: java image was auto-upgraded to current default '$CURRENT_JAVA' — blocking failed" >&2
+            exit 1
+          fi
+          echo "Images preserved at blocked version (not auto-upgraded):"
+          echo "  dotnet: $ACTUAL_DOTNET"
+          echo "  java:   $ACTUAL_JAVA"
+
           # Events are queued by the operator's event recorder and flushed
           # asynchronously, so the Instrumentation status may be updated before
           # the events surface in the API. Retry briefly to allow them to land.
@@ -206,7 +303,6 @@ spec:
         format: yaml
     - script:
         content: |
-          NS=opentelemetry-operator-system
-          kubectl logs -n "$NS" \
+          kubectl logs -n opentelemetry-operator-system \
             -l app.kubernetes.io/name=opentelemetry-operator \
             --container manager --tail=100 || true

--- a/tests/e2e-openshift-tls-profile/tls-profile/06-verify-changed-profile.sh
+++ b/tests/e2e-openshift-tls-profile/tls-profile/06-verify-changed-profile.sh
@@ -10,10 +10,13 @@ EXPECTED_MIN=$(oc get configmap tls-profile-expected -n "$NAMESPACE" -o jsonpath
 EXPECTED_CIPHERS=$(oc get configmap tls-profile-expected -n "$NAMESPACE" -o jsonpath='{.data.expect_ciphers}')
 echo "Verifying profile: min_version=$EXPECTED_MIN, expect_ciphers=$EXPECTED_CIPHERS"
 
-# Get the collector ConfigMap name (it includes a hash suffix)
-CM_NAME=$(kubectl get configmap -n "$NAMESPACE" -l app.kubernetes.io/component=opentelemetry-collector \
-  -o jsonpath='{.items[0].metadata.name}')
-[ -n "$CM_NAME" ] || fail "collector ConfigMap not found"
+# Get the collector ConfigMap name from the deployment's volume reference.
+# The operator intentionally keeps the previous ConfigMap for one extra reconcile cycle
+# (configVersionsToKeep+1) to support rollbacks, so listing by label can return a stale
+# ConfigMap. Reading from the deployment volume spec always gives the current one.
+CM_NAME=$(kubectl get deployment tls-profile-test-collector -n "$NAMESPACE" \
+  -o jsonpath='{.spec.template.spec.volumes[?(@.name=="otc-internal")].configMap.name}' 2>/dev/null || true)
+[ -n "$CM_NAME" ] || fail "collector ConfigMap not found in deployment volume spec"
 
 # Extract the collector.yaml from the ConfigMap and convert YAML to JSON
 CONFIG=$(kubectl get configmap "$CM_NAME" -n "$NAMESPACE" -o jsonpath='{.data.collector\.yaml}' | yq -o json)

--- a/tests/e2e-openshift/must-gather/check_must_gather.sh
+++ b/tests/e2e-openshift/must-gather/check_must_gather.sh
@@ -4,7 +4,7 @@
 MUST_GATHER_DIR=$(mktemp -d)
 
 # Run the must-gather script
-oc adm must-gather --dest-dir=$MUST_GATHER_DIR --image=ghcr.io/open-telemetry/opentelemetry-operator/must-gather:latest -- /usr/bin/gather --operator-namespace $otelnamespace
+oc adm must-gather --dest-dir=$MUST_GATHER_DIR --image=ghcr.io/open-telemetry/opentelemetry-operator/must-gather:main -- /usr/bin/gather --operator-namespace $otelnamespace
 
 # Define required files and directories
 REQUIRED_ITEMS=(
@@ -69,9 +69,17 @@ for item in "${OPTIONAL_ITEMS[@]}"; do
   fi
 done
 
-# Validate output with omc
+# Validate output with omc — download the binary matching the current host OS/arch
 OMC=/tmp/omc
-curl -sL -o "$OMC" https://github.com/gmeghnag/omc/releases/latest/download/omc_Linux_x86_64
+_OS=$(uname -s)
+_ARCH=$(uname -m)
+case "${_OS}/${_ARCH}" in
+  Darwin/arm64)  _OMC_BIN="omc_Darwin_arm64" ;;
+  Darwin/x86_64) _OMC_BIN="omc_Darwin_x86_64" ;;
+  Linux/aarch64) _OMC_BIN="omc_Linux_arm64" ;;
+  *)             _OMC_BIN="omc_Linux_x86_64" ;;
+esac
+curl -sL -o "$OMC" "https://github.com/gmeghnag/omc/releases/latest/download/${_OMC_BIN}"
 chmod +x "$OMC"
 
 OMC_ROOT=$(find "$MUST_GATHER_DIR" -maxdepth 1 -type d -name '*-must-gather-sha256-*' | head -1)


### PR DESCRIPTION
## Summary

Fixes three OpenShift e2e tests that fail when the operator is installed via OLM (OpenShift) with non-upstream image registries, and corrects two environment-specific issues in test tooling.

### must-gather
- Switch from `:latest` to `:main` tag — `:latest` is not published by the `publish-must-gather.yaml` workflow; `:main` is the correct tag built on every push to `main`.
- Make `omc` binary download platform-aware by detecting host OS/arch via `uname -s`/`uname -m`. Previously hardcoded `omc_Linux_x86_64` fails silently on macOS ARM and Linux aarch64 runners.

### tls-profile
- `06-verify-changed-profile.sh`: read the collector ConfigMap name from the deployment's volume spec rather than listing all ConfigMaps by label and sorting alphabetically. The controller intentionally keeps the previous ConfigMap for one extra reconcile cycle (`configVersionsToKeep + 1`) to support rollbacks; the label-based list can return the stale pre-change ConfigMap and produce a false `min_version=1.2` failure after the profile is changed to Modern.

### instrumentation-blocked-upgrade
- Detect the operator's effective default auto-instrumentation images at runtime from the running Deployment's `RELATED_IMAGE_AUTO_INSTRUMENTATION_*` env vars. `IsInstrumentationVersionUnupgradable` short-circuits when the image repo in the CR does not match the operator's configured default repo, so the test must use images from the same registry as the operator's defaults.
- When the default tag is semver-parseable (kind/direct installs, e.g. `1.15.0`), use `1.2.0`/`1.33.6` so the range check fires. When the default tag is non-semver (OLM installs with `latest`), use the exact blocked versions `1.3.0`/`2.0.0` so the exact-match fallback in `IsInstrumentationVersionUnupgradable` fires.
- Remove hardcoded `ghcr.io/open-telemetry/` image refs from assert files; add a dynamic image-preserved check in the step-5 script (verifies images were not auto-upgraded — direct replacement for the removed static image checks).
- Hardcode `NS=opentelemetry-operator-system` (the namespace the test expects) in all scripts instead of dynamic pod-label discovery.

## Test plan

- [x] `must-gather` — passes on OCP 4.22 nightly with OLM install
- [x] `instrumentation-blocked-upgrade` — passes on OCP 4.22 nightly with OLM install and custom quay.io image registry
- [x] `tls-profile` — passes on OCP 4.22 nightly (all 11 steps including Modern profile change)
- [x] Upstream kind CI — image selection logic falls back to `ghcr.io/open-telemetry/` defaults when no `RELATED_IMAGE_*` env vars are set, preserving existing upstream behavior