### PR TITLE
fix(instrumentation): apply security context to Java extensions

### DIFF
--- a/.chloggen/java-extension-init-container-security-context.yaml
+++ b/.chloggen/java-extension-init-container-security-context.yaml
@@ -1,0 +1,26 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Apply security context to Java extension init containers
+
+# One or more tracking issues related to the change
+issues: [5335]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Extension init containers injected alongside the Java agent were not receiving
+  a security context. This affected both the explicit `spec.initContainerSecurityContext`
+  field on the Instrumentation CR and the fallback behaviour that inherits the
+  security context from the instrumented application container. Only the main
+  `opentelemetry-auto-instrumentation-java` init container was having its security
+  context set; extension containers were always created with a nil security context.
+  This caused admission failures on clusters with policies that require all
+  containers to drop capabilities or disallow privilege escalation (e.g. OPA
+  Gatekeeper). The security context is now applied to all Java-related init
+  containers at construction time.

--- a/internal/instrumentation/javaagent.go
+++ b/internal/instrumentation/javaagent.go
@@ -40,7 +40,7 @@ func injectJavaagentToContainer(javaSpec v1alpha1.Java, container *corev1.Contai
 	return nil
 }
 
-func injectJavaagentToPod(javaSpec v1alpha1.Java, pod corev1.Pod, firstContainerName string, instSpec v1alpha1.InstrumentationSpec) corev1.Pod {
+func injectJavaagentToPod(javaSpec v1alpha1.Java, pod corev1.Pod, firstContainerName string, instSpec v1alpha1.InstrumentationSpec, sc *corev1.SecurityContext) corev1.Pod {
 	volume := instrVolume(javaSpec.VolumeClaimTemplate, javaVolumeName, javaSpec.VolumeSizeLimit)
 
 	// We just inject Volumes and init containers for the first processed container.
@@ -48,10 +48,11 @@ func injectJavaagentToPod(javaSpec v1alpha1.Java, pod corev1.Pod, firstContainer
 		pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
 
 		initContainer := corev1.Container{
-			Name:      javaInitContainerName,
-			Image:     javaSpec.Image,
-			Command:   []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"},
-			Resources: javaSpec.Resources,
+			Name:            javaInitContainerName,
+			Image:           javaSpec.Image,
+			Command:         []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"},
+			Resources:       javaSpec.Resources,
+			SecurityContext: sc,
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      volume.Name,
 				MountPath: javaInstrMountPath,
@@ -63,10 +64,11 @@ func injectJavaagentToPod(javaSpec v1alpha1.Java, pod corev1.Pod, firstContainer
 
 		for i, extension := range javaSpec.Extensions {
 			extContainer := corev1.Container{
-				Name:      initContainerName + fmt.Sprintf("-extension-%d", i),
-				Image:     extension.Image,
-				Command:   []string{"cp", "-r", extension.Dir + "/.", javaInstrMountPath + "/extensions"},
-				Resources: javaSpec.Resources,
+				Name:            initContainerName + fmt.Sprintf("-extension-%d", i),
+				Image:           extension.Image,
+				Command:         []string{"cp", "-r", extension.Dir + "/.", javaInstrMountPath + "/extensions"},
+				Resources:       javaSpec.Resources,
+				SecurityContext: sc,
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      volume.Name,
 					MountPath: javaInstrMountPath,
@@ -87,7 +89,8 @@ func injectJavaagent(javaSpec v1alpha1.Java, pod *corev1.Pod, containers []*core
 		}
 	}
 	if len(containers) > 0 {
-		*pod = injectJavaagentToPod(javaSpec, *pod, containers[0].Name, instSpec)
+		sc := resolveInitContainerSecurityContext(instSpec.InitContainerSecurityContext, containers[0].SecurityContext)
+		*pod = injectJavaagentToPod(javaSpec, *pod, containers[0].Name, instSpec, sc)
 	}
 	return nil
 }

--- a/internal/instrumentation/javaagent_test.go
+++ b/internal/instrumentation/javaagent_test.go
@@ -15,9 +15,20 @@ import (
 )
 
 func TestInjectJavaagent(t *testing.T) {
+	allowPrivilegeEscalation := false
+	runAsNonRoot := true
+	runAsUser := int64(1000)
+	testSecurityContext := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+		RunAsNonRoot:             &runAsNonRoot,
+		RunAsUser:                &runAsUser,
+		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+	}
+
 	tests := []struct {
-		name string
-		v1alpha1.Java
+		name     string
+		Java     v1alpha1.Java
+		instSpec v1alpha1.InstrumentationSpec
 		pod      corev1.Pod
 		expected corev1.Pod
 		err      error
@@ -379,6 +390,161 @@ func TestInjectJavaagent(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			name: "security context applied to java init container and all extensions",
+			Java: v1alpha1.Java{Image: "foo/bar:1", Extensions: []v1alpha1.Extensions{
+				{Image: "ex/ex:0", Dir: "/ex0"},
+				{Image: "ex/ex:1", Dir: "/ex1"},
+			}},
+			instSpec: v1alpha1.InstrumentationSpec{
+				InitContainerSecurityContext: testSecurityContext,
+			},
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test-container"},
+					},
+				},
+			},
+			expected: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "opentelemetry-auto-instrumentation-java",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:            "opentelemetry-auto-instrumentation-java",
+							Image:           "foo/bar:1",
+							Command:         []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation-java/javaagent.jar"},
+							SecurityContext: testSecurityContext,
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-java",
+								MountPath: "/otel-auto-instrumentation-java",
+							}},
+						},
+						{
+							Name:            "opentelemetry-auto-instrumentation-extension-0",
+							Image:           "ex/ex:0",
+							Command:         []string{"cp", "-r", "/ex0/.", "/otel-auto-instrumentation-java/extensions"},
+							SecurityContext: testSecurityContext,
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-java",
+								MountPath: "/otel-auto-instrumentation-java",
+							}},
+						},
+						{
+							Name:            "opentelemetry-auto-instrumentation-extension-1",
+							Image:           "ex/ex:1",
+							Command:         []string{"cp", "-r", "/ex1/.", "/otel-auto-instrumentation-java/extensions"},
+							SecurityContext: testSecurityContext,
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-java",
+								MountPath: "/otel-auto-instrumentation-java",
+							}},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "opentelemetry-auto-instrumentation-java",
+									MountPath: "/otel-auto-instrumentation-java-test-container",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "JAVA_TOOL_OPTIONS",
+									Value: " -javaagent:/otel-auto-instrumentation-java-test-container/javaagent.jar -Dotel.javaagent.extensions=/otel-auto-instrumentation-java-test-container/extensions",
+								},
+							},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "security context inherited from app container when initContainerSecurityContext unset",
+			Java: v1alpha1.Java{Image: "foo/bar:1", Extensions: []v1alpha1.Extensions{
+				{Image: "ex/ex:0", Dir: "/ex0"},
+			}},
+			instSpec: v1alpha1.InstrumentationSpec{
+				// InitContainerSecurityContext intentionally nil — should fall back to app container SC
+			},
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "test-container",
+							SecurityContext: testSecurityContext,
+						},
+					},
+				},
+			},
+			expected: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "opentelemetry-auto-instrumentation-java",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:            "opentelemetry-auto-instrumentation-java",
+							Image:           "foo/bar:1",
+							Command:         []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation-java/javaagent.jar"},
+							SecurityContext: testSecurityContext,
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-java",
+								MountPath: "/otel-auto-instrumentation-java",
+							}},
+						},
+						{
+							Name:            "opentelemetry-auto-instrumentation-extension-0",
+							Image:           "ex/ex:0",
+							Command:         []string{"cp", "-r", "/ex0/.", "/otel-auto-instrumentation-java/extensions"},
+							SecurityContext: testSecurityContext,
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-java",
+								MountPath: "/otel-auto-instrumentation-java",
+							}},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            "test-container",
+							SecurityContext: testSecurityContext,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "opentelemetry-auto-instrumentation-java",
+									MountPath: "/otel-auto-instrumentation-java-test-container",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "JAVA_TOOL_OPTIONS",
+									Value: " -javaagent:/otel-auto-instrumentation-java-test-container/javaagent.jar -Dotel.javaagent.extensions=/otel-auto-instrumentation-java-test-container/extensions",
+								},
+							},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
 	}
 
 	injector := sdkInjector{}
