### PR TITLE
[Chore] Restore OpenShift SCC setup for smoke-collector-daemonset test

### DIFF
--- a/tests/e2e/smoke-collector/smoke-collector-daemonset/chainsaw-test.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-daemonset/chainsaw-test.yaml
@@ -8,6 +8,19 @@ metadata:
 # per-attribute tests (affinity/additional-containers/node-selector).
 spec:
   steps:
+    - name: setup-scc
+      description: on OpenShift, create an SCC that allows hostNetwork and hostPID
+      try:
+        - script:
+            timeout: 1m
+            content: |
+              if kubectl api-resources --api-group=security.openshift.io -o name 2>/dev/null | grep -q securitycontextconstraints; then
+                echo "OpenShift detected — creating SCC for hostNetwork/hostPID"
+                kubectl apply -f scc.yaml
+                oc adm policy add-scc-to-user daemonset-with-hostport -z smoke-collector-collector -n $NAMESPACE
+              else
+                echo "Not OpenShift — skipping SCC setup"
+              fi
     - name: install
       description: install a daemonset collector with host-level and pod-spec fields set
       try:
@@ -15,3 +28,10 @@ spec:
             file: 00-install.yaml
         - assert:
             file: 00-assert.yaml
+      finally:
+        - script:
+            timeout: 1m
+            content: |
+              if kubectl api-resources --api-group=security.openshift.io -o name 2>/dev/null | grep -q securitycontextconstraints; then
+                kubectl delete scc daemonset-with-hostport --ignore-not-found
+              fi

--- a/tests/e2e/smoke-collector/smoke-collector-daemonset/scc.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-daemonset/scc.yaml
@@ -1,0 +1,17 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: daemonset-with-hostport
+  annotations:
+    kubernetes.io/description: 'Allows DaemonSets to bind to a well-known host port'
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+allowHostPorts: true
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: true
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: false


### PR DESCRIPTION
## Summary

- The `smoke-collector-daemonset` test uses `hostNetwork: true` and `hostPID: true`, which OpenShift's default SCCs (`restricted-v2`/`restricted-v3`) do not permit.
- The old `daemonset-features` test handled this via `scc.yaml` + `add-scc-openshift.sh`, but both were accidentally dropped during the consolidation in #5167.
- This PR restores the fix by adding `scc.yaml` and a conditional `setup-scc` step in `chainsaw-test.yaml`.

**What changed:**
- `scc.yaml`: `SecurityContextConstraints` named `daemonset-with-hostport` that grants `allowHostNetwork`, `allowHostPID`, and `allowHostPorts` (identical to the SCC from the deleted `daemonset-features` test).
- `chainsaw-test.yaml`: New `setup-scc` step that detects OpenShift, applies the SCC, and binds it to the collector's auto-created service account (`smoke-collector-collector`). A `finally` block deletes the cluster-scoped SCC after the test to prevent leakage between runs. Non-OpenShift clusters skip the step entirely.

**Root cause:** Pods were rejected at admission: `unable to validate against any security context constraint`.

## Test plan

- [x] Confirmed failing without fix (consistent failure across multiple runs)
- [x] Confirmed passing with fix (4/4 runs on OpenShift)
- [x] Non-OpenShift (kind) clusters unaffected — the `if` guard checks for `security.openshift.io` API group before applying anything