### PR TITLE
feat(operator-opamp-bridge):  Report the operator-opamp-bridge's own build version as service…

### DIFF
--- a/.chloggen/opamp-bridge-service-version.yaml
+++ b/.chloggen/opamp-bridge-service-version.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: operator-opamp-bridge
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Report the operator-opamp-bridge's own build version as `service.version` in its OpAMP AgentDescription, instead of always sending an empty string.
+
+# One or more tracking issues related to the change
+issues: []

--- a/.chloggen/opamp-bridge-service-version.yaml
+++ b/.chloggen/opamp-bridge-service-version.yaml
@@ -8,4 +8,4 @@ component: operator-opamp-bridge
 note: Report the operator-opamp-bridge's own build version as `service.version` in its OpAMP AgentDescription, instead of always sending an empty string.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [5360]

--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ targetallocator:
 # Build opamp bridge binary
 .PHONY: operator-opamp-bridge
 operator-opamp-bridge: generate
-	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -o cmd/operator-opamp-bridge/bin/opampbridge_${ARCH} -trimpath -ldflags "${COMMON_LDFLAGS}" ./cmd/operator-opamp-bridge
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -o cmd/operator-opamp-bridge/bin/opampbridge_${ARCH} -trimpath -ldflags "${COMMON_LDFLAGS} ${OPERATOR_LDFLAGS}" ./cmd/operator-opamp-bridge
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 .PHONY: run

--- a/cmd/operator-opamp-bridge/internal/config/config.go
+++ b/cmd/operator-opamp-bridge/internal/config/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/cmd/operator-opamp-bridge/internal/logger"
+	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 )
 
 const (
@@ -42,7 +43,6 @@ const (
 )
 
 var (
-	agentVersion  = os.Getenv("OPAMP_VERSION")
 	hostname, _   = os.Hostname()
 	schemeBuilder = k8sruntime.NewSchemeBuilder(registerKnownTypes)
 )
@@ -213,7 +213,7 @@ func (c *Config) GetAgentType() string {
 }
 
 func (*Config) GetAgentVersion() string {
-	return agentVersion
+	return version.OperatorOpAMPBridge()
 }
 
 func (c *Config) GetInstanceId() uuid.UUID {

--- a/cmd/operator-opamp-bridge/internal/config/config_test.go
+++ b/cmd/operator-opamp-bridge/internal/config/config_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-operator/internal/version"
 )
 
 func TestConfigLoadPriority(t *testing.T) {
@@ -406,6 +408,9 @@ func TestGetDescription(t *testing.T) {
 	assert.Contains(t, desc.IdentifyingAttributes, &protobufs.KeyValue{Key: "service.instance.id", Value: &protobufs.AnyValue{
 		Value: &protobufs.AnyValue_StringValue{StringValue: instanceId.String()},
 	}})
+	assert.Contains(t, desc.IdentifyingAttributes, &protobufs.KeyValue{Key: "service.version", Value: &protobufs.AnyValue{
+		Value: &protobufs.AnyValue_StringValue{StringValue: version.OperatorOpAMPBridge()},
+	}})
 	assert.Len(t, desc.NonIdentifyingAttributes, 3)
 	assert.Contains(t, desc.NonIdentifyingAttributes, &protobufs.KeyValue{Key: "custom.attribute", Value: &protobufs.AnyValue{
 		Value: &protobufs.AnyValue_StringValue{StringValue: "custom-value"},
@@ -422,6 +427,9 @@ func TestGetDescriptionNoneSet(t *testing.T) {
 	assert.Len(t, desc.IdentifyingAttributes, 3)
 	assert.Contains(t, desc.IdentifyingAttributes, &protobufs.KeyValue{Key: "service.instance.id", Value: &protobufs.AnyValue{
 		Value: &protobufs.AnyValue_StringValue{StringValue: instanceId.String()},
+	}})
+	assert.Contains(t, desc.IdentifyingAttributes, &protobufs.KeyValue{Key: "service.version", Value: &protobufs.AnyValue{
+		Value: &protobufs.AnyValue_StringValue{StringValue: version.OperatorOpAMPBridge()},
 	}})
 	assert.Len(t, desc.NonIdentifyingAttributes, 2)
 }

--- a/tests/e2e-opampbridge/opampbridge/chainsaw-test.yaml
+++ b/tests/e2e-opampbridge/opampbridge/chainsaw-test.yaml
@@ -22,6 +22,24 @@ spec:
             file: 01-install.yaml
         - assert:
             file: 01-assert.yaml
+    - name: Verify the bridge reports its own service.version
+      try:
+        - script:
+            content: |
+              #!/bin/bash
+              set -eu
+              last=""
+              for _ in $(seq 1 60); do
+                if last=$(kubectl get --raw /api/v1/namespaces/$NAMESPACE/services/e2e-test-app-bridge-server:4321/proxy/agents 2>/dev/null); then
+                  if printf '%s' "$last" | grep -Eq '"key":"service.version","value":\{"Value":\{"StringValue":"[0-9]+\.[0-9]+\.[0-9]+[^"]*"'; then
+                    exit 0
+                  fi
+                fi
+                sleep 1
+              done
+              printf '%s\n' "$last" >&2
+              echo "service.version was not reported as a non-empty semver-like string"
+              exit 1
     - name: Check effective config is empty for a valid agent id
       try:
         - script:


### PR DESCRIPTION

**Description:**
Adds support for the operator-opamp-bridge to report its own build version as `service.version` in its OpAMP AgentDescription, instead of always sending an empty string. This allows the monitoring and tracking of version back in the OpAMP Server.
