### PR TITLE
[chore] Use Debian 13 based image for nodejs test app

### DIFF
--- a/tests/test-e2e-apps/nodejs/Dockerfile
+++ b/tests/test-e2e-apps/nodejs/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Use an official Node.js image as a base.
-FROM docker.io/library/node:lts-bookworm@sha256:fdddfb3e688158251943d52eba361de991548f6814007acba4917ae6b512d6be
+FROM docker.io/library/node:lts-trixie-slim@sha256:5301bbf5e8046148348b1dea15436326f43c579031f8d76654a631225bdfe467
 
 # Set the working directory inside the container
 WORKDIR /usr/src/app


### PR DESCRIPTION
Debian 12 is now in LTS mode and doesn't support s390x anymore. See https://www.debian.org/News/2026/20260712. This the reason the app doesn't build in https://github.com/open-telemetry/opentelemetry-operator/pull/5310, the node image for bookworm doesn't support the arch anymore.
