### PR TITLE
Pin OpenShift must-gather image in e2e tests

### DIFF
--- a/tests/e2e-openshift/must-gather/chainsaw-test.yaml
+++ b/tests/e2e-openshift/must-gather/chainsaw-test.yaml
@@ -42,6 +42,6 @@ spec:
         - name: otelnamespace
           value: opentelemetry-operator-system
         - name: MUSTGATHER_IMG
-          value: ($MUSTGATHER_IMG)
+          value: (env('MUSTGATHER_IMG'))
         timeout: 5m
         content: ./check_must_gather.sh

--- a/tests/e2e-openshift/must-gather/chainsaw-test.yaml
+++ b/tests/e2e-openshift/must-gather/chainsaw-test.yaml
@@ -41,5 +41,7 @@ spec:
         env:
         - name: otelnamespace
           value: opentelemetry-operator-system
+        - name: MUSTGATHER_IMG
+          value: ($MUSTGATHER_IMG)
         timeout: 5m
         content: ./check_must_gather.sh

--- a/tests/e2e-openshift/must-gather/check_must_gather.sh
+++ b/tests/e2e-openshift/must-gather/check_must_gather.sh
@@ -3,8 +3,15 @@
 # Create a temporary directory to store must-gather
 MUST_GATHER_DIR=$(mktemp -d)
 
+# Use MUSTGATHER_IMG if set, otherwise derive from the operator version in versions.txt
+if [ -z "$MUSTGATHER_IMG" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  OPERATOR_VERSION=$(awk -F= '/^operator=/ {print $2}' "${SCRIPT_DIR}/../../../versions.txt")
+  MUSTGATHER_IMG="ghcr.io/open-telemetry/opentelemetry-operator/must-gather:${OPERATOR_VERSION}"
+fi
+
 # Run the must-gather script
-oc adm must-gather --dest-dir=$MUST_GATHER_DIR --image=ghcr.io/open-telemetry/opentelemetry-operator/must-gather:main -- /usr/bin/gather --operator-namespace $otelnamespace
+oc adm must-gather --dest-dir=$MUST_GATHER_DIR --image=$MUSTGATHER_IMG -- /usr/bin/gather --operator-namespace $otelnamespace
 
 # Define required files and directories
 REQUIRED_ITEMS=(


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

must-gather is tagged with operator version. I would like to use pinned version in e2e tests to make the test more reproducible. 

**Link to tracking Issue(s):** <Issue number if applicable>


**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
