### PR TITLE
Propagate the TargetAllocator CR's metadata annotations

### DIFF
--- a/.chloggen/ta-metadata-propagation.yaml
+++ b/.chloggen/ta-metadata-propagation.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Propagate the TargetAllocator CR's metadata annotations to all resources created for it, and restrict `podAnnotations` to the pod template
+
+# One or more tracking issues related to the change
+issues: [4393]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This aligns the TargetAllocator with the OpenTelemetryCollector behavior: CR metadata annotations now land
+  (respecting the annotations filter) on the Deployment, Service, ConfigMap, ServiceAccount, ServiceMonitor,
+  PodDisruptionBudget and NetworkPolicy, while `podAnnotations` is no longer copied to the NetworkPolicy and
+  PodDisruptionBudget.

--- a/internal/controllers/testdata/build_target_allocator_base.input.yaml
+++ b/internal/controllers/testdata/build_target_allocator_base.input.yaml
@@ -3,6 +3,8 @@ metadata:
   namespace: test
 spec:
   filterStrategy: relabel-config
+  podAnnotations:
+    pod-test: pod-value
   scrapeConfigs:
   - job_name: example
     metric_relabel_configs:

--- a/internal/controllers/testdata/build_target_allocator_base.yaml
+++ b/internal/controllers/testdata/build_target_allocator_base.yaml
@@ -164,8 +164,6 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  annotations:
-    opentelemetry-targetallocator-config/hash: 7a839fe32950e427672bf7038e88d953ceecf1531457af7c43dc78300dc85eca
   labels:
     app.kubernetes.io/component: opentelemetry-targetallocator
     app.kubernetes.io/instance: test.test

--- a/internal/controllers/testdata/build_target_allocator_base.yaml
+++ b/internal/controllers/testdata/build_target_allocator_base.yaml
@@ -68,6 +68,7 @@ spec:
     metadata:
       annotations:
         opentelemetry-targetallocator-config/hash: 7a839fe32950e427672bf7038e88d953ceecf1531457af7c43dc78300dc85eca
+        pod-test: pod-value
       labels:
         app.kubernetes.io/component: opentelemetry-targetallocator
         app.kubernetes.io/instance: test.test

--- a/internal/controllers/testdata/build_target_allocator_collector_present.yaml
+++ b/internal/controllers/testdata/build_target_allocator_collector_present.yaml
@@ -170,8 +170,6 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  annotations:
-    opentelemetry-targetallocator-config/hash: a81383bc4e7ebbf141d2fd9cde3dcd9758bc47f27af6cbaeb0f14ab6360e08c6
   labels:
     app.kubernetes.io/component: opentelemetry-targetallocator
     app.kubernetes.io/instance: test.test

--- a/internal/controllers/testdata/build_target_allocator_enable_metrics.yaml
+++ b/internal/controllers/testdata/build_target_allocator_enable_metrics.yaml
@@ -164,8 +164,6 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  annotations:
-    opentelemetry-targetallocator-config/hash: 7a839fe32950e427672bf7038e88d953ceecf1531457af7c43dc78300dc85eca
   labels:
     app.kubernetes.io/component: opentelemetry-targetallocator
     app.kubernetes.io/instance: test.test

--- a/internal/controllers/testdata/build_target_allocator_mtls.yaml
+++ b/internal/controllers/testdata/build_target_allocator_mtls.yaml
@@ -187,8 +187,6 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  annotations:
-    opentelemetry-targetallocator-config/hash: 02ef308f21c5312c388985bd8ca91246d1df7a3a5031135ec176f3c975e2fa37
   labels:
     app.kubernetes.io/component: opentelemetry-targetallocator
     app.kubernetes.io/instance: test.test

