### PR TITLE
[chore] Pin docker base images

### DIFF
--- a/.github/workflows/publish-test-e2e-images.yaml
+++ b/.github/workflows/publish-test-e2e-images.yaml
@@ -59,7 +59,7 @@ jobs:
     uses: ./.github/workflows/reusable-publish-test-e2e-images.yaml
     with:
       path: python
-      build-args: 'python_version=3.10'
+      build-args: 'BASE_IMAGE=docker.io/library/python:3.10-alpine3.22@sha256:8be23d04f6f85e79a56f6b86761f8bd1db7d3f673917c2fcecb049d4af510dc8'
       tag-suffix: '-3.10'
       platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
   java:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Get CA certificates from alpine package repo
-FROM alpine:3.23 AS certificates
+FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS certificates
 
 RUN apk --no-cache add ca-certificates
 

--- a/autoinstrumentation/apache-httpd/Dockerfile
+++ b/autoinstrumentation/apache-httpd/Dockerfile
@@ -2,7 +2,7 @@
 ############################
 # STEP 1 download the webserver agent 
 ############################
-FROM alpine:latest AS agent
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS agent
 
 ARG version
 
@@ -16,7 +16,7 @@ RUN unzip -p opentelemetry-webserver-sdk-x64-linux.tgz | tar -zx -C agent
 ############################
 # STEP 2 download the webserver agent 
 ############################
-FROM alpine:latest
+FROM alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 COPY --from=agent /opt/opentelemetry/agent/opentelemetry-webserver-sdk /opt/opentelemetry
 

--- a/autoinstrumentation/java/Dockerfile
+++ b/autoinstrumentation/java/Dockerfile
@@ -4,7 +4,7 @@
 #  - Grant the necessary access to the jar. `chmod -R go+r /javaagent.jar`
 #  - For auto-instrumentation by container injection, the Linux command cp is
 #    used and must be available in the image.
-FROM busybox
+FROM busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
 
 ARG version
 

--- a/autoinstrumentation/nodejs/Dockerfile
+++ b/autoinstrumentation/nodejs/Dockerfile
@@ -9,14 +9,14 @@
 # - Grant the necessary access to `/autoinstrumentation` directory. `chmod -R go+r /autoinstrumentation`
 # - For auto-instrumentation by container injection, the Linux command cp is
 #   used and must be available in the image.
-FROM node:26 AS build
+FROM node:26@sha256:e3ffe0cbaeebdcddbfe1ee7bca9b564a92863a8386d5b99a3d72677b3667b61d AS build
 
 WORKDIR /operator-build
 COPY . .
 
 RUN npm install
 
-FROM busybox
+FROM busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
 
 COPY --from=build /operator-build/build/workspace /autoinstrumentation
 

--- a/autoinstrumentation/php/Dockerfile
+++ b/autoinstrumentation/php/Dockerfile
@@ -8,7 +8,7 @@
 #  - For auto-instrumentation by container injection, the Linux command cp is
 #    used and must be available in the image.
 
-FROM busybox
+FROM busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
 
 ARG SUB_DIR_WITH_FILES_FOR_DOCKER_IMAGE
 

--- a/autoinstrumentation/python/Dockerfile
+++ b/autoinstrumentation/python/Dockerfile
@@ -9,7 +9,7 @@
 # - Grant the necessary access to `/autoinstrumentation{,-musl}` directory. `chmod -R go+r /autoinstrumentation`
 # - For auto-instrumentation by container injection, the Linux command cp is
 #   used and must be available in the image.
-FROM python:3.14 AS build
+FROM python:3.14@sha256:250e5c97be05e1eb2272fbdbd810dfd638f9012e1e6f65c99390ad3239943a08 AS build
 
 WORKDIR /operator-build
 
@@ -17,7 +17,7 @@ ADD requirements.txt .
 
 RUN mkdir workspace && pip install --target workspace -r requirements.txt
 
