### PR TITLE
[chore] Fix flaky opampbridge-standalone e2e test

### DIFF
--- a/tests/e2e-opampbridge/standalone/chainsaw-test.yaml
+++ b/tests/e2e-opampbridge/standalone/chainsaw-test.yaml
@@ -119,7 +119,7 @@ spec:
               )
 
               printf '%s' "$remote_config" | kubectl run -n "$NAMESPACE" send-valid-remote-config \
-                --image=mirror.gcr.io/alpine/curl:latest \
+                --image=mirror.gcr.io/alpine/curl:8.21.0 \
                 --restart=Never \
                 --rm -i \
                 --command -- curl -fsS \
@@ -236,7 +236,7 @@ spec:
               )
 
               printf '%s' "$remote_config" | kubectl run -n "$NAMESPACE" send-invalid-remote-config \
-                --image=mirror.gcr.io/alpine/curl:latest \
+                --image=mirror.gcr.io/alpine/curl:8.21.0 \
                 --restart=Never \
                 --rm -i \
                 --command -- curl -fsS \

--- a/tests/e2e-opampbridge/standalone/chainsaw-test.yaml
+++ b/tests/e2e-opampbridge/standalone/chainsaw-test.yaml
@@ -104,6 +104,7 @@ spec:
       name: send valid remote config
       try:
         - script:
+            timeout: 60s
             content: |
               #!/bin/bash
               set -eu
@@ -221,6 +222,7 @@ spec:
       name: reject invalid remote config
       try:
         - script:
+            timeout: 60s
             content: |
               #!/bin/bash
               set -eu


### PR DESCRIPTION
Pin `alpine/curl` image to `8.21.0` and add explicit `timeout: 60s` to the two `kubectl run` script steps in the opampbridge-standalone test.

The global chainsaw `exec` timeout is 15s. These steps create pods via `kubectl run`, and the image pull alone takes 12-13s on CI — leaving no margin for the actual curl request. Chainsaw kills the script with `signal: killed` before it can return. 

Pinning the image tag (previously `:latest` from #5301) restores layer caching. 