### PR TITLE
Stop honoring deprecated telemetry.metrics.address

### DIFF
--- a/internal/manifests/collector/service_test.go
+++ b/internal/manifests/collector/service_test.go
@@ -299,8 +299,19 @@ func TestMonitoringService(t *testing.T) {
 				Telemetry: &v1beta1.AnyConfig{
 					Object: map[string]any{
 						"metrics": map[string]any{
-							"level":   "detailed",
-							"address": "0.0.0.0:9090",
+							"level": "detailed",
+							"readers": []any{
+								map[string]any{
+									"pull": map[string]any{
+										"exporter": map[string]any{
+											"prometheus": map[string]any{
+												"host": "0.0.0.0",
+												"port": 9090,
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},

--- a/internal/otelconfig/config.go
+++ b/internal/otelconfig/config.go
@@ -411,13 +411,9 @@ func MetricsEndpoint(s *v1beta1.Service, logger logr.Logger) (host string, port 
 		return defaultServiceHost, defaultServicePort, nil
 	}
 
-	if telemetry.Metrics.Address != "" && len(telemetry.Metrics.Readers) == 0 {
-		host, port, err := parseAddressEndpoint(telemetry.Metrics.Address)
-		if err != nil {
-			return "", 0, err
-		}
-
-		return host, port, nil
+	if telemetry.Metrics.Address != "" {
+		logger.Info("telemetry.metrics.address is deprecated and ignored by the collector, use telemetry.metrics.readers instead",
+			"address", telemetry.Metrics.Address)
 	}
 
 	for _, r := range telemetry.Metrics.Readers {
@@ -459,10 +455,8 @@ func ServiceApplyDefaults(s *v1beta1.Service, logger logr.Logger) ([]v1beta1.Eve
 		}
 	}
 
-	if tel.Metrics.Address != "" || len(tel.Metrics.Readers) != 0 {
-		// The user already set the address or the readers, so we don't need to do anything
+	if len(tel.Metrics.Readers) != 0 {
 		logger.V(1).Info("telemetry configuration already provided by user, skipping defaults",
-			"metricsAddress", tel.Metrics.Address,
 			"readersCount", len(tel.Metrics.Readers))
 		return events, nil
 	}

--- a/internal/otelconfig/config_test.go
+++ b/internal/otelconfig/config_test.go
@@ -308,7 +308,18 @@ func TestConfigMetricsEndpoint(t *testing.T) {
 				Telemetry: &v1beta1.AnyConfig{
 					Object: map[string]any{
 						"metrics": map[string]any{
-							"address": "localhost:9090",
+							"readers": []any{
+								map[string]any{
+									"pull": map[string]any{
+										"exporter": map[string]any{
+											"prometheus": map[string]any{
+												"host": "localhost",
+												"port": 9090,
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -322,7 +333,18 @@ func TestConfigMetricsEndpoint(t *testing.T) {
 				Telemetry: &v1beta1.AnyConfig{
 					Object: map[string]any{
 						"metrics": map[string]any{
-							"address": "[::]:9090",
+							"readers": []any{
+								map[string]any{
+									"pull": map[string]any{
+										"exporter": map[string]any{
+											"prometheus": map[string]any{
+												"host": "[::]",
+												"port": 9090,
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -336,7 +358,17 @@ func TestConfigMetricsEndpoint(t *testing.T) {
 				Telemetry: &v1beta1.AnyConfig{
 					Object: map[string]any{
 						"metrics": map[string]any{
-							"address": "localhost",
+							"readers": []any{
+								map[string]any{
+									"pull": map[string]any{
+										"exporter": map[string]any{
+											"prometheus": map[string]any{
+												"host": "localhost",
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -350,89 +382,31 @@ func TestConfigMetricsEndpoint(t *testing.T) {
 				Telemetry: &v1beta1.AnyConfig{
 					Object: map[string]any{
 						"metrics": map[string]any{
-							"address": "[::]",
+							"readers": []any{
+								map[string]any{
+									"pull": map[string]any{
+										"exporter": map[string]any{
+											"prometheus": map[string]any{
+												"host": "[::]",
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
 			},
 		},
 		{
-			desc:         "env var and missing port",
-			expectedAddr: "${env:POD_IP}",
+			desc:         "deprecated address is ignored, returns defaults",
+			expectedAddr: "0.0.0.0",
 			expectedPort: 8888,
 			config: v1beta1.Service{
 				Telemetry: &v1beta1.AnyConfig{
 					Object: map[string]any{
 						"metrics": map[string]any{
-							"address": "${env:POD_IP}",
-						},
-					},
-				},
-			},
-		},
-		{
-			desc:         "env var and missing port ipv6",
-			expectedAddr: "[${env:POD_IP}]",
-			expectedPort: 8888,
-			config: v1beta1.Service{
-				Telemetry: &v1beta1.AnyConfig{
-					Object: map[string]any{
-						"metrics": map[string]any{
-							"address": "[${env:POD_IP}]",
-						},
-					},
-				},
-			},
-		},
-		{
-			desc:         "env var and with port",
-			expectedAddr: "${POD_IP}",
-			expectedPort: 1234,
-			config: v1beta1.Service{
-				Telemetry: &v1beta1.AnyConfig{
-					Object: map[string]any{
-						"metrics": map[string]any{
-							"address": "${POD_IP}:1234",
-						},
-					},
-				},
-			},
-		},
-		{
-			desc:         "env var and with port ipv6",
-			expectedAddr: "[${POD_IP}]",
-			expectedPort: 1234,
-			config: v1beta1.Service{
-				Telemetry: &v1beta1.AnyConfig{
-					Object: map[string]any{
-						"metrics": map[string]any{
-							"address": "[${POD_IP}]:1234",
-						},
-					},
-				},
-			},
-		},
-		{
-			desc:        "port is env var",
-			expectedErr: true,
-			config: v1beta1.Service{
-				Telemetry: &v1beta1.AnyConfig{
-					Object: map[string]any{
-						"metrics": map[string]any{
-							"address": "localhost:${env:POD_PORT}",
-						},
-					},
-				},
-			},
-		},
-		{
-			desc:        "port is env var ipv6",
-			expectedErr: true,
-			config: v1beta1.Service{
-				Telemetry: &v1beta1.AnyConfig{
-					Object: map[string]any{
-						"metrics": map[string]any{
-							"address": "[::]:${env:POD_PORT}",
+							"address": "localhost:9090",
 						},
 					},
 				},
@@ -466,9 +440,9 @@ func TestConfigMetricsEndpoint(t *testing.T) {
 			expectedPort: 8888,
 		},
 		{
-			desc:         "configured telemetry",
-			expectedAddr: "1.2.3.4",
-			expectedPort: 4567,
+			desc:         "configured telemetry with only address returns defaults",
+			expectedAddr: "0.0.0.0",
+			expectedPort: 8888,
 			config: v1beta1.Service{
 				Telemetry: &v1beta1.AnyConfig{
 					Object: map[string]any{


### PR DESCRIPTION
## Summary

- Stop parsing `telemetry.metrics.address` for the monitoring service; log a deprecation warning instead
- The v0.122.0 upgrade function already migrates `address` → `readers` automatically, so this field should no longer be present in practice
- Inject default telemetry readers when only `address` is set (since the collector ignores it)
