### PR TITLE
[chore] Update must-gather test ConfigMap hash for current collector config

### DIFF
--- a/tests/e2e-openshift/must-gather/assert-install-target-allocator.yaml
+++ b/tests/e2e-openshift/must-gather/assert-install-target-allocator.yaml
@@ -54,9 +54,6 @@ data:
                               prometheus:
                                   host: 0.0.0.0
                                   port: 8888
-                                  without_scope_info: false
-                                  without_type_suffix: false
-                                  without_units: false
 kind: ConfigMap
 metadata:
   labels:
@@ -65,7 +62,7 @@ metadata:
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/name: stateful-collector
     app.kubernetes.io/part-of: opentelemetry
-  name: stateful-collector-cbacb1a5
+  name: stateful-collector-95bef721
   namespace: chainsaw-must-gather
 ---
 apiVersion: v1


### PR DESCRIPTION
## Summary
- Updated the must-gather e2e test assert to match the current collector ConfigMap content hash
- The default prometheus telemetry config no longer includes `without_scope_info`, `without_type_suffix`, and `without_units` fields, which changed the ConfigMap name hash from `cbacb1a5` to `95bef721`

## Test plan
- [x] Ran `chainsaw test --test-dir tests/e2e-openshift/must-gather` on OCP 4.22 nightly — test passes