### PR TITLE
Add relabeling conformance tests for target allocator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,12 @@ manifests: controller-gen
 test: gotestsum
 	$(GOTESTSUM) -- ${GOTEST_OPTS} ./...
 
+# Regenerate the conformance goldens from raw Prometheus (promtool).
+# Run this after adding/changing fixtures or bumping the prometheus dependency.
+.PHONY: ta-conformance-regen
+ta-conformance-regen: promtool
+	PROMTOOL=$(PROMTOOL) go test -count=1 ./cmd/otel-allocator/internal/conformance/... -update
+
 # Run precommit checks (format, vet, lint, test, validation)
 .PHONY: precommit
 precommit: fmt vet lint test ensure-update-is-noop
@@ -794,6 +800,12 @@ CHAINSAW_VERSION ?= v0.2.15
 GOTESTSUM_VERSION ?= v1.13.0
 # renovate: datasource=go depName=golang.org/x/vuln/cmd/govulncheck
 GOVULNCHECK_VERSION ?= v1.4.0
+PROMTOOL ?= $(LOCALBIN)/promtool
+# promtool is the golden source for the target-allocator conformance suite. It must match
+# the prometheus/prometheus library the operator links against, so derive the release version
+# straight from go.mod. The library is tagged v0.<major><minor>.<patch> (e.g. v0.312.0 ==
+# Prometheus 3.12.0), hence the awk arithmetic below.
+PROMTOOL_VERSION ?= $(shell awk '$$1=="github.com/prometheus/prometheus"{split($$2,v,".");printf "%d.%d.%d",int(v[2]/100),v[2]%100,v[3]}' go.mod)
 
 # Install all development tools
 .PHONY: install-tools
@@ -839,6 +851,24 @@ gotestsum: ## Find or download gotestsum
 .PHONY: govulncheck
 govulncheck: ## Download govulncheck locally if necessary.
 	$(call go-install-tool,$(GOVULNCHECK),golang.org/x/vuln/cmd/govulncheck,$(GOVULNCHECK_VERSION))
+
+# Download promtool locally if necessary (conformance suite golden source; can't be go-installed
+# because prometheus/prometheus uses replace directives, so pull the release binary).
+.PHONY: promtool
+promtool: ## Download promtool locally if necessary.
+	@{ \
+	set -e ;\
+	if ($(PROMTOOL) --version 2>&1 | grep $(PROMTOOL_VERSION)) > /dev/null 2>&1 ; then \
+		exit 0; \
+	fi ;\
+	TMP_DIR=$$(mktemp -d) ;\
+	curl -fSL --retry 5 --retry-delay 2 --retry-all-errors -o $$TMP_DIR/prometheus.tar.gz https://github.com/prometheus/prometheus/releases/download/v$(PROMTOOL_VERSION)/prometheus-$(PROMTOOL_VERSION).`go env GOOS`-`go env GOARCH`.tar.gz ;\
+	gzip -t $$TMP_DIR/prometheus.tar.gz || { echo "ERROR: downloaded prometheus archive is corrupt or incomplete" >&2; exit 1; } ;\
+	tar xzf $$TMP_DIR/prometheus.tar.gz -C $$TMP_DIR --strip-components=1 --wildcards '*/promtool' ;\
+	[ -d $(LOCALBIN) ] || mkdir -p $(LOCALBIN) ;\
+	mv $$TMP_DIR/promtool $(PROMTOOL) ;\
+	rm -rf $$TMP_DIR ;\
+	}
 
 # Run govulncheck with the project's CVE exception list
 .PHONY: govulncheck-run

