### PR TITLE
Add support to set session affinity for Collector Services

### DIFF
--- a/.chloggen/session-affinity.yaml
+++ b/.chloggen/session-affinity.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for setting `sessionAffinity` and `sessionAffinityConfig` on the Services created for the Collector
+
+# One or more tracking issues related to the change
+issues: [4455]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1beta1/common.go
+++ b/apis/v1beta1/common.go
@@ -241,6 +241,14 @@ type OpenTelemetryCommonFields struct {
 	// This is only applicable to Service resources.
 	// +optional
 	TrafficDistribution *string `json:"trafficDistribution,omitempty"`
+	// SessionAffinity specifies the session affinity type for the Service.
+	// This is only applicable to Service resources.
+	// +optional
+	SessionAffinity *v1.ServiceAffinity `json:"sessionAffinity,omitempty"`
+	// SessionAffinityConfig specifies the session affinity configurations for the Service.
+	// This is only applicable to Service resources.
+	// +optional
+	SessionAffinityConfig *v1.SessionAffinityConfig `json:"sessionAffinityConfig,omitempty"`
 	// HostUsers isolates pod processes in a separate user namespace, reducing the risk of privilege escalation.
 	// +optional
 	HostUsers *bool `json:"hostUsers,omitempty"`

--- a/apis/v1beta1/zz_generated.deepcopy.go
+++ b/apis/v1beta1/zz_generated.deepcopy.go
@@ -553,6 +553,16 @@ func (in *OpenTelemetryCommonFields) DeepCopyInto(out *OpenTelemetryCommonFields
 		*out = new(string)
 		**out = **in
 	}
+	if in.SessionAffinity != nil {
+		in, out := &in.SessionAffinity, &out.SessionAffinity
+		*out = new(v1.ServiceAffinity)
+		**out = **in
+	}
+	if in.SessionAffinityConfig != nil {
+		in, out := &in.SessionAffinityConfig, &out.SessionAffinityConfig
+		*out = new(v1.SessionAffinityConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.HostUsers != nil {
 		in, out := &in.HostUsers, &out.HostUsers
 		*out = new(bool)

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-07-13T15:53:48Z"
+    createdAt: "2026-07-28T16:37:28Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -7616,6 +7616,17 @@ spec:
                 type: string
               serviceName:
                 type: string
+              sessionAffinity:
+                type: string
+              sessionAffinityConfig:
+                properties:
+                  clientIP:
+                    properties:
+                      timeoutSeconds:
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
               shareProcessNamespace:
                 type: boolean
               startupProbe:

--- a/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
@@ -2931,6 +2931,17 @@ spec:
                 type: object
               serviceAccount:
                 type: string
+              sessionAffinity:
+                type: string
+              sessionAffinityConfig:
+                properties:
+                  clientIP:
+                    properties:
+                      timeoutSeconds:
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
               shareProcessNamespace:
                 type: boolean
               terminationGracePeriodSeconds:

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-07-13T15:53:48Z"
+    createdAt: "2026-07-28T16:37:28Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -7615,6 +7615,17 @@ spec:
                 type: string
               serviceName:
                 type: string
+              sessionAffinity:
+                type: string
+              sessionAffinityConfig:
+                properties:
+                  clientIP:
+                    properties:
+                      timeoutSeconds:
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
               shareProcessNamespace:
                 type: boolean
               startupProbe:

--- a/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
@@ -2931,6 +2931,17 @@ spec:
                 type: object
               serviceAccount:
                 type: string
+              sessionAffinity:
+                type: string
+              sessionAffinityConfig:
+                properties:
+                  clientIP:
+                    properties:
+                      timeoutSeconds:
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
               shareProcessNamespace:
                 type: boolean
               terminationGracePeriodSeconds:

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -7602,6 +7602,17 @@ spec:
                 type: string
               serviceName:
                 type: string
+              sessionAffinity:
+                type: string
+              sessionAffinityConfig:
+                properties:
+                  clientIP:
+                    properties:
+                      timeoutSeconds:
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
               shareProcessNamespace:
                 type: boolean
               startupProbe:

--- a/config/crd/bases/opentelemetry.io_targetallocators.yaml
+++ b/config/crd/bases/opentelemetry.io_targetallocators.yaml
@@ -2929,6 +2929,17 @@ spec:
                 type: object
               serviceAccount:
                 type: string
+              sessionAffinity:
+                type: string
+              sessionAffinityConfig:
+                properties:
+                  clientIP:
+                    properties:
+                      timeoutSeconds:
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
               shareProcessNamespace:
                 type: boolean
               terminationGracePeriodSeconds:

--- a/docs/api/opentelemetrycollectors.md
+++ b/docs/api/opentelemetrycollectors.md
@@ -20533,6 +20533,22 @@ Note that the custom service name is not created by the operator.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>sessionAffinity</b></td>
+        <td>string</td>
+        <td>
+          SessionAffinity specifies the session affinity type for the Service.
+This is only applicable to Service resources.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#opentelemetrycollectorspecsessionaffinityconfig">sessionAffinityConfig</a></b></td>
+        <td>object</td>
+        <td>
+          SessionAffinityConfig specifies the session affinity configurations for the Service.
+This is only applicable to Service resources.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>shareProcessNamespace</b></td>
         <td>boolean</td>
         <td>
@@ -32068,6 +32084,65 @@ In addition, if HostProcess is true then HostNetwork must also be set to true.<b
 Defaults to the user specified in image metadata if unspecified.
 May also be set in PodSecurityContext. If set in both SecurityContext and
 PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### OpenTelemetryCollector.spec.sessionAffinityConfig
+<sup><sup>[↩ Parent](#opentelemetrycollectorspec-1)</sup></sup>
+
+
+
+SessionAffinityConfig specifies the session affinity configurations for the Service.
+This is only applicable to Service resources.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#opentelemetrycollectorspecsessionaffinityconfigclientip">clientIP</a></b></td>
+        <td>object</td>
+        <td>
+          clientIP contains the configurations of Client IP based session affinity.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### OpenTelemetryCollector.spec.sessionAffinityConfig.clientIP
+<sup><sup>[↩ Parent](#opentelemetrycollectorspecsessionaffinityconfig)</sup></sup>
+
+
+
+clientIP contains the configurations of Client IP based session affinity.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>timeoutSeconds</b></td>
+        <td>integer</td>
+        <td>
+          timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+Default value is 10800(for 3 hours).<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/docs/api/targetallocators.md
+++ b/docs/api/targetallocators.md
@@ -429,6 +429,22 @@ the operator will not automatically Create a ServiceAccount.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>sessionAffinity</b></td>
+        <td>string</td>
+        <td>
+          SessionAffinity specifies the session affinity type for the Service.
+This is only applicable to Service resources.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#targetallocatorspecsessionaffinityconfig">sessionAffinityConfig</a></b></td>
+        <td>object</td>
+        <td>
+          SessionAffinityConfig specifies the session affinity configurations for the Service.
+This is only applicable to Service resources.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>shareProcessNamespace</b></td>
         <td>boolean</td>
         <td>
@@ -12059,6 +12075,65 @@ In addition, if HostProcess is true then HostNetwork must also be set to true.<b
 Defaults to the user specified in image metadata if unspecified.
 May also be set in PodSecurityContext. If set in both SecurityContext and
 PodSecurityContext, the value specified in SecurityContext takes precedence.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TargetAllocator.spec.sessionAffinityConfig
+<sup><sup>[↩ Parent](#targetallocatorspec)</sup></sup>
+
+
+
+SessionAffinityConfig specifies the session affinity configurations for the Service.
+This is only applicable to Service resources.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#targetallocatorspecsessionaffinityconfigclientip">clientIP</a></b></td>
+        <td>object</td>
+        <td>
+          clientIP contains the configurations of Client IP based session affinity.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### TargetAllocator.spec.sessionAffinityConfig.clientIP
+<sup><sup>[↩ Parent](#targetallocatorspecsessionaffinityconfig)</sup></sup>
+
+
+
+clientIP contains the configurations of Client IP based session affinity.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>timeoutSeconds</b></td>
+        <td>integer</td>
+        <td>
+          timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+Default value is 10800(for 3 hours).<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/manifests/collector/service.go
+++ b/internal/manifests/collector/service.go
@@ -91,9 +91,11 @@ func MonitoringService(params manifests.Params) (*corev1.Service, error) {
 				Name: "monitoring",
 				Port: metricsPort,
 			}},
-			IPFamilies:          params.OtelCol.Spec.IpFamilies,
-			IPFamilyPolicy:      params.OtelCol.Spec.IpFamilyPolicy,
-			TrafficDistribution: params.OtelCol.Spec.TrafficDistribution,
+			IPFamilies:            params.OtelCol.Spec.IpFamilies,
+			IPFamilyPolicy:        params.OtelCol.Spec.IpFamilyPolicy,
+			TrafficDistribution:   params.OtelCol.Spec.TrafficDistribution,
+			SessionAffinity:       sessionAffinity(params),
+			SessionAffinityConfig: params.OtelCol.Spec.SessionAffinityConfig,
 		},
 	}, nil
 }
@@ -125,9 +127,11 @@ func ExtensionService(params manifests.Params) (*corev1.Service, error) {
 			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Ports:               ports,
-			Selector:            manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, ComponentOpenTelemetryCollector),
-			TrafficDistribution: params.OtelCol.Spec.TrafficDistribution,
+			Ports:                 ports,
+			Selector:              manifestutils.SelectorLabels(params.OtelCol.ObjectMeta, ComponentOpenTelemetryCollector),
+			TrafficDistribution:   params.OtelCol.Spec.TrafficDistribution,
+			SessionAffinity:       sessionAffinity(params),
+			SessionAffinityConfig: params.OtelCol.Spec.SessionAffinityConfig,
 		},
 	}, nil
 }
@@ -201,8 +205,17 @@ func Service(params manifests.Params) (*corev1.Service, error) {
 			IPFamilies:            params.OtelCol.Spec.IpFamilies,
 			IPFamilyPolicy:        params.OtelCol.Spec.IpFamilyPolicy,
 			TrafficDistribution:   params.OtelCol.Spec.TrafficDistribution,
+			SessionAffinity:       sessionAffinity(params),
+			SessionAffinityConfig: params.OtelCol.Spec.SessionAffinityConfig,
 		},
 	}, nil
