### PR TITLE
fix(target-allocator): refresh stale meta labels when target address is unchanged

### DIFF
--- a/.chloggen/fix-ta-stale-meta-labels-same-hash.yaml
+++ b/.chloggen/fix-ta-stale-meta-labels-same-hash.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Refresh stale Prometheus meta labels (e.g. `__meta_kubernetes_pod_name`) on rediscovered targets whose address is unchanged
+
+# One or more tracking issues related to the change
+issues: [4839]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Target identity is deliberately hashed without meta labels, since Prometheus discards them after
+  relabeling. But because the allocator's target map is keyed by that same hash, a rediscovered
+  target whose address is unchanged (e.g. a hostNetwork DaemonSet pod after a restart) was never
+  recognized as changed, so its stale meta labels persisted until target-allocator itself restarted.

--- a/cmd/otel-allocator/internal/allocation/allocator.go
+++ b/cmd/otel-allocator/internal/allocation/allocator.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/prometheus/model/labels"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -126,6 +127,24 @@ func (a *allocator) SetTargets(targets []*target.Item) {
 	// If there are any additions or removals
 	if len(targetsDiff.Additions()) != 0 || len(targetsDiff.Removals()) != 0 {
 		a.handleTargets(targetsDiff)
+	}
+	a.refreshExistingTargetLabels(targetMap)
+}
+
+// refreshExistingTargetLabels updates the stored labels for targets that already exist (same hash)
+// but were rediscovered with different meta labels, e.g. __meta_kubernetes_pod_name after a pod
+// restart of a hostNetwork DaemonSet, where __address__ (and therefore the target's hash, which
+// excludes meta labels, see target.HashFromBuilder) stays the same across restarts. Such changes
+// never surface as additions/removals in targetsDiff, so they must be applied separately. The
+// existing collector assignment is preserved since the target's identity (hash) is unchanged.
+func (a *allocator) refreshExistingTargetLabels(targetMap map[target.ItemHash]*target.Item) {
+	for hash, newItem := range targetMap {
+		existing, ok := a.targetItems[hash]
+		if !ok || labels.Equal(existing.Labels, newItem.Labels) {
+			continue
+		}
+		newItem.CollectorName = existing.CollectorName
+		a.targetItems[hash] = newItem
 	}
 }
 

--- a/cmd/otel-allocator/internal/allocation/allocator.go
+++ b/cmd/otel-allocator/internal/allocation/allocator.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/prometheus/prometheus/model/labels"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -131,16 +130,34 @@ func (a *allocator) SetTargets(targets []*target.Item) {
 	a.refreshExistingTargetLabels(targetMap)
 }
 
