### PR TITLE
Fix failing TA tests on IBM Z

### DIFF
--- a/tests/e2e-prometheuscr/create-sm-prometheus-exporters/08-install.yaml
+++ b/tests/e2e-prometheuscr/create-sm-prometheus-exporters/08-install.yaml
@@ -120,7 +120,7 @@ spec:
       - args:
         - /bin/sh
         - -c
-        - curl -s http://simplest-targetallocator/jobs | grep "targetallocator"
-        image: mirror.gcr.io/curlimages/curl:latest
+        - wget -q -O - http://simplest-targetallocator/jobs | grep "targetallocator"
+        image: mirror.gcr.io/alpine:latest
         name: check-metrics
       restartPolicy: OnFailure

--- a/tests/e2e-ta-collector-mtls/ta-collector-mtls-scrapeconfig-node/01-install.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-collector-mtls-scrapeconfig-node/01-install.yaml
@@ -11,11 +11,11 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "scrape-config-cr"
+            - wget -q -O - http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "scrape-config-cr"
 ---
 apiVersion: batch/v1
 kind: Job
@@ -30,8 +30,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-v1beta1-targetallocator/jobs | grep "scrape-config-cr"
+            - wget -q -O - http://prometheus-cr-v1beta1-targetallocator/jobs | grep "scrape-config-cr"

--- a/tests/e2e-ta-collector-mtls/ta-collector-mtls/00-install.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-collector-mtls/00-install.yaml
@@ -90,7 +90,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-ta
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           volumeMounts:
             - name: tls-secret
               mountPath: /etc/tls
@@ -99,7 +99,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              curl -s \
+              wget -q -O - \
                 --cert /etc/tls/tls.crt \
                 --key /etc/tls/tls.key \
                 --cacert /etc/tls/ca.crt \

--- a/tests/e2e-ta-collector-mtls/ta-collector-mtls/02-install.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-collector-mtls/02-install.yaml
@@ -19,13 +19,13 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
             - |
               for i in $(seq 30); do
-                if curl -m 1 -s http://prometheus-cr-collector:9090/metrics | grep "Client was authenticated"; then exit 0; fi
+                if wget -q -T 1 -O - http://prometheus-cr-collector:9090/metrics | grep "Client was authenticated"; then exit 0; fi
                 sleep 5
               done
               exit 1
@@ -40,7 +40,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           volumeMounts:
             - name: tls-secret
               mountPath: /etc/tls
@@ -48,12 +48,7 @@ spec:
           args:
             - /bin/sh
             - -c
-            - |-
-              curl -s \
-                --cert /etc/tls/tls.crt \
-                --key /etc/tls/tls.key \
-                --cacert /etc/tls/ca.crt \
-                https://prometheus-cr-targetallocator:443/scrape_configs | grep "prometheus-cr"
+            - wget -q -O - --certificate=/etc/tls/tls.crt --private-key=/etc/tls/tls.key --ca-certificate=/etc/tls/ca.crt https://prometheus-cr-targetallocator:443/scrape_configs | grep "prometheus-cr"
       volumes:
         - name: tls-secret
           secret:
@@ -69,7 +64,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           volumeMounts:
             - name: tls-secret
               mountPath: /etc/tls
@@ -77,12 +72,7 @@ spec:
           args:
             - /bin/sh
             - -c
-            - |-
-              curl -s \
-                --cert /etc/tls/tls.crt \
-                --key /etc/tls/tls.key \
-                --cacert /etc/tls/ca.crt \
-                https://prometheus-cr-targetallocator:443/jobs | grep "prometheus-cr"
+            - wget -q -O - --certificate=/etc/tls/tls.crt --private-key=/etc/tls/tls.key --ca-certificate=/etc/tls/ca.crt https://prometheus-cr-targetallocator:443/jobs | grep "prometheus-cr"
       volumes:
         - name: tls-secret
           secret:

--- a/tests/e2e-ta-collector-mtls/ta-collector-mtls/02b-install.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-collector-mtls/02b-install.yaml
@@ -91,7 +91,7 @@ spec:
               echo "Creating ConfigMap cert-date-tracker in namespace $NAMESPACE..."
 
               # Create ConfigMap and capture response