--- a/cmd/otel-allocator/internal/conformance/conformance_test.go
+++ b/cmd/otel-allocator/internal/conformance/conformance_test.go
@@ -1,0 +1,197 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package conformance
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/config"
+)
+
+var update = flag.Bool("update", false, "regenerate golden.json files via promtool ($PROMTOOL)")
+
+// seededLabels are the labels Prometheus's scrape layer (PopulateLabels) adds
+// before relabeling, which the target allocator intentionally does not seed
+// (the collector's prometheus receiver adds them later). They are excluded when
+// comparing the allocator's served pre-relabel labels to Prometheus's
+// discoveredLabels.
+var seededLabels = []string{
+	"job",
+	"__scheme__",
+	"__metrics_path__",
+	"__scrape_interval__",
+	"__scrape_timeout__",
+}
+
+// divergentFixtures are fixtures whose behavior is known to differ from raw
+// Prometheus. They are skipped until the allocator is fixed.
+var divergentFixtures = map[string]string{
+	"seeded-labels": "relabel rules referencing scrape-seeded labels diverge from Prometheus (regression of #4074); see testdata/gap-seeded-labels/",
+}
+
+// TestConformance runs every fixture under testdata/ through the target
+// allocator and compares against the committed promtool golden.
+func TestConformance(t *testing.T) {
+	fixtures, err := filepath.Glob("testdata/*/prometheus.yaml")
+	require.NoError(t, err)
+	require.NotEmpty(t, fixtures, "no fixtures found under testdata/")
+
+	for _, cfgPath := range fixtures {
+		dir := filepath.Dir(cfgPath)
+		name := filepath.Base(dir)
+		t.Run(name, func(t *testing.T) {
+			promYAML, err := os.ReadFile(cfgPath)
+			require.NoError(t, err)
+			goldenPath := filepath.Join(dir, "golden.json")
+
+			if *update {
+				regenGolden(t, cfgPath, jobNames(t, string(promYAML)), goldenPath)
+			}
+			if reason, ok := divergentFixtures[name]; ok {
+				t.Skip(reason)
+			}
+
+			golden := loadGolden(t, goldenPath)
+			allocator := runAllocatorPipeline(t, string(promYAML))
+			for _, m := range compare(allocator, golden) {
+				assert.Fail(t, m)
+			}
+		})
+	}
+}
+
+func jobNames(t *testing.T, promYAML string) []string {
+	cfg, err := promconfig.Load(promYAML, config.NopLogger)
+	require.NoError(t, err)
+	jobs := make([]string, 0, len(cfg.ScrapeConfigs))
+	for _, sc := range cfg.ScrapeConfigs {
+		jobs = append(jobs, sc.JobName)
+	}
+	return jobs
+}
+
+// matchedPair is a target matched between the allocator and the Prometheus
+// golden, joined on (job, address) and — for shared addresses — on the
+// pre-relabel label set.
+type matchedPair struct {
+	key targetKey
+	a   allocatorResult
+	gt  goldenTarget
+}
+
+// compare runs the three differential assertions against raw Prometheus and
+// returns a (sorted) list of mismatch descriptions; empty means conformant.
+//
+//	keep/drop parity:    the allocator keeps a target iff Prometheus does.
+//	merge fidelity:      the allocator's served (pre-relabel) labels equal
+//	                     Prometheus's discoveredLabels minus the scrape labels it
+//	                     defers to the receiver.
+//	identity grouping:   the allocator's identity-hash partition equals
+//	                     Prometheus's post-relabel-label partition (no silent
+//	                     collisions, no false splits).
+func compare(allocator map[targetKey][]allocatorResult, golden map[targetKey][]goldenTarget) []string {
+	var mismatches []string
+	var pairs []matchedPair
+
+	keys := map[targetKey]struct{}{}
+	for k := range allocator {
+		keys[k] = struct{}{}
+	}
+	for k := range golden {
+		keys[k] = struct{}{}
+	}
+	for k := range keys {
+		p, unmatched := matchBucket(k, allocator[k], golden[k])
+		pairs = append(pairs, p...)
+		mismatches = append(mismatches, unmatched...)
+	}
+
+	for _, p := range pairs {
+		if want := !p.gt.dropped(); want != p.a.kept {
+			mismatches = append(mismatches, fmt.Sprintf("keep/drop mismatch for %+v: Prometheus kept=%v, allocator kept=%v", p.key, want, p.a.kept))
+		}
+		if want, got := withoutSeeded(p.gt.DiscoveredLabels), p.a.item.Labels; !labels.Equal(want, got) {
+			mismatches = append(mismatches, fmt.Sprintf("merge/discovered-label mismatch for %+v:\n      want %v\n      got  %v", p.key, want, got))
+		}
+	}
+
+	mismatches = append(mismatches, identityPartitionMismatches(pairs)...)
+	slices.Sort(mismatches)
+	return mismatches
+}
+
+// matchBucket pairs the allocator and golden targets that share a (job, address)
+// bucket. The common case is exactly one of each, paired directly so keep/drop
+// and merge differences read cleanly. When several targets share an address they
+// are matched by their pre-relabel label set; leftovers are reported as unmatched.
+func matchBucket(key targetKey, al []allocatorResult, gl []goldenTarget) (pairs []matchedPair, unmatched []string) {
+	if len(al) == 1 && len(gl) == 1 {
+		return []matchedPair{{key, al[0], gl[0]}}, nil
+	}
+	used := make([]bool, len(gl))
+	for _, a := range al {
+		ah := a.item.Labels.Hash()
+		match := -1
+		for i, g := range gl {
+			if !used[i] && withoutSeeded(g.DiscoveredLabels).Hash() == ah {
+				match = i
+				break
+			}
+		}
+		if match < 0 {
+			unmatched = append(unmatched, fmt.Sprintf("allocator target %+v %v has no matching Prometheus target", key, a.item.Labels))
+			continue
+		}
+		used[match] = true
+		pairs = append(pairs, matchedPair{key, a, gl[match]})
+	}
+	for i, g := range gl {
+		if !used[i] {
+			unmatched = append(unmatched, fmt.Sprintf("Prometheus target %+v %v has no matching allocator target", key, withoutSeeded(g.DiscoveredLabels)))
+		}
+	}
+	return pairs, unmatched
+}
+
+// identityPartitionMismatches checks that, over surviving targets, the
+// equivalence relation induced by the allocator's identity hash matches the one
+// induced by Prometheus's post-relabel label set.
+func identityPartitionMismatches(pairs []matchedPair) []string {
+	var kept []matchedPair
+	for _, p := range pairs {
+		if p.a.kept && !p.gt.dropped() {
+			kept = append(kept, p)
+		}
+	}
+
+	var mismatches []string
+	for i := 0; i < len(kept); i++ {
+		for j := i + 1; j < len(kept); j++ {
+			p1, p2 := kept[i], kept[j]
+			sameProm := p1.gt.Labels.Hash() == p2.gt.Labels.Hash()
+			sameAllocator := p1.a.item.Hash() == p2.a.item.Hash()
+			if sameProm != sameAllocator {
+				mismatches = append(mismatches, fmt.Sprintf(
+					"identity-grouping mismatch for %+v vs %+v: Prometheus same-identity=%v, allocator same-hash=%v",
+					p1.key, p2.key, sameProm, sameAllocator))
+			}
+		}
+	}
+	return mismatches
+}
+
+// withoutSeeded returns the label set with the Prometheus-seeded labels removed.
+func withoutSeeded(ls labels.Labels) labels.Labels {
+	return labels.NewBuilder(ls).Del(seededLabels...).Labels()
+}

--- a/cmd/otel-allocator/internal/conformance/golden.go
+++ b/cmd/otel-allocator/internal/conformance/golden.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package conformance
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+// goldenTarget mirrors one element of `promtool check service-discovery` output
+// (promtool's own sdCheckResult, hence labels.Labels). An empty Labels set means
+// Prometheus dropped the target during relabeling.
+type goldenTarget struct {
+	DiscoveredLabels labels.Labels `json:"discoveredLabels"`
+	Labels           labels.Labels `json:"labels"`
+}
+
+func (g goldenTarget) dropped() bool { return g.Labels.IsEmpty() }
+
+func (g goldenTarget) key() targetKey {
+	return targetKey{job: g.DiscoveredLabels.Get("job"), address: g.DiscoveredLabels.Get("__address__")}
+}
+
+// loadGolden reads a committed promtool golden file, bucketed by (job, address).
+func loadGolden(t *testing.T, path string) map[targetKey][]goldenTarget {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoErrorf(t, err, "reading golden %s (run `make ta-conformance-regen` or `go test -update`)", path)
+	var targets []goldenTarget
+	require.NoErrorf(t, json.Unmarshal(data, &targets), "parsing golden %s", path)
+	out := make(map[targetKey][]goldenTarget, len(targets))
+	for _, gt := range targets {
+		out[gt.key()] = append(out[gt.key()], gt)
+	}
+	return out
+}
+
+// regenGolden (re)generates a golden file by running promtool against the
+// fixture, once per job, concatenating the results. The promtool binary is
+// taken from $PROMTOOL (default "promtool"); it must match the Prometheus
+// version in go.mod.
+func regenGolden(t *testing.T, promYAMLPath string, jobs []string, outPath string) {
+	t.Helper()
+	promtool := os.Getenv("PROMTOOL")
+	if promtool == "" {
+		promtool = "promtool"
+	}
+	// static_configs / file_sd resolve immediately; promtool waits the full
+	// --timeout before dumping, so a short timeout keeps regeneration fast.
+	timeout := os.Getenv("PROMTOOL_TIMEOUT")
+	if timeout == "" {
+		timeout = "2s"
+	}
+	var all []goldenTarget
+	for _, job := range jobs {
+		out, err := exec.CommandContext( //nolint:gosec,G702 // test code, not actual command injection
+			t.Context(),
+			promtool,
+			"check",
+			"service-discovery",
+			"--timeout="+timeout,
+			promYAMLPath,
+			job,
+		).Output()
+		require.NoErrorf(t, err, "promtool check service-discovery for job %q (stderr may have detail)", job)
+		var targets []goldenTarget
+		require.NoErrorf(t, json.Unmarshal(out, &targets), "parsing promtool output for job %q", job)
+		all = append(all, targets...)
+	}
+	data, err := json.MarshalIndent(all, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(outPath, append(data, '\n'), 0o600))
+}

