### PR TITLE
Use latest collector image for nightly build

### DIFF
--- a/tests/e2e/filelog-receiver/chainsaw-test.yaml
+++ b/tests/e2e/filelog-receiver/chainsaw-test.yaml
@@ -14,7 +14,10 @@ spec:
             -n opentelemetry-operator-system | \
             grep -o '"collector-image":"[^"]*"' | head -1 | \
             grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-          printf '%s' "$VERSION"
+          # --collector-image may be pinned to a non-semver tag (e.g. a
+          # ":latest" dev build); fall back to "latest" so the test still
+          # gets a resolvable image instead of a version-less tag.
+          printf '%s' "${VERSION:-latest}"
         outputs:
           - name: collectorVersion
             value: ($stdout)

--- a/tests/e2e/smoke-collector/smoke-collector-deployment/chainsaw-test.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-deployment/chainsaw-test.yaml
@@ -34,7 +34,10 @@ spec:
                 -n opentelemetry-operator-system | \
                 grep -o '"collector-image":"[^"]*"' | head -1 | \
                 grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-              printf '%s' "$VERSION"
+              # --collector-image may be pinned to a non-semver tag (e.g. a
+              # ":latest" dev build); fall back to "latest" so the test still
+              # gets a resolvable image instead of a version-less tag.
+              printf '%s' "${VERSION:-latest}"
             outputs:
               - name: collectorVersion
                 value: ($stdout)


### PR DESCRIPTION
Few tests try to pick up collector version by reading the pod log and regex of Semver format `A.B.C`. This doesn't work with Nightlybuild which picks up latest tag for collector. [Failure log](https://github.com/open-telemetry/opentelemetry-operator/actions/runs/29797503883/job/88532541648)
```bash
ink.go:61: | 03:25:40 | smoke-collector-deployment | install   | CMD       | LOG   |
        === STDOUT
        LAST SEEN   TYPE      REASON                                   OBJECT                                            MESSAGE
        12m         Normal    Scheduled                                pod/smoke-collector-collector-8579967b66-rswkh    Successfully assigned chainsaw-engaged-shark/smoke-collector-collector-8579967b66-rswkh to otel-operator-control-plane
        11m         Warning   FailedMount                              pod/smoke-collector-collector-8579967b66-rswkh    MountVolume.SetUp failed for volume "otc-internal" : failed to sync configmap cache: timed out waiting for the condition
        11m         Normal    Pulling                                  pod/smoke-collector-collector-8579967b66-rswkh    Pulling image "mirror.gcr.io/library/alpine:latest"
        11m         Normal    Pulled                                   pod/smoke-collector-collector-8579967b66-rswkh    Successfully pulled image "mirror.gcr.io/library/alpine:latest" in 2.493217774s (2.493225689s including waiting)
        11m         Normal    Created                                  pod/smoke-collector-collector-8579967b66-rswkh    Created container init-test-echo
        11m         Normal    Started                                  pod/smoke-collector-collector-8579967b66-rswkh    Started container init-test-echo
        113s        Warning   InspectFailed                            pod/smoke-collector-collector-8579967b66-rswkh    Failed to apply default image tag "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:": couldn't parse image reference "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:": invalid reference format
        10m         Warning   Failed                                   pod/smoke-collector-collector-8579967b66-rswkh    Error: InvalidImageName
        11m         Normal    Pulling                                  pod/smoke-collector-collector-8579967b66-rswkh    Pulling image "mirror.gcr.io/library/alpine:latest"

```

Solution is to fallback on `latest` if unable to find collector version of semver format `A.B.C`.

**Link to tracking Issue(s):** 

- Resolves: #5341 

**Testing:** 
```bash
make add-image-collector COLLECTOR_IMG=otel/opentelemetry-collector-contrib-dev:latest deploy
make e2e
```
**Documentation:** N/A