-              RESPONSE=$(curl -s -k -X POST \
+              RESPONSE=$(wget -q -O - -k -X POST \
                 -H "Authorization: Bearer $TOKEN" \
                 -H "Content-Type: application/json" \
                 -w "\n%{http_code}" \

--- a/tests/e2e-ta-collector-mtls/ta-collector-mtls/03-install.yaml
+++ b/tests/e2e-ta-collector-mtls/ta-collector-mtls/03-install.yaml
@@ -8,7 +8,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-ta
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           volumeMounts:
             - name: tls-secret
               mountPath: /etc/tls
@@ -24,14 +24,14 @@ spec:
 
               # Test that TA is still serving over HTTPS with renewed certificates
               # WITHOUT requiring manual Secret deletion
-              curl -s \
+              wget -q -O - \
                 --cert /etc/tls/tls.crt \
                 --key /etc/tls/tls.key \
                 --cacert /etc/tls/ca.crt \
                 https://prometheus-cr-targetallocator:443
 
               # Also test that scrape_configs endpoint is working
-              curl -s \
+              wget -q -O - \
                 --cert /etc/tls/tls.crt \
                 --key /etc/tls/tls.key \
                 --cacert /etc/tls/ca.crt \
@@ -74,7 +74,7 @@ spec:
 
               echo "Fetching ConfigMap cert-date-tracker from namespace $NAMESPACE..."
 
-              CM_RESPONSE=$(curl -s -k \
+              CM_RESPONSE=$(wget -q -O - -k \
                 -H "Authorization: Bearer $TOKEN" \
                 "https://kubernetes.default.svc/api/v1/namespaces/${NAMESPACE}/configmaps/cert-date-tracker")
 

--- a/tests/e2e-targetallocator/targetallocator-kubernetessd/01-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-kubernetessd/01-install.yaml
@@ -9,13 +9,13 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
             - |
               for i in $(seq 30); do
-                if curl -m 1 -s http://prometheus-kubernetessd-collector:9090/metrics | grep "kubelet_running_pods"; then exit 0; fi
+                if wget -q -T 1 -O - http://prometheus-kubernetessd-collector:9090/metrics | grep "kubelet_running_pods"; then exit 0; fi
                 sleep 5
               done
               exit 1
@@ -30,11 +30,11 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-kubernetessd-targetallocator/scrape_configs | grep "kubelet"
+            - wget -q -O - http://prometheus-kubernetessd-targetallocator/scrape_configs | grep "kubelet"
 ---
 apiVersion: batch/v1
 kind: Job
@@ -46,9 +46,9 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
             # First get the collector pod name, subsequently check that the targets for the collector include the node name label.
-            - curl -s http://prometheus-kubernetessd-targetallocator/jobs/kubelet/targets?collector_id=$(curl -s http://prometheus-kubernetessd-targetallocator/jobs/kubelet/targets | grep -oE "prometheus-kubernetessd-collector-.{5}") | grep "__meta_kubernetes_node_name"
+            - wget -q -O - http://prometheus-kubernetessd-targetallocator/jobs/kubelet/targets?collector_id=$(wget -q -O - http://prometheus-kubernetessd-targetallocator/jobs/kubelet/targets | grep -oE "prometheus-kubernetessd-collector-.{5}") | grep "__meta_kubernetes_node_name"

--- a/tests/e2e-targetallocator/targetallocator-namespace/resources/job-check-metrics.yaml
+++ b/tests/e2e-targetallocator/targetallocator-namespace/resources/job-check-metrics.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           env:
             - name: endpoint
               value: ($endpoint)
@@ -22,8 +22,8 @@ spec:
             - -c
             - |
               for i in $(seq $retries); do
-                if curl -m 1 -s $endpoint | grep "$pattern"; then
-                  echo "Found $pattern in $endpoint" 
+                if wget -q -T 1 -O - $endpoint | grep "$pattern"; then
+                  echo "Found $pattern in $endpoint"
                   exit 0
                 fi
                 echo "Waiting for $pattern in $endpoint"

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/01-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr-denyfs/01-install.yaml
@@ -81,13 +81,13 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-config
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
             - |
               set -e
-              CONFIG=$(curl -fs http://prometheus-cr-denyfs-targetallocator/scrape_configs)
+              CONFIG=$(wget -q -O - http://prometheus-cr-denyfs-targetallocator/scrape_configs)
               echo "$CONFIG"
               # The safe endpoint (port safe-metrics) must remain.
               echo "$CONFIG" | grep -q "safe-metrics"

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr-secrets/01-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr-secrets/01-install.yaml
@@ -85,12 +85,12 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-config
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
             - |
-              CONFIG=$(curl -s http://prometheus-cr-secrets-targetallocator/scrape_configs)
+              CONFIG=$(wget -q -O - http://prometheus-cr-secrets-targetallocator/scrape_configs)
               echo "$CONFIG" | grep -q "metrics-servicemonitor" && \
               echo "$CONFIG" | grep -q "basic_auth" && \
               echo "$CONFIG" | grep -q "user"

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr-secrets/02-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr-secrets/02-install.yaml
@@ -51,12 +51,12 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-update
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
             - |
-              CONFIG=$(curl -s http://prometheus-cr-secrets-targetallocator/scrape_configs)
+              CONFIG=$(wget -q -O - http://prometheus-cr-secrets-targetallocator/scrape_configs)
               echo "$CONFIG" | grep -q "metrics-servicemonitor" && \
               echo "$CONFIG" | grep -q "basic_auth" && \
               echo "$CONFIG" | grep -q "newuser"

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/01-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/01-install.yaml
@@ -20,13 +20,13 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
             - |
               for i in $(seq 30); do
-                if curl -m 1 -s http://prometheus-cr-collector:9090/metrics | grep "otelcol"; then exit 0; fi
+                if wget -q -T 1 -O - http://prometheus-cr-collector:9090/metrics | grep "otelcol"; then exit 0; fi
                 sleep 5
               done
               exit 1
@@ -41,11 +41,11 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-targetallocator/scrape_configs | grep "prometheus-cr"
+            - wget -q -O - http://prometheus-cr-targetallocator/scrape_configs | grep "prometheus-cr"
 ---
 apiVersion: batch/v1
 kind: Job
@@ -57,8 +57,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-targetallocator/jobs | grep "prometheus-cr"
+            - wget -q -O - http://prometheus-cr-targetallocator/jobs | grep "prometheus-cr"

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/02-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/02-install.yaml
@@ -73,11 +73,11 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "scrape-config-cr"
+            - wget -q -O - http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "scrape-config-cr"
 ---
 apiVersion: batch/v1
 kind: Job
@@ -92,11 +92,11 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "/scrapeclass-ca.pem"
+            - wget -q -O - http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "/scrapeclass-ca.pem"
 ---
 apiVersion: batch/v1
 kind: Job
@@ -111,11 +111,11 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-v1beta1-targetallocator/jobs | grep "scrape-config-cr"
+            - wget -q -O - http://prometheus-cr-v1beta1-targetallocator/jobs | grep "scrape-config-cr"
 ---
 apiVersion: batch/v1
 kind: Job
@@ -130,11 +130,11 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "blackbox-exporter"
+            - wget -q -O - http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "blackbox-exporter"
 ---
 apiVersion: batch/v1
 kind: Job
@@ -149,8 +149,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-v1beta1-targetallocator/jobs | grep "blackbox-exporter"
+            - wget -q -O - http://prometheus-cr-v1beta1-targetallocator/jobs | grep "blackbox-exporter"

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/03-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/03-install.yaml
@@ -57,8 +57,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-metrics
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-ns-discovery-v1beta1-targetallocator/scrape_configs | grep "ns-discovery-scrape-config-cr"
+            - wget -q -O - http://prometheus-cr-ns-discovery-v1beta1-targetallocator/scrape_configs | grep "ns-discovery-scrape-config-cr"

--- a/tests/e2e-targetallocator/targetallocator-prometheuscr/04-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-prometheuscr/04-install.yaml
@@ -43,11 +43,11 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-config
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "scrapeclass-smon"
+            - wget -q -O - http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "scrapeclass-smon"
 ---
 # Check scrapeClass TLS caFile is applied specifically to the ServiceMonitor's scrape config,
 # not just to the Probe which also uses the same scrapeClass.
@@ -64,8 +64,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: check-tls
-          image: mirror.gcr.io/curlimages/curl:latest
+          image: mirror.gcr.io/alpine:latest
           args:
             - /bin/sh
             - -c
-            - curl -s http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "scrapeclass-smon.*scrapeclass-ca.pem"
+            - wget -q -O - http://prometheus-cr-v1beta1-targetallocator/scrape_configs | grep "scrapeclass-smon.*scrapeclass-ca.pem"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #issue-number

The `curlimages/curl` is not available on IBM Z, causing our internal tests pipelines to fail. I am switching curl images to `alpine` and wget which is well supported for all platforms. 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
