### PR TITLE
feat(collector): promote operator.collector.usedefaulttelemetryshape gate to beta

### DIFF
--- a/.chloggen/feat_5075-promote-telemetry-shape-beta.yaml
+++ b/.chloggen/feat_5075-promote-telemetry-shape-beta.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote the operator.collector.usedefaulttelemetryshape feature gate to beta. The operator-injected Prometheus telemetry reader now uses collector defaults by default — metric names from operator-managed collectors no longer carry type suffixes, units, or scope_info.
+
+# One or more tracking issues related to the change
+issues: [5075]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Users wanting the pre-v0.152.0 metric name shape can disable the gate via --feature-gates=-operator.collector.usedefaulttelemetryshape, or pin without_type_suffix/without_units/without_scope_info to false explicitly under spec.config.service.telemetry. The gate will be promoted to stable and removed in a future release.

--- a/.chloggen/feat_5075-promote-telemetry-shape-beta.yaml
+++ b/.chloggen/feat_5075-promote-telemetry-shape-beta.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
 component: collector
@@ -14,4 +14,4 @@ issues: [5075]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  Users wanting the pre-v0.152.0 metric name shape can disable the gate via --feature-gates=-operator.collector.usedefaulttelemetryshape, or pin without_type_suffix/without_units/without_scope_info to false explicitly under spec.config.service.telemetry. The gate will be promoted to stable and removed in a future release.
+  Users wanting the pre-v0.154.0 metric name shape can disable the gate via --feature-gates=-operator.collector.usedefaulttelemetryshape, or pin without_type_suffix/without_units/without_scope_info to false explicitly under spec.config.service.telemetry. The gate will be promoted to stable and removed in a future release.

