### PR TITLE
Fix operator NetworkPolicy crash on OpenShift: separate ipBlock and selector peers

### DIFF
--- a/.chloggen/fix-operator-networkpolicy-ipblock-selectors.yaml
+++ b/.chloggen/fix-operator-networkpolicy-ipblock-selectors.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix operator NetworkPolicy crash on OpenShift by placing IPBlock and PodSelector/NamespaceSelector peers in separate egress rules.
+
+# One or more tracking issues related to the change
+issues: [5275]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The Kubernetes API forbids combining ipBlock with podSelector or namespaceSelector
+  in the same NetworkPolicy peer list. On OpenShift, the operator NetworkPolicy included
+  both types in a single egress rule, causing a CrashLoopBackOff on startup.

--- a/internal/operatornetworkpolicy/operatornetworkpolicy.go
+++ b/internal/operatornetworkpolicy/operatornetworkpolicy.go
@@ -144,19 +144,20 @@ func (n *networkPolicy) Start(ctx context.Context) error {
 		},
 	}
 
-	if n.apiServerPodSelector != nil {
-		np.Spec.Egress[0].To = append(np.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
-			PodSelector: n.apiServerPodSelector,
-		})
-	}
-	if n.apiServerNamespaceSelector != nil {
-		if np.Spec.Egress[0].To == nil {
-			np.Spec.Egress[0].To = append(np.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
-				NamespaceSelector: n.apiServerNamespaceSelector,
-			})
-		} else {
-			np.Spec.Egress[0].To[0].NamespaceSelector = n.apiServerNamespaceSelector
+	if n.apiServerPodSelector != nil || n.apiServerNamespaceSelector != nil {
+		peer := networkingv1.NetworkPolicyPeer{
+			PodSelector:       n.apiServerPodSelector,
+			NamespaceSelector: n.apiServerNamespaceSelector,
 		}
+		np.Spec.Egress = append(np.Spec.Egress, networkingv1.NetworkPolicyEgressRule{
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Protocol: &tcp,
+					Port:     &apiServerPort,
+				},
+			},
+			To: []networkingv1.NetworkPolicyPeer{peer},
+		})
 	}
 
 	if n.webhookPort != 0 {

--- a/internal/operatornetworkpolicy/operatornetworkpolicy_test.go
+++ b/internal/operatornetworkpolicy/operatornetworkpolicy_test.go
@@ -1,0 +1,341 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package operatornetworkpolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+	kubeTesting "k8s.io/client-go/testing"
+)
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = appsv1.AddToScheme(s)
+	_ = networkingv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+func operatorDeployment(namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operatorName,
+			Namespace: namespace,
+			UID:       "test-uid",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/name": "opentelemetry-operator"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app.kubernetes.io/name": "opentelemetry-operator"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "manager", Image: "test"}},
+				},
+			},
+		},
+	}
+}
+
+// startAndCapture runs Start() and captures the created NetworkPolicy
+// by using a reactor that cancels the context after creation.
+func startAndCapture(t *testing.T, clientset *fake.Clientset, scheme *runtime.Scheme, opts ...Option) *networkingv1.NetworkPolicy {
+	t.Helper()
+
+	var captured *networkingv1.NetworkPolicy
+	ctx, cancel := context.WithCancel(context.Background())
+
+	clientset.PrependReactor("create", "networkpolicies", func(action kubeTesting.Action) (bool, runtime.Object, error) {
+		createAction := action.(kubeTesting.CreateAction)
+		np := createAction.GetObject().(*networkingv1.NetworkPolicy)
+		captured = np.DeepCopy()
+		cancel()
+		return false, np, nil
+	})
+
+	n := NewOperatorNetworkPolicy(clientset, scheme, opts...)
+	err := n.(*networkPolicy).Start(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, captured, "NetworkPolicy was not created")
+	return captured
+}
+
+func ownerRef() []metav1.OwnerReference {
+	trueVal := true
+	return []metav1.OwnerReference{
+		{
+			APIVersion:         "apps/v1",
+			Kind:               "Deployment",
+			Name:               operatorName,
+			UID:                types.UID("test-uid"),
+			Controller:         &trueVal,
+			BlockOwnerDeletion: &trueVal,
+		},
+	}
+}
+
+func TestStart_IPBlockPeersOnly(t *testing.T) {
+	const namespace = "test-ns"
+	clientset := fake.NewClientset(operatorDeployment(namespace))
+
+	np := startAndCapture(t, clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithAPIServerPort(6443),
+		WithAPIServerIPs([]string{"10.0.0.1", "10.0.0.2"}),
+	)
+
+	tcp := corev1.ProtocolTCP
+	apiServerPort := intstr.FromInt32(6443)
+	expected := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "opentelemetry-operator",
+			Namespace:       namespace,
+			OwnerReferences: ownerRef(),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/name": "opentelemetry-operator"},
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{}},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &tcp, Port: &apiServerPort}},
+					To: []networkingv1.NetworkPolicyPeer{
+						{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.1/32"}},
+						{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.2/32"}},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		},
+	}
+
+	assert.Equal(t, expected, np)
+}
+
+func TestStart_SelectorPeersOnly(t *testing.T) {
+	const namespace = "test-ns"
+	clientset := fake.NewClientset(operatorDeployment(namespace))
+
+	podSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"apiserver": "true"},
+	}
+	nsSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-kube-apiserver"},
+	}
+
+	np := startAndCapture(t, clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithAPIServerPort(6443),
+		WithAPISererPodLabelSelector(podSelector),
+		WithAPISererNamespaceLabelSelector(nsSelector),
+	)
+
+	tcp := corev1.ProtocolTCP
+	apiServerPort := intstr.FromInt32(6443)
+	expected := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "opentelemetry-operator",
+			Namespace:       namespace,
+			OwnerReferences: ownerRef(),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/name": "opentelemetry-operator"},
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{}},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &tcp, Port: &apiServerPort}},
+				},
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &tcp, Port: &apiServerPort}},
+					To: []networkingv1.NetworkPolicyPeer{
+						{PodSelector: podSelector, NamespaceSelector: nsSelector},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		},
+	}
+
+	assert.Equal(t, expected, np)
+}
+
+func TestStart_CombinedIPBlockAndSelectors(t *testing.T) {
+	const namespace = "openshift-opentelemetry-operator"
+	clientset := fake.NewClientset(operatorDeployment(namespace))
+
+	podSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"apiserver": "true"},
+	}
+	nsSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-kube-apiserver"},
+	}
+
+	np := startAndCapture(t, clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithAPIServerPort(6443),
+		WithAPIServerIPs([]string{"10.0.0.1"}),
+		WithAPISererPodLabelSelector(podSelector),
+		WithAPISererNamespaceLabelSelector(nsSelector),
+	)
+
+	tcp := corev1.ProtocolTCP
+	apiServerPort := intstr.FromInt32(6443)
+	expected := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "opentelemetry-operator",
+			Namespace:       namespace,
+			OwnerReferences: ownerRef(),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/name": "opentelemetry-operator"},
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{}},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &tcp, Port: &apiServerPort}},
+					To:    []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.1/32"}}},
+				},
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &tcp, Port: &apiServerPort}},
+					To:    []networkingv1.NetworkPolicyPeer{{PodSelector: podSelector, NamespaceSelector: nsSelector}},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		},
+	}
+
+	assert.Equal(t, expected, np)
+}
+
+func TestStart_WithIngressPorts(t *testing.T) {
+	const namespace = "test-ns"
+	clientset := fake.NewClientset(operatorDeployment(namespace))
+
+	np := startAndCapture(t, clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithAPIServerPort(6443),
+		WithAPIServerIPs([]string{"10.0.0.1"}),
+		WithWebhookPort(9443),
+		WithMetricsPort(8443),
+	)
+
+	tcp := corev1.ProtocolTCP
+	apiServerPort := intstr.FromInt32(6443)
+	webhookPort := intstr.FromInt32(9443)
+	metricsPort := intstr.FromInt32(8443)
+	expected := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "opentelemetry-operator",
+			Namespace:       namespace,
+			OwnerReferences: ownerRef(),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/name": "opentelemetry-operator"},
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &tcp, Port: &webhookPort},
+						{Protocol: &tcp, Port: &metricsPort},
+					},
+				},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &tcp, Port: &apiServerPort}},
+					To:    []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.1/32"}}},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		},
+	}
+
+	assert.Equal(t, expected, np)
+}
+
+func TestStart_FullOpenShiftConfig(t *testing.T) {
+	const namespace = "openshift-opentelemetry-operator"
+	clientset := fake.NewClientset(operatorDeployment(namespace))
+
+	podSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"apiserver": "true"},
+	}
+	nsSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-kube-apiserver"},
+	}
+
+	np := startAndCapture(t, clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithAPIServerPort(6443),
+		WithAPIServerIPs([]string{"10.0.0.1", "10.0.0.2"}),
+		WithAPISererPodLabelSelector(podSelector),
+		WithAPISererNamespaceLabelSelector(nsSelector),
+		WithWebhookPort(9443),
+		WithMetricsPort(8443),
+	)
+
+	tcp := corev1.ProtocolTCP
+	apiServerPort := intstr.FromInt32(6443)
+	webhookPort := intstr.FromInt32(9443)
+	metricsPort := intstr.FromInt32(8443)
+	expected := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "opentelemetry-operator",
+			Namespace:       namespace,
+			OwnerReferences: ownerRef(),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/name": "opentelemetry-operator"},
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &tcp, Port: &webhookPort},
+						{Protocol: &tcp, Port: &metricsPort},
+					},
+				},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &tcp, Port: &apiServerPort}},
+					To: []networkingv1.NetworkPolicyPeer{
+						{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.1/32"}},
+						{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.2/32"}},
+					},
+				},
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &tcp, Port: &apiServerPort}},
+					To:    []networkingv1.NetworkPolicyPeer{{PodSelector: podSelector, NamespaceSelector: nsSelector}},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+		},
+	}
+
+	assert.Equal(t, expected, np)
+}
+
+func TestNeedLeaderElection(t *testing.T) {
+	n := &networkPolicy{}
+	assert.True(t, n.NeedLeaderElection())
+}

