### PR TITLE
[Chore] Fix e2e tests for webhook rename and collector version

### DIFF
--- a/tests/e2e-openshift/env-config/02-assert-pod-webhook-scaled.yaml
+++ b/tests/e2e-openshift/env-config/02-assert-pod-webhook-scaled.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: opentelemetry-operator-pod-webhook
-  namespace: opentelemetry-operator-system
-spec:
-  replicas: 1
-status:
-  availableReplicas: 1

--- a/tests/e2e-openshift/env-config/03-assert-pod-webhook-default.yaml
+++ b/tests/e2e-openshift/env-config/03-assert-pod-webhook-default.yaml
@@ -1,9 +1,0 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: opentelemetry-operator-pod-webhook
-  namespace: opentelemetry-operator-system
-spec:
-  replicas: 2
-status:
-  availableReplicas: 2

--- a/tests/e2e-openshift/env-config/assert-pod-webhook-replicas.yaml
+++ b/tests/e2e-openshift/env-config/assert-pod-webhook-replicas.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-operator-webhook
+  namespace: opentelemetry-operator-system
+spec:
+  replicas: ($webhook_replicas)
+status:
+  availableReplicas: ($webhook_replicas)

--- a/tests/e2e-openshift/env-config/chainsaw-test.yaml
+++ b/tests/e2e-openshift/env-config/chainsaw-test.yaml
@@ -128,6 +128,9 @@ spec:
           echo "Cleanup complete"
 
   - name: Patch operator Subscription with OPENSHIFT_WEBHOOK_REPLICAS env var
+    bindings:
+    - name: webhook_replicas
+      value: 1
     try:
     - script:
         env:
@@ -139,7 +142,7 @@ spec:
           set -e
 
           # Check if pod-webhook deployment exists (OpenShift with OLM only)
-          if ! kubectl get deployment opentelemetry-operator-pod-webhook -n "$OTEL_NAMESPACE" &>/dev/null; then
+          if ! kubectl get deployment opentelemetry-operator-webhook -n "$OTEL_NAMESPACE" &>/dev/null; then
             echo "SKIP: pod-webhook deployment not found"
             exit 0
           fi
@@ -173,9 +176,12 @@ spec:
     - sleep:
         duration: 10s
     - assert:
-        file: 02-assert-pod-webhook-scaled.yaml
+        file: assert-pod-webhook-replicas.yaml
 
   - name: Remove OPENSHIFT_WEBHOOK_REPLICAS and verify default restored
+    bindings:
+    - name: webhook_replicas
+      value: 2
     try:
     - script:
         env:
@@ -187,7 +193,7 @@ spec:
           set -e
 
           # Check if pod-webhook deployment exists
-          if ! kubectl get deployment opentelemetry-operator-pod-webhook -n "$OTEL_NAMESPACE" &>/dev/null; then
+          if ! kubectl get deployment opentelemetry-operator-webhook -n "$OTEL_NAMESPACE" &>/dev/null; then
             echo "SKIP: pod-webhook deployment not found"
             exit 0
           fi
@@ -217,7 +223,7 @@ spec:
           TIMEOUT=60
           ELAPSED=0
           while [ $ELAPSED -lt $TIMEOUT ]; do
