### PR TITLE
[fix] Operator crash when Gateway API CRDs are not installed

### DIFF
--- a/.chloggen/fix_gateway-api-scheme-registration.yaml
+++ b/.chloggen/fix_gateway-api-scheme-registration.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix operator crash on startup when Gateway API CRDs are not installed by moving gatewayv1 scheme registration to be gated on autodetect result.
+
+# One or more tracking issues related to the change
+issues: [5357]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -25,10 +25,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/certmanager"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/collector"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/gatewayapi"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/opampbridge"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/prometheus"
@@ -139,6 +141,12 @@ func runOperator(cfg config.Config, configFile string, opts zap.Options, feature
 		utilruntime.Must(cmv1.AddToScheme(scheme))
 	} else {
 		setupLog.Info("Cert-Manager is not available to the operator, skipping adding to scheme.")
+	}
+	if result.Config.GatewayAPIsAvailability == gatewayapi.ApiAvailable {
+		setupLog.Info("Gateway API CRDs are installed, adding to scheme.")
+		utilruntime.Must(gatewayv1.Install(scheme))
+	} else {
+		setupLog.Info("Gateway API CRDs are not installed, skipping adding to scheme.")
 	}
 	if result.Config.CollectorAvailability == collector.Available {
 		setupLog.Info("OpenTelemetryCollectorCRDSs are available to the operator")

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	otelv1alpha1 "github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
@@ -29,7 +28,6 @@ func init() {
 	utilruntime.Must(otelv1beta1.AddToScheme(scheme))
 	utilruntime.Must(networkingv1.AddToScheme(scheme))
 	utilruntime.Must(configv1.AddToScheme(scheme))
-	utilruntime.Must(gatewayv1.Install(scheme))
 	utilruntime.Must(operatorsv1alpha1.AddToScheme(scheme))
 
 	// +kubebuilder:scaffold:scheme


### PR DESCRIPTION
Move `gatewayv1.Install(scheme)` from `main.go` `init()` to `operator.go`, gated on the autodetect result, so the scheme registration only happens when Gateway API CRDs are present, consistent with how Prometheus, OpenShift, and cert-manager CRDs are handled.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #5357