### PR TITLE
fix(collector): support declarative telemetry resource format

### DIFF
--- a/.chloggen/fix-declarative-telemetry-resource.yaml
+++ b/.chloggen/fix-declarative-telemetry-resource.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mutating webhook no longer overwrites service.telemetry when using declarative resource.attributes schema
+
+# One or more tracking issues related to the change
+issues: [5207]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/otelconfig/config.go
+++ b/internal/otelconfig/config.go
@@ -59,7 +59,7 @@ func (in *MetricsConfig) DeepCopy() *MetricsConfig {
 type Telemetry struct {
 	Metrics MetricsConfig `json:"metrics,omitzero" yaml:"metrics,omitempty"`
 
-	Resource json.RawMessage `json:"resource,omitempty" yaml:"resource,omitempty"`
+	Resource json.RawMessage `json:"resource,omitempty"`
 }
 
 // GetEnabledComponents constructs a list of enabled components by component type.
@@ -407,7 +407,6 @@ func MetricsEndpoint(s *v1beta1.Service, logger logr.Logger) (host string, port 
 		return defaultServiceHost, defaultServicePort, nil
 	}
 
-	// TODO: I think telemetry::metrics::address might be now ignored? https://opentelemetry.io/docs/collector/internal-telemetry/#service-address
 	if telemetry.Metrics.Address != "" && len(telemetry.Metrics.Readers) == 0 {
 		host, port, err := parseAddressEndpoint(telemetry.Metrics.Address)
 		if err != nil {

--- a/internal/otelconfig/config.go
+++ b/internal/otelconfig/config.go
@@ -59,11 +59,7 @@ func (in *MetricsConfig) DeepCopy() *MetricsConfig {
 type Telemetry struct {
 	Metrics MetricsConfig `json:"metrics,omitzero" yaml:"metrics,omitempty"`
 
-	// Resource specifies user-defined attributes to include with all emitted telemetry.
-	// Note that some attributes are added automatically (e.g. service.version) even
-	// if they are not specified here. In order to suppress such attributes the
-	// attribute must be specified in this map with null YAML value (nil string pointer).
-	Resource map[string]*string `json:"resource,omitempty" yaml:"resource,omitempty"`
+	Resource json.RawMessage `json:"resource,omitempty" yaml:"resource,omitempty"`
 }
 
 // GetEnabledComponents constructs a list of enabled components by component type.
@@ -411,6 +407,7 @@ func MetricsEndpoint(s *v1beta1.Service, logger logr.Logger) (host string, port 
 		return defaultServiceHost, defaultServicePort, nil
 	}
 
+	// TODO: I think telemetry::metrics::address might be now ignored? https://opentelemetry.io/docs/collector/internal-telemetry/#service-address
 	if telemetry.Metrics.Address != "" && len(telemetry.Metrics.Readers) == 0 {
 		host, port, err := parseAddressEndpoint(telemetry.Metrics.Address)
 		if err != nil {

--- a/internal/otelconfig/config_test.go
+++ b/internal/otelconfig/config_test.go
@@ -1595,166 +1595,175 @@ func TestAddPrometheusMetricsEndpointPreservesShapeWhenGateDisabled(t *testing.T
 	require.False(t, *reader.Pull.Exporter.Prometheus.WithoutScopeInfo)
 }
 
-func TestGetTelemetryWithLegacyResource(t *testing.T) {
-	svc := v1beta1.Service{
-		Telemetry: &v1beta1.AnyConfig{
-			Object: map[string]any{
-				"metrics":  map[string]any{"level": "detailed"},
-				"resource": map[string]any{"service.name": "my-collector"},
-			},
-		},
-	}
-
-	tel := GetTelemetry(&svc, logr.Discard())
-	require.NotNil(t, tel)
-	assert.Equal(t, "detailed", tel.Metrics.Level)
-	assert.JSONEq(t, `{"service.name":"my-collector"}`, string(tel.Resource))
-}
-
-func TestGetTelemetryWithDeclarativeResource(t *testing.T) {
-	svc := v1beta1.Service{
-		Telemetry: &v1beta1.AnyConfig{
-			Object: map[string]any{
-				"metrics": map[string]any{"level": "detailed"},
-				"resource": map[string]any{
-					"attributes": []any{
-						map[string]any{"name": "service.name", "value": "my-collector"},
-						map[string]any{"name": "deployment.environment.name", "value": "production"},
+func TestGetTelemetryResourceFormats(t *testing.T) {
+	tests := []struct {
+		name             string
+		service          v1beta1.Service
+		expectedResource string // JSON; empty means nil
+	}{
+		{
+			name: "no resource field",
+			service: v1beta1.Service{
+				Telemetry: &v1beta1.AnyConfig{
+					Object: map[string]any{
+						"metrics": map[string]any{"level": "basic"},
 					},
 				},
 			},
 		},
-	}
-
-	tel := GetTelemetry(&svc, logr.Discard())
-	require.NotNil(t, tel, "GetTelemetry must not return nil for declarative resource format")
-	assert.Equal(t, "detailed", tel.Metrics.Level)
-}
-
-func TestServiceApplyDefaultsPreservesLegacyResource(t *testing.T) {
-	cfg := &v1beta1.Config{
-		Service: v1beta1.Service{
-			Telemetry: &v1beta1.AnyConfig{
-				Object: map[string]any{
-					"resource": map[string]any{"service.name": "my-collector"},
+		{
+			name: "legacy key-value resource",
+			service: v1beta1.Service{
+				Telemetry: &v1beta1.AnyConfig{
+					Object: map[string]any{
+						"metrics":  map[string]any{"level": "detailed"},
+						"resource": map[string]any{"service.name": "my-collector"},
+					},
 				},
 			},
+			expectedResource: `{"service.name":"my-collector"}`,
 		},
-	}
-
-	_, err := ServiceApplyDefaults(&cfg.Service, logr.Discard())
-	require.NoError(t, err)
-
-	assert.Equal(t, map[string]any{"service.name": "my-collector"}, cfg.Service.Telemetry.Object["resource"])
-
-	tel := GetTelemetry(&cfg.Service, logr.Discard())
-	require.NotNil(t, tel)
-	require.Len(t, tel.Metrics.Readers, 1, "default Prometheus reader should be injected")
-	assert.JSONEq(t, `{"service.name":"my-collector"}`, string(tel.Resource))
-}
-
-func TestServiceApplyDefaultsPreservesDeclarativeResource(t *testing.T) {
-	declResource := map[string]any{
-		"attributes": []any{
-			map[string]any{"name": "deployment.environment.name", "value": "production"},
-		},
-	}
-	cfg := &v1beta1.Config{
-		Service: v1beta1.Service{
-			Telemetry: &v1beta1.AnyConfig{
-				Object: map[string]any{
-					"resource": declResource,
-					"metrics": map[string]any{
-						"readers": []any{
-							map[string]any{"periodic": map[string]any{
-								"interval": 60000,
-								"exporter": map[string]any{"otlp": map[string]any{
-									"protocol": "grpc", "endpoint": "otel-collector:4317", "insecure": true,
-								}},
-							}},
+		{
+			name: "declarative attributes resource",
+			service: v1beta1.Service{
+				Telemetry: &v1beta1.AnyConfig{
+					Object: map[string]any{
+						"metrics": map[string]any{"level": "detailed"},
+						"resource": map[string]any{
+							"attributes": []any{
+								map[string]any{"name": "service.name", "value": "my-collector"},
+								map[string]any{"name": "deployment.environment.name", "value": "production"},
+							},
 						},
 					},
 				},
 			},
+			expectedResource: `{"attributes":[{"name":"service.name","value":"my-collector"},{"name":"deployment.environment.name","value":"production"}]}`,
 		},
 	}
 
-	_, err := ServiceApplyDefaults(&cfg.Service, logr.Discard())
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tel := GetTelemetry(&tt.service, logr.Discard())
+			require.NotNil(t, tel)
 
-	assert.Equal(t, declResource, cfg.Service.Telemetry.Object["resource"])
+			if tt.expectedResource == "" {
+				assert.Nil(t, tel.Resource)
+			} else {
+				assert.JSONEq(t, tt.expectedResource, string(tel.Resource))
+			}
 
-	tel := GetTelemetry(&cfg.Service, logr.Discard())
-	require.NotNil(t, tel, "GetTelemetry must not return nil for declarative resource format")
+			ac, err := TelemetryToAnyConfig(tel)
+			require.NoError(t, err)
+			if tt.expectedResource == "" {
+				assert.Nil(t, ac.Object["resource"])
+			} else {
+				roundTripped, err := json.Marshal(ac.Object["resource"])
+				require.NoError(t, err)
+				assert.JSONEq(t, tt.expectedResource, string(roundTripped))
+			}
+		})
+	}
 }
 
-func TestServiceApplyDefaultsDoesNotClobberDeclarativeResourceAndReaders(t *testing.T) {
-	declResource := map[string]any{
-		"attributes": []any{
-			map[string]any{"name": "deployment.environment.name", "value": "production"},
-		},
-	}
-	otlpReader := map[string]any{"periodic": map[string]any{
+func TestServiceApplyDefaultsPreservesResourceFormats(t *testing.T) {
+	otlpPeriodicReader := map[string]any{"periodic": map[string]any{
 		"interval": 60000,
 		"exporter": map[string]any{"otlp": map[string]any{
 			"protocol": "grpc", "endpoint": "otel-collector:4317", "insecure": true,
 		}},
 	}}
-	cfg := &v1beta1.Config{
-		Service: v1beta1.Service{
-			Telemetry: &v1beta1.AnyConfig{
-				Object: map[string]any{
-					"resource": declResource,
-					"metrics": map[string]any{
-						"level":   "detailed",
-						"readers": []any{otlpReader},
+
+	tests := []struct {
+		name                string
+		service             v1beta1.Service
+		expectedResource    string // JSON; empty means nil
+		expectedReaderCount int
+	}{
+		{
+			name: "legacy resource gets default Prometheus reader",
+			service: v1beta1.Service{
+				Telemetry: &v1beta1.AnyConfig{
+					Object: map[string]any{
+						"resource": map[string]any{"service.name": "my-collector"},
 					},
 				},
 			},
+			expectedResource:    `{"service.name":"my-collector"}`,
+			expectedReaderCount: 1,
 		},
-	}
-
-	_, err := ServiceApplyDefaults(&cfg.Service, logr.Discard())
-	require.NoError(t, err)
-
-	telObj := cfg.Service.Telemetry.Object
-	assert.Equal(t, declResource, telObj["resource"])
-	assert.Equal(t, map[string]any{
-		"level":   "detailed",
-		"readers": []any{otlpReader},
-	}, telObj["metrics"])
-}
-
-func TestTelemetryToAnyConfigPreservesLegacyResource(t *testing.T) {
-	tel := &Telemetry{
-		Metrics:  MetricsConfig{Level: "basic"},
-		Resource: json.RawMessage(`{"service.name":"my-collector"}`),
-	}
-
-	ac, err := TelemetryToAnyConfig(tel)
-	require.NoError(t, err)
-	assert.Equal(t, map[string]any{"service.name": "my-collector"}, ac.Object["resource"])
-}
-
-func TestGetTelemetryRoundTripPreservesDeclarativeResource(t *testing.T) {
-	declResource := map[string]any{
-		"attributes": []any{
-			map[string]any{"name": "service.name", "value": "my-collector"},
-		},
-	}
-	svc := v1beta1.Service{
-		Telemetry: &v1beta1.AnyConfig{
-			Object: map[string]any{
-				"resource": declResource,
-				"metrics":  map[string]any{"level": "basic"},
+		{
+			name: "declarative resource gets default Prometheus reader",
+			service: v1beta1.Service{
+				Telemetry: &v1beta1.AnyConfig{
+					Object: map[string]any{
+						"resource": map[string]any{
+							"attributes": []any{
+								map[string]any{"name": "deployment.environment.name", "value": "production"},
+							},
+						},
+					},
+				},
 			},
+			expectedResource:    `{"attributes":[{"name":"deployment.environment.name","value":"production"}]}`,
+			expectedReaderCount: 1,
+		},
+		{
+			name: "existing readers not replaced with default",
+			service: v1beta1.Service{
+				Telemetry: &v1beta1.AnyConfig{
+					Object: map[string]any{
+						"resource": map[string]any{
+							"attributes": []any{
+								map[string]any{"name": "deployment.environment.name", "value": "production"},
+							},
+						},
+						"metrics": map[string]any{
+							"readers": []any{otlpPeriodicReader},
+						},
+					},
+				},
+			},
+			expectedResource:    `{"attributes":[{"name":"deployment.environment.name","value":"production"}]}`,
+			expectedReaderCount: 1,
+		},
+		{
+			name: "existing readers and level not clobbered",
+			service: v1beta1.Service{
+				Telemetry: &v1beta1.AnyConfig{
+					Object: map[string]any{
+						"resource": map[string]any{
+							"attributes": []any{
+								map[string]any{"name": "deployment.environment.name", "value": "production"},
+							},
+						},
+						"metrics": map[string]any{
+							"level":   "detailed",
+							"readers": []any{otlpPeriodicReader},
+						},
+					},
+				},
+			},
+			expectedResource:    `{"attributes":[{"name":"deployment.environment.name","value":"production"}]}`,
+			expectedReaderCount: 1,
 		},
 	}
 
-	tel := GetTelemetry(&svc, logr.Discard())
-	require.NotNil(t, tel, "GetTelemetry must not return nil for declarative resource format")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &v1beta1.Config{Service: tt.service}
+			_, err := ServiceApplyDefaults(&cfg.Service, logr.Discard())
+			require.NoError(t, err)
 
-	ac, err := TelemetryToAnyConfig(tel)
-	require.NoError(t, err)
-	assert.Equal(t, declResource, ac.Object["resource"])
+			tel := GetTelemetry(&cfg.Service, logr.Discard())
+			require.NotNil(t, tel)
+
+			if tt.expectedResource == "" {
+				assert.Nil(t, tel.Resource)
+			} else {
+				assert.JSONEq(t, tt.expectedResource, string(tel.Resource))
+			}
+			require.Len(t, tel.Metrics.Readers, tt.expectedReaderCount)
+		})
+	}
 }

--- a/internal/otelconfig/config_test.go
+++ b/internal/otelconfig/config_test.go
@@ -1596,7 +1596,6 @@ func TestAddPrometheusMetricsEndpointPreservesShapeWhenGateDisabled(t *testing.T
 }
 
 func TestGetTelemetryWithLegacyResource(t *testing.T) {
-	name := "my-collector"
 	svc := v1beta1.Service{
 		Telemetry: &v1beta1.AnyConfig{
 			Object: map[string]any{
@@ -1609,7 +1608,7 @@ func TestGetTelemetryWithLegacyResource(t *testing.T) {
 	tel := GetTelemetry(&svc, logr.Discard())
 	require.NotNil(t, tel)
 	assert.Equal(t, "detailed", tel.Metrics.Level)
-	assert.Equal(t, map[string]*string{"service.name": &name}, tel.Resource)
+	assert.JSONEq(t, `{"service.name":"my-collector"}`, string(tel.Resource))
 }
 
 func TestGetTelemetryWithDeclarativeResource(t *testing.T) {
@@ -1648,11 +1647,10 @@ func TestServiceApplyDefaultsPreservesLegacyResource(t *testing.T) {
 
 	assert.Equal(t, map[string]any{"service.name": "my-collector"}, cfg.Service.Telemetry.Object["resource"])
 
-	name := "my-collector"
 	tel := GetTelemetry(&cfg.Service, logr.Discard())
 	require.NotNil(t, tel)
 	require.Len(t, tel.Metrics.Readers, 1, "default Prometheus reader should be injected")
-	assert.Equal(t, map[string]*string{"service.name": &name}, tel.Resource)
+	assert.JSONEq(t, `{"service.name":"my-collector"}`, string(tel.Resource))
 }
 
 func TestServiceApplyDefaultsPreservesDeclarativeResource(t *testing.T) {
@@ -1728,10 +1726,9 @@ func TestServiceApplyDefaultsDoesNotClobberDeclarativeResourceAndReaders(t *test
 }
 
 func TestTelemetryToAnyConfigPreservesLegacyResource(t *testing.T) {
-	name := "my-collector"
 	tel := &Telemetry{
 		Metrics:  MetricsConfig{Level: "basic"},
-		Resource: map[string]*string{"service.name": &name},
+		Resource: json.RawMessage(`{"service.name":"my-collector"}`),
 	}
 
 	ac, err := TelemetryToAnyConfig(tel)

--- a/internal/otelconfig/config_test.go
+++ b/internal/otelconfig/config_test.go
@@ -1594,3 +1594,170 @@ func TestAddPrometheusMetricsEndpointPreservesShapeWhenGateDisabled(t *testing.T
 	require.NotNil(t, reader.Pull.Exporter.Prometheus.WithoutScopeInfo)
 	require.False(t, *reader.Pull.Exporter.Prometheus.WithoutScopeInfo)
 }
+
+func TestGetTelemetryWithLegacyResource(t *testing.T) {
+	name := "my-collector"
+	svc := v1beta1.Service{
+		Telemetry: &v1beta1.AnyConfig{
+			Object: map[string]any{
+				"metrics":  map[string]any{"level": "detailed"},
+				"resource": map[string]any{"service.name": "my-collector"},
+			},
+		},
+	}
+
+	tel := GetTelemetry(&svc, logr.Discard())
+	require.NotNil(t, tel)
+	assert.Equal(t, "detailed", tel.Metrics.Level)
+	assert.Equal(t, map[string]*string{"service.name": &name}, tel.Resource)
+}
+
+func TestGetTelemetryWithDeclarativeResource(t *testing.T) {
+	svc := v1beta1.Service{
+		Telemetry: &v1beta1.AnyConfig{
+			Object: map[string]any{
+				"metrics": map[string]any{"level": "detailed"},
+				"resource": map[string]any{
+					"attributes": []any{
+						map[string]any{"name": "service.name", "value": "my-collector"},
+						map[string]any{"name": "deployment.environment.name", "value": "production"},
+					},
+				},
+			},
+		},
+	}
+
+	tel := GetTelemetry(&svc, logr.Discard())
+	require.NotNil(t, tel, "GetTelemetry must not return nil for declarative resource format")
+	assert.Equal(t, "detailed", tel.Metrics.Level)
+}
+
+func TestServiceApplyDefaultsPreservesLegacyResource(t *testing.T) {
+	cfg := &v1beta1.Config{
+		Service: v1beta1.Service{
+			Telemetry: &v1beta1.AnyConfig{
+				Object: map[string]any{
+					"resource": map[string]any{"service.name": "my-collector"},
+				},
+			},
+		},
+	}
+
+	_, err := ServiceApplyDefaults(&cfg.Service, logr.Discard())
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]any{"service.name": "my-collector"}, cfg.Service.Telemetry.Object["resource"])
+
+	name := "my-collector"
+	tel := GetTelemetry(&cfg.Service, logr.Discard())
+	require.NotNil(t, tel)
+	require.Len(t, tel.Metrics.Readers, 1, "default Prometheus reader should be injected")
+	assert.Equal(t, map[string]*string{"service.name": &name}, tel.Resource)
+}
+
+func TestServiceApplyDefaultsPreservesDeclarativeResource(t *testing.T) {
+	declResource := map[string]any{
+		"attributes": []any{
+			map[string]any{"name": "deployment.environment.name", "value": "production"},
+		},
+	}
+	cfg := &v1beta1.Config{
+		Service: v1beta1.Service{
+			Telemetry: &v1beta1.AnyConfig{
+				Object: map[string]any{
+					"resource": declResource,
+					"metrics": map[string]any{
+						"readers": []any{
+							map[string]any{"periodic": map[string]any{
+								"interval": 60000,
+								"exporter": map[string]any{"otlp": map[string]any{
+									"protocol": "grpc", "endpoint": "otel-collector:4317", "insecure": true,
+								}},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := ServiceApplyDefaults(&cfg.Service, logr.Discard())
+	require.NoError(t, err)
+
+	assert.Equal(t, declResource, cfg.Service.Telemetry.Object["resource"])
+
+	tel := GetTelemetry(&cfg.Service, logr.Discard())
+	require.NotNil(t, tel, "GetTelemetry must not return nil for declarative resource format")
+}
+
+func TestServiceApplyDefaultsDoesNotClobberDeclarativeResourceAndReaders(t *testing.T) {
+	declResource := map[string]any{
+		"attributes": []any{
+			map[string]any{"name": "deployment.environment.name", "value": "production"},
+		},
+	}
+	otlpReader := map[string]any{"periodic": map[string]any{
+		"interval": 60000,
+		"exporter": map[string]any{"otlp": map[string]any{
+			"protocol": "grpc", "endpoint": "otel-collector:4317", "insecure": true,
+		}},
+	}}
+	cfg := &v1beta1.Config{
+		Service: v1beta1.Service{
+			Telemetry: &v1beta1.AnyConfig{
+				Object: map[string]any{
+					"resource": declResource,
+					"metrics": map[string]any{
+						"level":   "detailed",
+						"readers": []any{otlpReader},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := ServiceApplyDefaults(&cfg.Service, logr.Discard())
+	require.NoError(t, err)
+
+	telObj := cfg.Service.Telemetry.Object
+	assert.Equal(t, declResource, telObj["resource"])
+	assert.Equal(t, map[string]any{
+		"level":   "detailed",
+		"readers": []any{otlpReader},
+	}, telObj["metrics"])
+}
+
+func TestTelemetryToAnyConfigPreservesLegacyResource(t *testing.T) {
+	name := "my-collector"
+	tel := &Telemetry{
+		Metrics:  MetricsConfig{Level: "basic"},
+		Resource: map[string]*string{"service.name": &name},
+	}
+
+	ac, err := TelemetryToAnyConfig(tel)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"service.name": "my-collector"}, ac.Object["resource"])
+}
+
+func TestGetTelemetryRoundTripPreservesDeclarativeResource(t *testing.T) {
+	declResource := map[string]any{
+		"attributes": []any{
+			map[string]any{"name": "service.name", "value": "my-collector"},
+		},
+	}
+	svc := v1beta1.Service{
+		Telemetry: &v1beta1.AnyConfig{
+			Object: map[string]any{
+				"resource": declResource,
+				"metrics":  map[string]any{"level": "basic"},
+			},
+		},
+	}
+
+	tel := GetTelemetry(&svc, logr.Discard())
+	require.NotNil(t, tel, "GetTelemetry must not return nil for declarative resource format")
+
+	ac, err := TelemetryToAnyConfig(tel)
+	require.NoError(t, err)
+	assert.Equal(t, declResource, ac.Object["resource"])
+}


### PR DESCRIPTION
## Summary

Fixes #5207.

- The `Telemetry.Resource` field was typed as `map[string]*string`, which rejected the declarative `resource.attributes` array format introduced in Collector v0.151.0
- `GetTelemetry` failed to unmarshal, returned nil, and `ServiceApplyDefaults` overwrote the entire telemetry block with defaults — dropping user-provided resource attributes, metrics level, and custom readers
- Changed `Resource` to `json.RawMessage` so both legacy and declarative formats pass through without interpretation

## Test plan

- Added 7 unit tests covering legacy and declarative resource formats through `GetTelemetry`, `ServiceApplyDefaults`, and `TelemetryToAnyConfig`
