### PR TITLE
fix(tests): pin Go e2e test app to 1.26.1 for eBPF offset compatibility

### DIFF
--- a/tests/test-e2e-apps/golang/Dockerfile
+++ b/tests/test-e2e-apps/golang/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go application
-FROM docker.io/library/golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM docker.io/library/golang:1.26.1-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS builder
 
 # Set the working directory inside the container for the build stage.
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Pins the Go e2e test app base image to `golang:1.26.1-alpine` instead of the floating `1.26-alpine` tag
- The Go auto-instrumentation (`v0.24.0`) only has cached eBPF offsets up to Go 1.26.1. The recent Go 1.26 upgrade (#5173) resolved to Go 1.26.3 via the floating tag, causing `instrumentation-go` e2e tests to fail with no telemetry data produced
- Once a new `opentelemetry-go-instrumentation` release adds offsets for Go 1.26.3+, this pin can be removed

See: https://github.com/open-telemetry/opentelemetry-go-instrumentation/releases/

## Test plan
- [x] `e2e-instrumentation` CI job passes (specifically `instrumentation-go` test)