### PR TITLE
[chore] Fix flaky TestServerStartsHealthEndpoint

### DIFF
--- a/cmd/operator-opamp-bridge/internal/healthcheck/server_test.go
+++ b/cmd/operator-opamp-bridge/internal/healthcheck/server_test.go
@@ -20,7 +20,8 @@ func TestServerStartsHealthEndpoint(t *testing.T) {
 
 	require.NoError(t, server.Start(t.Context()))
 	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		// t.Context() is already canceled when cleanup runs; use Background.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 		require.NoError(t, server.Stop(ctx))
 	})


### PR DESCRIPTION
## Summary

- Fix flaky `TestServerStartsHealthEndpoint` that has been intermittently failing CI on `main` and feature branches since at least June 20
- Root cause: `t.Context()` is already canceled when `t.Cleanup` runs ([documented](https://tip.golang.org/doc/go1.24#testingpkgtesting) Go 1.24 behavior), so `context.WithTimeout(t.Context(), ...)` 
- Fix: use `context.Background()` as the parent context in the cleanup function

## Evidence

Same failure confirmed in multiple CI runs across different branches:
- [Run 28030913826](https://github.com/open-telemetry/opentelemetry-operator/actions/runs/28030913826) (`fix/instrumentation-reconciler`)
- [Run 27939913053](https://github.com/open-telemetry/opentelemetry-operator/actions/runs/27939913053) (`main`)
- [Run 27877857267](https://github.com/open-telemetry/opentelemetry-operator/actions/runs/27877857267) (`main`)