--- a/cmd/otel-allocator/internal/conformance/pipeline.go
+++ b/cmd/otel-allocator/internal/conformance/pipeline.go
@@ -1,0 +1,126 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package conformance contains a differential conformance suite for the target
+// allocator's discovery + relabel pipeline. It runs the allocator's real code
+// (label merge, relabel filtering, identity hashing) over a matrix of scrape
+// configs and compares the result against raw Prometheus, captured via
+// `promtool check service-discovery` golden files.
+//
+// The suite asserts purely on target label sets and identity — the target
+// allocator's actual job and where its historically recurring bugs live
+// (silent target loss from identity/label-set divergence). It needs no
+// Kubernetes cluster, no collector, and no metrics backend.
+package conformance
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/go-logr/logr"
+	promconfig "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/prehook"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/target"
+)
+
+// targetKey joins a Prometheus golden target to an allocator target. Both sides
+// retain the pre-relabel address, so (job, address) is a stable join key for the
+// fixtures, which use distinct addresses per target except where they
+// deliberately share one (then disambiguated by their label set).
+type targetKey struct {
+	job     string
+	address string
+}
+
+// allocatorResult is the target allocator's view of one discovered target: the
+// produced target.Item plus whether it survived relabel filtering — a status the
+// Item itself does not carry. When kept, item is the filtered Item, so item.Hash()
+// returns the allocator's relabel-computed identity hash.
+type allocatorResult struct {
+	item *target.Item
+	kept bool
+}
+
+func (r allocatorResult) key() targetKey {
+	return targetKey{r.item.JobName, r.item.TargetURL}
+}
+
+// runAllocatorPipeline drives the target allocator's real discovery + relabel
+// pipeline over a raw Prometheus config and returns its per-target results,
+// bucketed by (job, address). A bucket holds more than one result only when
+// several targets share a pre-relabel address.
+//
+// It reuses the allocator's own code paths:
+//   - target.Discoverer.UpdateTsets + Reload run processTargetGroups/mergeLabels
+//     synchronously (bypassing the production 5s reload debounce).
+//   - prehook.Hook.Apply runs relabel filtering and computes the identity hash.
+//
+// Only static_configs are supported for now; file_sd and others can be added later.
+func runAllocatorPipeline(t *testing.T, promYAML string) map[targetKey][]allocatorResult {
+	t.Helper()
+
+	cfg, err := promconfig.Load(promYAML, config.NopLogger)
+	require.NoError(t, err, "loading fixture prometheus config")
+
+	// Drive processTargetGroups via the real Discoverer. The capture callback
+	// receives all discovered items (post-merge, pre-relabel-filter).
+	var captured []*target.Item
+	discoverer, err := target.NewDiscoverer(logr.Discard(), nil, nil, nil, func(items []*target.Item) {
+		captured = items
+	})
+	require.NoError(t, err)
+
+	tsets := map[string][]*targetgroup.Group{}
+	relabelCfg := map[string][]*relabel.Config{}
+	for _, sc := range cfg.ScrapeConfigs {
+		var groups []*targetgroup.Group
+		for _, sdc := range sc.ServiceDiscoveryConfigs {
+			static, ok := sdc.(discovery.StaticConfig)
+			require.Truef(t, ok, "job %q uses unsupported service discovery %T; only static_configs are supported", sc.JobName, sdc)
+			groups = append(groups, static...)
+		}
+		tsets[sc.JobName] = groups
+		relabelCfg[sc.JobName] = sc.RelabelConfigs
+	}
+
+	discoverer.UpdateTsets(tsets)
+	discoverer.Reload()
+	allItems := captured
+
+	// Apply relabel filtering exactly as production does. Apply mutates its
+	// input slice in place, so feed it a clone to keep allItems intact.
+	hook := prehook.New("relabel-config", logr.Discard())
+	require.NotNil(t, hook)
+	hook.SetConfig(relabelCfg)
+	kept := hook.Apply(slices.Clone(allItems))
+
+	// Index kept items by (job, full pre-relabel label-set hash) — not by address,
+	// so targets that share a pre-relabel address are not confused. We keep a
+	// pointer to the filtered Item because it carries the relabel-computed identity
+	// hash used later.
+	type labelIndexKey struct {
+		job       string
+		labelHash uint64
+	}
+	keptByLabels := make(map[labelIndexKey]*target.Item, len(kept))
+	for _, it := range kept {
+		keptByLabels[labelIndexKey{it.JobName, it.Labels.Hash()}] = it
+	}
+
+	out := make(map[targetKey][]allocatorResult, len(allItems))
+	for _, it := range allItems {
+		r := allocatorResult{item: it}
+		if filtered, ok := keptByLabels[labelIndexKey{it.JobName, it.Labels.Hash()}]; ok {
+			r.item = filtered
+			r.kept = true
+		}
+		out[r.key()] = append(out[r.key()], r)
+	}
+	return out
+}

--- a/cmd/otel-allocator/internal/conformance/testdata/README.md
+++ b/cmd/otel-allocator/internal/conformance/testdata/README.md
@@ -1,0 +1,56 @@
+# Target allocator conformance fixtures
+
+Each subdirectory is one differential test case:
+
+- `prometheus.yaml` - a **raw Prometheus** config (top-level `scrape_configs:`), consumed by both the target allocator
+  and `promtool` (the golden source). Use
+  `static_configs`; `__meta_*` labels may be set directly on static targets to exercise relabeling that would normally
+  come from Kubernetes service discovery.
+- `golden.json` - the committed golden: `promtool check service-discovery`
+  output, one entry per discovered target (`discoveredLabels` pre-relabel,
+  `labels` post-relabel; empty `labels` means the target was dropped).
+
+## Scope
+
+Fixtures use `static_configs` only. That is deliberate, not a coverage gap:
+
+- **Relabeling is service-discovery-agnostic.** It operates on the discovered label set, so static targets carrying
+  synthetic `__meta_*` labels exercise the same relabel/merge/identity logic that `kubernetes_sd`/`file_sd` feed into.
+  Target *production* for those mechanisms is upstream Prometheus code the allocator uses unchanged via
+  `discovery.Manager`, so the suite hands target groups straight to the merge/filter rather than running discovery
+  (whose update debounce also adds ~5s per config). `file_sd` would additionally require reproducing Prometheus's
+  `__meta_filepath` exactly.
+- **Sharding** - the prometheus-operator `$(SHARD)`/hashmod rules the allocator neutralizes via `addNoShardingConfig` -
+  is allocator-specific behavior that intentionally diverges from raw Prometheus, so it does not fit this differential
+  model. It is covered by `TestApplyHashmodAction` in `internal/prehook`.
+
+## What is asserted
+
+For every fixture the suite compares the allocator's discovery+relabel result against the golden (see
+`../conformance_test.go`):
+
+- **keep/drop parity**: the allocator keeps a target iff Prometheus does.
+- **identity grouping**: the allocator's identity-hash partition equals Prometheus's post-relabel-label partition. This
+  guards against the recurring target-identity bug class.
+- **merge fidelity**: the allocator's served pre-relabel labels equal Prometheus's `discoveredLabels` minus the scrape
+  labels it defers to the collector (`job`, `__scheme__`, `__metrics_path__`, `__scrape_interval__`,
+  `__scrape_timeout__`).
+
+## Known divergences
+
+Fixtures whose behavior currently differs from raw Prometheus are listed in
+`divergentFixtures` in `../conformance_test.go` and skipped with a reason. See `seeded-labels/` for an example (relabel rules on scrape-seeded labels).
+
+## Adding or updating a case
+
+1. Add `cmd/otel-allocator/internal/conformance/testdata/<name>/prometheus.yaml`.
+2. Regenerate goldens against raw Prometheus:
+
+   ```
+   make ta-conformance-regen      # downloads pinned promtool, runs -update
+   ```
+
+   Review the resulting `golden.json` and commit it alongside the fixture.
+3. Run the suite (no promtool needed): `go test ./cmd/otel-allocator/internal/conformance/...`
+   (also runs as part of `make test`).
+