--- a/tests/e2e-openshift/networkpolicy/00-assert-operator-network-policy.yaml
+++ b/tests/e2e-openshift/networkpolicy/00-assert-operator-network-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: opentelemetry-operator
+  namespace: opentelemetry-operator-system
+spec:
+  egress:
+    - ports:
+        - port: 6443
+          protocol: TCP
+    - ports:
+        - port: 6443
+          protocol: TCP
+  ingress:
+    - ports:
+        - port: 9443
+          protocol: TCP
+        - port: 8443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-operator
+  policyTypes:
+    - Ingress
+    - Egress

--- a/tests/e2e-openshift/networkpolicy/00-assert-operator-pod.yaml
+++ b/tests/e2e-openshift/networkpolicy/00-assert-operator-pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/name: opentelemetry-operator
+    control-plane: controller-manager
+  namespace: opentelemetry-operator-system
+status:
+  containerStatuses:
+  - name: manager
+    ready: true
+    started: true
+  phase: Running

--- a/tests/e2e-openshift/networkpolicy/01-assert-collector.yaml
+++ b/tests/e2e-openshift/networkpolicy/01-assert-collector.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: otel-collector
+status:
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-targetallocator
+status:
+  readyReplicas: 1
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: otel-collector-networkpolicy
+spec:
+  ingress:
+    - ports:
+        - port: 8888
+          protocol: TCP
+        - port: 4317
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: otel-targetallocator-networkpolicy
+spec:
+  ingress:
+    - ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-targetallocator
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+  policyTypes:
+    - Ingress
+    - Egress

