### PR TITLE
[chore] Fix inverted ApiAvailability.String() values

### DIFF
--- a/internal/autodetect/certmanager/operator_test.go
+++ b/internal/autodetect/certmanager/operator_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package certmanager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAvailabilityString(t *testing.T) {
+	tests := []struct {
+		name         string
+		availability Availability
+		want         string
+	}{
+		{"not available", NotAvailable, "NotAvailable"},
+		{"available", Available, "Available"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.availability.String())
+		})
+	}
+}

--- a/internal/autodetect/collector/operator_test.go
+++ b/internal/autodetect/collector/operator_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package collector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAvailabilityString(t *testing.T) {
+	tests := []struct {
+		name         string
+		availability Availability
+		want         string
+	}{
+		{"not available", NotAvailable, "NotAvailable"},
+		{"available", Available, "Available"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.availability.String())
+		})
+	}
+}

--- a/internal/autodetect/gatewayapi/api.go
+++ b/internal/autodetect/gatewayapi/api.go
@@ -14,5 +14,5 @@ const (
 )
 
 func (p ApiAvailability) String() string {
-	return [...]string{"Available", "NotAvailable"}[p]
+	return [...]string{"NotAvailable", "Available"}[p]
 }

--- a/internal/autodetect/gatewayapi/api_test.go
+++ b/internal/autodetect/gatewayapi/api_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gatewayapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApiAvailabilityString(t *testing.T) {
+	tests := []struct {
+		name         string
+		availability ApiAvailability
+		want         string
+	}{
+		{"not available", ApiNotAvailable, "NotAvailable"},
+		{"available", ApiAvailable, "Available"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.availability.String())
+		})
+	}
+}

--- a/internal/autodetect/opampbridge/operator_test.go
+++ b/internal/autodetect/opampbridge/operator_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package opampbridge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAvailabilityString(t *testing.T) {
+	tests := []struct {
+		name         string
+		availability Availability
+		want         string
+	}{
+		{"not available", NotAvailable, "NotAvailable"},
+		{"available", Available, "Available"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.availability.String())
+		})
+	}
+}

--- a/internal/autodetect/openshift/routes_test.go
+++ b/internal/autodetect/openshift/routes_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package openshift
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoutesAvailabilityString(t *testing.T) {
+	tests := []struct {
+		name         string
+		availability RoutesAvailability
+		want         string
+	}{
+		{"available", RoutesAvailable, "Available"},
+		{"not available", RoutesNotAvailable, "NotAvailable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.availability.String())
+		})
+	}
+}

--- a/internal/autodetect/prometheus/operator_test.go
+++ b/internal/autodetect/prometheus/operator_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAvailabilityString(t *testing.T) {
+	tests := []struct {
+		name         string
+		availability Availability
+		want         string
+	}{
+		{"not available", NotAvailable, "NotAvailable"},
+		{"available", Available, "Available"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.availability.String())
+		})
+	}
+}

--- a/internal/autodetect/rbac/operator_test.go
+++ b/internal/autodetect/rbac/operator_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rbac
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAvailabilityString(t *testing.T) {
+	tests := []struct {
+		name         string
+		availability Availability
+		want         string
+	}{
+		{"not available", NotAvailable, "NotAvailable"},
+		{"available", Available, "Available"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.availability.String())
+		})
+	}
+}

--- a/internal/autodetect/targetallocator/operator_test.go
+++ b/internal/autodetect/targetallocator/operator_test.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package targetallocator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAvailabilityString(t *testing.T) {
+	tests := []struct {
+		name         string
+		availability Availability
+		want         string
+	}{
+		{"not available", NotAvailable, "NotAvailable"},
+		{"available", Available, "Available"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.availability.String())
+		})
+	}
+}


### PR DESCRIPTION
The string slice in gatewayapi.ApiAvailability.String() was ordered inversely.