@@ -395,7 +561,7 @@ func TestInjectJavaagent(t *testing.T) {
 				containers = append(containers, &pod.Spec.InitContainers[i])
 			}
 
-			err := injectJavaagent(test.Java, &pod, containers, v1alpha1.InstrumentationSpec{})
+			err := injectJavaagent(test.Java, &pod, containers, test.instSpec)
 			if err != nil {
 				assert.Equal(t, test.expected, pod)
 				assert.Equal(t, test.err, err)

--- a/internal/instrumentation/javaagent_test.go
+++ b/internal/instrumentation/javaagent_test.go
@@ -15,13 +15,10 @@ import (
 )
 
 func TestInjectJavaagent(t *testing.T) {
-	allowPrivilegeEscalation := false
-	runAsNonRoot := true
-	runAsUser := int64(1000)
 	testSecurityContext := &corev1.SecurityContext{
-		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-		RunAsNonRoot:             &runAsNonRoot,
-		RunAsUser:                &runAsUser,
+		AllowPrivilegeEscalation: new(false),
+		RunAsNonRoot:             new(true),
+		RunAsUser:                new(int64(1000)),
 		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 	}
 

--- a/internal/instrumentation/sdk.go
+++ b/internal/instrumentation/sdk.go
@@ -92,8 +92,8 @@ func (i *sdkInjector) injectJava(ctx context.Context, inst instrumentationWithCo
 				pod = i.injectCommonSDKConfig(ctx, otelinst, ns, pod, container, container)
 			}
 		}
-		pod = injectJavaagentToPod(otelinst.Spec.Java, pod, containers[0].Name, otelinst.Spec)
-		pod = i.setInitContainerSecurityContext(pod, resolveInitContainerSecurityContext(otelinst.Spec.InitContainerSecurityContext, containers[0].SecurityContext), javaInitContainerName)
+		pod = injectJavaagentToPod(otelinst.Spec.Java, pod, containers[0].Name, otelinst.Spec,
+			resolveInitContainerSecurityContext(otelinst.Spec.InitContainerSecurityContext, containers[0].SecurityContext))
 	}
 
 	return pod


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Extension init containers injected alongside the Java agent were not receiving a security context. This affected both the explicit spec.initContainerSecurityContext field on the Instrumentation CR and the fallback that inherits the security context from the instrumented application container.

Only the main opentelemetry-auto-instrumentation-java init container was having its security context set; extension containers were always created with a nil security context, causing admission failures on clusters with policies requiring all containers to drop capabilities or disallow privilege escalation (e.g. OPA Gatekeeper).

The fix passes the resolved security context into injectJavaagentToPod and sets it at construction time for all Java-related init containers.

**Link to tracking Issue(s):** [#5335](https://github.com/open-telemetry/opentelemetry-operator/issues/5335)

- Resolves: #5335

**Testing:** 

Added test cases for both behaviours (e.g. `securityContext` from the instrumented container or `securityContext` from `initContainerSecurityContext`.

**Documentation:** n/a