--- a/cmd/otel-allocator/internal/conformance/testdata/blackbox-param-instance/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/blackbox-param-instance/golden.json
@@ -1,0 +1,42 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "a.example.com:443",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "blackbox"
+    },
+    "labels": {
+      "__address__": "blackbox:9115",
+      "__metrics_path__": "/metrics",
+      "__param_target": "a.example.com:443",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "instance": "a.example.com:443",
+      "job": "blackbox"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "b.example.com:443",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "blackbox"
+    },
+    "labels": {
+      "__address__": "blackbox:9115",
+      "__metrics_path__": "/metrics",
+      "__param_target": "b.example.com:443",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "instance": "b.example.com:443",
+      "job": "blackbox"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/blackbox-param-instance/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/blackbox-param-instance/prometheus.yaml
@@ -1,0 +1,11 @@
+# Blackbox-exporter pattern: several targets are rewritten to one __address__
+# (the prober) but kept distinct by __param_target / instance. They must NOT
+# collide into one identity. A real-world false-collision risk for the allocator.
+scrape_configs:
+  - job_name: blackbox
+    static_configs:
+      - targets: ['a.example.com:443', 'b.example.com:443']
+    relabel_configs:
+      - {source_labels: [__address__], target_label: __param_target}
+      - {source_labels: [__param_target], target_label: instance}
+      - {target_label: __address__, replacement: 'blackbox:9115'}

--- a/cmd/otel-allocator/internal/conformance/testdata/dedup-address-rewrite/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/dedup-address-rewrite/golden.json
@@ -1,0 +1,44 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.0.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "cluster": "a",
+      "job": "dedup"
+    },
+    "labels": {
+      "__address__": "collector.local:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "cluster": "a",
+      "instance": "collector.local:9100",
+      "job": "dedup"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.0.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "cluster": "a",
+      "job": "dedup"
+    },
+    "labels": {
+      "__address__": "collector.local:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "cluster": "a",
+      "instance": "collector.local:9100",
+      "job": "dedup"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/dedup-address-rewrite/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/dedup-address-rewrite/prometheus.yaml
@@ -1,0 +1,14 @@
+# Two distinct discovered targets are relabeled to the SAME __address__, so they
+# collapse to one identity in Prometheus. Exercises the dedup scenario (#3617)
+# and assertion B's positive branch: the allocator must give both the same hash.
+scrape_configs:
+  - job_name: dedup
+    static_configs:
+      - targets: ['10.0.0.1:9100', '10.0.0.2:9100']
+        labels:
+          cluster: a
+    relabel_configs:
+      - source_labels: [cluster]
+        target_label: __address__
+        replacement: collector.local:9100
+        action: replace

--- a/cmd/otel-allocator/internal/conformance/testdata/labelmap/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/labelmap/golden.json
@@ -1,0 +1,48 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.0.0.1:9100",
+      "__meta_kubernetes_pod_label_app": "web",
+      "__meta_kubernetes_pod_label_tier": "frontend",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "lm"
+    },
+    "labels": {
+      "__address__": "10.0.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "app": "web",
+      "instance": "10.0.0.1:9100",
+      "job": "lm",
+      "tier": "frontend"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.0.0.2:9100",
+      "__meta_kubernetes_pod_label_app": "web",
+      "__meta_kubernetes_pod_label_tier": "frontend",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "lm"
+    },
+    "labels": {
+      "__address__": "10.0.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "app": "web",
+      "instance": "10.0.0.2:9100",
+      "job": "lm",
+      "tier": "frontend"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/labelmap/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/labelmap/prometheus.yaml
@@ -1,0 +1,14 @@
+# labelmap copies __meta_kubernetes_pod_label_<x> meta labels into real labels.
+# Exercises the labelmap action and meta-label promotion (the common
+# ServiceMonitor/PodMonitor pattern), with no cluster.
+scrape_configs:
+  - job_name: lm
+    static_configs:
+      - targets: ['10.0.0.1:9100', '10.0.0.2:9100']
+        labels:
+          __meta_kubernetes_pod_label_app: web
+          __meta_kubernetes_pod_label_tier: frontend
+    relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+        replacement: $1

--- a/cmd/otel-allocator/internal/conformance/testdata/multi-job-same-address/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/multi-job-same-address/golden.json
@@ -1,0 +1,40 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.0.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "job-a"
+    },
+    "labels": {
+      "__address__": "10.0.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "instance": "10.0.0.1:9100",
+      "job": "job-a"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.0.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "job-b"
+    },
+    "labels": {
+      "__address__": "10.0.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "instance": "10.0.0.1:9100",
+      "job": "job-b"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/multi-job-same-address/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/multi-job-same-address/prometheus.yaml
@@ -1,0 +1,10 @@
+# The same address is scraped by two different jobs. Their identities must stay
+# distinct (the identity hash mixes in the job name). Guards #4044, where the
+# job was missing from the hash and one job's target silently vanished.
+scrape_configs:
+  - job_name: job-a
+    static_configs:
+      - targets: ['10.0.0.1:9100']
+  - job_name: job-b
+    static_configs:
+      - targets: ['10.0.0.1:9100']

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-case/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-case/golden.json
@@ -1,0 +1,25 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.5.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "foo": "bAr123Foo",
+      "job": "case-upper-lower"
+    },
+    "labels": {
+      "__address__": "10.5.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "foo": "bAr123Foo",
+      "foo_lowercase": "bar123foo",
+      "foo_uppercase": "BAR123FOO",
+      "instance": "10.5.0.1:9100",
+      "job": "case-upper-lower"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-case/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-case/prometheus.yaml
@@ -1,0 +1,9 @@
+# Uppercase / Lowercase actions.
+scrape_configs:
+  - job_name: case-upper-lower
+    static_configs:
+      - targets: ['10.5.0.1:9100']
+        labels: {foo: bAr123Foo}
+    relabel_configs:
+      - {source_labels: [foo], action: uppercase, target_label: foo_uppercase}
+      - {source_labels: [foo], action: lowercase, target_label: foo_lowercase}

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-hashmod/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-hashmod/golden.json
@@ -1,0 +1,50 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.3.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "b": "bar",
+      "c": "baz",
+      "job": "hashmod-basic"
+    },
+    "labels": {
+      "__address__": "10.3.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "b": "bar",
+      "c": "baz",
+      "d": "976",
+      "instance": "10.3.0.1:9100",
+      "job": "hashmod-basic"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.3.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo\nbar",
+      "job": "hashmod-multiline"
+    },
+    "labels": {
+      "__address__": "10.3.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo\nbar",
+      "b": "734",
+      "instance": "10.3.0.2:9100",
+      "job": "hashmod-multiline"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-hashmod/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-hashmod/prometheus.yaml
@@ -1,0 +1,15 @@
+# HashMod action (deterministic bucketing). Values from relabel_test.go.
+scrape_configs:
+  - job_name: hashmod-basic
+    static_configs:
+      - targets: ['10.3.0.1:9100']
+        labels: {a: foo, b: bar, c: baz}
+    relabel_configs:
+      - {source_labels: [c], target_label: d, separator: ';', action: hashmod, modulus: 1000}
+
+  - job_name: hashmod-multiline
+    static_configs:
+      - targets: ['10.3.0.2:9100']
+        labels: {a: "foo\nbar"}
+    relabel_configs:
+      - {source_labels: [a], target_label: b, separator: ';', action: hashmod, modulus: 1000}

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-keep-drop/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-keep-drop/golden.json
@@ -1,0 +1,102 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.2.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "b": "bar",
+      "job": "drop-match"
+    },
+    "labels": {}
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.2.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "job": "drop-then-replace-pipeline"
+    },
+    "labels": {}
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.2.0.3:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "job": "drop-nomatch-keeps"
+    },
+    "labels": {
+      "__address__": "10.2.0.3:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "instance": "10.2.0.3:9100",
+      "job": "drop-nomatch-keeps"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.2.0.4:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "job": "drop-partial-regex-keeps"
+    },
+    "labels": {
+      "__address__": "10.2.0.4:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "instance": "10.2.0.4:9100",
+      "job": "drop-partial-regex-keeps"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.2.0.5:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "job": "keep-nomatch-drops"
+    },
+    "labels": {}
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.2.0.6:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "job": "keep-match"
+    },
+    "labels": {
+      "__address__": "10.2.0.6:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "instance": "10.2.0.6:9100",
+      "job": "keep-match"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-keep-drop/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-keep-drop/prometheus.yaml
@@ -1,0 +1,45 @@
+# Keep/Drop action variations (ported from relabel_test.go). Dropped targets are
+# expected to be dropped by the allocator too (assertion A).
+scrape_configs:
+  - job_name: drop-match
+    static_configs:
+      - targets: ['10.2.0.1:9100']
+        labels: {a: foo, b: bar}
+    relabel_configs:
+      - {source_labels: [a], regex: '.*o.*', action: drop}
+
+  - job_name: drop-then-replace-pipeline
+    static_configs:
+      - targets: ['10.2.0.2:9100']
+        labels: {a: foo}
+    relabel_configs:
+      - {source_labels: [a], regex: '.*o.*', action: drop}
+      - {source_labels: [a], regex: 'f(.*)', target_label: d, separator: ';', replacement: 'ch$1-ch$1', action: replace}
+
+  - job_name: drop-nomatch-keeps
+    static_configs:
+      - targets: ['10.2.0.3:9100']
+        labels: {a: foo}
+    relabel_configs:
+      - {source_labels: [a], regex: 'no-match', action: drop}
+
+  - job_name: drop-partial-regex-keeps
+    static_configs:
+      - targets: ['10.2.0.4:9100']
+        labels: {a: foo}
+    relabel_configs:
+      - {source_labels: [a], regex: 'f|o', action: drop}
+
+  - job_name: keep-nomatch-drops
+    static_configs:
+      - targets: ['10.2.0.5:9100']
+        labels: {a: foo}
+    relabel_configs:
+      - {source_labels: [a], regex: 'no-match', action: keep}
+
+  - job_name: keep-match
+    static_configs:
+      - targets: ['10.2.0.6:9100']
+        labels: {a: foo}
+    relabel_configs:
+      - {source_labels: [a], regex: 'f.*', action: keep}

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-keepequal-dropequal/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-keepequal-dropequal/golden.json
@@ -1,0 +1,80 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.6.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__port1": "1234",
+      "__port2": "5678",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "__tmp_port": "1234",
+      "job": "keepequal-match"
+    },
+    "labels": {
+      "__address__": "10.6.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__port1": "1234",
+      "__port2": "5678",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "__tmp_port": "1234",
+      "instance": "10.6.0.1:9100",
+      "job": "keepequal-match"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.6.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__port1": "1234",
+      "__port2": "5678",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "__tmp_port": "1234",
+      "job": "keepequal-nomatch-drops"
+    },
+    "labels": {}
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.6.0.3:9100",
+      "__metrics_path__": "/metrics",
+      "__port1": "1234",
+      "__port2": "5678",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "__tmp_port": "1234",
+      "job": "dropequal-match-drops"
+    },
+    "labels": {}
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.6.0.4:9100",
+      "__metrics_path__": "/metrics",
+      "__port1": "1234",
+      "__port2": "5678",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "__tmp_port": "1234",
+      "job": "dropequal-nomatch"
+    },
+    "labels": {
+      "__address__": "10.6.0.4:9100",
+      "__metrics_path__": "/metrics",
+      "__port1": "1234",
+      "__port2": "5678",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "__tmp_port": "1234",
+      "instance": "10.6.0.4:9100",
+      "job": "dropequal-nomatch"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-keepequal-dropequal/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-keepequal-dropequal/prometheus.yaml
@@ -1,0 +1,30 @@
+# KeepEqual / DropEqual: keep or drop the target when source value equals the
+# target label's current value.
+scrape_configs:
+  - job_name: keepequal-match
+    static_configs:
+      - targets: ['10.6.0.1:9100']
+        labels: {__tmp_port: "1234", __port1: "1234", __port2: "5678"}
+    relabel_configs:
+      - {source_labels: [__tmp_port], action: keepequal, target_label: __port1}
+
+  - job_name: keepequal-nomatch-drops
+    static_configs:
+      - targets: ['10.6.0.2:9100']
+        labels: {__tmp_port: "1234", __port1: "1234", __port2: "5678"}
+    relabel_configs:
+      - {source_labels: [__tmp_port], action: keepequal, target_label: __port2}
+
+  - job_name: dropequal-match-drops
+    static_configs:
+      - targets: ['10.6.0.3:9100']
+        labels: {__tmp_port: "1234", __port1: "1234", __port2: "5678"}
+    relabel_configs:
+      - {source_labels: [__tmp_port], action: dropequal, target_label: __port1}
+
+  - job_name: dropequal-nomatch
+    static_configs:
+      - targets: ['10.6.0.4:9100']
+        labels: {__tmp_port: "1234", __port1: "1234", __port2: "5678"}
+    relabel_configs:
+      - {source_labels: [__tmp_port], action: dropequal, target_label: __port2}

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-labeldrop/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-labeldrop/golden.json
@@ -1,0 +1,25 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.7.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "b1": "bar",
+      "b2": "baz",
+      "job": "labeldrop-prefix"
+    },
+    "labels": {
+      "__address__": "10.7.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "instance": "10.7.0.1:9100",
+      "job": "labeldrop-prefix"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-labeldrop/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-labeldrop/prometheus.yaml
@@ -1,0 +1,9 @@
+# LabelDrop removes label names matching a regex (keeps the rest, incl. scrape
+# internals). LabelKeep, which would remove __address__, is covered separately.
+scrape_configs:
+  - job_name: labeldrop-prefix
+    static_configs:
+      - targets: ['10.7.0.1:9100']
+        labels: {a: foo, b1: bar, b2: baz}
+    relabel_configs:
+      - {regex: '(b.*)', action: labeldrop}

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-labelkeep/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-labelkeep/golden.json
@@ -1,0 +1,26 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.10.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "b1": "bar",
+      "b2": "baz",
+      "job": "labelkeep-prefix"
+    },
+    "labels": {
+      "__address__": "10.10.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "b1": "bar",
+      "b2": "baz",
+      "instance": "10.10.0.1:9100",
+      "job": "labelkeep-prefix"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-labelkeep/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-labelkeep/prometheus.yaml
@@ -1,0 +1,11 @@
+# LabelKeep removes every label name NOT matching the regex. In a scrape context
+# that would also strip __address__/__scheme__/job and drop the target, so the
+# regex explicitly preserves the scrape essentials while still testing that
+# user labels not matching (a) are removed.
+scrape_configs:
+  - job_name: labelkeep-prefix
+    static_configs:
+      - targets: ['10.10.0.1:9100']
+        labels: {a: foo, b1: bar, b2: baz}
+    relabel_configs:
+      - {regex: '(b.*|__.*|job)', action: labelkeep}

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-labelmap/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-labelmap/golden.json
@@ -1,0 +1,55 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.4.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "b1": "bar",
+      "b2": "baz",
+      "job": "labelmap-prefix"
+    },
+    "labels": {
+      "__address__": "10.4.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "b1": "bar",
+      "b2": "baz",
+      "bar_b1": "bar",
+      "bar_b2": "baz",
+      "instance": "10.4.0.1:9100",
+      "job": "labelmap-prefix"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.4.0.2:9100",
+      "__meta_my_bar": "aaa",
+      "__meta_my_baz": "bbb",
+      "__meta_other": "ccc",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "job": "labelmap-meta"
+    },
+    "labels": {
+      "__address__": "10.4.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "instance": "10.4.0.2:9100",
+      "job": "labelmap-meta",
+      "my_bar": "aaa",
+      "my_baz": "bbb"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-labelmap/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-labelmap/prometheus.yaml
@@ -1,0 +1,19 @@
+# LabelMap action: copy label names matching a regex into new names.
+scrape_configs:
+  - job_name: labelmap-prefix
+    static_configs:
+      - targets: ['10.4.0.1:9100']
+        labels: {a: foo, b1: bar, b2: baz}
+    relabel_configs:
+      - {regex: '(b.*)', replacement: 'bar_${1}', action: labelmap}
+
+  - job_name: labelmap-meta
+    static_configs:
+      - targets: ['10.4.0.2:9100']
+        labels:
+          a: foo
+          __meta_my_bar: aaa
+          __meta_my_baz: bbb
+          __meta_other: ccc
+    relabel_configs:
+      - {regex: '__meta_(my.*)', replacement: '${1}', action: labelmap}

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-multistage/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-multistage/golden.json
@@ -1,0 +1,44 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.8.0.1:9100",
+      "__meta_sd_tags": "path:/secret,job:some-job,label:foo=bar",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "sd-tags"
+    },
+    "labels": {
+      "__address__": "10.8.0.1:9100",
+      "__metrics_path__": "/secret",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "foo": "bar",
+      "instance": "10.8.0.1:9100",
+      "job": "some-job"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.8.0.2:9100",
+      "__meta_kubernetes_pod_annotation_XXX_metrics_port": "9091",
+      "__meta_kubernetes_pod_container_port_name": "foo",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "k8s-port-name"
+    },
+    "labels": {
+      "__address__": "10.8.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "instance": "10.8.0.2:9100",
+      "job": "k8s-port-name"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-multistage/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-multistage/prometheus.yaml
@@ -1,0 +1,25 @@
+# Multi-stage, real-life-like relabel pipelines.
+scrape_configs:
+  # Parse a packed __meta_sd_tags string into metrics_path, job, and a label.
+  - job_name: sd-tags
+    static_configs:
+      - targets: ['10.8.0.1:9100']
+        labels:
+          __meta_sd_tags: 'path:/secret,job:some-job,label:foo=bar'
+    relabel_configs:
+      - {source_labels: [__meta_sd_tags], regex: '(?:.+,|^)path:(/[^,]+).*', action: replace, replacement: '${1}', target_label: __metrics_path__}
+      - {source_labels: [__meta_sd_tags], regex: '(?:.+,|^)job:([^,]+).*', action: replace, replacement: '${1}', target_label: job}
+      - {source_labels: [__meta_sd_tags], regex: '(?:.+,|^)label:([^=]+)=([^,]+).*', action: replace, replacement: '${2}', target_label: '${1}'}
+
+  # https://github.com/prometheus/prometheus/issues/12283 — promote an annotation
+  # to the container port name, then keep only the matching target.
+  - job_name: k8s-port-name
+    static_configs:
+      - targets: ['10.8.0.2:9100']
+        labels:
+          __meta_kubernetes_pod_container_port_name: foo
+          __meta_kubernetes_pod_annotation_XXX_metrics_port: "9091"
+    relabel_configs:
+      - {regex: '^__meta_kubernetes_pod_container_port_name$', action: labeldrop}
+      - {source_labels: [__meta_kubernetes_pod_annotation_XXX_metrics_port], regex: '(.+)', action: replace, replacement: metrics, target_label: __meta_kubernetes_pod_container_port_name}
+      - {source_labels: [__meta_kubernetes_pod_container_port_name], regex: '^metrics$', action: keep}

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-replace/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-replace/golden.json
@@ -1,0 +1,162 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.1.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "b": "bar",
+      "c": "baz",
+      "job": "replace-basic"
+    },
+    "labels": {
+      "__address__": "10.1.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "b": "bar",
+      "c": "baz",
+      "d": "choo-choo",
+      "instance": "10.1.0.1:9100",
+      "job": "replace-basic"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.1.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "b": "bar",
+      "c": "baz",
+      "job": "replace-multi-source"
+    },
+    "labels": {
+      "__address__": "10.1.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "boobam",
+      "b": "bar",
+      "c": "baz",
+      "d": "boooom",
+      "instance": "10.1.0.2:9100",
+      "job": "replace-multi-source"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.1.0.3:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "abc",
+      "job": "replace-capture"
+    },
+    "labels": {
+      "__address__": "10.1.0.3:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "abc",
+      "d": "b",
+      "instance": "10.1.0.3:9100",
+      "job": "replace-capture"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.1.0.4:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "boo",
+      "job": "replace-nomatch-noop"
+    },
+    "labels": {
+      "__address__": "10.1.0.4:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "boo",
+      "instance": "10.1.0.4:9100",
+      "job": "replace-nomatch-noop"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.1.0.5:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "f": "baz",
+      "job": "replace-blank-deletes"
+    },
+    "labels": {
+      "__address__": "10.1.0.5:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "foo",
+      "instance": "10.1.0.5:9100",
+      "job": "replace-blank-deletes"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.1.0.6:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "some-name-value",
+      "job": "replace-named-target"
+    },
+    "labels": {
+      "__address__": "10.1.0.6:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "some-name-value",
+      "instance": "10.1.0.6:9100",
+      "job": "replace-named-target",
+      "name": "value"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.1.0.7:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "some-name-value",
+      "job": "replace-invalid-group"
+    },
+    "labels": {
+      "__address__": "10.1.0.7:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "some-name-value",
+      "instance": "10.1.0.7:9100",
+      "job": "replace-invalid-group"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-replace/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-replace/prometheus.yaml
@@ -1,0 +1,52 @@
+# Replace action variations, ported from prometheus model/relabel/relabel_test.go.
+# Each job is one case; targets carry __address__ so they are valid scrape targets.
+scrape_configs:
+  - job_name: replace-basic
+    static_configs:
+      - targets: ['10.1.0.1:9100']
+        labels: {a: foo, b: bar, c: baz}
+    relabel_configs:
+      - {source_labels: [a], regex: 'f(.*)', target_label: d, separator: ';', replacement: 'ch${1}-ch${1}', action: replace}
+
+  - job_name: replace-multi-source
+    static_configs:
+      - targets: ['10.1.0.2:9100']
+        labels: {a: foo, b: bar, c: baz}
+    relabel_configs:
+      - {source_labels: [a, b], regex: 'f(.*);(.*)r', target_label: a, separator: ';', replacement: 'b${1}${2}m', action: replace}
+      - {source_labels: [c, a], regex: '(b).*b(.*)ba(.*)', target_label: d, separator: ';', replacement: '$1$2$2$3', action: replace}
+
+  - job_name: replace-capture
+    static_configs:
+      - targets: ['10.1.0.3:9100']
+        labels: {a: abc}
+    relabel_configs:
+      - {source_labels: [a], regex: '.*(b).*', target_label: d, separator: ';', replacement: '$1', action: replace}
+
+  - job_name: replace-nomatch-noop
+    static_configs:
+      - targets: ['10.1.0.4:9100']
+        labels: {a: boo}
+    relabel_configs:
+      - {source_labels: [a], regex: 'f', target_label: b, replacement: bar, action: replace}
+
+  - job_name: replace-blank-deletes
+    static_configs:
+      - targets: ['10.1.0.5:9100']
+        labels: {a: foo, f: baz}
+    relabel_configs:
+      - {source_labels: [a], regex: '(f).*', target_label: '$1', replacement: '$2', action: replace}
+
+  - job_name: replace-named-target
+    static_configs:
+      - targets: ['10.1.0.6:9100']
+        labels: {a: some-name-value}
+    relabel_configs:
+      - {source_labels: [a], regex: 'some-([^-]+)-([^,]+)', target_label: '${1}', replacement: '${2}', action: replace}
+
+  - job_name: replace-invalid-group
+    static_configs:
+      - targets: ['10.1.0.7:9100']
+        labels: {a: some-name-value}
+    relabel_configs:
+      - {source_labels: [a], regex: 'some-([^-]+)-([^,]+)', target_label: '${1}', replacement: '${3}', action: replace}

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-utf8-multiline/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-utf8-multiline/golden.json
@@ -1,0 +1,106 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.9.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "line1\nline2",
+      "b": "bar",
+      "c": "baz",
+      "job": "replace-multiline"
+    },
+    "labels": {
+      "__address__": "10.9.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "line1\nline2",
+      "b": "bar",
+      "c": "baz",
+      "d": "match",
+      "instance": "10.9.0.1:9100",
+      "job": "replace-multiline"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.9.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "b": "bar",
+      "c": "baz",
+      "job": "replace-utf8-source",
+      "utf-8.label": "line1\nline2"
+    },
+    "labels": {
+      "__address__": "10.9.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "b": "bar",
+      "c": "baz",
+      "d": "match",
+      "instance": "10.9.0.2:9100",
+      "job": "replace-utf8-source",
+      "utf-8.label": "line1\nline2"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.9.0.3:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "line1\nline2",
+      "b": "bar",
+      "c": "baz",
+      "job": "replace-utf8-target"
+    },
+    "labels": {
+      "__address__": "10.9.0.3:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "line1\nline2",
+      "b": "bar",
+      "c": "baz",
+      "instance": "10.9.0.3:9100",
+      "job": "replace-utf8-target",
+      "utf-8.label": "match"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.9.0.4:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "line1\nline2",
+      "b": "bar",
+      "c": "baz",
+      "job": "replace-utf8-target-var"
+    },
+    "labels": {
+      "__address__": "10.9.0.4:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "a": "line1\nline2",
+      "b": "bar",
+      "c": "baz",
+      "instance": "10.9.0.4:9100",
+      "job": "replace-utf8-target-var",
+      "utf-8.label": "match"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/relabel-utf8-multiline/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/relabel-utf8-multiline/prometheus.yaml
@@ -1,0 +1,31 @@
+# UTF-8 label names and multiline label values in relabeling (ported from
+# relabel_test.go). promtool and the allocator share the same relabel engine, so
+# the differential check holds regardless of dotall/UTF-8 matching subtleties.
+scrape_configs:
+  - job_name: replace-multiline
+    static_configs:
+      - targets: ['10.9.0.1:9100']
+        labels: {a: "line1\nline2", b: bar, c: baz}
+    relabel_configs:
+      - {source_labels: [a], regex: 'line1.*line2', target_label: d, separator: ';', replacement: 'match${1}', action: replace}
+
+  - job_name: replace-utf8-source
+    static_configs:
+      - targets: ['10.9.0.2:9100']
+        labels: {"utf-8.label": "line1\nline2", b: bar, c: baz}
+    relabel_configs:
+      - {source_labels: ["utf-8.label"], regex: 'line1.*line2', target_label: d, separator: ';', replacement: 'match${1}', action: replace}
+
+  - job_name: replace-utf8-target
+    static_configs:
+      - targets: ['10.9.0.3:9100']
+        labels: {a: "line1\nline2", b: bar, c: baz}
+    relabel_configs:
+      - {source_labels: [a], regex: 'line1.*line2', target_label: "utf-8.label", separator: ';', replacement: 'match${1}', action: replace}
+
+  - job_name: replace-utf8-target-var
+    static_configs:
+      - targets: ['10.9.0.4:9100']
+        labels: {a: "line1\nline2", b: bar, c: baz}
+    relabel_configs:
+      - {source_labels: [a], regex: 'line1.*line2', target_label: "utf-8.label${1}", separator: ';', replacement: 'match${1}', action: replace}

--- a/cmd/otel-allocator/internal/conformance/testdata/replace-keep-drop/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/replace-keep-drop/golden.json
@@ -1,0 +1,64 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.0.0.1:9100",
+      "__meta_kubernetes_namespace": "prod",
+      "__meta_kubernetes_pod_label_app": "frontend",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "demo",
+      "team": "web"
+    },
+    "labels": {
+      "__address__": "10.0.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "instance": "10.0.0.1:9100",
+      "job": "demo",
+      "ns": "prod",
+      "team": "web"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.0.0.2:9100",
+      "__meta_kubernetes_namespace": "prod",
+      "__meta_kubernetes_pod_label_app": "frontend",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "demo",
+      "team": "web"
+    },
+    "labels": {}
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.0.0.3:9100",
+      "__meta_kubernetes_namespace": "prod",
+      "__meta_kubernetes_pod_label_app": "frontend",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "demo",
+      "team": "web"
+    },
+    "labels": {
+      "__address__": "10.0.0.3:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "instance": "10.0.0.3:9100",
+      "job": "demo",
+      "ns": "prod",
+      "team": "web"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/replace-keep-drop/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/replace-keep-drop/prometheus.yaml
@@ -1,0 +1,21 @@
+# Exercises: keep on a __meta_ label, replace creating a new label, drop by address.
+# Targets carry __meta_kubernetes_* labels via static_configs (no cluster needed)
+# and a user label (team) that sorts after __address__ (guards the merge-sort bug).
+scrape_configs:
+  - job_name: demo
+    static_configs:
+      - targets: ['10.0.0.1:9100', '10.0.0.2:9100', '10.0.0.3:9100']
+        labels:
+          __meta_kubernetes_pod_label_app: frontend
+          __meta_kubernetes_namespace: prod
+          team: web
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        regex: frontend
+        action: keep
+      - source_labels: [__meta_kubernetes_namespace]
+        target_label: ns
+        action: replace
+      - source_labels: [__address__]
+        regex: '10\.0\.0\.2:9100'
+        action: drop

--- a/cmd/otel-allocator/internal/conformance/testdata/same-address-distinct-path/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/same-address-distinct-path/golden.json
@@ -1,0 +1,42 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.30.0.1:9100",
+      "__meta_path": "/a",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "same-address"
+    },
+    "labels": {
+      "__address__": "10.30.0.1:9100",
+      "__metrics_path__": "/a",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "instance": "10.30.0.1:9100",
+      "job": "same-address"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.30.0.1:9100",
+      "__meta_path": "/b",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "same-address"
+    },
+    "labels": {
+      "__address__": "10.30.0.1:9100",
+      "__metrics_path__": "/b",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "instance": "10.30.0.1:9100",
+      "job": "same-address"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/same-address-distinct-path/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/same-address-distinct-path/prometheus.yaml
@@ -1,0 +1,13 @@
+# Two targets share a pre-relabel __address__ but are relabeled to different
+# __metrics_path__ values from a per-target meta label. They must stay DISTINCT
+# identities. Exercises the harness's same-address bucket matching and the
+# allocator's identity computation when the distinguishing label is set by relabel.
+scrape_configs:
+  - job_name: same-address
+    static_configs:
+      - targets: ['10.30.0.1:9100']
+        labels: {__meta_path: /a}
+      - targets: ['10.30.0.1:9100']
+        labels: {__meta_path: /b}
+    relabel_configs:
+      - {source_labels: [__meta_path], target_label: __metrics_path__, action: replace}

--- a/cmd/otel-allocator/internal/conformance/testdata/seeded-labels/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/seeded-labels/golden.json
@@ -1,0 +1,51 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.20.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "gap-keep-on-job"
+    },
+    "labels": {
+      "__address__": "10.20.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "instance": "10.20.0.1:9100",
+      "job": "gap-keep-on-job"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.20.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "gap-keep-on-scheme"
+    },
+    "labels": {
+      "__address__": "10.20.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "instance": "10.20.0.2:9100",
+      "job": "gap-keep-on-scheme"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.20.0.3:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "gap-drop-on-job"
+    },
+    "labels": {}
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/seeded-labels/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/seeded-labels/prometheus.yaml
@@ -1,0 +1,26 @@
+# SEEDING-GAP PROBES (documented divergence). Each job's relabel rule references
+# a label Prometheus seeds before relabeling (job, __scheme__, ...) but the
+# allocator's filter does not. Prometheus and the allocator therefore make
+# different keep/drop decisions. See KNOWN_DIVERGENCE.md.
+scrape_configs:
+  # keep on `job`: Prometheus keeps (job is seeded), allocator drops -> silent loss.
+  - job_name: gap-keep-on-job
+    static_configs:
+      - targets: ['10.20.0.1:9100']
+    relabel_configs:
+      - {source_labels: [job], regex: 'gap-keep-on-job', action: keep}
+
+  # keep on `__scheme__`: same class, different seeded label.
+  - job_name: gap-keep-on-scheme
+    static_configs:
+      - targets: ['10.20.0.2:9100']
+    relabel_configs:
+      - {source_labels: [__scheme__], regex: 'http', action: keep}
+
+  # drop on `job`: opposite direction — Prometheus drops, allocator keeps
+  # (over-allocates; the collector re-relabels and drops, so less harmful).
+  - job_name: gap-drop-on-job
+    static_configs:
+      - targets: ['10.20.0.3:9100']
+    relabel_configs:
+      - {source_labels: [job], regex: 'gap-drop-on-job', action: drop}

