### PR TITLE
[chore] Fix minor tooling breakage after the api module was introduced

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,9 +355,14 @@ release-artifacts: set-image-controller
 	$(KUSTOMIZE) build config/overlays/openshift -o dist/opentelemetry-operator-openshift.yaml
 
 # Generate manifests e.g. CRD, RBAC etc.
+# apis/ is a nested Go module, which the "./..." pattern does not descend into, so
+# controller-gen only sees the CRD types as an imported dependency. Passing ./apis/...
+# explicitly loads them as source roots, keeping generation deterministic even when a
+# stray copy of the apis module exists on disk (e.g. a git worktree under .claude/),
+# which can otherwise shadow the types and silently drop fields from the CRDs.
 .PHONY: manifests
 manifests: controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=${MANIFEST_DIR}
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." paths="./apis/..." output:crd:artifacts:config=${MANIFEST_DIR}
 
 # Run tests
 .PHONY: test
@@ -386,9 +391,11 @@ lint: golangci-lint
 	$(GOLANGCI_LINT) run
 
 # Generate code
+# apis/ is a nested Go module; pass it explicitly so DeepCopy methods are regenerated
+# for the API types (the "./..." pattern does not descend into nested modules).
 .PHONY: generate
 generate: controller-gen
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..." paths="./apis/..."
 
 ##@ E2E
 # end-to-tests

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 e2e-httproute: chainsaw
 	$(CHAINSAW) test --test-dir ./tests/e2e/httpRoute --report-name e2e-httproute
 # Current Operator version
-VERSION ?= $(shell git describe --tags | sed 's/^v//')
+VERSION ?= $(shell git describe --tags --match 'v*' | sed 's/^v//')
 VERSION_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 VERSION_PKG ?= github.com/open-telemetry/opentelemetry-operator/internal/version
 OTELCOL_VERSION ?= "$(shell awk -F= '/^opentelemetry-collector=/ {print $$2}' versions.txt)"

--- a/hack/ignore-createdAt-bundle.sh
+++ b/hack/ignore-createdAt-bundle.sh
@@ -5,7 +5,9 @@
 # This code checks if only the createdAt field. If is the only change, it is ignored.
 # Else, it will do nothing.
 # https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333
-git diff --quiet -I'^    createdAt: ' bundle
+# --no-ext-diff ensures a globally configured external diff driver (e.g. difftastic)
+# does not bypass the -I regex, which would leave the createdAt-only change unstripped.
+git diff --no-ext-diff --quiet -I'^    createdAt: ' bundle
 if ((! $?)) ; then
     git checkout bundle
 fi


### PR DESCRIPTION
- We determine the version used for local builds from git tags. The tags for the apis module interferes with this, so we filter it out.
- If there's worktrees living in the repo root, controller-gen can get confused about which apis module it should use. Fix it by explicitly passing the path.
- The check for ignoring timestamps in bundles was broken if an external diff viewer was set. Explicitly specify that we shouldn't use one.