-// refreshExistingTargetLabels updates the stored labels for targets that already exist (same hash)
-// but were rediscovered with different meta labels, e.g. __meta_kubernetes_pod_name after a pod
-// restart of a hostNetwork DaemonSet, where __address__ (and therefore the target's hash, which
-// excludes meta labels, see target.HashFromBuilder) stays the same across restarts. Such changes
-// never surface as additions/removals in targetsDiff, so they must be applied separately. The
-// existing collector assignment is preserved since the target's identity (hash) is unchanged.
+// refreshExistingTargetLabels replaces the stored Item of every target that is present
+// both before and after this update, so that what we serve reflects the latest
+// discovery rather than the first sighting.
+//
+// A target's identity is the hash of its post-relabel labels, which excludes meta
+// labels (see target.HashFromBuilder), mirroring Prometheus: meta labels are
+// discarded when the final label set is computed, so two targets differing only in
+// them are the same scrape target. That means a target can keep its identity while
+// the meta labels discovery reports for it change — a DaemonSet pod with
+// hostNetwork replaced on the same host address, for instance, keeps its address
+// and its relabeled labels while its pod name and UID change. The diff below sees
+// no change for such a target, but Item.Labels is not internal bookkeeping: we
+// serve it verbatim on the HTTP SD endpoint, and the collector turns those meta
+// labels into resource attributes. Keeping the old Item would attribute the new
+// pod's metrics to the departed one, forever, since the hash never moves again.
+//
+// Prometheus does the same thing for the same reason, overwriting a retained
+// target's discovered labels on every sync:
+// https://github.com/prometheus/prometheus/blob/v3.12.0/scrape/scrape.go#L491
+//
+// The collector assignment lives on the Item, so it has to carry over. Dropping it
+// would make the least-weighted strategy treat every surviving target as newly
+// assigned and reshuffle the whole set on each update, and would leave the
+// per-collector target counts unbalanced when the target is eventually removed.
 func (a *allocator) refreshExistingTargetLabels(targetMap map[target.ItemHash]*target.Item) {
 	for hash, newItem := range targetMap {
 		existing, ok := a.targetItems[hash]
-		if !ok || labels.Equal(existing.Labels, newItem.Labels) {
+		if !ok {
 			continue
 		}
 		newItem.CollectorName = existing.CollectorName

--- a/cmd/otel-allocator/internal/allocation/allocator_test.go
+++ b/cmd/otel-allocator/internal/allocation/allocator_test.go
@@ -269,6 +269,49 @@ func TestTargetUpdatePreservesCount(t *testing.T) {
 	})
 }
 
+// TestSetTargetsUpdatesMetaLabelsForUnchangedHash covers
+// https://github.com/open-telemetry/opentelemetry-operator/issues/4839: for a hostNetwork
+// DaemonSet pod, __address__ (and therefore the target's hash, which excludes meta labels) stays
+// the same across pod restarts, but meta labels such as __meta_kubernetes_pod_name change. The
+// allocator must still surface the refreshed meta labels, while keeping the existing collector
+// assignment since the target's identity is unchanged.
+func TestSetTargetsUpdatesMetaLabelsForUnchangedHash(t *testing.T) {
+	RunForAllStrategies(t, func(t *testing.T, allocator Allocator) {
+		cols := MakeNCollectors(3, 0)
+		allocator.SetCollectors(cols)
+
+		jobName := "sample-job"
+		nonMetaLabels := labels.New(labels.Label{Name: "test", Value: "test1"})
+		hash := target.HashLabels(nonMetaLabels, jobName)
+
+		firstLabels := labels.New(
+			labels.Label{Name: "test", Value: "test1"},
+			labels.Label{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
+			labels.Label{Name: "__meta_kubernetes_pod_name", Value: "pod-1"},
+		)
+		firstTarget := target.NewItem(jobName, "0.0.0.0:8000", firstLabels, "", hash)
+		allocator.SetTargets([]*target.Item{firstTarget})
+
+		targetItems := allocator.TargetItems()
+		assert.Len(t, targetItems, 1)
+		originalCollector := targetItems[hash].CollectorName
+		assert.NotEmpty(t, originalCollector)
+
+		secondLabels := labels.New(
+			labels.Label{Name: "test", Value: "test1"},
+			labels.Label{Name: "__meta_kubernetes_pod_node_name", Value: "node-0"},
+			labels.Label{Name: "__meta_kubernetes_pod_name", Value: "pod-2"},
+		)
+		secondTarget := target.NewItem(jobName, "0.0.0.0:8000", secondLabels, "", hash)
+		allocator.SetTargets([]*target.Item{secondTarget})
+
+		targetItems = allocator.TargetItems()
+		assert.Len(t, targetItems, 1)
+		assert.Equal(t, "pod-2", targetItems[hash].Labels.Get("__meta_kubernetes_pod_name"))
+		assert.Equal(t, originalCollector, targetItems[hash].CollectorName)
+	})
+}
+
 func TestNewAllocatorInvalidStrategy(t *testing.T) {
 	_, err := New("invalid-strategy", logger)
 	assert.Error(t, err)


### PR DESCRIPTION
Fixes #4839

Motivation:
For a hostNetwork DaemonSet pod, __address__ is the node's IP, which
stays the same across pod restarts even though the pod itself (and
its __meta_kubernetes_pod_name) changes. Target-allocator's target
hash (target.HashFromBuilder) deliberately excludes __meta_*-prefixed
labels, since Prometheus discards meta labels after relabeling and two
targets differing only in meta labels are the same scrape target. The
allocator's target map (allocator.targetItems) is keyed by that same
hash, so diff.Maps(a.targetItems, targetMap) can never observe a meta
label change for a hash it already has an entry for: the "found but
changed" branch compares Hash() to Hash(), which are equal by
construction since the map key IS the hash. The result is that a
rediscovered target's stale *target.Item (with the old pod name) is
kept forever, and the /jobs/{job}/targets API and downstream
collectors keep seeing the pod name from before the restart, until
target-allocator itself restarts.

This is a data-correctness issue only: it does not cause a crash,
outage, or scrape failure. Labels are still correct without
Target Allocator (plain Prometheus service discovery), so this is
specific to sharding.

Approach:
Add allocator.refreshExistingTargetLabels, called at the end of
SetTargets under the existing lock. For every hash present in both the
new discovery result and the current target map, if the labels differ,
swap the stored *target.Item for the freshly discovered one, copying
over the existing item's CollectorName so the collector assignment
(which is unaffected, since hash and job name are unchanged) is
preserved.

Validation:
go test ./cmd/otel-allocator/internal/allocation/... -race
(all pass, including added regression test
TestSetTargetsUpdatesMetaLabelsForUnchangedHash, verified to fail
without the fix and pass with it, across all three allocation
strategies)

go build ./... && go vet ./... && go test ./...
(run from cmd/otel-allocator; all pass)

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>