### PR TITLE
[chore] Run go mod tidy on modules in renovate PRs

### DIFF
--- a/.github/workflows/tidy-dependencies.yaml
+++ b/.github/workflows/tidy-dependencies.yaml
@@ -1,0 +1,105 @@
+name: "Tidy Go modules"
+
+# Renovate runs `go mod tidy` only in the modules whose go.mod it edited. The
+# cmd/otel-allocator/integrationtest module follows the root and apis modules through
+# local replace directives, so a bump of a dependency it shares with the root module
+# leaves it untidy and its tests then fail with "updates to go.mod needed". Renovate
+# cannot tidy across a module graph joined by replace directives yet
+# (https://github.com/renovatebot/renovate/issues/12999), so until it can, tidy every
+# module here and push the result back to the Renovate branch.
+#
+# This needs an otelbot GitHub App with `contents: write` installed on this repository,
+# exposed as the OTELBOT_CLIENT_ID variable and the OTELBOT_PRIVATE_KEY secret - the
+# shared org-wide otelbot only has `pull_requests: write`. See
+# https://github.com/open-telemetry/community/blob/main/assets.md#otelbot.
+# The push cannot use GITHUB_TOKEN: pushes made with it do not trigger workflows, which
+# would leave the tidy commit - the new head of the pull request - without any CI runs.
+
+on: # zizmor: ignore[dangerous-triggers] writing to the pull request branch needs a privileged token, and the job below only ever runs against non-fork Renovate branches
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [ main ]
+    paths:
+      - '**/go.mod'
+      - '**/go.sum'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  COMMIT_MESSAGE: "Run go mod tidy in every module"
+
+jobs:
+  tidy:
+    name: Tidy Go modules
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # This job holds credentials that can write to the repository, so it must only ever
+    # check out code we trust: Renovate branches in this repository, never forks.
+    # `pull_request_target` additionally keeps the job definition pinned to main, so a
+    # pull request cannot change what runs here.
+    if: >-
+      github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+    - name: Generate otelbot token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      id: otelbot-token
+      with:
+        client-id: ${{ vars.OTELBOT_CLIENT_ID }}
+        private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+        permission-contents: write
+
+    # Check out the exact commit that triggered this run, so that a Renovate push racing
+    # with this job makes the push below fail instead of overwriting it.
+    - name: Check out the pull request branch
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
+
+    # Our own push re-triggers this workflow; stop here instead of tidying again.
+    - name: Skip branches that were tidied already
+      id: guard
+      run: |
+        if [ "$(git log -1 --format=%s)" = "$COMMIT_MESSAGE" ]; then
+          echo "The branch tip is already a tidy commit, nothing to do."
+        else
+          echo "run=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Set up Go
+      if: steps.guard.outputs.run == 'true'
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        go-version: "~1.26.5"
+
+    - name: Run go mod tidy in every module
+      if: steps.guard.outputs.run == 'true'
+      run: make tidy
+
+    - name: Commit and push the tidied modules
+      if: steps.guard.outputs.run == 'true'
+      env:
+        GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+        HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      run: |
+        if git diff --quiet -- ':(glob)**/go.mod' ':(glob)**/go.sum'; then
+          echo "All modules are tidy already."
+          exit 0
+        fi
+
+        # otelbot is on the EasyCLA allowlist, so its commits pass the CLA check.
+        git config user.name otelbot
+        git config user.email 197425009+otelbot@users.noreply.github.com
+
+        git add -- ':(glob)**/go.mod' ':(glob)**/go.sum'
+        git commit -m "$COMMIT_MESSAGE"
+
+        auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+        git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth_header" \
+          push origin "HEAD:$HEAD_REF"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ We gratefully welcome improvements to documentation as well as to code.
 * `make lint` - Run golangci-lint
 * `make fmt` - Format Go code and auto-fix issues
 * `make vet` - Run go vet
+* `make tidy` - Run `go mod tidy` in every Go module in the repository
 * `make update` - Generate code and manifests based on Go struct definitions for CRDs (includes generate, manifests, bundle, api-docs)
 * `make precommit` - Run all checks: fmt, vet, lint, test, ensure-update-is-noop (run before committing)
 

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,12 @@ BUNDLE_BUILD_GEN_FLAGS ?= $(BUNDLE_GEN_FLAGS) --output-dir . --kustomize-dir ../
 MIN_KUBERNETES_VERSION ?= 1.25.0
 MIN_OPENSHIFT_VERSION ?= 4.12
 
+## Directories of all Go modules in the repository, root first. The ./... patterns of
+## the root module do not descend into nested modules, so anything that has to happen
+## per module iterates over this list. Hidden directories (.git, worktrees, ...) are
+## skipped.
+GO_MODULE_DIRS ?= $(shell find . -path './.*' -prune -o -name go.mod -print | sed 's|/go\.mod$$||' | sort)
+
 ## On MacOS, use gsed instead of sed, to make sed behavior
 ## consistent with Linux.
 SED ?= $(shell which gsed 2>/dev/null || which sed)
@@ -443,6 +449,14 @@ vet:
 .PHONY: lint
 lint: golangci-lint
 	$(GOLANGCI_LINT) run
+
+# Run go mod tidy in every Go module in the repository
+.PHONY: tidy
+tidy:
+	@set -e; for dir in $(GO_MODULE_DIRS); do \
+		echo "go mod tidy: $$dir"; \
+		(cd $$dir && go mod tidy); \
+	done
 
 # Generate code
 # apis/ is a nested Go module; pass it explicitly so DeepCopy methods are regenerated


### PR DESCRIPTION
Renovate does not tidy modules it doesn't edit. If there's an update to the root module, the otel allocator integration test module which imports it via a replace becomes tidy, and running the tests fail. Until renovate adds the feature to automate this, we can have otelbot commit to the PR branch with the tidy results.

We add a `make tidy` target that tidies all the modules and a GHA workflow that commits to renovate branches which modify the root module. This roughly mirrors what collector-contrib does.

Do not merge this until we have a repo-specific otelbot with content write permission. As is, this will not work.