--- a/cmd/otel-allocator/internal/conformance/testdata/sorted-merge-multitarget/golden.json
+++ b/cmd/otel-allocator/internal/conformance/testdata/sorted-merge-multitarget/golden.json
@@ -1,0 +1,68 @@
+[
+  {
+    "discoveredLabels": {
+      "__address__": "10.40.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "sorted-merge",
+      "vendor": "acme"
+    },
+    "labels": {
+      "__address__": "10.40.0.1:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "addr_copy": "10.40.0.1:9100",
+      "instance": "10.40.0.1:9100",
+      "job": "sorted-merge",
+      "vendor": "acme"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.40.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "sorted-merge",
+      "vendor": "acme"
+    },
+    "labels": {
+      "__address__": "10.40.0.2:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "addr_copy": "10.40.0.2:9100",
+      "instance": "10.40.0.2:9100",
+      "job": "sorted-merge",
+      "vendor": "acme"
+    }
+  },
+  {
+    "discoveredLabels": {
+      "__address__": "10.40.0.3:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "job": "sorted-merge",
+      "vendor": "acme"
+    },
+    "labels": {
+      "__address__": "10.40.0.3:9100",
+      "__metrics_path__": "/metrics",
+      "__scheme__": "http",
+      "__scrape_interval__": "1m",
+      "__scrape_timeout__": "10s",
+      "addr_copy": "10.40.0.3:9100",
+      "instance": "10.40.0.3:9100",
+      "job": "sorted-merge",
+      "vendor": "acme"
+    }
+  }
+]

