### PR TITLE
[chore] Handle modules correctly with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -142,7 +142,16 @@
     },
     {
       "matchManagers": ["gomod"],
-      "matchFileNames": ["tests/test-e2e-apps/**/go.mod", "apis/go.mod"],
+      "matchFileNames": ["tests/test-e2e-apps/**/go.mod"],
+      "enabled": false
+    },
+    {
+      "description": "Never bump the in-repo module references (resolved via local replace directives)",
+      "matchManagers": ["gomod"],
+      "matchDepNames": [
+        "github.com/open-telemetry/opentelemetry-operator",
+        "github.com/open-telemetry/opentelemetry-operator/apis"
+      ],
       "enabled": false
     },
     {
@@ -175,6 +184,15 @@
       "matchManagers": ["gomod"],
       "matchPackageNames": ["go.opentelemetry.io/otel{,/**}"],
       "groupName": "opentelemetry"
+    },
+    {
+      "description": "Keep the unpublished otel-allocator integration test module on its own update stream, independent of the published apis/main modules it follows via local replace",
+      "matchManagers": ["gomod"],
+      "matchFileNames": ["cmd/otel-allocator/integrationtest/go.mod"],
+      "groupName": "otel-allocator integration test module",
+      "additionalBranchPrefix": "integrationtest-",
+      "commitMessageSuffix": "(integrationtest)",
+      "postUpdateOptions": ["gomodTidy"]
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
**Description:**

Make renovate handle module dependencies in this repository correctly.

- The apis module's dependencies are now explicitly tracked. Renovate should do the right thing here automatically, which is bumping the affected dependencies in a single PR in apis and the root module.
- Separate weekly bump PR for the target allocator integration test module's own dependencies. The dependencies inherited from the main module will be bumped alongside it.
- Explicitly disable bumps for the replaced dependencies out of an abundance of caution.
- The e2e test app go.mod remains ignored for now.

**Link to tracking Issue(s):** <Issue number if applicable>

- Relates: #5242