--- a/internal/otelconfig/config.go
+++ b/internal/otelconfig/config.go
@@ -499,7 +499,7 @@ func ServiceApplyDefaults(s *v1beta1.Service, logger logr.Logger) ([]v1beta1.Eve
 // By default (operator.collector.usedefaulttelemetryshape beta gate enabled) the
 // reader carries no overrides, so the collector's defaults for without_type_suffix,
 // without_units, and without_scope_info apply. Disabling the gate explicitly sets
-// all three to false to preserve the pre-v0.152.0 metric name shape. See #5075.
+// all three to false to preserve the pre-v0.154.0 metric name shape. See #5075.
 func AddPrometheusMetricsEndpoint(host string, port int32) otelConfig.MetricReader {
 	portInt := int(port)
 	prom := &otelConfig.Prometheus{

--- a/internal/otelconfig/config.go
+++ b/internal/otelconfig/config.go
@@ -496,10 +496,10 @@ func ServiceApplyDefaults(s *v1beta1.Service, logger logr.Logger) ([]v1beta1.Eve
 }
 
 // AddPrometheusMetricsEndpoint creates a MetricReader with a Prometheus pull exporter.
-// without_type_suffix/without_units/without_scope_info are explicitly set to false to
-// preserve the historical metric name shape produced by operator-managed collectors
-// before open-telemetry/opentelemetry-collector#15027. Opt into collector defaults via
-// the operator.collector.usedefaulttelemetryshape feature gate. See issue #5075.
+// By default (operator.collector.usedefaulttelemetryshape beta gate enabled) the
+// reader carries no overrides, so the collector's defaults for without_type_suffix,
+// without_units, and without_scope_info apply. Disabling the gate explicitly sets
+// all three to false to preserve the pre-v0.152.0 metric name shape. See #5075.
 func AddPrometheusMetricsEndpoint(host string, port int32) otelConfig.MetricReader {
 	portInt := int(port)
 	prom := &otelConfig.Prometheus{

--- a/internal/otelconfig/config_test.go
+++ b/internal/otelconfig/config_test.go
@@ -1488,11 +1488,8 @@ func TestTelemetryLogsPreservedWithMetrics(t *testing.T) {
 								"pull": map[string]any{
 									"exporter": map[string]any{
 										"prometheus": map[string]any{
-											"host":                "0.0.0.0",
-											"port":                int32(8888),
-											"without_type_suffix": false,
-											"without_units":       false,
-											"without_scope_info":  false,
+											"host": "0.0.0.0",
+											"port": int32(8888),
 										},
 									},
 								},
@@ -1551,38 +1548,49 @@ func TestTelemetryIncompleteConfigAppliesDefaults(t *testing.T) {
 	require.NotNil(t, telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus)
 	require.Equal(t, "0.0.0.0", *telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.Host)
 	require.Equal(t, 8888, *telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.Port)
-	require.Equal(t, false, *telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.WithoutTypeSuffix)
-	require.Equal(t, false, *telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.WithoutUnits)
-	require.Equal(t, false, *telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.WithoutScopeInfo)
+	require.Nil(t, telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.WithoutTypeSuffix)
+	require.Nil(t, telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.WithoutUnits)
+	require.Nil(t, telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.WithoutScopeInfo)
 }
 
-func TestAddPrometheusMetricsEndpointPreservesShape(t *testing.T) {
+// withTelemetryShapeGate temporarily flips the operator.collector.usedefaulttelemetryshape
+// gate to the given value for the duration of the test and restores it on cleanup.
+func withTelemetryShapeGate(t *testing.T, enabled bool) {
+	t.Helper()
+	registry := colfeaturegate.GlobalRegistry()
+	original := featuregate.UseCollectorDefaultTelemetryShape.IsEnabled()
+	require.NoError(t, registry.Set(featuregate.UseCollectorDefaultTelemetryShape.ID(), enabled))
+	t.Cleanup(func() {
+		require.NoError(t, registry.Set(featuregate.UseCollectorDefaultTelemetryShape.ID(), original))
+	})
+}
+
+// Default behavior (beta gate enabled): the injected reader carries no shape overrides,
+// so the collector's defaults apply.
+func TestAddPrometheusMetricsEndpointUsesCollectorDefaultsByDefault(t *testing.T) {
 	reader := AddPrometheusMetricsEndpoint("0.0.0.0", 8888)
 	require.NotNil(t, reader.Pull)
-	require.NotNil(t, reader.Pull.Exporter.Prometheus)
-	require.Equal(t, "0.0.0.0", *reader.Pull.Exporter.Prometheus.Host)
-	require.Equal(t, 8888, *reader.Pull.Exporter.Prometheus.Port)
-	require.NotNil(t, reader.Pull.Exporter.Prometheus.WithoutTypeSuffix)
-	require.Equal(t, false, *reader.Pull.Exporter.Prometheus.WithoutTypeSuffix)
-	require.NotNil(t, reader.Pull.Exporter.Prometheus.WithoutUnits)
-	require.Equal(t, false, *reader.Pull.Exporter.Prometheus.WithoutUnits)
-	require.NotNil(t, reader.Pull.Exporter.Prometheus.WithoutScopeInfo)
-	require.Equal(t, false, *reader.Pull.Exporter.Prometheus.WithoutScopeInfo)
-}
-
-func TestAddPrometheusMetricsEndpointGateUsesCollectorDefaults(t *testing.T) {
-	registry := colfeaturegate.GlobalRegistry()
-	originalVal := featuregate.UseCollectorDefaultTelemetryShape.IsEnabled()
-	require.NoError(t, registry.Set(featuregate.UseCollectorDefaultTelemetryShape.ID(), true))
-	t.Cleanup(func() {
-		require.NoError(t, registry.Set(featuregate.UseCollectorDefaultTelemetryShape.ID(), originalVal))
-	})
-
-	reader := AddPrometheusMetricsEndpoint("0.0.0.0", 8888)
 	require.NotNil(t, reader.Pull.Exporter.Prometheus)
 	require.Equal(t, "0.0.0.0", *reader.Pull.Exporter.Prometheus.Host)
 	require.Equal(t, 8888, *reader.Pull.Exporter.Prometheus.Port)
 	require.Nil(t, reader.Pull.Exporter.Prometheus.WithoutTypeSuffix)
 	require.Nil(t, reader.Pull.Exporter.Prometheus.WithoutUnits)
 	require.Nil(t, reader.Pull.Exporter.Prometheus.WithoutScopeInfo)
+}
+
+// Opt-out behavior: when the gate is disabled, the operator pins all three
+// fields to false to preserve the pre-v0.152.0 metric name shape.
+func TestAddPrometheusMetricsEndpointPreservesShapeWhenGateDisabled(t *testing.T) {
+	withTelemetryShapeGate(t, false)
+
+	reader := AddPrometheusMetricsEndpoint("0.0.0.0", 8888)
+	require.NotNil(t, reader.Pull.Exporter.Prometheus)
+	require.Equal(t, "0.0.0.0", *reader.Pull.Exporter.Prometheus.Host)
+	require.Equal(t, 8888, *reader.Pull.Exporter.Prometheus.Port)
+	require.NotNil(t, reader.Pull.Exporter.Prometheus.WithoutTypeSuffix)
+	require.False(t, *reader.Pull.Exporter.Prometheus.WithoutTypeSuffix)
+	require.NotNil(t, reader.Pull.Exporter.Prometheus.WithoutUnits)
+	require.False(t, *reader.Pull.Exporter.Prometheus.WithoutUnits)
+	require.NotNil(t, reader.Pull.Exporter.Prometheus.WithoutScopeInfo)
+	require.False(t, *reader.Pull.Exporter.Prometheus.WithoutScopeInfo)
 }

--- a/internal/otelconfig/config_test.go
+++ b/internal/otelconfig/config_test.go
@@ -1579,7 +1579,7 @@ func TestAddPrometheusMetricsEndpointUsesCollectorDefaultsByDefault(t *testing.T
 }
 
 // Opt-out behavior: when the gate is disabled, the operator pins all three
-// fields to false to preserve the pre-v0.152.0 metric name shape.
+// fields to false to preserve the pre-v0.154.0 metric name shape.
 func TestAddPrometheusMetricsEndpointPreservesShapeWhenGateDisabled(t *testing.T) {
 	withTelemetryShapeGate(t, false)
 

--- a/internal/webhook/collector_webhook_test.go
+++ b/internal/webhook/collector_webhook_test.go
@@ -167,7 +167,7 @@ func TestCollectorDefaultingWebhook(t *testing.T) {
 					Mode:            v1beta1.ModeDeployment,
 					UpgradeStrategy: v1beta1.UpgradeStrategyAutomatic,
 					Config: func() v1beta1.Config {
-						const input = `{"receivers":{"otlp":{"protocols":{"grpc":{"endpoint":"0.0.0.0:4317"},"http":{"endpoint":"0.0.0.0:4318"}}}},"exporters":{"debug":null},"service":{"telemetry":{"metrics":{"readers":[{"pull":{"exporter":{"prometheus":{"host":"0.0.0.0","port":8888,"without_scope_info":false,"without_type_suffix":false,"without_units":false}}}}]}},"pipelines":{"traces":{"receivers":["otlp"],"exporters":["debug"]}}}}`
+						const input = `{"receivers":{"otlp":{"protocols":{"grpc":{"endpoint":"0.0.0.0:4317"},"http":{"endpoint":"0.0.0.0:4318"}}}},"exporters":{"debug":null},"service":{"telemetry":{"metrics":{"readers":[{"pull":{"exporter":{"prometheus":{"host":"0.0.0.0","port":8888}}}}]}},"pipelines":{"traces":{"receivers":["otlp"],"exporters":["debug"]}}}}`
 						var cfg v1beta1.Config
 						require.NoError(t, go_yaml.Unmarshal([]byte(input), &cfg))
 						// This is a workaround to avoid the type mismatch because how go-yaml unmarshals

--- a/pkg/collector/upgrade/v0_122_0_test.go
+++ b/pkg/collector/upgrade/v0_122_0_test.go
@@ -67,11 +67,8 @@ func TestUpgrade0_122_0(t *testing.T) {
 												"pull": map[string]any{
 													"exporter": map[string]any{
 														"prometheus": map[string]any{
-															"host":                "0.0.0.0",
-															"port":                int32(8888),
-															"without_scope_info":  false,
-															"without_type_suffix": false,
-															"without_units":       false,
+															"host": "0.0.0.0",
+															"port": int32(8888),
 														},
 													},
 												},

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -56,12 +56,12 @@ var (
 	// for without_type_suffix, without_units, and without_scope_info — metric
 	// names emitted by operator-managed collectors no longer carry type
 	// suffixes, units, or scope_info. When disabled, the operator explicitly
-	// sets all three to false to preserve the pre-v0.152.0 metric name shape.
+	// sets all three to false to preserve the pre-v0.154.0 metric name shape.
 	// See open-telemetry/opentelemetry-operator#5075.
 	UseCollectorDefaultTelemetryShape = featuregate.GlobalRegistry().MustRegister(
 		"operator.collector.usedefaulttelemetryshape",
 		featuregate.StageBeta,
-		featuregate.WithRegisterDescription("when enabled (default), the operator-injected Prometheus telemetry reader uses collector defaults for without_type_suffix/without_units/without_scope_info. When disabled, the operator explicitly sets all three to false to preserve the pre-v0.152.0 metric name shape."),
+		featuregate.WithRegisterDescription("when enabled (default), the operator-injected Prometheus telemetry reader uses collector defaults for without_type_suffix/without_units/without_scope_info. When disabled, the operator explicitly sets all three to false to preserve the pre-v0.154.0 metric name shape."),
 		featuregate.WithRegisterFromVersion("v0.152.0"),
 	)
 )

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -51,15 +51,17 @@ var (
 		featuregate.WithRegisterDescription("enables the ClusterObservability controller for managed observability deployment"),
 		featuregate.WithRegisterFromVersion("v0.134.0"),
 	)
-	// UseCollectorDefaultTelemetryShape, when enabled, makes the operator-injected
-	// Prometheus telemetry reader use collector defaults for without_type_suffix,
-	// without_units, and without_scope_info. When disabled (default), the operator
-	// explicitly sets all three to false to preserve historical metric name shape.
+	// UseCollectorDefaultTelemetryShape, when enabled (default at beta), makes
+	// the operator-injected Prometheus telemetry reader use collector defaults
+	// for without_type_suffix, without_units, and without_scope_info — metric
+	// names emitted by operator-managed collectors no longer carry type
+	// suffixes, units, or scope_info. When disabled, the operator explicitly
+	// sets all three to false to preserve the pre-v0.152.0 metric name shape.
 	// See open-telemetry/opentelemetry-operator#5075.
 	UseCollectorDefaultTelemetryShape = featuregate.GlobalRegistry().MustRegister(
 		"operator.collector.usedefaulttelemetryshape",
-		featuregate.StageAlpha,
-		featuregate.WithRegisterDescription("when enabled, the operator-injected Prometheus telemetry reader uses collector defaults for without_type_suffix/without_units/without_scope_info. When disabled (default), the operator explicitly sets all three to false to preserve historical metric name shape."),
+		featuregate.StageBeta,
+		featuregate.WithRegisterDescription("when enabled (default), the operator-injected Prometheus telemetry reader uses collector defaults for without_type_suffix/without_units/without_scope_info. When disabled, the operator explicitly sets all three to false to preserve the pre-v0.152.0 metric name shape."),
 		featuregate.WithRegisterFromVersion("v0.152.0"),
 	)
 )

--- a/tests/e2e-openshift/must-gather/assert-install-target-allocator.yaml
+++ b/tests/e2e-openshift/must-gather/assert-install-target-allocator.yaml
@@ -54,9 +54,6 @@ data:
                               prometheus:
                                   host: 0.0.0.0
                                   port: 8888
-                                  without_scope_info: false
-                                  without_type_suffix: false
-                                  without_units: false
 kind: ConfigMap
 metadata:
   labels:
@@ -65,7 +62,7 @@ metadata:
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/name: stateful-collector
     app.kubernetes.io/part-of: opentelemetry
-  name: stateful-collector-cbacb1a5
+  name: stateful-collector-95bef721
   namespace: chainsaw-must-gather
 ---
 apiVersion: v1

--- a/tests/e2e-ta-collector-mtls/ta-collector-mtls/00-assert.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-collector-mtls/00-assert.yaml
@@ -68,9 +68,6 @@ data:
                               prometheus:
                                   host: 0.0.0.0
                                   port: 8888
-                                  without_scope_info: false
-                                  without_type_suffix: false
-                                  without_units: false
 kind: ConfigMap
 metadata:
   (starts_with(name, 'prometheus-cr-collector-')): true

--- a/tests/e2e-ta-collector-mtls/ta-disabled/00-assert.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-disabled/00-assert.yaml
@@ -40,9 +40,6 @@ data:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
-                    without_scope_info: false
-                    without_type_suffix: false
-                    without_units: false
       pipelines:
         traces:
           exporters:

--- a/tests/e2e-targetallocator-cr/targetallocator-label/00-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/00-assert.yaml
@@ -26,9 +26,6 @@ data:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
-                    without_scope_info: false
-                    without_type_suffix: false
-                    without_units: false
       pipelines:
         metrics:
           exporters:

--- a/tests/e2e-targetallocator-cr/targetallocator-label/01-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/01-assert.yaml
@@ -30,9 +30,6 @@ data:
                               prometheus:
                                   host: 0.0.0.0
                                   port: 8888
-                                  without_scope_info: false
-                                  without_type_suffix: false
-                                  without_units: false
 ---
 apiVersion: v1
 data:

--- a/tests/e2e-targetallocator-cr/targetallocator-label/02-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/02-assert.yaml
@@ -30,9 +30,6 @@ data:
                               prometheus:
                                   host: 0.0.0.0
                                   port: 8888
-                                  without_scope_info: false
-                                  without_type_suffix: false
-                                  without_units: false
 ---
 apiVersion: v1
 data:

--- a/tests/e2e-targetallocator/targetallocator-kubernetessd/00-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-kubernetessd/00-assert.yaml
@@ -43,9 +43,6 @@ data:
                               prometheus:
                                   host: 0.0.0.0
                                   port: 8888
-                                  without_scope_info: false
-                                  without_type_suffix: false
-                                  without_units: false
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/00-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/00-assert.yaml
@@ -48,9 +48,6 @@ data:
                               prometheus:
                                   host: 0.0.0.0
                                   port: 8888
-                                  without_scope_info: false
-                                  without_type_suffix: false
-                                  without_units: false
 kind: ConfigMap
 metadata:
   labels:

--- a/tests/e2e/conversion-webhook-invalid-config/00-assert-created.yaml
+++ b/tests/e2e/conversion-webhook-invalid-config/00-assert-created.yaml
@@ -16,7 +16,4 @@ spec:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
-                    without_scope_info: false
-                    without_type_suffix: false
-                    without_units: false
       pipelines: {}

--- a/tests/e2e/managed-reconcile/02-assert.yaml
+++ b/tests/e2e/managed-reconcile/02-assert.yaml
@@ -73,9 +73,6 @@ data:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
-                    without_scope_info: false
-                    without_type_suffix: false
-                    without_units: false
       pipelines:
         traces:
           exporters:

--- a/tests/e2e/prometheus-config-validation/00-promreceiver-allocatorconfig.yaml
+++ b/tests/e2e/prometheus-config-validation/00-promreceiver-allocatorconfig.yaml
@@ -70,9 +70,6 @@ spec:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
-                    without_scope_info: false
-                    without_type_suffix: false
-                    without_units: false
       extensions:
         - health_check
       pipelines:

--- a/tests/e2e/prometheus-config-validation/02-promreceiver-allocatorconfig-extra.yaml
+++ b/tests/e2e/prometheus-config-validation/02-promreceiver-allocatorconfig-extra.yaml
@@ -46,9 +46,6 @@ spec:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
-                    without_scope_info: false
-                    without_type_suffix: false
-                    without_units: false
       extensions:
         - health_check
       pipelines:

--- a/tests/e2e/prometheus-config-validation/03-promreceiver-nopromconfig.yaml
+++ b/tests/e2e/prometheus-config-validation/03-promreceiver-nopromconfig.yaml
@@ -41,9 +41,6 @@ spec:
                   prometheus:
                     host: 0.0.0.0
                     port: 8888
-                    without_scope_info: false
-                    without_type_suffix: false
-                    without_units: false
       extensions:
         - health_check
       pipelines:

--- a/tests/e2e/smoke-collector/smoke-targetallocator/00-assert.yaml
+++ b/tests/e2e/smoke-collector/smoke-targetallocator/00-assert.yaml
@@ -58,9 +58,6 @@ data:
                               prometheus:
                                   host: 0.0.0.0
                                   port: 8888
-                                  without_scope_info: false
-                                  without_type_suffix: false
-                                  without_units: false
 kind: ConfigMap
 metadata:
   (starts_with(name, 'stateful-collector-')): true

--- a/tests/e2e/versioned-configmaps/00-assert.yaml
+++ b/tests/e2e/versioned-configmaps/00-assert.yaml
@@ -9,11 +9,11 @@ spec:
       volumes:
         - name: otc-internal
           configMap:
-            name: simple-collector-713de77b
+            name: simple-collector-5723ff27
 status:
   readyReplicas: 1
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: simple-collector-713de77b
+  name: simple-collector-5723ff27

--- a/tests/e2e/versioned-configmaps/01-assert.yaml
+++ b/tests/e2e/versioned-configmaps/01-assert.yaml
@@ -9,16 +9,16 @@ spec:
       volumes:
         - name: otc-internal
           configMap:
-            name: simple-collector-726b4c75
+            name: simple-collector-dfcfaead
 status:
   readyReplicas: 1
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: simple-collector-726b4c75
+  name: simple-collector-dfcfaead
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: simple-collector-713de77b
+  name: simple-collector-5723ff27

--- a/tests/step-templates/validate-collector-metrics.yaml
+++ b/tests/step-templates/validate-collector-metrics.yaml
@@ -50,10 +50,10 @@ spec:
           ($error == null): true
     - assert:
         resource:
-          ($metrics[?as_string(metric."__name__") == 'otelcol_exporter_sent_spans_total'].value | [0] > `1`): true
-          ($metrics[?as_string(metric."__name__") == 'otelcol_receiver_accepted_spans_total'].value | [0] > `1`): true
-          ($metrics[?as_string(metric."__name__") == 'otelcol_exporter_sent_metric_points_total'].value | [0] > `1`): true
-          ($metrics[?as_string(metric."__name__") == 'otelcol_receiver_accepted_metric_points_total'].value | [0] > `1`): true
+          ($metrics[?as_string(metric."__name__") == 'otelcol_exporter_sent_spans'].value | [0] > `1`): true
+          ($metrics[?as_string(metric."__name__") == 'otelcol_receiver_accepted_spans'].value | [0] > `1`): true
+          ($metrics[?as_string(metric."__name__") == 'otelcol_exporter_sent_metric_points'].value | [0] > `1`): true
+          ($metrics[?as_string(metric."__name__") == 'otelcol_receiver_accepted_metric_points'].value | [0] > `1`): true
   catch:
     - podLogs:
         selector: ($catchPodLabelSelector)

--- a/tests/step-templates/validate-collector-spans.yaml
+++ b/tests/step-templates/validate-collector-spans.yaml
@@ -50,8 +50,8 @@ spec:
           ($error == null): true
     - assert:
         resource:
-          ($metrics[?as_string(metric."__name__") == 'otelcol_exporter_sent_spans_total'].value | [0] > `0`): true
-          ($metrics[?as_string(metric."__name__") == 'otelcol_receiver_accepted_spans_total'].value | [0] > `0`): true
+          ($metrics[?as_string(metric."__name__") == 'otelcol_exporter_sent_spans'].value | [0] > `0`): true
+          ($metrics[?as_string(metric."__name__") == 'otelcol_receiver_accepted_spans'].value | [0] > `0`): true
   catch:
     - podLogs:
         selector: ($catchPodLabelSelector)


### PR DESCRIPTION
**Description:** Promotes the `operator.collector.usedefaulttelemetryshape` feature gate from Alpha to Beta. Beta gates default ON, so the operator-injected Prometheus telemetry reader now uses collector
  defaults — metric names from operator-managed collectors no longer carry type suffixes, units, or scope_info.

  `AddPrometheusMetricsEndpoint` retains the gate check so users who need the pre-v0.152.0 metric name shape can opt out via `--feature-gates=-operator.collector.usedefaulttelemetryshape`, or pin
  `without_type_suffix`/`without_units`/`without_scope_info` to `false` explicitly under `spec.config.service.telemetry`. The gate will be promoted to Stable and removed in a future release.

  This is the next step in the SIG plan from 2026-05-05 tracked in #5075.

  **Link to tracking Issue(s):** #5075

  - Part of: #5075

  **Testing:**
  - Updated `internal/otelconfig/config_test.go`:
    - Renamed the gate-toggle tests to `TestAddPrometheusMetricsEndpointUsesCollectorDefaultsByDefault` (no toggle, default behavior) and `TestAddPrometheusMetricsEndpointPreservesShapeWhenGateDisabled`
  (explicitly disables the gate via a new `withTelemetryShapeGate` helper).
    - Adjusted `TestTelemetryLogsPreservedWithMetrics` and `TestTelemetryIncompleteConfigAppliesDefaults` to expect the 3 fields to be absent under the new default.
  - Updated `internal/webhook/collector_webhook_test.go` (`TestCollectorDefaultingWebhook`) and `pkg/collector/upgrade/v0_122_0_test.go` (`TestUpgrade0_122_0/should_remove_address_field_from_metrics_config`)
  to drop the 3 fields from their expected configs.
  - Updated 14 e2e assert YAMLs (`tests/e2e/*`, `tests/e2e-targetallocator*`, `tests/e2e-ta-collector-mtls`, `tests/e2e-openshift/must-gather`) to drop the 3 `without_*: false` lines.
  - Recomputed the 3 hash-suffixed ConfigMap names in `tests/e2e/versioned-configmaps/{00,01}-assert.yaml` and `tests/e2e-openshift/must-gather/assert-install-target-allocator.yaml` for the new rendered config
  bytes.

  Verified locally: `go test ./...` (45 packages, 0 failures) and `./bin/chainsaw test --test-dir ./tests/e2e/versioned-configmaps` → `PASS`.

  **Documentation:** Added a changelog entry at `.chloggen/feat_5075-promote-telemetry-shape-beta.yaml` (`enhancement`, `collector`). The feature-gate's `WithRegisterDescription` and the comment on
  `AddPrometheusMetricsEndpoint` have been updated to reflect the new default.