--- a/cmd/otel-allocator/internal/conformance/testdata/sorted-merge-multitarget/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/sorted-merge-multitarget/prometheus.yaml
@@ -1,0 +1,13 @@
+# Multiple targets share a group label (`vendor`) that sorts AFTER __address__,
+# and a relabel rule reads __address__ into a new label. If the group+target
+# label merge is not globally sorted (#4967/#4082), the __address__ binary-search
+# lookup fails, every target's addr_copy collapses to the same value, and their
+# identities collide. With a correct merge the three stay distinct.
+scrape_configs:
+  - job_name: sorted-merge
+    static_configs:
+      - targets: ['10.40.0.1:9100', '10.40.0.2:9100', '10.40.0.3:9100']
+        labels:
+          vendor: acme
+    relabel_configs:
+      - {source_labels: [__address__], target_label: addr_copy, action: replace}


### PR DESCRIPTION
**Description:**

Add target relabeling conformance tests for target allocator. The test cases are ported from Prometheus' own [relabel tests](https://github.com/prometheus/prometheus/blob/main/model/relabel/relabel_test.go). The PR includes a README explaining how the test cases are laid out, what is checked, and how to add more.

The intent is to verify that target allocator's relabeling implementation is consistent with upstream Prometheus.

This actually already found a bug, whose test is skipped. See https://github.com/open-telemetry/opentelemetry-operator/issues/5246.

**Link to tracking Issue(s):** <Issue number if applicable>

- Part of https://github.com/open-telemetry/opentelemetry-operator/issues/5242

**Documentation:**

Added a README.md.
