### PR TITLE
Add a way to customize the command/entrypoint of the main container

### DIFF
--- a/.chloggen/customize-command.yaml
+++ b/.chloggen/customize-command.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `command` field to override the main container's executable
+
+# One or more tracking issues related to the change
+issues: [5188]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1beta1/common.go
+++ b/apis/v1beta1/common.go
@@ -106,6 +106,9 @@ type OpenTelemetryCommonFields struct {
 	// Args is the set of arguments to pass to the main container's binary.
 	// +optional
 	Args map[string]string `json:"args,omitempty"`
+	// Command is used to override the default command of the main container.
+	// +optional
+	Command string `json:"command,omitempty"`
 	// Replicas is the number of pod instances for the underlying replicaset. Set this if you are not using autoscaling.
 	// +optional
 	// +kubebuilder:default:=1

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-05-25T20:16:13Z"
+    createdAt: "2026-06-05T08:12:19Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -6087,6 +6087,8 @@ spec:
                     minimum: 1
                     type: integer
                 type: object
+              command:
+                type: string
               config:
                 properties:
                   connectors:

--- a/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
@@ -1217,6 +1217,8 @@ spec:
                 default: 30s
                 format: duration
                 type: string
+              command:
+                type: string
               dnsPolicy:
                 type: string
               env:

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-05-25T20:16:13Z"
+    createdAt: "2026-06-05T08:12:26Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -6086,6 +6086,8 @@ spec:
                     minimum: 1
                     type: integer
                 type: object
+              command:
+                type: string
               config:
                 properties:
                   connectors:

--- a/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
@@ -1217,6 +1217,8 @@ spec:
                 default: 30s
                 format: duration
                 type: string
+              command:
+                type: string
               dnsPolicy:
                 type: string
               env:

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -6073,6 +6073,8 @@ spec:
                     minimum: 1
                     type: integer
                 type: object
+              command:
+                type: string
               config:
                 properties:
                   connectors:

--- a/config/crd/bases/opentelemetry.io_targetallocators.yaml
+++ b/config/crd/bases/opentelemetry.io_targetallocators.yaml
@@ -1215,6 +1215,8 @@ spec:
                 default: 30s
                 format: duration
                 type: string
+              command:
+                type: string
               dnsPolicy:
                 type: string
               env:

--- a/docs/api/opentelemetrycollectors.md
+++ b/docs/api/opentelemetrycollectors.md
@@ -20199,6 +20199,13 @@ for the workload.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>command</b></td>
+        <td>string</td>
+        <td>
+          Command is used to override the default command of the main container.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>configVersions</b></td>
         <td>integer</td>
         <td>

--- a/docs/api/targetallocators.md
+++ b/docs/api/targetallocators.md
@@ -147,6 +147,13 @@ The default is 30s, which means that if a collector becomes not Ready, the targe
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>command</b></td>
+        <td>string</td>
+        <td>
+          Command is used to override the default command of the main container.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>dnsPolicy</b></td>
         <td>string</td>
         <td>

--- a/internal/manifests/collector/container.go
+++ b/internal/manifests/collector/container.go
@@ -119,6 +119,7 @@ func Container(cfg config.Config, logger logr.Logger, otelcol v1beta1.OpenTeleme
 		ImagePullPolicy: otelcol.Spec.ImagePullPolicy,
 		Ports:           ports,
 		VolumeMounts:    volumeMounts,
+		Command:         commandArgs(otelcol.Spec.Command),
 		Args:            args,
 		Env:             getContainerEnvVars(cfg, otelcol, logger),
 		EnvFrom:         otelcol.Spec.EnvFrom,
@@ -172,6 +173,13 @@ func getConfigContainerPorts(logger logr.Logger, conf v1beta1.Config) ([]corev1.
 	})
 
 	return ports, nil
+}
+
+func commandArgs(command string) []string {
+	if command == "" {
+		return nil
+	}
+	return []string{command}
 }
 
 func defaultProbeSettings(probe *corev1.Probe, probeConfig *v1beta1.Probe) {

--- a/internal/manifests/collector/container_test.go
+++ b/internal/manifests/collector/container_test.go
@@ -604,6 +604,21 @@ func TestContainerDefaultResourceRequirements(t *testing.T) {
 	assert.Empty(t, c.Resources)
 }
 
+func TestContainerCommand(t *testing.T) {
+	otelcol := v1beta1.OpenTelemetryCollector{
+		Spec: v1beta1.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+				Command: "/otelcol-contrib",
+			},
+		},
+	}
+	cfg := config.New()
+
+	c := Container(cfg, testLogger, otelcol, true, nil)
+
+	assert.Equal(t, []string{"/otelcol-contrib"}, c.Command)
+}
+
 func TestContainerArgs(t *testing.T) {
 	// prepare
 	otelcol := v1beta1.OpenTelemetryCollector{


### PR DESCRIPTION
## Motivation

When using the collector Helm chart, we can specify ([link](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml#L327-L329)):
```yaml
# OpenTelemetry Collector executable
command:
  name: ""
  extraArgs: []
```
1. `command.name` allows overriding the container's entrypoint. Note that a `/` is prepended to the value provided
2. `command.extraArgs` allows adding arguments after the `--config=/conf/relay.yaml` one.

With the operator, only the args are customizable (only `--key=value` args, which is fine for collectors)

## Description

To align what is customizable with the Helm chart vs with the operator, I propose adding a `command` field to the CRD. It will be equivalent to the chart's `command.name`, and allow overriding the container's entrypoint.

## Testing

Added a unit test confirming the generated container has its command set to the provided value.