-FROM python:3.14-alpine AS build-musl
+FROM python:3.14-alpine@sha256:5a824eb82cc75361f98611f3cfc5091ea33f10a6ccea4d4ebdabbc523b9a1614 AS build-musl
 
 WORKDIR /operator-build
 
@@ -26,7 +26,7 @@ ADD requirements.txt .
 RUN apk add gcc python3-dev musl-dev linux-headers
 RUN mkdir workspace && pip install --target workspace -r requirements.txt
 
-FROM busybox
+FROM busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
 
 COPY --from=build /operator-build/workspace /autoinstrumentation
 COPY --from=build-musl /operator-build/workspace /autoinstrumentation-musl

--- a/cmd/gather/Dockerfile
+++ b/cmd/gather/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9-minimal:9.8
+FROM registry.access.redhat.com/ubi9-minimal:9.8@sha256:ae09ecc3d754bc1726cbda3e2599cc7839e09fe1cc547ce173cf669b645be3cc
 
 RUN INSTALL_PKGS=" \
   rsync \

--- a/cmd/operator-opamp-bridge/Dockerfile
+++ b/cmd/operator-opamp-bridge/Dockerfile
@@ -1,5 +1,5 @@
 # Get CA certificates from the Alpine package repo
-FROM alpine:3.23 AS certificates
+FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS certificates
 
 RUN apk --no-cache add ca-certificates
 

--- a/cmd/otel-allocator/Dockerfile
+++ b/cmd/otel-allocator/Dockerfile
@@ -1,5 +1,5 @@
 # Get CA certificates from the Alpine package repo
-FROM alpine:3.23 AS certificates
+FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS certificates
 
 RUN apk --no-cache add ca-certificates
 

--- a/renovate.json
+++ b/renovate.json
@@ -76,6 +76,17 @@
       "matchStrings": [
         "image: kindest/node:(?<currentValue>v[\\d\\.]+)@(?<currentDigest>sha256:[a-f0-9]+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update BASE_IMAGE build-arg in test e2e publish workflow",
+      "datasourceTemplate": "docker",
+      "fileMatch": [
+        "(^|/)\\.github/workflows/publish-test-e2e-images\\.yaml$"
+      ],
+      "matchStrings": [
+        "build-args:\\s*['\"]BASE_IMAGE=(?<depName>[^:@'\"\\s]+):(?<currentValue>[^@'\"\\s]+)@(?<currentDigest>sha256:[a-f0-9]{64})['\"]"
+      ]
     }
   ],
   "packageRules": [
@@ -180,8 +191,15 @@
     },
     {
       "matchManagers": ["dockerfile"],
-      "matchFileNames": ["tests/test-e2e-apps/**"],
-      "enabled": false
+      "matchFileNames": ["Dockerfile", "cmd/**/Dockerfile", "autoinstrumentation/**/Dockerfile"],
+      "groupName": "production base images"
+    },
+    {
+      "matchManagers": ["dockerfile", "regex"],
+      "matchDatasources": ["docker"],
+      "matchFileNames": ["tests/**/Dockerfile", ".github/workflows/publish-test-e2e-images.yaml"],
+      "groupName": "test base images",
+      "schedule": ["on monday"]
     }
   ]
 }

--- a/tests/e2e-openshift/Dockerfile
+++ b/tests/e2e-openshift/Dockerfile
@@ -1,6 +1,6 @@
 # The Dockerfile's resulting image is purpose-built for executing OpenTelemetry Operator e2e tests within the OpenShift release (https://github.com/openshift/release) using Prow CI.
 
-FROM docker.io/library/golang:1.26
+FROM docker.io/library/golang:1.26@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a
 
 # Copy the repository files
 COPY . /tmp/opentelemetry-operator

--- a/tests/test-e2e-apps/apache-httpd/Dockerfile
+++ b/tests/test-e2e-apps/apache-httpd/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM docker.io/library/httpd:2.4
+FROM docker.io/library/httpd:2.4@sha256:2a7deaaaf357261a1dffcb8fc725f4aaba2af95fbde1a40a68bca7cb0f03594e
 
 RUN sed -i "s#Listen 80#Listen 8080#g" /usr/local/apache2/conf/httpd.conf
 RUN chmod 777 -R /usr/local/apache2/

