### PR TITLE
[chore] Reduce flakiness in instrumentation e2e tests

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-apache-httpd/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-httpd/chainsaw-test.yaml
@@ -39,6 +39,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-apache-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-multicontainer/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
           file: 00-install-collector.yaml
       - apply:
           file: 00-install-instrumentation.yaml
+      - sleep:
+          duration: 1s
   - name: step-02
     try:
       - apply:

--- a/tests/e2e-instrumentation/instrumentation-dotnet-initcontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-initcontainer/chainsaw-test.yaml
@@ -14,6 +14,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-multicontainer/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-02
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-dotnet-musl/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet-musl/chainsaw-test.yaml
@@ -15,6 +15,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-dotnet/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-dotnet/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-go/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-go/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - script:

--- a/tests/e2e-instrumentation/instrumentation-java-initcontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-initcontainer/chainsaw-test.yaml
@@ -14,6 +14,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-java-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-multicontainer/chainsaw-test.yaml
@@ -30,6 +30,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-02
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-java-other-ns/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-other-ns/chainsaw-test.yaml
@@ -36,6 +36,8 @@ spec:
         file: 02-install-collector.yaml
     - apply:
         file: 02-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-03
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-java-tls/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java-tls/chainsaw-test.yaml
@@ -35,6 +35,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-java/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-java/chainsaw-test.yaml
@@ -29,6 +29,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nginx-contnr-secctx/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-contnr-secctx/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx-multicontainer/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nginx/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nodejs-initcontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-initcontainer/chainsaw-test.yaml
@@ -14,6 +14,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-multicontainer/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nodejs-volume/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs-volume/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-nodejs/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-python-initcontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-initcontainer/chainsaw-test.yaml
@@ -14,6 +14,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-python-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-multicontainer/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-python-musl/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-musl/chainsaw-test.yaml
@@ -40,6 +40,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-python-specenv/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python-specenv/chainsaw-test.yaml
@@ -8,6 +8,8 @@ spec:
     try:
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-python/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-python/chainsaw-test.yaml
@@ -39,6 +39,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: Install test app
     try:
     - apply:
@@ -103,6 +105,8 @@ spec:
             file: 00-install-collector.yaml
         - apply:
             file: 00-install-instrumentation.yaml
+        - sleep:
+            duration: 1s
     - name: Install test app
       try:
         - apply:

--- a/tests/e2e-instrumentation/instrumentation-sdk-initcontainer/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-sdk-initcontainer/chainsaw-test.yaml
@@ -14,6 +14,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-instrumentation/instrumentation-sdk/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-sdk/chainsaw-test.yaml
@@ -15,6 +15,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer-go/chainsaw-test.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer-go/chainsaw-test.yaml
@@ -15,6 +15,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - script:

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/chainsaw-test.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/chainsaw-test.yaml
@@ -15,6 +15,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-no-containers/chainsaw-test.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-no-containers/chainsaw-test.yaml
@@ -15,6 +15,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:

--- a/tests/e2e-multi-instrumentation/instrumentation-single-instr-first-container/chainsaw-test.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-single-instr-first-container/chainsaw-test.yaml
@@ -15,6 +15,8 @@ spec:
         file: 00-install-collector.yaml
     - apply:
         file: 00-install-instrumentation.yaml
+    - sleep:
+        duration: 1s
   - name: step-01
     try:
     - apply:


### PR DESCRIPTION
The instrumentation e2e tests in tests/e2e-instrumentation and tests/e2e-multi-instrumentation create an Instrumentation and then immediately create a Pod that should be instrumented by the pod mutating webhook. The webhook resolves the Instrumentation from the operator's cache and has failurePolicy: Ignore, so when the Pod is created before the cache has synced the Instrumentation, injection is silently skipped and the test flakes.

Sleep for 1s after applying the Instrumentation so the operator's cache has a chance to catch up before the instrumented Pod is created. This is a pretty stupid solution, but I stress tested it a fair bit in https://github.com/swiatekm/opentelemetry-operator/pull/146 and couldn't get it to fail.

I'd like to fix this in a less hacky way by having the webhook emit a log line whenever it sees an Instrumentation update and gate on that. There's no solution to this problem in general, since we could have multiple replicas of the webhook server and no guarantee about where a particular request will be routed to.