+}
+
+func sessionAffinity(params manifests.Params) corev1.ServiceAffinity {
+	if params.OtelCol.Spec.SessionAffinity != nil {
+		return *params.OtelCol.Spec.SessionAffinity
+	}
+	return ""
 }
 
 type PortNumberKey struct {

--- a/internal/manifests/collector/service_test.go
+++ b/internal/manifests/collector/service_test.go
@@ -602,6 +602,31 @@ func TestServiceWithIpFamily(t *testing.T) {
 	})
 }
 
+func TestServiceWithSessionAffinity(t *testing.T) {
+	t.Run("should set SessionAffinity when specified", func(t *testing.T) {
+		params := deploymentParams()
+		sessionAffinity := v1.ServiceAffinityClientIP
+		timeoutSeconds := int32(10800)
+		sessionAffinityConfig := &v1.SessionAffinityConfig{
+			ClientIP: &v1.ClientIPConfig{TimeoutSeconds: &timeoutSeconds},
+		}
+		params.OtelCol.Spec.SessionAffinity = &sessionAffinity
+		params.OtelCol.Spec.SessionAffinityConfig = sessionAffinityConfig
+		actual, err := Service(params)
+		assert.NoError(t, err)
+		assert.Equal(t, sessionAffinity, actual.Spec.SessionAffinity)
+		assert.Equal(t, sessionAffinityConfig, actual.Spec.SessionAffinityConfig)
+	})
+
+	t.Run("should not set SessionAffinity when not specified", func(t *testing.T) {
+		params := deploymentParams()
+		actual, err := Service(params)
+		assert.NoError(t, err)
+		assert.Empty(t, actual.Spec.SessionAffinity)
+		assert.Nil(t, actual.Spec.SessionAffinityConfig)
+	})
+}
+
 func TestServiceWithTrafficDistribution(t *testing.T) {
 	t.Run("should set TrafficDistribution when specified", func(t *testing.T) {
 		params := deploymentParams()

--- a/tests/e2e/smoke-collector/smoke-collector-deployment/00-assert.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-deployment/00-assert.yaml
@@ -45,6 +45,10 @@ spec:
   ipFamilyPolicy: SingleStack
   ipFamilies:
     - IPv4
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800
   (length(ports[?name == 'extra-port'])): 1
 ---
 apiVersion: opentelemetry.io/v1beta1

--- a/tests/e2e/smoke-collector/smoke-collector-deployment/00-install.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-deployment/00-install.yaml
@@ -42,6 +42,10 @@ spec:
     - IPv4
   ipFamilyPolicy: SingleStack
   trafficDistribution: PreferClose
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800
   ports:
     - name: extra-port
       port: 9090


### PR DESCRIPTION
**Description:** Add support to set `sessionAffinity` and `sessionAffinityConfig` on the Services the operator creates for the Collector. Follows the same pattern as
 `trafficDistribution`. v1beta1 only — v1alpha1 round-trip drops the field, same as `ipFamilies`.

   **Link to tracking Issue(s):**

   - Resolves: #4455

   **Testing:** Unit tests covering set/unset on the generated Service.

   **Documentation:** API docs regenerated via `make api-docs`.