--- a/tests/test-e2e-apps/bridge-server/Dockerfile
+++ b/tests/test-e2e-apps/bridge-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.25-alpine AS builder
+FROM docker.io/library/golang:1.25-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/tests/test-e2e-apps/dotnet/Dockerfile
+++ b/tests/test-e2e-apps/dotnet/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim@sha256:fc69dc5e0c9789adaac5c8efce71ead4d016a51318667c4f26ce93574b1b9403 AS build
 ARG TARGETARCH
 WORKDIR /source
 
@@ -19,7 +19,7 @@ WORKDIR /source/DiceRoller
 RUN dotnet publish -a $TARGETARCH -c Release -o /app --no-restore
 
 # Stage 2: Create the runtime image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim@sha256:19be23fe71e885186495d8da1f2d417e553daaa99e16e5148c5ca3ee2f062512
 
 # Environment variables for .NET runtime behavior
 ENV DOTNET_ROLL_FORWARD=Major

--- a/tests/test-e2e-apps/golang/Dockerfile
+++ b/tests/test-e2e-apps/golang/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go application
-FROM docker.io/library/golang:1.23.0-alpine AS builder
+FROM docker.io/library/golang:1.23.0-alpine@sha256:d0b31558e6b3e4cc59f6011d79905835108c919143ebecc58f35965bf79948f4 AS builder
 
 # Set the working directory inside the container for the build stage.
 WORKDIR /app

--- a/tests/test-e2e-apps/java/Dockerfile
+++ b/tests/test-e2e-apps/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk-focal AS builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk-focal@sha256:5751a59a993d1011047d52df2b56a961a328596d75f6bea23c68b6647490db20 AS builder
 
 RUN apt update
 RUN apt install zip unzip -y
@@ -22,7 +22,7 @@ COPY build.gradle .
 RUN find /app/src/main/java -name 'Application.java' -delete
 RUN ./gradlew bootJar --no-daemon
 
-FROM docker.io/library/eclipse-temurin:17.0.8.1_1-jre
+FROM docker.io/library/eclipse-temurin:17.0.8.1_1-jre@sha256:c9ec11571cb0ebc008aadd6ec73d1c14a9e6dec79e88178cf4118cbfee03b3aa
 
 COPY --from=builder /app/build/libs/app-0.0.1-SNAPSHOT.jar .
 ENTRYPOINT ["java", "-jar", "app-0.0.1-SNAPSHOT.jar"]

--- a/tests/test-e2e-apps/metrics-basic-auth/Dockerfile
+++ b/tests/test-e2e-apps/metrics-basic-auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.11-slim
+FROM docker.io/library/python:3.11-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/tests/test-e2e-apps/nodejs/Dockerfile
+++ b/tests/test-e2e-apps/nodejs/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Use an official Node.js image as a base.
-FROM docker.io/library/node:lts-bookworm
+FROM docker.io/library/node:lts-bookworm@sha256:8530f76a96d88820d288761f022e318970dda93d01536919fbc16076b7983e63
 
 # Set the working directory inside the container
 WORKDIR /usr/src/app

--- a/tests/test-e2e-apps/python/Dockerfile
+++ b/tests/test-e2e-apps/python/Dockerfile
@@ -1,6 +1,5 @@
-ARG python_version=3.13
-
-FROM docker.io/library/python:${python_version}-alpine3.22
+ARG BASE_IMAGE=docker.io/library/python:3.13-alpine3.22@sha256:e81548ac35b07a3bd4805f275107592ef458b1e893c0e04d45aedaa19416cca5
+FROM ${BASE_IMAGE}
 
 WORKDIR /app
 


### PR DESCRIPTION
**Description:**

Pin docker base images to specific hashes. This improves our security posture at no additional cost. I've also updated the renovate config so we get all the base image updates in a single PR weekly.

**Link to tracking Issue(s):**

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/5169