--- a/tests/e2e-openshift/networkpolicy/01-install-collector.yaml
+++ b/tests/e2e-openshift/networkpolicy/01-install-collector.yaml
@@ -1,0 +1,108 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+spec:
+  mode: "statefulset"
+  targetAllocator:
+    enabled: true
+    prometheusCR:
+      enabled: true
+      serviceMonitorSelector: { }
+      podMonitorSelector: { }
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: otel-collector
+              scrape_interval: 10s
+              static_configs:
+                - targets: ["0.0.0.0:8888"]
+    processors:
+      batch:
+        timeout: 10s
+    exporters:
+      debug:
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [debug]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ta-role
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ta-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ta-role
+subjects:
+  - kind: ServiceAccount
+    name: ta-role
+    namespace: ($namespace)
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ta-cr-role
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+      - podmonitors
+    verbs:
+      - '*'
+  - apiGroups: [""]
+    resources:
+      - namespaces
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ta-cr-role
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ta-cr-role
+subjects:
+  - kind: ServiceAccount
+    name: otel-targetallocator
+    namespace: ($namespace)

--- a/tests/e2e-openshift/networkpolicy/chainsaw-test.yaml
+++ b/tests/e2e-openshift/networkpolicy/chainsaw-test.yaml
@@ -1,0 +1,20 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: networkpolicy
+spec:
+  concurrent: false
+  steps:
+  - name: Assert operator network policy
+    try:
+    - assert:
+        file: 00-assert-operator-pod.yaml
+    - assert:
+        file: 00-assert-operator-network-policy.yaml
+
+  - name: Verify operand network policies
+    try:
+    - apply:
+        file: 01-install-collector.yaml
+    - assert:
+        file: 01-assert-collector.yaml


### PR DESCRIPTION
## Summary

- Fix CrashLoopBackOff on OpenShift caused by mixing `ipBlock` with `podSelector`/`namespaceSelector` in the same NetworkPolicy egress rule peer list. Place them in separate egress rules instead.
- Add unit tests for the `operatornetworkpolicy` package (previously had zero tests).
- Add OpenShift e2e test validating both operator and operand NetworkPolicies.
- Update kind e2e assertion to also verify egress rules.

## Root Cause

The Kubernetes API forbids combining `ipBlock` with `podSelector` or `namespaceSelector` within the same `NetworkPolicyPeer` list ([docs](https://kubernetes.io/docs/concepts/services-networking/network-policies/#behavior-of-to-and-from-selectors)). On OpenShift, after #5253 changed the startup order so autodetect runs before NetworkPolicy creation, both IPBlock and selector peers were added to the same egress rule, triggering:

```
spec.egress[0].to[0]: Forbidden: may not specify both ipBlock and another peer
```

## Test plan

- [x] Unit tests pass: `go test ./internal/operatornetworkpolicy/... -v` (8 tests)
- [x] Full test suite passes: `make test` (2218 tests)
- [x] Lint passes: `make lint`
- [x] Changelog validated: `make chlog-validate`
- [x] OpenShift e2e test passes on OCP 4.22: `chainsaw test --test-dir ./tests/e2e-openshift/networkpolicy`

Fixes #5275