### PR TITLE
[chore] Fix renovate config for the apis module

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -142,7 +142,7 @@
     },
     {
       "matchManagers": ["gomod"],
-      "matchFileNames": ["tests/test-e2e-apps/**/go.mod"],
+      "matchFileNames": ["tests/test-e2e-apps/**/go.mod", "apis/go.mod"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Renovate should not update this module's version. We manage it via a local replace. This will prevent unnecessary update PRs like https://github.com/open-telemetry/opentelemetry-operator/pull/5214.