--- a/internal/manifests/targetallocator/annotations.go
+++ b/internal/manifests/targetallocator/annotations.go
@@ -16,6 +16,19 @@ import (
 
 const configMapHashAnnotationKey = "opentelemetry-targetallocator-config/hash"
 
+// ResourceAnnotations returns the TargetAllocator CR's metadata annotations,
+// filtered, for propagation to the resources the operator creates for it,
+// mirroring what manifestutils.Annotations does for the OpenTelemetryCollector.
+func ResourceAnnotations(instance v1alpha1.TargetAllocator, filterAnnotations []string) map[string]string {
+	annotations := make(map[string]string, len(instance.Annotations))
+	for k, v := range instance.Annotations {
+		if !manifestutils.IsFilteredSet(k, filterAnnotations) {
+			annotations[k] = v
+		}
+	}
+	return annotations
+}
+
 // Annotations returns the annotations for the TargetAllocator Pod.
 func Annotations(instance v1alpha1.TargetAllocator, configMap *v1.ConfigMap, filterAnnotations []string) map[string]string {
 	// Make a copy of PodAnnotations to be safe

--- a/internal/manifests/targetallocator/annotations_test.go
+++ b/internal/manifests/targetallocator/annotations_test.go
@@ -24,6 +24,42 @@ func TestPodAnnotations(t *testing.T) {
 	assert.Subset(t, annotations, instance.Spec.PodAnnotations)
 }
 
+func TestResourceAnnotations(t *testing.T) {
+	t.Run("propagates CR metadata annotations", func(t *testing.T) {
+		instance := targetAllocatorInstance()
+		instance.Annotations = map[string]string{
+			"key":        "value",
+			"foo.bar.io": "filtered",
+		}
+		annotations := ResourceAnnotations(instance, []string{".*\\.bar\\.io"})
+		assert.Equal(t, map[string]string{"key": "value"}, annotations)
+	})
+
+	t.Run("does not include pod annotations", func(t *testing.T) {
+		instance := targetAllocatorInstance()
+		instance.Spec.PodAnnotations = map[string]string{"key": "value"}
+		instance.Annotations = map[string]string{"meta": "value"}
+		annotations := ResourceAnnotations(instance, nil)
+		assert.Equal(t, map[string]string{"meta": "value"}, annotations)
+	})
+
+	t.Run("returns an empty map when the CR has no annotations", func(t *testing.T) {
+		instance := targetAllocatorInstance()
+		instance.Annotations = nil
+		annotations := ResourceAnnotations(instance, nil)
+		assert.NotNil(t, annotations)
+		assert.Empty(t, annotations)
+	})
+
+	t.Run("does not mutate the instance annotations", func(t *testing.T) {
+		instance := targetAllocatorInstance()
+		instance.Annotations = map[string]string{"key": "value"}
+		annotations := ResourceAnnotations(instance, nil)
+		annotations["other"] = "other"
+		assert.Equal(t, map[string]string{"key": "value"}, instance.Annotations)
+	})
+}
+
 func TestConfigMapHash(t *testing.T) {
 	cfg := config.New()
 	collector := collectorInstance()

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -162,7 +162,7 @@ func ConfigMap(params Params) (*corev1.ConfigMap, error) {
 			Name:        name,
 			Namespace:   instance.Namespace,
 			Labels:      labels,
-			Annotations: instance.Annotations,
+			Annotations: ResourceAnnotations(params.TargetAllocator, params.Config.AnnotationsFilter),
 		},
 		Data: map[string]string{
 			targetAllocatorFilename: string(taConfigYAML),

--- a/internal/manifests/targetallocator/deployment.go
+++ b/internal/manifests/targetallocator/deployment.go
@@ -26,9 +26,10 @@ func Deployment(params Params) (*appsv1.Deployment, error) {
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: params.TargetAllocator.Namespace,
-			Labels:    labels,
+			Name:        name,
+			Namespace:   params.TargetAllocator.Namespace,
+			Labels:      labels,
+			Annotations: ResourceAnnotations(params.TargetAllocator, params.Config.AnnotationsFilter),
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: params.TargetAllocator.Spec.Replicas,

--- a/internal/manifests/targetallocator/deployment_test.go
+++ b/internal/manifests/targetallocator/deployment_test.go
@@ -174,6 +174,39 @@ func TestDeploymentPodAnnotations(t *testing.T) {
 	assert.Subset(t, ds.Spec.Template.Annotations, testPodAnnotationValues)
 }
 
+func TestDeploymentResourceAnnotations(t *testing.T) {
+	// prepare
+	testMetaAnnotations := map[string]string{"meta-annotation-key": "meta-annotation-value"}
+	testPodAnnotations := map[string]string{"pod-annotation-key": "pod-annotation-value"}
+	otelcol := collectorInstance()
+	targetAllocator := targetAllocatorInstance()
+	targetAllocator.Annotations = map[string]string{
+		"meta-annotation-key": "meta-annotation-value",
+		"filtered.io/key":     "excluded",
+	}
+	targetAllocator.Spec.PodAnnotations = testPodAnnotations
+	cfg := config.New()
+	cfg.AnnotationsFilter = []string{"filtered\\.io/.*"}
+
+	params := Params{
+		Collector:       otelcol,
+		TargetAllocator: targetAllocator,
+		Config:          cfg,
+		Log:             logger,
+	}
+
+	// test
+	d, err := Deployment(params)
+	assert.NoError(t, err)
+
+	// CR metadata annotations land on the Deployment itself and on the pod template, filtered
+	assert.Equal(t, testMetaAnnotations, d.Annotations)
+	assert.Subset(t, d.Spec.Template.Annotations, testMetaAnnotations)
+	// pod annotations only land on the pod template
+	assert.NotContains(t, d.Annotations, "pod-annotation-key")
+	assert.Subset(t, d.Spec.Template.Annotations, testPodAnnotations)
+}
+
 func collectorInstance() *v1beta1.OpenTelemetryCollector {
 	configYAML, err := os.ReadFile("testdata/test.yaml")
 	if err != nil {

--- a/internal/manifests/targetallocator/networkpolicy.go
+++ b/internal/manifests/targetallocator/networkpolicy.go
@@ -26,7 +26,7 @@ func NetworkPolicy(params Params) (*networkingv1.NetworkPolicy, error) {
 
 	name := naming.TargetAllocatorNetworkPolicy(params.TargetAllocator.Name)
 	labels := manifestutils.Labels(params.TargetAllocator.ObjectMeta, name, params.TargetAllocator.Status.Image, ComponentOpenTelemetryTargetAllocator, params.Config.LabelsFilter)
-	annotations := Annotations(params.TargetAllocator, nil, params.Config.AnnotationsFilter)
+	annotations := ResourceAnnotations(params.TargetAllocator, params.Config.AnnotationsFilter)
 
 	tcp := corev1.ProtocolTCP
 	apiServerPort := intstr.FromInt32(params.Config.Internal.KubeAPIServerPort)

--- a/internal/manifests/targetallocator/networkpolicy_test.go
+++ b/internal/manifests/targetallocator/networkpolicy_test.go
@@ -135,3 +135,36 @@ func TestNetworkPolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestNetworkPolicyResourceAnnotations(t *testing.T) {
+	testConfig := config.Config{}
+	testConfig.Internal.KubeAPIServerPort = 6443
+
+	ta := v1alpha1.TargetAllocator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-ta",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"meta-annotation-key": "meta-annotation-value",
+			},
+		},
+		Spec: v1alpha1.TargetAllocatorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+				PodAnnotations: map[string]string{"pod-annotation-key": "pod-annotation-value"},
+			},
+			NetworkPolicy: v1beta1.NetworkPolicy{
+				Enabled: &[]bool{true}[0],
+			},
+		},
+	}
+
+	actual, err := NetworkPolicy(Params{
+		TargetAllocator: ta,
+		Config:          testConfig,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+
+	// CR metadata annotations propagate, pod annotations do not
+	assert.Equal(t, map[string]string{"meta-annotation-key": "meta-annotation-value"}, actual.Annotations)
+}

--- a/internal/manifests/targetallocator/poddisruptionbudget.go
+++ b/internal/manifests/targetallocator/poddisruptionbudget.go
@@ -44,12 +44,7 @@ func PodDisruptionBudget(params Params) (*policyV1.PodDisruptionBudget, error) {
 
 	name := naming.TAPodDisruptionBudget(params.TargetAllocator.Name)
 	labels := manifestutils.Labels(params.TargetAllocator.ObjectMeta, name, params.TargetAllocator.Spec.Image, ComponentOpenTelemetryTargetAllocator, nil)
-	configMap, err := ConfigMap(params)
-	if err != nil {
-		params.Log.Info("failed to construct target allocator config map for annotations")
-		configMap = nil
-	}
-	annotations := Annotations(params.TargetAllocator, configMap, params.Config.AnnotationsFilter)
+	annotations := ResourceAnnotations(params.TargetAllocator, params.Config.AnnotationsFilter)
 
 	objectMeta := metav1.ObjectMeta{
 		Name:        name,

--- a/internal/manifests/targetallocator/poddisruptionbudget_test.go
+++ b/internal/manifests/targetallocator/poddisruptionbudget_test.go
@@ -99,6 +99,35 @@ var tests = []test{
 	},
 }
 
+func TestPDBResourceAnnotations(t *testing.T) {
+	targetAllocator := v1alpha1.TargetAllocator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-instance",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"meta-annotation-key": "meta-annotation-value",
+			},
+		},
+		Spec: v1alpha1.TargetAllocatorSpec{
+			AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+				PodAnnotations: map[string]string{"pod-annotation-key": "pod-annotation-value"},
+			},
+		},
+	}
+	configuration := config.New()
+
+	pdb, err := PodDisruptionBudget(Params{
+		TargetAllocator: targetAllocator,
+		Config:          configuration,
+		Log:             logger,
+	})
+
+	// verify: CR metadata annotations propagate, pod annotations do not
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"meta-annotation-key": "meta-annotation-value"}, pdb.Annotations)
+}
+
 func TestPDBWithValidStrategy(t *testing.T) {
 	for _, test := range tests {
 		for _, strategy := range []v1beta1.TargetAllocatorAllocationStrategy{v1beta1.TargetAllocatorAllocationStrategyPerNode, v1beta1.TargetAllocatorAllocationStrategyConsistentHashing} {

--- a/internal/manifests/targetallocator/service.go
+++ b/internal/manifests/targetallocator/service.go
@@ -34,9 +34,10 @@ func Service(params Params) *corev1.Service {
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      naming.TAService(params.TargetAllocator.Name),
-			Namespace: params.TargetAllocator.Namespace,
-			Labels:    labels,
+			Name:        naming.TAService(params.TargetAllocator.Name),
+			Namespace:   params.TargetAllocator.Namespace,
+			Labels:      labels,
+			Annotations: ResourceAnnotations(params.TargetAllocator, params.Config.AnnotationsFilter),
 		},
 		Spec: corev1.ServiceSpec{
 			Selector:            selector,

--- a/internal/manifests/targetallocator/serviceaccount.go
+++ b/internal/manifests/targetallocator/serviceaccount.go
@@ -34,7 +34,7 @@ func ServiceAccount(params Params) *corev1.ServiceAccount {
 			Name:        name,
 			Namespace:   params.TargetAllocator.Namespace,
 			Labels:      labels,
-			Annotations: params.TargetAllocator.Annotations,
+			Annotations: ResourceAnnotations(params.TargetAllocator, params.Config.AnnotationsFilter),
 		},
 	}
 }

--- a/internal/manifests/targetallocator/servicemonitor.go
+++ b/internal/manifests/targetallocator/servicemonitor.go
@@ -19,9 +19,10 @@ func ServiceMonitor(params Params) *monitoringv1.ServiceMonitor {
 
 	return &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: params.TargetAllocator.Namespace,
-			Name:      name,
-			Labels:    labels,
+			Namespace:   params.TargetAllocator.Namespace,
+			Name:        name,
+			Labels:      labels,
+			Annotations: ResourceAnnotations(params.TargetAllocator, params.Config.AnnotationsFilter),
 		},
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{

--- a/tests/e2e-targetallocator/targetallocator-annotations/00-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-annotations/00-assert.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     example.com/propagated: "true"
   (!contains(keys(annotations), 'kubectl.kubernetes.io/last-applied-configuration')): true
+  (!contains(keys(annotations), 'example.com/pod-only')): true
 spec:
   template:
     metadata:
@@ -23,6 +24,7 @@ metadata:
   name: annotated-targetallocator
   annotations:
     example.com/propagated: "true"
+  (!contains(keys(annotations), 'example.com/pod-only')): true
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -30,6 +32,7 @@ metadata:
   name: annotated-targetallocator
   annotations:
     example.com/propagated: "true"
+  (!contains(keys(annotations), 'example.com/pod-only')): true
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/tests/e2e-targetallocator/targetallocator-annotations/00-assert.yaml
+++ b/tests/e2e-targetallocator/targetallocator-annotations/00-assert.yaml
@@ -1,0 +1,40 @@
+# Asserts that the CR's metadata.annotations propagate to every TA-owned
+# resource, podAnnotations stays on the pod template only, and the default
+# annotations filter drops kubectl's last-applied-configuration.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: annotated-targetallocator
+  annotations:
+    example.com/propagated: "true"
+  (!contains(keys(annotations), 'kubectl.kubernetes.io/last-applied-configuration')): true
+spec:
+  template:
+    metadata:
+      annotations:
+        example.com/propagated: "true"
+        example.com/pod-only: "true"
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: annotated-targetallocator
+  annotations:
+    example.com/propagated: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: annotated-targetallocator
+  annotations:
+    example.com/propagated: "true"
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: annotated-targetallocator
+  annotations:
+    example.com/propagated: "true"
+  (!contains(keys(annotations), 'example.com/pod-only')): true

--- a/tests/e2e-targetallocator/targetallocator-annotations/00-install.yaml
+++ b/tests/e2e-targetallocator/targetallocator-annotations/00-install.yaml
@@ -1,0 +1,15 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: TargetAllocator
+metadata:
+  name: annotated
+  namespace: ($namespace)
+  annotations:
+    example.com/propagated: "true"
+spec:
+  podAnnotations:
+    example.com/pod-only: "true"
+  prometheusCR:
+    enabled: true
+    serviceMonitorSelector: {}
+    podMonitorSelector: {}
+  serviceAccount: ta

--- a/tests/e2e-targetallocator/targetallocator-annotations/chainsaw-test.yaml
+++ b/tests/e2e-targetallocator/targetallocator-annotations/chainsaw-test.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: targetallocator-annotations
+# Verifies that a standalone TargetAllocator CR's metadata.annotations propagate
+# to every resource the operator creates for it (Deployment, Service, ConfigMap,
+# PodDisruptionBudget), that spec.podAnnotations only lands on the pod template,
+# and that the operator's default annotations filter keeps
+# kubectl.kubernetes.io/last-applied-configuration from propagating.
+spec:
+  steps:
+  - name: Setup Target Allocator RBAC
+    use:
+      template: ../../step-templates/target-allocator-rbac-comprehensive.yaml
+      with:
+        bindings:
+        - name: clusterRoleName
+          value: targetallocator-annotations
+        - name: clusterRoleBindingName
+          value: (join('-', ['ta', $namespace]))
+  - name: step-00
+    try:
+    - apply:
+        template: true
+        file: 00-install.yaml
+    - assert:
+        template: true
+        file: 00-assert.yaml
+    catch:
+    - podLogs:
+        selector: app.kubernetes.io/component=opentelemetry-targetallocator


### PR DESCRIPTION
**Description:**
   Annotations set on the `TargetAllocator` CR were not propagated to the resources
   the operator creates for it, unlike the `OpenTelemetryCollector` CR, whose
   metadata annotations propagate to its owned resources. Additionally, the TA's
   `podAnnotations` was counter-intuitively also applied to the NetworkPolicy and
   PodDisruptionBudget.

   **Link to tracking Issue(s):**

   - Resolves: #4393