### PR TITLE
fix(collector): preserve string values written in exponential notation when generating collector config

### DIFF
--- a/.chloggen/fix-yaml-string-quoting-4314.yaml
+++ b/.chloggen/fix-yaml-string-quoting-4314.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix collector config string values written in exponential notation without a decimal point (e.g. `\"0e12\"`) being emitted unquoted in the generated ConfigMap, causing the collector to misread them as numbers and fail to start."
+
+# One or more tracking issues related to the change
+issues: [4314]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/apis/v1beta1/config.go
+++ b/apis/v1beta1/config.go
@@ -7,8 +7,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"maps"
+	"regexp"
+	"strconv"
 
 	go_yaml "github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/token"
 )
 
 type ComponentKind int
@@ -115,10 +118,27 @@ type Config struct {
 	Service    Service    `json:"service" yaml:"service"`
 }
 
+// exponentWithoutDotRegex matches integers written in exponential notation without a
+// decimal point (e.g. "0e12", "1e10"). goccy/go-yaml's own number detection treats such
+// strings as plain text and does not quote them, but YAML consumers that follow the
+// YAML core schema (e.g. the collector's config loader) parse them back as floats.
+var exponentWithoutDotRegex = regexp.MustCompile(`^[-+]?[0-9]+[eE][-+]?[0-9]+$`)
+
+// quoteAmbiguousStrings forces quoting of string values that would otherwise be emitted
+// as plain scalars but are ambiguous under the YAML core schema, so they round-trip back
+// as strings instead of being reinterpreted as numbers/bools/null downstream.
+func quoteAmbiguousStrings(s string) ([]byte, error) {
+	if token.IsNeedQuoted(s) || exponentWithoutDotRegex.MatchString(s) {
+		return []byte(strconv.Quote(s)), nil
+	}
+	return []byte(s), nil
+}
+
 // Yaml encodes the Config as a YAML string.
 func (c *Config) Yaml() (string, error) {
 	var buf bytes.Buffer
-	yamlEncoder := go_yaml.NewEncoder(&buf, go_yaml.IndentSequence(true), go_yaml.AutoInt())
+	yamlEncoder := go_yaml.NewEncoder(&buf, go_yaml.IndentSequence(true), go_yaml.AutoInt(),
+		go_yaml.CustomMarshaler[string](quoteAmbiguousStrings))
 	if err := yamlEncoder.Encode(&c); err != nil {
 		return "", err
 	}

--- a/apis/v1beta1/config.go
+++ b/apis/v1beta1/config.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 
 	go_yaml "github.com/goccy/go-yaml"
-	"github.com/goccy/go-yaml/token"
 )
 
 type ComponentKind int