-            REPLICAS=$(kubectl get deployment opentelemetry-operator-pod-webhook \
+            REPLICAS=$(kubectl get deployment opentelemetry-operator-webhook \
               -n "$OTEL_NAMESPACE" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "0")
             if [ "$REPLICAS" = "2" ]; then
               echo "Pod-webhook scaled to 2 replicas after ${ELAPSED}s"
@@ -234,4 +240,4 @@ spec:
     - sleep:
         duration: 5s
     - assert:
-        file: 03-assert-pod-webhook-default.yaml
+        file: assert-pod-webhook-replicas.yaml

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/chainsaw-test.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/chainsaw-test.yaml
@@ -8,7 +8,18 @@ spec:
   steps:
   - name: Create the OTEL collector instance
     try:
+    - script:
+        content: |
+          VERSION=$(kubectl logs deployment/opentelemetry-operator-controller-manager \
+            -n opentelemetry-operator-system | \
+            grep -o '"collector-image":"[^"]*"' | head -1 | \
+            grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          printf '%s' "$VERSION"
+        outputs:
+          - name: collectorVersion
+            value: ($stdout)
     - apply:
+        template: true
         file: otel-collector.yaml
     - assert:
         file: otel-collector-assert.yaml
@@ -49,7 +60,7 @@ spec:
         - -A
         - -l app.kubernetes.io/component=operator
         - -l app.kubernetes.io/name=observability-operator
-        - -o 
+        - -o
         - jsonpath={.items[0].metadata.namespace}
         outputs:
         - name: COO_NAMESPACE

--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/otel-collector.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/otel-collector.yaml
@@ -42,7 +42,7 @@ metadata:
   name: otel
   namespace: openshift-logging
 spec:
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.140.0
+  image: (join('', ['ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:', $collectorVersion]))
   serviceAccount: otel-collector-deployment
   config:
     extensions:

--- a/tests/e2e-openshift/fsgroup-anyuid-pvc/chainsaw-test.yaml
+++ b/tests/e2e-openshift/fsgroup-anyuid-pvc/chainsaw-test.yaml
@@ -34,20 +34,14 @@ spec:
                 range=$(kubectl get namespace $NAMESPACE \
                   -o jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.uid-range}')
               fi
-              echo "${range%%[/-]*}"
-            outputs:
-              - name: expected_fsgroup
-                value: (to_number($stdout))
-        - assert:
-            resource:
-              apiVersion: apps/v1
-              kind: StatefulSet
-              metadata:
-                name: fsgroup-test-collector
-              spec:
-                template:
-                  spec:
-                    (securityContext.fsGroup == $expected_fsgroup): true
+              expected="${range%%[/-]*}"
+              actual=$(kubectl get statefulset fsgroup-test-collector -n $NAMESPACE \
+                -o jsonpath='{.spec.template.spec.securityContext.fsGroup}')
+              if [[ "$actual" != "$expected" ]]; then
+                echo "fsGroup mismatch: expected=$expected actual=$actual" >&2
+                exit 1
+              fi
+              echo "fsGroup=$actual matches namespace UID range"
     - name: cleanup
       try:
         - script:

--- a/tests/e2e/filelog-receiver/00-install-collector.yaml
+++ b/tests/e2e/filelog-receiver/00-install-collector.yaml
@@ -5,7 +5,7 @@ metadata:
   name: filelog
 spec:
   mode: sidecar
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.150.1
+  image: (join('', ['ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:', $collectorVersion]))
   volumeMounts:
   - name: logs
     mountPath: /var/log/app

--- a/tests/e2e/filelog-receiver/chainsaw-test.yaml
+++ b/tests/e2e/filelog-receiver/chainsaw-test.yaml
@@ -8,7 +8,18 @@ spec:
   steps:
   - name: Install collector and configmap
     try:
+    - script:
+        content: |
+          VERSION=$(kubectl logs deployment/opentelemetry-operator-controller-manager \
+            -n opentelemetry-operator-system | \
+            grep -o '"collector-image":"[^"]*"' | head -1 | \
+            grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          printf '%s' "$VERSION"
+        outputs:
+          - name: collectorVersion
+            value: ($stdout)
     - apply:
+        template: true
         file: 00-install-collector.yaml
   - name: Install app with sidecar
     try:
@@ -48,8 +59,8 @@ spec:
             echo "Attempt $i: Fetching metrics from pod ${podName}..." >&2
             if metrics_output=$(kubectl get --raw /api/v1/namespaces/$NAMESPACE/pods/${podName}:8888/proxy/metrics 2>/dev/null); then
               # Check if we have received any log records
-              if echo "$metrics_output" | grep -q "otelcol_receiver_accepted_log_records_total"; then
-                log_count=$(echo "$metrics_output" | grep "otelcol_receiver_accepted_log_records_total" | grep -v "#" | awk '{print $2}' | head -1)
+              if echo "$metrics_output" | grep -q "otelcol_receiver_accepted_log_records"; then
+                log_count=$(echo "$metrics_output" | grep "otelcol_receiver_accepted_log_records" | grep -v "#" | awk '{print $2}' | head -1)
                 if [ -n "$log_count" ] && [ "$log_count" -gt 0 ] 2>/dev/null; then
                   echo "Successfully fetched metrics on attempt $i with $log_count log records" >&2
                   echo "$metrics_output"
@@ -73,7 +84,7 @@ spec:
           ($error == null): true
     - assert:
         resource:
-          ($metrics[?as_string(metric."__name__") == 'otelcol_receiver_accepted_log_records_total'].value | [0] > `0`): true
+          ($metrics[?as_string(metric."__name__") == 'otelcol_receiver_accepted_log_records'].value | [0] > `0`): true
     catch:
     - podLogs:
         selector: app=log-generator

--- a/tests/e2e/operator-restart/chainsaw-test.yaml
+++ b/tests/e2e/operator-restart/chainsaw-test.yaml
@@ -8,18 +8,39 @@ spec:
   steps:
   - name: Enable operator network policy
     try:
-    - command:
-        entrypoint: kubectl
-        args:
-          - patch
-          - deployment
-          - opentelemetry-operator-controller-manager
-          - -n
-          - opentelemetry-operator-system
-          - --type=json
-          - -p
-          - '[{"op": "add", "path": "/spec/template/spec/containers/0/env/-", "value": {"name": "FEATURE_GATES", "value": "operator.networkpolicy,operand.networkpolicy"}}]'
-    # Adding 10s sleep here cause sometimes the pod will be in running state for a while but can fail later if there is any issue with the component startup.
+    - script:
+        timeout: 180s
+        content: |
+          #!/bin/bash
+          set -e
+          OTEL_NAMESPACE=opentelemetry-operator-system
+          GATE_VALUE="operator.networkpolicy,operand.networkpolicy"
+
+          # Check if operator is deployed via OLM (Subscription exists)
+          SUB_NAME=$(kubectl get subscription.operators.coreos.com -n "$OTEL_NAMESPACE" \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+            | grep -i opentelemetry | head -1 || true)
+
+          if [ -n "$SUB_NAME" ]; then
+            echo "OLM detected — feature gates are expected to be set via CSV already"
+            DEP_ENV=$(kubectl get deployment opentelemetry-operator-controller-manager \
+              -n "$OTEL_NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].env}' 2>/dev/null || true)
+            if echo "$DEP_ENV" | grep -q "FEATURE_GATES"; then
+              echo "FEATURE_GATES already present in controller-manager, no patching needed"
+            else
+              echo "WARNING: FEATURE_GATES not found in controller-manager deployment"
+              exit 1
+            fi
+          else
+            echo "No OLM — patching deployment directly"
+            kubectl patch deployment opentelemetry-operator-controller-manager \
+              -n "$OTEL_NAMESPACE" --type=json \
+              -p "[{\"op\":\"add\",\"path\":\"/spec/template/spec/containers/0/env/-\",\"value\":{\"name\":\"FEATURE_GATES\",\"value\":\"$GATE_VALUE\"}}]"
+          fi
+
+          kubectl rollout status deployment/opentelemetry-operator-controller-manager \
+            -n "$OTEL_NAMESPACE" --timeout=120s
+          echo "Operator ready with network policy feature gates"
     - sleep:
         duration: 10s
     - assert:

--- a/tests/e2e/smoke-collector/smoke-collector-deployment/00-assert.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-deployment/00-assert.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: opentelemetry-operator
     app.kubernetes.io/name: smoke-collector-collector
     app.kubernetes.io/part-of: opentelemetry
-    app.kubernetes.io/version: 0.121.0
+    app.kubernetes.io/version: ($collectorVersion)
 spec:
   template:
     metadata:

--- a/tests/e2e/smoke-collector/smoke-collector-deployment/00-install.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-deployment/00-install.yaml
@@ -6,8 +6,7 @@ metadata:
     regular-annotation: regular-value
 spec:
   mode: deployment
-  # pinned image so we can assert the version label is derived from it
-  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.121.0
+  image: (join('', ['ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:', $collectorVersion]))
   # scheduling: nodeSelector + affinity
   nodeSelector:
     kubernetes.io/os: linux

--- a/tests/e2e/smoke-collector/smoke-collector-deployment/chainsaw-test.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-deployment/chainsaw-test.yaml
@@ -28,9 +28,21 @@ spec:
     - name: install
       description: install a collector with all propagatable fields set
       try:
+        - script:
+            content: |
+              VERSION=$(kubectl logs deployment/opentelemetry-operator-controller-manager \
+                -n opentelemetry-operator-system | \
+                grep -o '"collector-image":"[^"]*"' | head -1 | \
+                grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+              printf '%s' "$VERSION"
+            outputs:
+              - name: collectorVersion
+                value: ($stdout)
         - apply:
+            template: true
             file: 00-install.yaml
         - assert:
+            template: true
             file: 00-assert.yaml
         # trafficDistribution is only honoured on k8s >= 1.31; on older API
         # servers the field is pruned. Gate the assertion on the server version.


### PR DESCRIPTION
## Summary
- Rename `opentelemetry-operator-pod-webhook` to `opentelemetry-operator-webhook` in env-config test assertions to match the deployment name change from #5288
- Replace hardcoded collector image versions with dynamic version lookup from operator logs in smoke-collector-deployment, filelog-receiver, and export-to-cluster-logging-lokistack tests
- Fix operator-restart test to detect OLM-managed installs and skip direct deployment patching when feature gates are already set via CSV
- Fix fsgroup-anyuid-pvc test to use shell-based comparison instead of chainsaw assertion for fsGroup validation
- Fix metric name `otelcol_receiver_accepted_log_records_total` → `otelcol_receiver_accepted_log_records` in filelog-receiver test

## Test plan
- [ ] Run `make e2e` on kind cluster
- [ ] Run e2e-openshift tests on OpenShift cluster with OLM