### PR TITLE
[chore] Publish the `apis` module on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ./.ci/create-release-github.sh
 
-    - name: "refresh go proxy module info on release"
-      run: |
-        curl https://proxy.golang.org/github.com/open-telemetry/opentelemetry-operator/@v/${DESIRED_VERSION}.info
+    # Note: the release created above is a draft, so the v${DESIRED_VERSION} git
+    # tag does not exist yet. Tagging the apis/ submodule and refreshing the Go
+    # module proxy happen once the draft is published and the tag is created, in
+    # the tag-release.yaml workflow.

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,49 @@
+name: "Tag the release"
+# Runs when the operator's v* tag is created, which happens when the release
+# draft created by release.yaml is published. At that point the tag exists, so
+# we can tag the apis/ submodule at the same commit and refresh the Go module
+# proxy for both modules.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  tag-apis-module:
+    permissions:
+      contents: write # required for creating the apis/ submodule tag
+    runs-on: ubuntu-latest
+    env:
+      # github.ref_name is the operator tag, e.g. v0.152.0
+      OPERATOR_TAG: ${{ github.ref_name }}
+    steps:
+      - name: "tag the apis submodule"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The apis/ directory is published as its own Go module
+          # (github.com/open-telemetry/opentelemetry-operator/apis). Per Go's
+          # rules for multiple modules in a single repository, it must be tagged
+          # with the module's directory as a prefix, i.e. apis/vX.Y.Z.
+          # https://go.dev/doc/modules/managing-source#multiple-module-source
+          #
+          # The tag points at the same commit as the operator tag that triggered
+          # this workflow. Creating the apis/ tag does not re-trigger this
+          # workflow: it doesn't match the v* filter, and tags created via
+          # GITHUB_TOKEN don't trigger workflow runs.
+          APIS_TAG="apis/${OPERATOR_TAG}"
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${APIS_TAG}" >/dev/null 2>&1; then
+            echo "Tag ${APIS_TAG} already exists, skipping."
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f "ref=refs/tags/${APIS_TAG}" \
+              -f "sha=${GITHUB_SHA}"
+          fi
+
+      - name: "refresh go proxy module info on release"
+        run: |
+          curl "https://proxy.golang.org/github.com/open-telemetry/opentelemetry-operator/@v/${OPERATOR_TAG}.info"
+          curl "https://proxy.golang.org/github.com/open-telemetry/opentelemetry-operator/apis/@v/${OPERATOR_TAG}.info"


### PR DESCRIPTION
**Description:**

Publish the apis module by creating a tag after the main operator release tag is published. This PR also moves the Go proxy refresh to the right place - before it ran before the main module tag was published, making it a noop.

**Link to tracking Issue(s):**

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/5175

**Testing:**

Tested in my fork:

- the release: https://github.com/swiatekm/opentelemetry-operator/releases/tag/v0.153.0
- the workflow: https://github.com/swiatekm/opentelemetry-operator/actions/runs/26967992340
- the tag: https://github.com/swiatekm/opentelemetry-operator/releases/tag/apis%2Fv0.153.0