@@ -124,22 +123,79 @@ type Config struct {
 // YAML core schema (e.g. the collector's config loader) parse them back as floats.
 var exponentWithoutDotRegex = regexp.MustCompile(`^[-+]?[0-9]+[eE][-+]?[0-9]+$`)
 
-// quoteAmbiguousStrings forces quoting of string values that would otherwise be emitted
-// as plain scalars but are ambiguous under the YAML core schema, so they round-trip back
-// as strings instead of being reinterpreted as numbers/bools/null downstream.
-func quoteAmbiguousStrings(s string) ([]byte, error) {
-	if token.IsNeedQuoted(s) || exponentWithoutDotRegex.MatchString(s) {
-		return []byte(strconv.Quote(s)), nil
+// quotedString forces goccy/go-yaml to emit the wrapped value as a quoted scalar. It is
+// only ever used to wrap individual ambiguous string values (see quoteAmbiguousValues)
+// rather than being registered for the whole `string` type: registering a
+// go_yaml.CustomMarshaler for `string` globally was tried first, but it interferes with
+// the encoder's IndentSequence(true) handling for every string, not just the ambiguous
+// ones, corrupting the indentation of unrelated nested sequences (e.g. Prometheus
+// receiver's static_configs/targets) elsewhere in the generated config.
+type quotedString string
+
+func (q quotedString) MarshalYAML() ([]byte, error) {
+	return []byte(strconv.Quote(string(q))), nil
+}
+
+// quoteAmbiguousValues returns a copy of a decoded YAML value tree (as produced by
+// AnyConfig, i.e. nested map[string]any/[]any) with string values that are ambiguous
+// under the YAML core schema rewritten to quotedString, so that Yaml() emits them quoted
+// and they round-trip back as strings instead of being reinterpreted as numbers
+// downstream. The input tree is left untouched: Config.Object maps are shared with the
+// source CR (e.g. via a shallow struct copy of Spec), so mutating them in place would
+// leak into the original object.
+func quoteAmbiguousValues(v any) any {
+	switch val := v.(type) {
+	case string:
+		if exponentWithoutDotRegex.MatchString(val) {
+			return quotedString(val)
+		}
+		return val
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, elem := range val {
+			out[k] = quoteAmbiguousValues(elem)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, elem := range val {
+			out[i] = quoteAmbiguousValues(elem)
+		}
+		return out
+	default:
+		return v
 	}
-	return []byte(s), nil
 }
 
 // Yaml encodes the Config as a YAML string.
 func (c *Config) Yaml() (string, error) {
+	encodable := *c
+	encodable.Receivers.Object, _ = quoteAmbiguousValues(c.Receivers.Object).(map[string]any)
+	encodable.Exporters.Object, _ = quoteAmbiguousValues(c.Exporters.Object).(map[string]any)
+	if c.Processors != nil {
+		processors := *c.Processors
+		processors.Object, _ = quoteAmbiguousValues(c.Processors.Object).(map[string]any)
+		encodable.Processors = &processors
+	}
+	if c.Connectors != nil {
+		connectors := *c.Connectors
+		connectors.Object, _ = quoteAmbiguousValues(c.Connectors.Object).(map[string]any)
+		encodable.Connectors = &connectors
+	}
+	if c.Extensions != nil {
+		extensions := *c.Extensions
+		extensions.Object, _ = quoteAmbiguousValues(c.Extensions.Object).(map[string]any)
+		encodable.Extensions = &extensions
+	}
+	if c.Service.Telemetry != nil {
+		telemetry := *c.Service.Telemetry
+		telemetry.Object, _ = quoteAmbiguousValues(c.Service.Telemetry.Object).(map[string]any)
+		encodable.Service.Telemetry = &telemetry
+	}
+
 	var buf bytes.Buffer
-	yamlEncoder := go_yaml.NewEncoder(&buf, go_yaml.IndentSequence(true), go_yaml.AutoInt(),
-		go_yaml.CustomMarshaler[string](quoteAmbiguousStrings))
-	if err := yamlEncoder.Encode(&c); err != nil {
+	yamlEncoder := go_yaml.NewEncoder(&buf, go_yaml.IndentSequence(true), go_yaml.AutoInt())
+	if err := yamlEncoder.Encode(&encodable); err != nil {
 		return "", err
 	}
 	return buf.String(), nil

--- a/internal/otelconfig/config_test.go
+++ b/internal/otelconfig/config_test.go
@@ -264,6 +264,49 @@ service:
 	assert.Equal(t, expected, yamlCollector)
 }
 
+func TestConfigYamlPreservesAmbiguousNumericStrings(t *testing.T) {
+	// Regression test for https://github.com/open-telemetry/opentelemetry-operator/issues/4314
+	// Strings written in exponential notation without a decimal point (e.g. "0e12") must stay
+	// quoted, otherwise YAML consumers following the core schema read them back as floats.
+	cfg := &v1beta1.Config{
+		Receivers: v1beta1.AnyConfig{
+			Object: map[string]any{
+				"otlp": nil,
+			},
+		},
+		Processors: &v1beta1.AnyConfig{
+			Object: map[string]any{
+				"metricstransform/cluster-code": map[string]any{
+					"new_value": "0e12",
+				},
+			},
+		},
+		Exporters: v1beta1.AnyConfig{
+			Object: map[string]any{
+				"debug": nil,
+			},
+		},
+		Service: v1beta1.Service{
+			Pipelines: map[string]*v1beta1.Pipeline{
+				"metrics": {
+					Receivers:  []string{"otlp"},
+					Processors: []string{"metricstransform/cluster-code"},
+					Exporters:  []string{"debug"},
+				},
+			},
+		},
+	}
+	yamlCollector, err := cfg.Yaml()
+	require.NoError(t, err)
+	assert.Contains(t, yamlCollector, `new_value: "0e12"`)
+
+	var roundTripped map[string]any
+	require.NoError(t, go_yaml.Unmarshal([]byte(yamlCollector), &roundTripped))
+	processors := roundTripped["processors"].(map[string]any)
+	transform := processors["metricstransform/cluster-code"].(map[string]any)
+	assert.Equal(t, "0e12", transform["new_value"])
+}
+
 func TestGetTelemetryFromYAML(t *testing.T) {
 	collectorYaml, err := os.ReadFile("./testdata/otelcol-demo.yaml")
 	require.NoError(t, err)


### PR DESCRIPTION
Strings that happen to look like exponential numbers can currently change type when the Operator generates the Collector YAML.

For example, a value such as `"0e12"` is meant to stay a string, but it can be emitted without quotes. The Collector then parses it as a number and fails when the component expects a string.

I initially looked at removing `AutoInt()`, but that is too broad and changes legitimate numeric serialization. This fix keeps the existing behavior and only forces quoting for the exponent-style strings that would otherwise be ambiguous.

I added a regression test that round-trips this case and verifies the value is still a string. The relevant test suites, build, lint and changelog validation pass.

AI assistance: I used AI tools while investigating this and preparing the change; I have reviewed and tested it myself.

Fixes #4314