### PR TITLE
Upload test coverage information to codecov

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -43,16 +43,24 @@ jobs:
         KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: "true"  # Get control plane output in case of envtest errors
       run: make ci
 
-    # `make ci` runs `make test` with CI set, which writes coverage.out. Reporting
-    # must never gate a merge: a Codecov hiccup (or a fork PR without upload
-    # credentials) shouldn't fail the required unit-tests check, so this step is
-    # best-effort, mirroring the e2e workflow's upload job.
-    - name: Upload coverage to Codecov
+    # `make ci` runs `make test` with CI set, which writes coverage.out (main
+    # module) and coverage-integration.out (target allocator integration tests).
+    # Reporting must never gate a merge: a Codecov hiccup (or a fork PR without
+    # upload credentials) shouldn't fail the required unit-tests check, so these
+    # steps are best-effort, mirroring the e2e workflow's upload job. The two
+    # profiles use distinct flags so coverage is attributable per source.
+    - name: Upload unit-test coverage to Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       continue-on-error: true
       with:
         files: ./coverage.out
         flags: unittests
+    - name: Upload integration-test coverage to Codecov
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      continue-on-error: true
+      with:
+        files: ./coverage-integration.out
+        flags: integration
 
   lint:
     name: Code standards (linting)

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -43,6 +43,17 @@ jobs:
         KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT: "true"  # Get control plane output in case of envtest errors
       run: make ci
 
+    # `make ci` runs `make test` with CI set, which writes coverage.out. Reporting
+    # must never gate a merge: a Codecov hiccup (or a fork PR without upload
+    # credentials) shouldn't fail the required unit-tests check, so this step is
+    # best-effort, mirroring the e2e workflow's upload job.
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      continue-on-error: true
+      with:
+        files: ./coverage.out
+        flags: unittests
+
   lint:
     name: Code standards (linting)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,15 @@ else
 GOTEST_OPTS=-race -v $(if $(GOTEST_EXTRA_OPTS),$(GOTEST_EXTRA_OPTS))
 endif
 
+# Unit-test coverage profile. Generated automatically in CI (where the workflow
+# uploads coverage.out to Codecov) and on demand locally with
+# `make test GOTEST_COVER=true`. coverage.out is matched by the *.out entry in
+# .gitignore. -covermode=atomic is required for correct counts under -race.
+GOTEST_COVER ?= $(if $(CI),true,)
+ifeq ($(GOTEST_COVER),true)
+GOTEST_COVER_OPTS = -coverprofile=coverage.out -covermode=atomic
+endif
+
 START_KIND_CLUSTER ?= true
 
 KUBE_VERSION ?= 1.35
@@ -390,7 +399,7 @@ manifests: controller-gen
 # no cluster or network, so they run unconditionally here).
 .PHONY: test
 test: gotestsum
-	$(GOTESTSUM) -- ${GOTEST_OPTS} ./...
+	$(GOTESTSUM) -- ${GOTEST_OPTS} ${GOTEST_COVER_OPTS} ./...
 	$(MAKE) ta-integration-test
 
 # Regenerate the conformance goldens from raw Prometheus (promtool).

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,12 @@ endif
 GOTEST_COVER ?= $(if $(CI),true,)
 ifeq ($(GOTEST_COVER),true)
 GOTEST_COVER_OPTS = -coverprofile=coverage.out -covermode=atomic
+# The target allocator integration tests live in a separate module (so the
+# collector/receiver deps stay out of the TA binary) and exercise the real TA
+# code from the main module. -coverpkg attributes that coverage to the
+# otel-allocator packages; the profile is written to the repo root ($(CURDIR))
+# because the recipe cds into the module directory.
+GOTEST_COVER_INTEGRATION_OPTS = -coverprofile=$(CURDIR)/coverage-integration.out -covermode=atomic -coverpkg=github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/...
 endif
 
 START_KIND_CLUSTER ?= true
@@ -414,7 +420,7 @@ ta-conformance-regen: promtool
 # `make test` runs them too; this target is for iterating on them in isolation.
 .PHONY: ta-integration-test
 ta-integration-test: gotestsum
-	cd cmd/otel-allocator/integrationtest && $(GOTESTSUM) -- ${GOTEST_OPTS} ./...
+	cd cmd/otel-allocator/integrationtest && $(GOTESTSUM) -- ${GOTEST_OPTS} ${GOTEST_COVER_INTEGRATION_OPTS} ./...
 
 # Run precommit checks (format, vet, lint, test, validation)
 .PHONY: precommit

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+# Codecov configuration.
+#
+# Two kinds of data are uploaded from CI:
+#   * Unit-test code coverage (Go profile) from the "Continuous Integration"
+#     workflow, tagged with the `unittests` flag.
+#   * e2e JUnit results from the e2e workflow as Test Analytics
+#     (report_type: test_results) -- this is independent of code coverage.
+#
+# Coverage is reported for visibility but is informational only: it never posts a
+# failing status that could block a merge, consistent with the e2e upload job
+# being best-effort (continue-on-error).
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+flags:
+  unittests:
+    paths:
+      - .
+    carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,11 @@
 # Codecov configuration.
 #
-# Two kinds of data are uploaded from CI:
+# Three kinds of data are uploaded from CI:
 #   * Unit-test code coverage (Go profile) from the "Continuous Integration"
 #     workflow, tagged with the `unittests` flag.
+#   * Target allocator integration-test coverage from the same workflow, tagged
+#     with the `integration` flag (it covers the otel-allocator packages via
+#     -coverpkg).
 #   * e2e JUnit results from the e2e workflow as Test Analytics
 #     (report_type: test_results) -- this is independent of code coverage.
 #
@@ -22,4 +25,8 @@ flags:
   unittests:
     paths:
       - .
+    carryforward: true
+  integration:
+    paths:
+      - cmd/otel-allocator
     carryforward: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -21,6 +21,13 @@ coverage:
       default:
         informational: true
 
+# Packages that exist solely to support tests and should not be counted towards
+# production code coverage.
+ignore:
+  - "internal/testenv"
+  - "cmd/otel-allocator/internal/conformance"
+  - "cmd/otel-allocator/integrationtest"
+
 flags:
   unittests:
     paths:


### PR DESCRIPTION
**Description:**

We're now using codecov for test flakiness tracking, let's also use it for unit test coverage.

**Testing:**

Tested in a fork.

