### PR TITLE
Add new snake_case spellings of remaining receivers and processors

### DIFF
--- a/.chloggen/fix-receiver-rbac-snakecase.yaml
+++ b/.chloggen/fix-receiver-rbac-snakecase.yaml
@@ -1,0 +1,13 @@
+change_type: bug_fix
+component: collector
+issues: [5317]
+
+note: "Register the `kubelet_stats`, `k8s_objects`, and `resource_detection` snake-case component names alongside their original spellings when generating RBAC from a Collector CR, so either spelling produces the permissions (and, for `kubelet_stats`, the `K8S_NODE_NAME` env var) the component needs."
+
+subtext: |
+  These components were renamed to snake_case in
+  opentelemetry-collector-contrib (#47957 for kubeletstats, #47440 for
+  k8sobjects, #48525 for resourcedetection) while keeping the original
+  names accepted, but the operator only parsed the original spelling and
+  emitted no RBAC for configs using the new names. This extends the
+  k8s_attributes fix (#4983) to the remaining renamed components.

--- a/.chloggen/fix-receiver-rbac-snakecase.yaml
+++ b/.chloggen/fix-receiver-rbac-snakecase.yaml
@@ -2,12 +2,15 @@ change_type: bug_fix
 component: collector
 issues: [5317]
 
-note: "Register the `kubelet_stats`, `k8s_objects`, and `resource_detection` snake-case component names alongside their original spellings when generating RBAC from a Collector CR, so either spelling produces the permissions (and, for `kubelet_stats`, the `K8S_NODE_NAME` env var) the component needs."
+note: "Register the snake-case spellings of several renamed receivers (`kubelet_stats`, `k8s_objects`, `resource_detection`, `fluent_forward`, `tcp_log`, `udp_log`, `ssh_check`, `cloud_foundry`, `http_check`, `flink_metrics`) alongside their original spellings when generating RBAC and service ports from a Collector CR, so either spelling produces the same result."
 
 subtext: |
-  These components were renamed to snake_case in
-  opentelemetry-collector-contrib (#47957 for kubeletstats, #47440 for
-  k8sobjects, #48525 for resourcedetection) while keeping the original
-  names accepted, but the operator only parsed the original spelling and
-  emitted no RBAC for configs using the new names. This extends the
-  k8s_attributes fix (#4983) to the remaining renamed components.
+  These components were renamed to snake_case in opentelemetry-collector-contrib
+  (#47957 kubeletstats, #47440 k8sobjects, #48525 resourcedetection, #47930
+  fluentforward, #47369 tcplog, #47370 udplog, #47515 sshcheck, #47932
+  cloudfoundry, #47505 httpcheck, #47929 flinkmetrics) while keeping the
+  original names accepted, but the operator only recognized one spelling per
+  component, so configs using the other spelling got no RBAC/ports or the
+  wrong service port name. This extends the k8s_attributes fix (#4983) to
+  the remaining renamed components, and makes `NewScraperParser` accept
+  aliases so future renames of this kind are a one-line fix.

--- a/internal/components/builder.go
+++ b/internal/components/builder.go
@@ -29,6 +29,7 @@ type Settings[ComponentConfigType any] struct {
 	startupGen      ProbeGenerator[ComponentConfigType]
 	defaultsApplier Defaulter[ComponentConfigType]
 	envVarGen       EnvVarGenerator[ComponentConfigType]
+	aliases         []string
 }
 
 func NewEmptySettings[ComponentConfigType any]() *Settings[ComponentConfigType] {
@@ -94,6 +95,17 @@ func (b Builder[ComponentConfigType]) WithName(name string) Builder[ComponentCon
 	})
 }
 
+// WithAlias registers one or more additional names that resolve to the same
+// parser. This is used for components that accept more than one spelling - for
+// example the lower_snake_case names introduced by the collector-contrib
+// component rename - so the operator produces the same RBAC and environment
+// variables regardless of which spelling a Collector config uses.
+func (b Builder[ComponentConfigType]) WithAlias(aliases ...string) Builder[ComponentConfigType] {
+	return append(b, func(o *Settings[ComponentConfigType]) {
+		o.aliases = append(o.aliases, aliases...)
+	})
+}
+
 func (b Builder[ComponentConfigType]) WithPort(port int32) Builder[ComponentConfigType] {
 	return append(b, func(o *Settings[ComponentConfigType]) {
 		o.port = port
@@ -150,6 +162,7 @@ func (b Builder[ComponentConfigType]) Build() (*GenericParser[ComponentConfigTyp
 	}
 	return &GenericParser[ComponentConfigType]{
 		name:            o.name,
+		aliases:         o.aliases,
 		portParser:      o.portParser,
 		rbacGen:         o.rbacGen,
 		envVarGen:       o.envVarGen,

--- a/internal/components/component.go
+++ b/internal/components/component.go
@@ -132,6 +132,9 @@ type Parser interface {
 
 	// ParserName is an internal name for the parser
 	ParserName() string
+
+	// ParserAliases returns alternative names that resolve to this parser.
+	ParserAliases() []string
 }
 
 func ConstructServicePort(current *corev1.ServicePort, port int32) corev1.ServicePort {

--- a/internal/components/generic_parser.go
+++ b/internal/components/generic_parser.go
@@ -18,6 +18,7 @@ var _ Parser = &GenericParser[SingleEndpointConfig]{}
 // functionality to idempotent functions.
 type GenericParser[T any] struct {
 	name            string
+	aliases         []string
 	settings        *Settings[T]
 	portParser      PortParser[T]
 	rbacGen         RBACRuleGenerator[T]
@@ -120,6 +121,11 @@ func (g *GenericParser[T]) Ports(logger logr.Logger, name string, config any) ([
 
 func (g *GenericParser[T]) ParserType() string {
 	return ComponentType(g.name)
+}
+
+// ParserAliases returns alternative names that resolve to this parser.
+func (g *GenericParser[T]) ParserAliases() []string {
+	return g.aliases
 }
 
 func (g *GenericParser[T]) ParserName() string {

--- a/internal/components/multi_endpoint.go
+++ b/internal/components/multi_endpoint.go
@@ -64,6 +64,10 @@ func (m *MultiPortReceiver) ParserName() string {
 	return fmt.Sprintf("__%s", m.name)
 }
 
+func (m *MultiPortReceiver) ParserAliases() []string {
+	return nil
+}
+
 func (m *MultiPortReceiver) GetDefaultConfig(logger logr.Logger, config any, opts ...DefaultOption) (any, error) {
 	// Apply options to build the DefaultConfig
 	defaultCfg := &DefaultConfig{}

--- a/internal/components/multi_endpoint.go
+++ b/internal/components/multi_endpoint.go
@@ -64,7 +64,7 @@ func (m *MultiPortReceiver) ParserName() string {
 	return fmt.Sprintf("__%s", m.name)
 }
 
-func (m *MultiPortReceiver) ParserAliases() []string {
+func (*MultiPortReceiver) ParserAliases() []string {
 	return nil
 }
 

--- a/internal/components/processors/helpers.go
+++ b/internal/components/processors/helpers.go
@@ -35,6 +35,11 @@ var componentParsers = []components.Parser{
 	// must generate the same RBAC for either spelling (#4922).
 	components.NewBuilder[K8sAttributeConfig]().WithName("k8s_attributes").WithRbacGen(GenerateK8SAttrRbacRules).MustBuild(),
 	components.NewBuilder[ResourceDetectionConfig]().WithName("resourcedetection").WithRbacGen(GenerateResourceDetectionRbacRules).MustBuild(),
+	// resource_detection is the snake-case alias introduced in
+	// open-telemetry/opentelemetry-collector-contrib#48525. Both names
+	// resolve to the same processor in the collector, so the operator
+	// must generate the same RBAC for either spelling.
+	components.NewBuilder[ResourceDetectionConfig]().WithName("resource_detection").WithRbacGen(GenerateResourceDetectionRbacRules).MustBuild(),
 }
 
 func init() {

--- a/internal/components/processors/helpers.go
+++ b/internal/components/processors/helpers.go
@@ -28,22 +28,19 @@ func ProcessorFor(name string) components.Parser {
 }
 
 var componentParsers = []components.Parser{
-	components.NewBuilder[K8sAttributeConfig]().WithName("k8sattributes").WithRbacGen(GenerateK8SAttrRbacRules).MustBuild(),
-	// k8s_attributes is the snake-case alias introduced in
-	// open-telemetry/opentelemetry-collector-contrib#45901. Both names
-	// resolve to the same processor in the collector, so the operator
-	// must generate the same RBAC for either spelling (#4922).
-	components.NewBuilder[K8sAttributeConfig]().WithName("k8s_attributes").WithRbacGen(GenerateK8SAttrRbacRules).MustBuild(),
-	components.NewBuilder[ResourceDetectionConfig]().WithName("resourcedetection").WithRbacGen(GenerateResourceDetectionRbacRules).MustBuild(),
-	// resource_detection is the snake-case alias introduced in
-	// open-telemetry/opentelemetry-collector-contrib#48525. Both names
-	// resolve to the same processor in the collector, so the operator
-	// must generate the same RBAC for either spelling.
-	components.NewBuilder[ResourceDetectionConfig]().WithName("resource_detection").WithRbacGen(GenerateResourceDetectionRbacRules).MustBuild(),
+	// k8s_attributes, formerly k8sattributes
+	// (open-telemetry/opentelemetry-collector-contrib#45901, see #4922).
+	components.NewBuilder[K8sAttributeConfig]().WithName("k8s_attributes").WithRbacGen(GenerateK8SAttrRbacRules).WithAlias("k8sattributes").MustBuild(),
+	// resource_detection, formerly resourcedetection
+	// (open-telemetry/opentelemetry-collector-contrib#48525).
+	components.NewBuilder[ResourceDetectionConfig]().WithName("resource_detection").WithRbacGen(GenerateResourceDetectionRbacRules).WithAlias("resourcedetection").MustBuild(),
 }
 
 func init() {
 	for _, parser := range componentParsers {
 		Register(parser.ParserType(), parser)
+		for _, alias := range parser.ParserAliases() {
+			Register(alias, parser)
+		}
 	}
 }

--- a/internal/components/processors/helpers_test.go
+++ b/internal/components/processors/helpers_test.go
@@ -48,9 +48,9 @@ func TestDownstreamParsers(t *testing.T) {
 		parserName    string
 	}{
 		{"k8s_attributes", "k8s_attributes", "__k8s_attributes"},
-		{"k8sattributes deprecated alias", "k8sattributes", "__k8s_attributes"},
+		{"k8sattributes", "k8sattributes", "__k8s_attributes"},
 		{"resource_detection", "resource_detection", "__resource_detection"},
-		{"resourcedetection deprecated alias", "resourcedetection", "__resource_detection"},
+		{"resourcedetection", "resourcedetection", "__resource_detection"},
 	} {
 		t.Run(tt.processorName, func(t *testing.T) {
 			t.Run("builds successfully", func(t *testing.T) {

--- a/internal/components/processors/helpers_test.go
+++ b/internal/components/processors/helpers_test.go
@@ -47,8 +47,10 @@ func TestDownstreamParsers(t *testing.T) {
 		processorName string
 		parserName    string
 	}{
-		{"k8sattributes", "k8sattributes", "__k8sattributes"},
-		{"resourcedetection", "resourcedetection", "__resourcedetection"},
+		{"k8s_attributes", "k8s_attributes", "__k8s_attributes"},
+		{"k8sattributes deprecated alias", "k8sattributes", "__k8s_attributes"},
+		{"resource_detection", "resource_detection", "__resource_detection"},
+		{"resourcedetection deprecated alias", "resourcedetection", "__resource_detection"},
 	} {
 		t.Run(tt.processorName, func(t *testing.T) {
 			t.Run("builds successfully", func(t *testing.T) {

--- a/internal/components/receivers/helpers.go
+++ b/internal/components/receivers/helpers.go
@@ -120,17 +120,12 @@ var componentParsers = []components.Parser{
 		WithProtocol(corev1.ProtocolTCP).
 		WithTargetPort(3100).
 		MustBuild(),
-	components.NewBuilder[kubeletStatsConfig]().WithName("kubeletstats").
-		WithRbacGen(generateKubeletStatsRbacRules).
-		WithEnvVarGen(generateKubeletStatsEnvVars).
-		MustBuild(),
-	// kubelet_stats is the snake-case alias introduced in
-	// open-telemetry/opentelemetry-collector-contrib#47957. Both names
-	// resolve to the same receiver in the collector, so the operator must
-	// generate the same RBAC and env vars for either spelling.
+	// kubelet_stats, formerly kubeletstats
+	// (open-telemetry/opentelemetry-collector-contrib#47957).
 	components.NewBuilder[kubeletStatsConfig]().WithName("kubelet_stats").
 		WithRbacGen(generateKubeletStatsRbacRules).
 		WithEnvVarGen(generateKubeletStatsEnvVars).
+		WithAlias("kubeletstats").
 		MustBuild(),
 	components.NewBuilder[k8seventsConfig]().WithName("k8s_events").
 		WithRbacGen(generatek8seventsRbacRules).
@@ -138,15 +133,11 @@ var componentParsers = []components.Parser{
 	components.NewBuilder[k8sclusterConfig]().WithName("k8s_cluster").
 		WithRbacGen(generatek8sclusterRbacRules).
 		MustBuild(),
-	components.NewBuilder[k8sobjectsConfig]().WithName("k8sobjects").
-		WithRbacGen(generatek8sobjectsRbacRules).
-		MustBuild(),
-	// k8s_objects is the snake-case alias introduced in
-	// open-telemetry/opentelemetry-collector-contrib#47440. Both names
-	// resolve to the same receiver in the collector, so the operator must
-	// generate the same RBAC for either spelling.
+	// k8s_objects, formerly k8sobjects
+	// (open-telemetry/opentelemetry-collector-contrib#47440).
 	components.NewBuilder[k8sobjectsConfig]().WithName("k8s_objects").
 		WithRbacGen(generatek8sobjectsRbacRules).
+		WithAlias("k8sobjects").
 		MustBuild(),
 	NewPrometheusParser(),
 	NewScraperParser("sshcheck"),
@@ -183,5 +174,8 @@ var componentParsers = []components.Parser{
 func init() {
 	for _, parser := range componentParsers {
 		Register(parser.ParserType(), parser)
+		for _, alias := range parser.ParserAliases() {
+			Register(alias, parser)
+		}
 	}
 }

--- a/internal/components/receivers/helpers.go
+++ b/internal/components/receivers/helpers.go
@@ -32,8 +32,9 @@ func ReceiverFor(name string) components.Parser {
 }
 
 // NewScraperParser is an instance of a generic parser that returns nothing when called and never fails.
-func NewScraperParser(name string) *components.GenericParser[any] {
-	return components.NewBuilder[any]().WithName(name).WithPort(components.UnsetPort).MustBuild()
+// Additional aliases can be passed for components that accept more than one spelling.
+func NewScraperParser(name string, aliases ...string) *components.GenericParser[any] {
+	return components.NewBuilder[any]().WithName(name).WithPort(components.UnsetPort).WithAlias(aliases...).MustBuild()
 }
 
 var componentParsers = []components.Parser{
@@ -87,8 +88,11 @@ var componentParsers = []components.Parser{
 	components.NewSinglePortParserBuilder("collectd", 8081).
 		WithTargetPort(8081).
 		MustBuild(),
-	components.NewSinglePortParserBuilder("fluentforward", 8006).
+	// fluent_forward, formerly fluentforward
+	// (open-telemetry/opentelemetry-collector-contrib#47930).
+	components.NewSinglePortParserBuilder("fluent_forward", 8006).
 		WithTargetPort(8006).
+		WithAlias("fluentforward").
 		MustBuild(),
 	components.NewSinglePortParserBuilder("influxdb", 8086).
 		WithTargetPort(8086).
@@ -106,11 +110,17 @@ var componentParsers = []components.Parser{
 		WithProtocol(corev1.ProtocolUDP).
 		WithTargetPort(8125).
 		MustBuild(),
-	components.NewSinglePortParserBuilder("tcplog", components.UnsetPort).
+	// tcp_log, formerly tcplog
+	// (open-telemetry/opentelemetry-collector-contrib#47369).
+	components.NewSinglePortParserBuilder("tcp_log", components.UnsetPort).
 		WithProtocol(corev1.ProtocolTCP).
+		WithAlias("tcplog").
 		MustBuild(),
-	components.NewSinglePortParserBuilder("udplog", components.UnsetPort).
+	// udp_log, formerly udplog
+	// (open-telemetry/opentelemetry-collector-contrib#47370).
+	components.NewSinglePortParserBuilder("udp_log", components.UnsetPort).
 		WithProtocol(corev1.ProtocolUDP).
+		WithAlias("udplog").
 		MustBuild(),
 	components.NewSinglePortParserBuilder("wavefront", 2003).
 		WithTargetPort(2003).
@@ -140,8 +150,12 @@ var componentParsers = []components.Parser{
 		WithAlias("k8sobjects").
 		MustBuild(),
 	NewPrometheusParser(),
-	NewScraperParser("sshcheck"),
-	NewScraperParser("cloudfoundry"),
+	// ssh_check, formerly sshcheck
+	// (open-telemetry/opentelemetry-collector-contrib#47515).
+	NewScraperParser("ssh_check", "sshcheck"),
+	// cloud_foundry, formerly cloudfoundry
+	// (open-telemetry/opentelemetry-collector-contrib#47932).
+	NewScraperParser("cloud_foundry", "cloudfoundry"),
 	NewScraperParser("vcenter"),
 	NewScraperParser("oracledb"),
 	NewScraperParser("snmp"),
@@ -164,9 +178,13 @@ var componentParsers = []components.Parser{
 	NewScraperParser("nginx"),
 	NewScraperParser("mysql"),
 	NewScraperParser("memcached"),
-	NewScraperParser("httpcheck"),
+	// http_check, formerly httpcheck
+	// (open-telemetry/opentelemetry-collector-contrib#47505).
+	NewScraperParser("http_check", "httpcheck"),
 	NewScraperParser("haproxy"),
-	NewScraperParser("flinkmetrics"),
+	// flink_metrics, formerly flinkmetrics
+	// (open-telemetry/opentelemetry-collector-contrib#47929).
+	NewScraperParser("flink_metrics", "flinkmetrics"),
 	NewScraperParser("couchdb"),
 	NewScraperParser("filelog"),
 }

--- a/internal/components/receivers/helpers.go
+++ b/internal/components/receivers/helpers.go
@@ -124,6 +124,14 @@ var componentParsers = []components.Parser{
 		WithRbacGen(generateKubeletStatsRbacRules).
 		WithEnvVarGen(generateKubeletStatsEnvVars).
 		MustBuild(),
+	// kubelet_stats is the snake-case alias introduced in
+	// open-telemetry/opentelemetry-collector-contrib#47957. Both names
+	// resolve to the same receiver in the collector, so the operator must
+	// generate the same RBAC and env vars for either spelling.
+	components.NewBuilder[kubeletStatsConfig]().WithName("kubelet_stats").
+		WithRbacGen(generateKubeletStatsRbacRules).
+		WithEnvVarGen(generateKubeletStatsEnvVars).
+		MustBuild(),
 	components.NewBuilder[k8seventsConfig]().WithName("k8s_events").
 		WithRbacGen(generatek8seventsRbacRules).
 		MustBuild(),
@@ -131,6 +139,13 @@ var componentParsers = []components.Parser{
 		WithRbacGen(generatek8sclusterRbacRules).
 		MustBuild(),
 	components.NewBuilder[k8sobjectsConfig]().WithName("k8sobjects").
+		WithRbacGen(generatek8sobjectsRbacRules).
+		MustBuild(),
+	// k8s_objects is the snake-case alias introduced in
+	// open-telemetry/opentelemetry-collector-contrib#47440. Both names
+	// resolve to the same receiver in the collector, so the operator must
+	// generate the same RBAC for either spelling.
+	components.NewBuilder[k8sobjectsConfig]().WithName("k8s_objects").
 		WithRbacGen(generatek8sobjectsRbacRules).
 		MustBuild(),
 	NewPrometheusParser(),

--- a/internal/components/receivers/single_endpoint_receiver_test.go
+++ b/internal/components/receivers/single_endpoint_receiver_test.go
@@ -48,6 +48,23 @@ func TestFailedToParseEndpoint(t *testing.T) {
 	assert.Len(t, ports, 0)
 }
 
+func TestScraperParserAliases(t *testing.T) {
+	for _, tt := range []struct {
+		alias        string
+		canonicalTag string
+	}{
+		{"sshcheck", "__ssh_check"},
+		{"cloudfoundry", "__cloud_foundry"},
+		{"httpcheck", "__http_check"},
+		{"flinkmetrics", "__flink_metrics"},
+	} {
+		t.Run(tt.alias, func(t *testing.T) {
+			parser := receivers.ReceiverFor(tt.alias)
+			assert.Equal(t, tt.canonicalTag, parser.ParserName())
+		})
+	}
+}
+
 func TestDownstreamParsers(t *testing.T) {
 	for _, tt := range []struct {
 		desc             string
@@ -64,13 +81,16 @@ func TestDownstreamParsers(t *testing.T) {
 		{"sapm", "sapm", "__sapm", 7276, false},
 		{"signalfx", "signalfx", "__signalfx", 9943, false},
 		{"wavefront", "wavefront", "__wavefront", 2003, false},
-		{"fluentforward", "fluentforward", "__fluentforward", 8006, false},
+		{"fluentforward", "fluentforward", "__fluent_forward", 8006, false},
+		{"fluent_forward", "fluent_forward", "__fluent_forward", 8006, false},
 		{"statsd", "statsd", "__statsd", 8125, false},
 		{"influxdb", "influxdb", "__influxdb", 8086, false},
 		{"splunk_hec", "splunk_hec", "__splunk_hec", 8088, false},
 		{"awsxray", "awsxray", "__awsxray", 2000, false},
-		{"tcplog", "tcplog", "__tcplog", 0, true},
-		{"udplog", "udplog", "__udplog", 0, true},
+		{"tcplog", "tcplog", "__tcp_log", 0, true},
+		{"tcp_log", "tcp_log", "__tcp_log", 0, true},
+		{"udplog", "udplog", "__udp_log", 0, true},
+		{"udp_log", "udp_log", "__udp_log", 0, true},
 	} {
 		t.Run(tt.receiverName, func(t *testing.T) {
 			t.Run("builds successfully", func(t *testing.T) {

--- a/internal/manifests/collector/rbac_test.go
+++ b/internal/manifests/collector/rbac_test.go
@@ -122,6 +122,39 @@ func TestDesiredClusterRoles(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:       "kubelet_stats receiver - snake_case alias",
+			configPath: "testdata/rbac_kubelet_stats_snake_case.yaml",
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"nodes/stats"},
+					Verbs:     []string{"get"},
+				},
+			},
+		},
+		{
+			desc:       "k8s_objects receiver - snake_case alias",
+			configPath: "testdata/rbac_k8s_objects_snake_case.yaml",
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"v1"},
+					Resources: []string{"pods"},
+					Verbs:     []string{"list", "get"},
+				},
+			},
+		},
+		{
+			desc:       "resource_detection processor - snake_case alias",
+			configPath: "testdata/rbac_resource_detection_snake_case.yaml",
+			expectedRules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"nodes"},
+					Verbs:     []string{"get", "list"},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/manifests/collector/testdata/rbac_k8s_objects_snake_case.yaml
+++ b/internal/manifests/collector/testdata/rbac_k8s_objects_snake_case.yaml
@@ -1,0 +1,14 @@
+receivers:
+  k8s_objects:
+    objects:
+      - name: pods
+        mode: pull
+        group: v1
+exporters:
+  otlp:
+    endpoint: "otlp:4317"
+service:
+  pipelines:
+    logs:
+      receivers: [k8s_objects]
+      exporters: [otlp]

--- a/internal/manifests/collector/testdata/rbac_kubelet_stats_snake_case.yaml
+++ b/internal/manifests/collector/testdata/rbac_kubelet_stats_snake_case.yaml
@@ -1,0 +1,11 @@
+receivers:
+  kubelet_stats:
+    auth_type: serviceAccount
+exporters:
+  otlp:
+    endpoint: "otlp:4317"
+service:
+  pipelines:
+    metrics:
+      receivers: [kubelet_stats]
+      exporters: [otlp]

--- a/internal/manifests/collector/testdata/rbac_resource_detection_snake_case.yaml
+++ b/internal/manifests/collector/testdata/rbac_resource_detection_snake_case.yaml
@@ -1,0 +1,16 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+processors:
+  resource_detection:
+    detectors: [k8snode]
+exporters:
+  otlp:
+    endpoint: "otlp:4317"
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resource_detection]
+      exporters: [otlp]


### PR DESCRIPTION
**Description:** 

Add new snake_case spellings for:
- `kubelet_stats`
- `k8s_objects`
- `resource_detection`
- `fluent_forward`
- `tcp_log`
- `udp_log`
- `ssh_check`
- `cloud_foundry`
- `http_check`
- `flink_metrics`

Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45339

Similar to #4983

The Operator looks for components in the config in the CR, using their legacy name without an underscore.
We must add the new name to allow both names to be used.