### PR TITLE
Created preservedLabels and Annotations

### DIFF
--- a/.chloggen/fix-pod-template-metadata-deletion.yaml
+++ b/.chloggen/fix-pod-template-metadata-deletion.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make pod template annotations and labels authoritative from the CR, so entries removed from `spec.podAnnotations` are removed from the managed workloads. Keys managed by external tooling (e.g. ArgoCD, `kubectl rollout restart`, policy engines) can be exempted via the new `--preserved-annotations` and `--preserved-labels` operator flags. Annotations and labels on the managed objects themselves (not their pod templates) are still preserved.
+
+# One or more tracking issues related to the change
+issues: [2795]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This supersedes the `operator.opentelemetry.io/prometheus-annotations-added` ownership marker introduced in #5069, which is no longer necessary and has been removed. `prometheus.io/*` (or any other) annotations applied out of band directly on the managed workloads' pod templates are now removed during reconciliation unless they match `--preserved-annotations` (e.g. `--preserved-annotations=prometheus.io/*`).

--- a/internal/config/cli.go
+++ b/internal/config/cli.go
@@ -51,6 +51,8 @@ func CreateCLIParser(cfg Config) *pflag.FlagSet {
 	f.String("auto-instrumentation-nginx-image", cfg.AutoInstrumentationNginxImage, "The default OpenTelemetry Nginx instrumentation image. This image is used when no image is specified in the CustomResource.")
 	f.StringArray("labels-filter", cfg.LabelsFilter, "Labels to filter away from propagating onto deploys. It should be a string array containing patterns, which are literal strings optionally containing a * wildcard character. Example: --labels-filter=.*filter.out will filter out labels that looks like: label.filter.out: true")
 	f.StringArray("annotations-filter", cfg.AnnotationsFilter, "Annotations to filter away from propagating onto deploys. It should be a string array containing patterns, which are literal strings optionally containing a * wildcard character. Example: --annotations-filter=.*filter.out will filter out annotations that looks like: annotation.filter.out: true")
+	f.StringArray("preserved-labels", cfg.PreservedLabels, "Label keys on managed pod templates to preserve during reconciliation even when they are no longer present in the CR. It should be a string array containing patterns, which are literal strings optionally containing a * wildcard character. Example: --preserved-labels=argocd.argoproj.io/* keeps labels stamped by external tools. Note: a key matching both the CR and a preserve pattern can only be changed, not deleted, via the CR.")
+	f.StringArray("preserved-annotations", cfg.PreservedAnnotations, "Annotation keys on managed pod templates to preserve during reconciliation even when they are no longer present in the CR. It should be a string array containing patterns, which are literal strings optionally containing a * wildcard character. Example: --preserved-annotations=kubectl.kubernetes.io/* keeps annotations stamped by external tools. Note: a key matching both the CR and a preserve pattern can only be changed, not deleted, via the CR.")
 	f.String("fips-disabled-components", cfg.FipsDisabledComponents, "Disabled collector components when operator runs on FIPS enabled platform. Example flag value =receiver.foo,receiver.bar,exporter.baz")
 	f.Int("webhook-port", cfg.WebhookPort, "The port the webhook endpoint binds to.")
 	f.Bool("tls-cluster-profile", false, "Retrieves the TLS profile (min version and ciphers) from the cluster. Supported only on OpenShift clusters. The TLS profile is obtained from APIServer CR.")
@@ -122,6 +124,10 @@ func ApplyCLI(cfg *Config) error {
 				cfg.LabelsFilter, _ = f.GetStringArray("labels-filter")
 			case "annotations-filter":
 				cfg.AnnotationsFilter, _ = f.GetStringArray("annotations-filter")
+			case "preserved-labels":
+				cfg.PreservedLabels, _ = f.GetStringArray("preserved-labels")
+			case "preserved-annotations":
+				cfg.PreservedAnnotations, _ = f.GetStringArray("preserved-annotations")
 			case "openshift-create-dashboard":
 				cfg.OpenshiftCreateDashboard, _ = f.GetBool("openshift-create-dashboard")
 			case "metrics-addr":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,10 @@ type Config struct {
 	LabelsFilter []string `yaml:"labels-filter"`
 	// AnnotationsFilter Returns the filters converted to regex strings used to filter out unwanted labels from propagations.
 	AnnotationsFilter []string `yaml:"annotations-filter"`
+	// PreservedLabels holds patterns for label keys on managed pod templates that must survive reconciliation even when absent from the desired state.
+	PreservedLabels []string `yaml:"preserved-labels"`
+	// PreservedAnnotations holds patterns for annotation keys on managed pod templates that must survive reconciliation even when absent from the desired state.
+	PreservedAnnotations []string `yaml:"preserved-annotations"`
 	// MetricsAddr is the address the metric endpoint binds to.
 	MetricsAddr string `yaml:"metrics-addr"`
 	// MetricsSecure enables serving metrics via HTTPS with authentication and authorization.
@@ -212,6 +216,8 @@ func New() Config {
 		AutoInstrumentationNginxImage:       fmt.Sprintf("ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-apache-httpd:%s", v.AutoInstrumentationNginx),
 		LabelsFilter:                        []string{},
 		AnnotationsFilter:                   []string{constants.KubernetesLastAppliedConfigurationAnnotation},
+		PreservedLabels:                     []string{},
+		PreservedAnnotations:                []string{},
 		CreateRBACPermissions:               autoRBAC.NotAvailable,
 		OpAmpBridgeAvailability:             opampbridge.NotAvailable,
 		MetricsAddr:                         ":8443",

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -97,6 +97,12 @@ func ApplyEnvVars(cfg *Config) {
 	if v, ok := os.LookupEnv("ANNOTATIONS_FILTER"); ok {
 		cfg.AnnotationsFilter = strings.Split(v, ",")
 	}
+	if v, ok := os.LookupEnv("PRESERVED_LABELS"); ok {
+		cfg.PreservedLabels = strings.Split(v, ",")
+	}
+	if v, ok := os.LookupEnv("PRESERVED_ANNOTATIONS"); ok {
+		cfg.PreservedAnnotations = strings.Split(v, ",")
+	}
 	if v, ok := os.LookupEnv("ZAP_TIME_KEY"); ok {
 		cfg.Zap.TimeKey = v
 	}

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -29,8 +29,10 @@ target-allocator-availability: 0
 collector-availability: 0
 ignore-missing-collector-crds: false
 labels-filter: []
+preserved-labels: []
 annotations-filter:
   - ^kubectl\.kubernetes\.io/last-applied-configuration$
+preserved-annotations: []
 metrics-addr: :8443
 metrics-secure: true
 metrics-tls-cert-file: ""

--- a/internal/controllers/clusterobservability_controller.go
+++ b/internal/controllers/clusterobservability_controller.go
@@ -184,7 +184,7 @@ func (r *ClusterObservabilityReconciler) Reconcile(ctx context.Context, req ctrl
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		err = reconcileDesiredObjects(ctx, r.Client, log, &params.ClusterObservability, params.Scheme, regularObjects, ownedObjects)
+		err = reconcileDesiredObjects(ctx, r.Client, log, &params.ClusterObservability, params.Scheme, params.Config, regularObjects, ownedObjects)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controllers/common.go
+++ b/internal/controllers/common.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/collector"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/opampbridge"
@@ -121,7 +122,7 @@ func getList[T client.Object](ctx context.Context, cl client.Client, l T, option
 }
 
 // reconcileDesiredObjects runs the reconcile process using the mutateFn over the given list of objects.
-func reconcileDesiredObjects(ctx context.Context, kubeClient client.Client, logger logr.Logger, owner metav1.Object, scheme *runtime.Scheme, desiredObjects []client.Object, ownedObjects map[types.UID]client.Object) error {
+func reconcileDesiredObjects(ctx context.Context, kubeClient client.Client, logger logr.Logger, owner metav1.Object, scheme *runtime.Scheme, cfg config.Config, desiredObjects []client.Object, ownedObjects map[types.UID]client.Object) error {
 	var errs []error
 	for _, desired := range desiredObjects {
 		l := logger.WithValues(
@@ -138,7 +139,7 @@ func reconcileDesiredObjects(ctx context.Context, kubeClient client.Client, logg
 		// existing is an object the controller runtime will hydrate for us
 		// we obtain the existing object by deep copying the desired object because it's the most convenient way
 		existing := desired.DeepCopyObject().(client.Object)
-		mutateFn := manifests.MutateFuncFor(existing, desired)
+		mutateFn := manifests.MutateFuncFor(existing, desired, cfg)
 		var op controllerutil.OperationResult
 		crudErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			result, createOrUpdateErr := ctrl.CreateOrUpdate(ctx, kubeClient, existing, mutateFn)

--- a/internal/controllers/opampbridge_controller.go
+++ b/internal/controllers/opampbridge_controller.go
@@ -92,7 +92,7 @@ func (r *OpAMPBridgeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if buildErr != nil {
 		return ctrl.Result{}, buildErr
 	}
-	err := reconcileDesiredObjects(ctx, r.Client, log, &params.OpAMPBridge, params.Scheme, desiredObjects, nil)
+	err := reconcileDesiredObjects(ctx, r.Client, log, &params.OpAMPBridge, params.Scheme, params.Config, desiredObjects, nil)
 	return opampbridgeStatus.HandleReconcileStatus(ctx, log, params, err)
 }
 

--- a/internal/controllers/opentelemetrycollector_controller.go
+++ b/internal/controllers/opentelemetrycollector_controller.go
@@ -342,7 +342,7 @@ func (r *OpenTelemetryCollectorReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
-	err = reconcileDesiredObjects(ctx, r.Client, log, &instance, params.Scheme, desiredObjects, ownedObjects)
+	err = reconcileDesiredObjects(ctx, r.Client, log, &instance, params.Scheme, params.Config, desiredObjects, ownedObjects)
 	return collectorStatus.HandleReconcileStatus(ctx, log, params, instance, err)
 }
 

--- a/internal/controllers/reconcile_test.go
+++ b/internal/controllers/reconcile_test.go
@@ -1088,8 +1088,9 @@ func TestOpAMPBridgeReconciler_Reconcile(t *testing.T) {
 							exists, err := populateObjectIfExists(t, &d, namespacedObjectName(naming.OpAMPBridge(params.Name), params.Namespace))
 							assert.NoError(t, err)
 							assert.True(t, exists)
-							// confirm that we don't remove annotations and labels even if we don't set them
-							assert.Contains(t, d.Spec.Template.Annotations, annotationName)
+							// pod template metadata is authoritative: entries removed from the CR are removed from the template
+							assert.NotContains(t, d.Spec.Template.Annotations, annotationName)
+							// object-level metadata is still preserved when the CR stops setting it
 							assert.Contains(t, d.Labels, labelName)
 							actual := v1.Service{}
 							exists, err = populateObjectIfExists(t, &actual, namespacedObjectName(naming.OpAMPBridgeService(params.Name), params.Namespace))

--- a/internal/controllers/targetallocator_controller.go
+++ b/internal/controllers/targetallocator_controller.go
@@ -180,7 +180,7 @@ func (r *TargetAllocatorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, buildErr
 	}
 
-	err = reconcileDesiredObjects(ctx, r.Client, log, &params.TargetAllocator, params.Scheme, desiredObjects, nil)
+	err = reconcileDesiredObjects(ctx, r.Client, log, &params.TargetAllocator, params.Scheme, params.Config, desiredObjects, nil)
 	return taStatus.HandleReconcileStatus(ctx, log, params, err)
 }
 

--- a/internal/controllers/testdata/build_collector_base.yaml
+++ b/internal/controllers/testdata/build_collector_base.yaml
@@ -23,7 +23,6 @@ spec:
     metadata:
       annotations:
         opentelemetry-operator-config/sha256: 2d266e55025628659355f1271b689d6fb53648ef6cd5595831f5835d18e59a25
-        operator.opentelemetry.io/prometheus-annotations-added: "true"
         prometheus.io/path: /metrics
         prometheus.io/port: "8888"
         prometheus.io/scrape: "true"

--- a/internal/controllers/testdata/build_collector_ingress.yaml
+++ b/internal/controllers/testdata/build_collector_ingress.yaml
@@ -23,7 +23,6 @@ spec:
     metadata:
       annotations:
         opentelemetry-operator-config/sha256: 2d266e55025628659355f1271b689d6fb53648ef6cd5595831f5835d18e59a25
-        operator.opentelemetry.io/prometheus-annotations-added: "true"
         prometheus.io/path: /metrics
         prometheus.io/port: "8888"
         prometheus.io/scrape: "true"

--- a/internal/controllers/testdata/build_collector_service_account.yaml
+++ b/internal/controllers/testdata/build_collector_service_account.yaml
@@ -23,7 +23,6 @@ spec:
     metadata:
       annotations:
         opentelemetry-operator-config/sha256: 2d266e55025628659355f1271b689d6fb53648ef6cd5595831f5835d18e59a25
-        operator.opentelemetry.io/prometheus-annotations-added: "true"
         prometheus.io/path: /metrics
         prometheus.io/port: "8888"
         prometheus.io/scrape: "true"

--- a/internal/controllers/testdata/build_collector_ta_cr_base.yaml
+++ b/internal/controllers/testdata/build_collector_ta_cr_base.yaml
@@ -24,7 +24,6 @@ spec:
     metadata:
       annotations:
         opentelemetry-operator-config/sha256: 42773025f65feaf30df59a306a9e38f1aaabe94c8310983beaddb7f648d699b0
-        operator.opentelemetry.io/prometheus-annotations-added: "true"
         prometheus.io/path: /metrics
         prometheus.io/port: "8888"
         prometheus.io/scrape: "true"

--- a/internal/controllers/testdata/build_collector_ta_cr_enable_metrics.yaml
+++ b/internal/controllers/testdata/build_collector_ta_cr_enable_metrics.yaml
@@ -24,7 +24,6 @@ spec:
     metadata:
       annotations:
         opentelemetry-operator-config/sha256: 42773025f65feaf30df59a306a9e38f1aaabe94c8310983beaddb7f648d699b0
-        operator.opentelemetry.io/prometheus-annotations-added: "true"
         prometheus.io/path: /metrics
         prometheus.io/port: "8888"
         prometheus.io/scrape: "true"

--- a/internal/manifests/collector/daemonset_test.go
+++ b/internal/manifests/collector/daemonset_test.go
@@ -49,11 +49,10 @@ func TestDaemonSetNewDefault(t *testing.T) {
 
 	// verify sha256 podAnnotation
 	expectedAnnotations := map[string]string{
-		"opentelemetry-operator-config/sha256":                   "fbcdae6a02b2115cd5ca4f34298202ab041d1dfe62edebfaadb48b1ee178231d",
-		"prometheus.io/path":                                     "/metrics",
-		"prometheus.io/port":                                     "8888",
-		"prometheus.io/scrape":                                   "true",
-		"operator.opentelemetry.io/prometheus-annotations-added": "true",
+		"opentelemetry-operator-config/sha256": "fbcdae6a02b2115cd5ca4f34298202ab041d1dfe62edebfaadb48b1ee178231d",
+		"prometheus.io/path":                   "/metrics",
+		"prometheus.io/port":                   "8888",
+		"prometheus.io/scrape":                 "true",
 	}
 	assert.Equal(t, expectedAnnotations, d.Spec.Template.Annotations)
 
@@ -295,12 +294,11 @@ func TestDaemonsetPodAnnotations(t *testing.T) {
 		"prometheus.io/path":                   "/metrics",
 		"prometheus.io/port":                   "8888",
 		"prometheus.io/scrape":                 "true",
-		"operator.opentelemetry.io/prometheus-annotations-added": "true",
 	}
 
 	// verify
 	assert.Equal(t, "my-instance-collector", ds.Name)
-	assert.Len(t, ds.Spec.Template.Annotations, 6)
+	assert.Len(t, ds.Spec.Template.Annotations, 5)
 	assert.Equal(t, expectedAnnotations, ds.Spec.Template.Annotations)
 }
 

--- a/internal/manifests/collector/deployment_test.go
+++ b/internal/manifests/collector/deployment_test.go
@@ -92,11 +92,10 @@ func TestDeploymentNewDefault(t *testing.T) {
 
 	// verify sha256 podAnnotation
 	expectedAnnotations := map[string]string{
-		"opentelemetry-operator-config/sha256":                   "fbcdae6a02b2115cd5ca4f34298202ab041d1dfe62edebfaadb48b1ee178231d",
-		"prometheus.io/path":                                     "/metrics",
-		"prometheus.io/port":                                     "8888",
-		"prometheus.io/scrape":                                   "true",
-		"operator.opentelemetry.io/prometheus-annotations-added": "true",
+		"opentelemetry-operator-config/sha256": "fbcdae6a02b2115cd5ca4f34298202ab041d1dfe62edebfaadb48b1ee178231d",
+		"prometheus.io/path":                   "/metrics",
+		"prometheus.io/port":                   "8888",
+		"prometheus.io/scrape":                 "true",
 	}
 	assert.Equal(t, expectedAnnotations, d.Spec.Template.Annotations)
 
@@ -158,11 +157,10 @@ func TestDeploymentPodAnnotations(t *testing.T) {
 		"prometheus.io/path":                   "/metrics",
 		"prometheus.io/port":                   "8888",
 		"prometheus.io/scrape":                 "true",
-		"operator.opentelemetry.io/prometheus-annotations-added": "true",
 	}
 
 	// verify
-	assert.Len(t, d.Spec.Template.Annotations, 6)
+	assert.Len(t, d.Spec.Template.Annotations, 5)
 	assert.Equal(t, "my-instance-collector", d.Name)
 	assert.Equal(t, expectedPodAnnotationValues, d.Spec.Template.Annotations)
 }

--- a/internal/manifests/collector/statefulset_test.go
+++ b/internal/manifests/collector/statefulset_test.go
@@ -53,11 +53,10 @@ func TestStatefulSetNewDefault(t *testing.T) {
 
 	// verify sha256 podAnnotation
 	expectedAnnotations := map[string]string{
-		"opentelemetry-operator-config/sha256":                   "fbcdae6a02b2115cd5ca4f34298202ab041d1dfe62edebfaadb48b1ee178231d",
-		"prometheus.io/path":                                     "/metrics",
-		"prometheus.io/port":                                     "8888",
-		"prometheus.io/scrape":                                   "true",
-		"operator.opentelemetry.io/prometheus-annotations-added": "true",
+		"opentelemetry-operator-config/sha256": "fbcdae6a02b2115cd5ca4f34298202ab041d1dfe62edebfaadb48b1ee178231d",
+		"prometheus.io/path":                   "/metrics",
+		"prometheus.io/port":                   "8888",
+		"prometheus.io/scrape":                 "true",
 	}
 	assert.Equal(t, expectedAnnotations, ss.Spec.Template.Annotations)
 
@@ -238,7 +237,6 @@ func TestStatefulSetPodAnnotations(t *testing.T) {
 		"prometheus.io/path":                   "/metrics",
 		"prometheus.io/port":                   "8888",
 		"prometheus.io/scrape":                 "true",
-		"operator.opentelemetry.io/prometheus-annotations-added": "true",
 	}
 	// verify
 	assert.Equal(t, "my-instance-collector", ss.Name)

--- a/internal/manifests/manifestutils/annotations.go
+++ b/internal/manifests/manifestutils/annotations.go
@@ -11,14 +11,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 )
 
-// PrometheusAnnotationsAddedKey is the pod-template annotation the operator
-// stamps when it adds the default prometheus.io/* scrape annotations. The
-// mutate path uses its presence on an existing resource to decide whether the
-// operator is the owner of the prometheus.io/* annotations and may therefore
-// remove them when DisablePrometheusAnnotations is toggled to true. This
-// avoids clobbering prometheus.io/* annotations that the user set out of band.
-const PrometheusAnnotationsAddedKey = "operator.opentelemetry.io/prometheus-annotations-added"
-
 // Annotations return the annotations for OpenTelemetryCollector resources.
 func Annotations(instance v1beta1.OpenTelemetryCollector, filterAnnotations []string) (map[string]string, error) {
 	// new map every time, so that we don't touch the instance's annotations
@@ -67,20 +59,10 @@ func PodAnnotations(instance v1beta1.OpenTelemetryCollector, filterAnnotations [
 			"prometheus.io/path":   "/metrics",
 		}
 		// Default Prometheus annotations do not override existing
-		stamped := false
 		for kMeta, vMeta := range prometheusAnnotations {
 			if _, ok := podAnnotations[kMeta]; !ok {
 				podAnnotations[kMeta] = vMeta
-				stamped = true
 			}
-		}
-		// Stamp a marker only when the operator actually added at least one
-		// default prometheus.io/* annotation. The mutate path uses the marker
-		// to distinguish operator-stamped prom annotations from prom
-		// annotations the user supplied out of band. Both are removed together
-		// when DisablePrometheusAnnotations is toggled to true.
-		if stamped {
-			podAnnotations[PrometheusAnnotationsAddedKey] = "true"
 		}
 	}
 

--- a/internal/manifests/manifestutils/annotations_test.go
+++ b/internal/manifests/manifestutils/annotations_test.go
@@ -37,8 +37,6 @@ func TestDefaultAnnotations(t *testing.T) {
 	assert.Equal(t, "true", podAnnotations["prometheus.io/scrape"])
 	assert.Equal(t, "8888", podAnnotations["prometheus.io/port"])
 	assert.Equal(t, "/metrics", podAnnotations["prometheus.io/path"])
-	// the operator stamps an ownership marker when it adds default prom annotations
-	assert.Equal(t, "true", podAnnotations[PrometheusAnnotationsAddedKey])
 	assert.Equal(t, "5b3b62aa5e0a3c7250084c2b49190e30b72fc2ad352ffbaa699224e1aa900834", podAnnotations["opentelemetry-operator-config/sha256"])
 }
 
@@ -72,8 +70,6 @@ func TestNonDefaultPodAnnotation(t *testing.T) {
 	assert.NotContains(t, podAnnotations, "prometheus.io/scrape", "Prometheus scrape annotation should not exist in pod annotations")
 	assert.NotContains(t, podAnnotations, "prometheus.io/port", "Prometheus port annotation should not exist in pod annotations")
 	assert.NotContains(t, podAnnotations, "prometheus.io/path", "Prometheus path annotation should not exist in pod annotations")
-	// the ownership marker is not stamped when DisablePrometheusAnnotations=true
-	assert.NotContains(t, podAnnotations, PrometheusAnnotationsAddedKey, "operator-owned marker should not be stamped when DisablePrometheusAnnotations=true")
 	assert.Equal(t, "fbcdae6a02b2115cd5ca4f34298202ab041d1dfe62edebfaadb48b1ee178231d", podAnnotations["opentelemetry-operator-config/sha256"])
 }
 
@@ -108,10 +104,6 @@ func TestUserAnnotations(t *testing.T) {
 	assert.Equal(t, "false", annotations["prometheus.io/scrape"])
 	assert.Equal(t, "1234", annotations["prometheus.io/port"])
 	assert.Equal(t, "/test", annotations["prometheus.io/path"])
-	// the ownership marker is not stamped when the user pre-set all three
-	// default prom annotations on metadata.annotations — the operator added
-	// nothing on top, so it claims nothing.
-	assert.NotContains(t, podAnnotations, PrometheusAnnotationsAddedKey, "operator-owned marker should not be stamped when user supplied all default prom annotations")
 	assert.Equal(t, "29cb15a4b87f8c6284e7c3377f6b6c5c74519f5aee8ca39a90b3cf3ca2043c4d", podAnnotations["opentelemetry-operator-config/sha256"])
 }
 

--- a/internal/manifests/mutate.go
+++ b/internal/manifests/mutate.go
@@ -5,6 +5,7 @@ package manifests
 
 import (
 	"fmt"
+	"maps"
 	"reflect"
 
 	"dario.cat/mergo"
@@ -23,6 +24,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 )
 
@@ -59,7 +61,7 @@ var ImmutableChangeErr *ImmutableFieldChangeErr
 // In order for the operator to reconcile other types, they must be added here.
 // The function returned takes no arguments but instead uses the existing and desired inputs here. Existing is expected
 // to be set by the controller-runtime package through a client get call.
-func MutateFuncFor(existing, desired client.Object) controllerutil.MutateFn {
+func MutateFuncFor(existing, desired client.Object, cfg config.Config) controllerutil.MutateFn {
 	return func() error {
 		// Get the existing annotations and override any conflicts with the desired annotations
 		// This will preserve any annotations on the existing set.
@@ -120,17 +122,17 @@ func MutateFuncFor(existing, desired client.Object) controllerutil.MutateFn {
 		case *appsv1.Deployment:
 			dpl := existing
 			wantDpl := desired.(*appsv1.Deployment)
-			return mutateDeployment(dpl, wantDpl)
+			return mutateDeployment(dpl, wantDpl, cfg)
 
 		case *appsv1.DaemonSet:
 			dpl := existing
 			wantDpl := desired.(*appsv1.DaemonSet)
-			return mutateDaemonset(dpl, wantDpl)
+			return mutateDaemonset(dpl, wantDpl, cfg)
 
 		case *appsv1.StatefulSet:
 			sts := existing
 			wantSts := desired.(*appsv1.StatefulSet)
-			return mutateStatefulSet(sts, wantSts)
+			return mutateStatefulSet(sts, wantSts, cfg)
 
 		case *monitoringv1.ServiceMonitor:
 			svcMonitor := existing
@@ -308,7 +310,7 @@ func mutateService(existing, desired *corev1.Service) {
 	existing.Spec.ClusterIPs = clusterIPs
 }
 
-func mutateDaemonset(existing, desired *appsv1.DaemonSet) error {
+func mutateDaemonset(existing, desired *appsv1.DaemonSet, cfg config.Config) error {
 	if !existing.CreationTimestamp.IsZero() {
 		if !apiequality.Semantic.DeepEqual(desired.Spec.Selector, existing.Spec.Selector) {
 			return &ImmutableFieldChangeErr{Field: "Spec.Selector"}
@@ -322,10 +324,10 @@ func mutateDaemonset(existing, desired *appsv1.DaemonSet) error {
 	existing.Spec.RevisionHistoryLimit = desired.Spec.RevisionHistoryLimit
 	existing.Spec.UpdateStrategy = desired.Spec.UpdateStrategy
 
-	return mutatePodTemplate(&existing.Spec.Template, &desired.Spec.Template)
+	return mutatePodTemplate(&existing.Spec.Template, &desired.Spec.Template, cfg)
 }
 
-func mutateDeployment(existing, desired *appsv1.Deployment) error {
+func mutateDeployment(existing, desired *appsv1.Deployment, cfg config.Config) error {
 	if !existing.CreationTimestamp.IsZero() {
 		if !apiequality.Semantic.DeepEqual(desired.Spec.Selector, existing.Spec.Selector) {
 			return &ImmutableFieldChangeErr{Field: "Spec.Selector"}
@@ -342,10 +344,10 @@ func mutateDeployment(existing, desired *appsv1.Deployment) error {
 	existing.Spec.RevisionHistoryLimit = desired.Spec.RevisionHistoryLimit
 	existing.Spec.Strategy = desired.Spec.Strategy
 
-	return mutatePodTemplate(&existing.Spec.Template, &desired.Spec.Template)
+	return mutatePodTemplate(&existing.Spec.Template, &desired.Spec.Template, cfg)
 }
 
-func mutateStatefulSet(existing, desired *appsv1.StatefulSet) error {
+func mutateStatefulSet(existing, desired *appsv1.StatefulSet, cfg config.Config) error {
 	if !existing.CreationTimestamp.IsZero() {
 		if !apiequality.Semantic.DeepEqual(desired.Spec.Selector, existing.Spec.Selector) {
 			return &ImmutableFieldChangeErr{Field: "Spec.Selector"}
@@ -376,7 +378,7 @@ func mutateStatefulSet(existing, desired *appsv1.StatefulSet) error {
 		existing.Spec.VolumeClaimTemplates[i].Spec = desired.Spec.VolumeClaimTemplates[i].Spec
 	}
 
-	return mutatePodTemplate(&existing.Spec.Template, &desired.Spec.Template)
+	return mutatePodTemplate(&existing.Spec.Template, &desired.Spec.Template, cfg)
 }
 
 func mutateCertificate(existing, desired *cmv1.Certificate) {
@@ -391,49 +393,42 @@ func mutateIssuer(existing, desired *cmv1.Issuer) {
 	existing.Spec = desired.Spec
 }
 
-// operatorPrometheusAnnotationKeys is the set of pod-template annotation keys
-// the operator stamps when it adds the default prometheus.io/* scrape
-// annotations. The mutate path treats these as operator-owned only when the
-// marker manifestutils.PrometheusAnnotationsAddedKey is present on the
-// existing pod template; in that case any key in this set that is absent from
-// the desired pod template is stripped from the existing pod template before
-// the preserve-external-annotations merge runs. This lets the
-// spec.observability.metrics.disablePrometheusAnnotations feature toggle take
-// effect on already-running collectors without clobbering prometheus.io/*
-// annotations the user set out of band.
-var operatorPrometheusAnnotationKeys = []string{
-	"prometheus.io/scrape",
-	"prometheus.io/port",
-	"prometheus.io/path",
-	manifestutils.PrometheusAnnotationsAddedKey,
-}
-
-func mutatePodTemplate(existing, desired *corev1.PodTemplateSpec) error {
-	if err := mergeWithOverride(&existing.Labels, desired.Labels); err != nil {
-		return err
-	}
-
-	// Strip operator-stamped prometheus annotations when the marker on the
-	// existing pod template signals operator ownership and the desired pod
-	// template no longer includes them. See the comment on
-	// operatorPrometheusAnnotationKeys for the rationale.
-	if existing.Annotations != nil {
-		if _, hasMarker := existing.Annotations[manifestutils.PrometheusAnnotationsAddedKey]; hasMarker {
-			for _, key := range operatorPrometheusAnnotationKeys {
-				if _, inDesired := desired.Annotations[key]; !inDesired {
-					delete(existing.Annotations, key)
-				}
-			}
-		}
-	}
-
-	if err := mergeWithOverride(&existing.Annotations, desired.Annotations); err != nil {
-		return err
-	}
-
+// mutatePodTemplate makes the pod template metadata authoritative: annotations
+// and labels are replaced with the desired state generated from the CR, so
+// entries removed from the CR (e.g. spec.podAnnotations) are also removed from
+// the workload. Entries on the existing template whose key matches one of the
+// configured preserve patterns (config.PreservedAnnotations /
+// config.PreservedLabels) are carried over, which lets external tooling
+// (ArgoCD, kubectl rollout restart, policy engines) own specific keys.
+// Note: a key that is both present in the CR and matches a preserve pattern can
+// be changed but not deleted via the CR.
+func mutatePodTemplate(existing, desired *corev1.PodTemplateSpec, cfg config.Config) error {
+	existing.Labels = mergePreserved(existing.Labels, desired.Labels, cfg.PreservedLabels)
+	existing.Annotations = mergePreserved(existing.Annotations, desired.Annotations, cfg.PreservedAnnotations)
 	existing.Spec = desired.Spec
 
 	return nil
+}
+
+// mergePreserved returns a copy of desired, carrying over entries from existing
+// whose key matches one of the preservePatterns. Keys present in desired always
+// take precedence. A nil result is returned when there is nothing to set, so
+// that an empty map never round-trips into a perpetual update loop.
+func mergePreserved(existing, desired map[string]string, preservePatterns []string) map[string]string {
+	result := make(map[string]string, len(desired))
+	maps.Copy(result, desired)
+	for k, v := range existing {
+		if _, ok := result[k]; ok {
+			continue
+		}
+		if manifestutils.IsFilteredSet(k, preservePatterns) {
+			result[k] = v
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 func hasImmutableLabelChange(existingSelectorLabels, desiredLabels map[string]string) error {

--- a/internal/manifests/mutate_podtemplate_test.go
+++ b/internal/manifests/mutate_podtemplate_test.go
@@ -1,0 +1,237 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package manifests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/open-telemetry/opentelemetry-operator/internal/config"
+)
+
+// TestMutatePodTemplateAuthoritativeMetadata covers the pod template metadata
+// semantics: the desired state generated from the CR is authoritative, so
+// entries removed from the CR (e.g. spec.podAnnotations) are removed from the
+// workload (Refs #2795). Only keys matching the configured preserve patterns
+// survive when absent from the desired state.
+func TestMutatePodTemplateAuthoritativeMetadata(t *testing.T) {
+	const (
+		sha256Key = "opentelemetry-operator-config/sha256"
+		oldHash   = "old-hash"
+		newHash   = "new-hash"
+	)
+
+	tests := []struct {
+		name              string
+		cfg               config.Config
+		existingTemplate  corev1.PodTemplateSpec
+		desiredTemplate   corev1.PodTemplateSpec
+		expectAnnotations map[string]string
+		expectLabels      map[string]string
+	}{
+		{
+			name: "entries removed from the CR are removed from the pod template",
+			existingTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"actokey": "actokey",
+						sha256Key: oldHash,
+					},
+				},
+			},
+			desiredTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						sha256Key: newHash,
+					},
+				},
+			},
+			expectAnnotations: map[string]string{
+				sha256Key: newHash,
+			},
+		},
+		{
+			name: "out-of-band template annotations are dropped by default",
+			existingTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/restartedAt": "2024-01-01T00:00:00Z",
+						sha256Key:                           oldHash,
+					},
+				},
+			},
+			desiredTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						sha256Key: newHash,
+					},
+				},
+			},
+			expectAnnotations: map[string]string{
+				sha256Key: newHash,
+			},
+		},
+		{
+			name: "annotations matching a preserve pattern survive",
+			cfg: config.Config{
+				PreservedAnnotations: []string{"kubectl.kubernetes.io/*"},
+			},
+			existingTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/restartedAt": "2024-01-01T00:00:00Z",
+						"argocd.argoproj.io/tracking-id":    "should-not-survive",
+						sha256Key:                           oldHash,
+					},
+				},
+			},
+			desiredTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						sha256Key: newHash,
+					},
+				},
+			},
+			expectAnnotations: map[string]string{
+				"kubectl.kubernetes.io/restartedAt": "2024-01-01T00:00:00Z",
+				sha256Key:                           newHash,
+			},
+		},
+		{
+			name: "desired value wins over preserved value for the same key",
+			cfg: config.Config{
+				PreservedAnnotations: []string{"prometheus.io/*"},
+			},
+			existingTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"prometheus.io/port": "9999",
+						sha256Key:            oldHash,
+					},
+				},
+			},
+			desiredTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"prometheus.io/port": "8888",
+						sha256Key:            newHash,
+					},
+				},
+			},
+			expectAnnotations: map[string]string{
+				"prometheus.io/port": "8888",
+				sha256Key:            newHash,
+			},
+		},
+		{
+			name: "disablePrometheusAnnotations transition removes operator-stamped defaults",
+			existingTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"prometheus.io/scrape": "true",
+						"prometheus.io/port":   "8888",
+						"prometheus.io/path":   "/metrics",
+						sha256Key:              oldHash,
+					},
+				},
+			},
+			desiredTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						sha256Key: newHash,
+					},
+				},
+			},
+			expectAnnotations: map[string]string{
+				sha256Key: newHash,
+			},
+		},
+		{
+			name: "labels removed from the CR are removed from the pod template",
+			existingTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "test",
+						"stale-label":            "stale",
+					},
+				},
+			},
+			desiredTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "test",
+					},
+				},
+			},
+			expectLabels: map[string]string{
+				"app.kubernetes.io/name": "test",
+			},
+		},
+		{
+			name: "labels matching a preserve pattern survive",
+			cfg: config.Config{
+				PreservedLabels: []string{"cost-center.io/*"},
+			},
+			existingTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "test",
+						"cost-center.io/team":    "payments",
+						"stale-label":            "stale",
+					},
+				},
+			},
+			desiredTemplate: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/name": "test",
+					},
+				},
+			},
+			expectLabels: map[string]string{
+				"app.kubernetes.io/name": "test",
+				"cost-center.io/team":    "payments",
+			},
+		},
+		{
+			name:             "empty desired metadata results in nil maps, never empty maps",
+			existingTemplate: corev1.PodTemplateSpec{},
+			desiredTemplate:  corev1.PodTemplateSpec{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			existing := tt.existingTemplate.DeepCopy()
+			desired := tt.desiredTemplate.DeepCopy()
+			err := mutatePodTemplate(existing, desired, tt.cfg)
+			require.NoError(t, err)
+			assert.Exactly(t, tt.expectAnnotations, existing.Annotations)
+			assert.Exactly(t, tt.expectLabels, existing.Labels)
+		})
+	}
+}
+
+// TestMutatePodTemplateSpecReplaced guards that the pod spec itself keeps being
+// fully replaced, independent of the metadata semantics.
+func TestMutatePodTemplateSpecReplaced(t *testing.T) {
+	existing := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "old"}},
+		},
+	}
+	desired := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "new"}},
+		},
+	}
+
+	err := mutatePodTemplate(existing, desired, config.Config{})
+	require.NoError(t, err)
+	assert.Exactly(t, desired.Spec, existing.Spec)
+}

--- a/internal/manifests/mutate_test.go
+++ b/internal/manifests/mutate_test.go
@@ -13,7 +13,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
+	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 )
 
 func TestMutateServiceAccount(t *testing.T) {
@@ -31,7 +31,7 @@ func TestMutateServiceAccount(t *testing.T) {
 		},
 	}
 
-	mutateFn := MutateFuncFor(&existing, &desired)
+	mutateFn := MutateFuncFor(&existing, &desired, config.Config{})
 	err := mutateFn()
 	require.NoError(t, err)
 	assert.Equal(t, corev1.ServiceAccount{
@@ -66,7 +66,7 @@ func TestMutateService(t *testing.T) {
 			},
 		}
 
-		mutateFn := MutateFuncFor(&existing, &desired)
+		mutateFn := MutateFuncFor(&existing, &desired, config.Config{})
 		err := mutateFn()
 		require.NoError(t, err)
 
@@ -215,7 +215,7 @@ func TestMutateDaemonsetAdditionalContainers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing, tt.desired)
@@ -359,7 +359,7 @@ func TestMutateDeploymentAdditionalContainers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing, tt.desired)
@@ -503,7 +503,7 @@ func TestMutateStatefulSetAdditionalContainers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing, tt.desired)
@@ -699,7 +699,7 @@ func TestMutateDaemonsetAffinity(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing, tt.desired)
@@ -895,7 +895,7 @@ func TestMutateDeploymentAffinity(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing, tt.desired)
@@ -1091,7 +1091,7 @@ func TestMutateStatefulSetAffinity(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing, tt.desired)
@@ -1225,7 +1225,7 @@ func TestMutateDaemonsetCollectorArgs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing, tt.desired)
@@ -1359,7 +1359,7 @@ func TestMutateDeploymentCollectorArgs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing, tt.desired)
@@ -1493,7 +1493,7 @@ func TestMutateStatefulSetCollectorArgs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing, tt.desired)
@@ -1702,7 +1702,7 @@ func TestMutateDaemonsetError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			assert.Error(t, err)
 		})
@@ -1858,7 +1858,7 @@ func TestMutateDeploymentError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			assert.Error(t, err)
 		})
@@ -2078,7 +2078,7 @@ func TestMutateStatefulSetError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			assert.Error(t, err)
 		})
@@ -2239,7 +2239,7 @@ func TestMutateDaemonsetLabelChange(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing.Spec, tt.desired.Spec)
@@ -2401,7 +2401,7 @@ func TestMutateDeploymentLabelChange(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing.Spec, tt.desired.Spec)
@@ -2563,7 +2563,7 @@ func TestMutateStatefulSetLabelChange(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mutateFn := MutateFuncFor(&tt.existing, &tt.desired)
+			mutateFn := MutateFuncFor(&tt.existing, &tt.desired, config.Config{})
 			err := mutateFn()
 			require.NoError(t, err)
 			assert.Equal(t, tt.existing.Spec, tt.desired.Spec)
@@ -2611,7 +2611,7 @@ func TestMutateIngress(t *testing.T) {
 		},
 	}
 
-	mutateFn := MutateFuncFor(existing, desired)
+	mutateFn := MutateFuncFor(existing, desired, config.Config{})
 	err := mutateFn()
 	require.NoError(t, err)
 
@@ -2655,7 +2655,7 @@ func TestGetMutateFunc_MutateNetworkPolicy(t *testing.T) {
 		},
 	}
 
-	f := MutateFuncFor(got, want)
+	f := MutateFuncFor(got, want, config.Config{})
 	err := f()
 	require.NoError(t, err)
 
@@ -2663,189 +2663,4 @@ func TestGetMutateFunc_MutateNetworkPolicy(t *testing.T) {
 	require.Exactly(t, got.Labels, want.Labels)
 	require.Exactly(t, got.Annotations, want.Annotations)
 	require.Exactly(t, got.Spec, want.Spec)
-}
-
-// TestMutatePodTemplateStripsOperatorStampedPrometheusAnnotations exercises the
-// marker-gated strip introduced for the design pivot agreed in
-// https://github.com/open-telemetry/opentelemetry-operator/pull/5069 (Refs #5043).
-// When PodAnnotations stamps the default prometheus.io/* annotations it also stamps
-// PrometheusAnnotationsAddedKey as an ownership marker. The mutate path only removes
-// the prometheus.io/* keys when that marker is present on the existing pod template,
-// so prom annotations the user supplied out of band are preserved.
-func TestMutatePodTemplateStripsOperatorStampedPrometheusAnnotations(t *testing.T) {
-	const (
-		marker    = manifestutils.PrometheusAnnotationsAddedKey
-		userKept  = "ops/internal-bookkeeping"
-		userValue = "should-be-preserved-across-reconciles"
-		sha256Key = "opentelemetry-operator-config/sha256"
-		oldHash   = "old-hash"
-		newHash   = "new-hash"
-	)
-
-	tests := []struct {
-		name              string
-		existingTemplate  corev1.PodTemplateSpec
-		desiredTemplate   corev1.PodTemplateSpec
-		expectAnnotations map[string]string
-	}{
-		{
-			name: "marker present + disable transition removes prom annotations and marker, keeps user keys",
-			existingTemplate: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port":   "8888",
-						"prometheus.io/path":   "/metrics",
-						marker:                 "true",
-						sha256Key:              oldHash,
-						userKept:               userValue,
-					},
-				},
-			},
-			desiredTemplate: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						sha256Key: newHash,
-					},
-				},
-			},
-			expectAnnotations: map[string]string{
-				sha256Key: newHash,
-				userKept:  userValue,
-			},
-		},
-		{
-			name: "marker absent (out-of-band user prom annotations) leaves them intact on disable",
-			existingTemplate: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port":   "9090",
-						"prometheus.io/path":   "/probe",
-						sha256Key:              oldHash,
-						userKept:               userValue,
-					},
-				},
-			},
-			desiredTemplate: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						sha256Key: newHash,
-					},
-				},
-			},
-			expectAnnotations: map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   "9090",
-				"prometheus.io/path":   "/probe",
-				sha256Key:              newHash,
-				userKept:               userValue,
-			},
-		},
-		{
-			name: "enable path keeps marker and prom annotations and user keys",
-			existingTemplate: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port":   "8888",
-						"prometheus.io/path":   "/metrics",
-						marker:                 "true",
-						sha256Key:              oldHash,
-						userKept:               userValue,
-					},
-				},
-			},
-			desiredTemplate: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port":   "8888",
-						"prometheus.io/path":   "/metrics",
-						marker:                 "true",
-						sha256Key:              newHash,
-					},
-				},
-			},
-			expectAnnotations: map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   "8888",
-				"prometheus.io/path":   "/metrics",
-				marker:                 "true",
-				sha256Key:              newHash,
-				userKept:               userValue,
-			},
-		},
-		{
-			name: "upgrade compat: pre-upgrade prom annotations gain the marker on first reconcile under enable",
-			existingTemplate: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port":   "8888",
-						"prometheus.io/path":   "/metrics",
-						sha256Key:              oldHash,
-						userKept:               userValue,
-					},
-				},
-			},
-			desiredTemplate: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port":   "8888",
-						"prometheus.io/path":   "/metrics",
-						marker:                 "true",
-						sha256Key:              newHash,
-					},
-				},
-			},
-			expectAnnotations: map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   "8888",
-				"prometheus.io/path":   "/metrics",
-				marker:                 "true",
-				sha256Key:              newHash,
-				userKept:               userValue,
-			},
-		},
-		{
-			name: "upgrade + immediate disable: pre-upgrade prom annotations survive one toggle (marker never stamped)",
-			existingTemplate: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"prometheus.io/scrape": "true",
-						"prometheus.io/port":   "8888",
-						"prometheus.io/path":   "/metrics",
-						sha256Key:              oldHash,
-						userKept:               userValue,
-					},
-				},
-			},
-			desiredTemplate: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						sha256Key: newHash,
-					},
-				},
-			},
-			expectAnnotations: map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   "8888",
-				"prometheus.io/path":   "/metrics",
-				sha256Key:              newHash,
-				userKept:               userValue,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			existing := tt.existingTemplate.DeepCopy()
-			desired := tt.desiredTemplate.DeepCopy()
-			err := mutatePodTemplate(existing, desired)
-			require.NoError(t, err)
-			assert.Exactly(t, tt.expectAnnotations, existing.Annotations)
-		})
-	}
 }

--- a/tests/e2e/annotation-change-collector/02-assert-daemonset-without-extra-annotation.yaml
+++ b/tests/e2e/annotation-change-collector/02-assert-daemonset-without-extra-annotation.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   template:
     metadata:
-      (contains(keys(annotations), 'user-annotation')): true
-      (contains(keys(annotations), 'new-annotation')): true
-      annotations:
-        manual-annotation: "true"
+      (contains(keys(annotations), 'user-annotation')): false
+      (contains(keys(annotations), 'new-annotation')): false
+      (contains(keys(annotations), 'manual-annotation')): false

--- a/tests/e2e/annotation-change-collector/02-assert-deployment-without-extra-annotation.yaml
+++ b/tests/e2e/annotation-change-collector/02-assert-deployment-without-extra-annotation.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   template:
     metadata:
-      (contains(keys(annotations), 'user-annotation')): true
-      (contains(keys(annotations), 'new-annotation')): true
-      annotations:
-        manual-annotation: "true"
+      (contains(keys(annotations), 'user-annotation')): false
+      (contains(keys(annotations), 'new-annotation')): false
+      (contains(keys(annotations), 'manual-annotation')): false

--- a/tests/e2e/annotation-change-collector/02-assert-statefulset-without-extra-annotation.yaml
+++ b/tests/e2e/annotation-change-collector/02-assert-statefulset-without-extra-annotation.yaml
@@ -9,7 +9,6 @@ metadata:
 spec:
   template:
     metadata:
-      (contains(keys(annotations), 'user-annotation')): true
-      (contains(keys(annotations), 'new-annotation')): true
-      annotations:
-        manual-annotation: "true"
+      (contains(keys(annotations), 'user-annotation')): false
+      (contains(keys(annotations), 'new-annotation')): false
+      (contains(keys(annotations), 'manual-annotation')): false

--- a/tests/e2e/label-change-collector/02-assert-daemonset-without-extra-label.yaml
+++ b/tests/e2e/label-change-collector/02-assert-daemonset-without-extra-label.yaml
@@ -12,7 +12,6 @@ metadata:
 spec:
   template:
     metadata:
-      (contains(keys(labels),'user-label')): true
-      (contains(keys(labels),'new-label')): true
-      labels:
-        manual-label: "true"
+      (contains(keys(labels),'user-label')): false
+      (contains(keys(labels),'new-label')): false
+      (contains(keys(labels),'manual-label')): false

--- a/tests/e2e/label-change-collector/02-assert-deployment-without-extra-label.yaml
+++ b/tests/e2e/label-change-collector/02-assert-deployment-without-extra-label.yaml
@@ -12,7 +12,6 @@ metadata:
 spec:
   template:
     metadata:
-      (contains(keys(labels),'user-label')): true
-      (contains(keys(labels),'new-label')): true
-      labels:
-        manual-label: "true"
+      (contains(keys(labels),'user-label')): false
+      (contains(keys(labels),'new-label')): false
+      (contains(keys(labels),'manual-label')): false

--- a/tests/e2e/label-change-collector/02-assert-statefulset-without-extra-label.yaml
+++ b/tests/e2e/label-change-collector/02-assert-statefulset-without-extra-label.yaml
@@ -12,7 +12,6 @@ metadata:
 spec:
   template:
     metadata:
-      (contains(keys(labels),'user-label')): true
-      (contains(keys(labels),'new-label')): true
-      labels:
-        manual-label: "true"
+      (contains(keys(labels),'user-label')): false
+      (contains(keys(labels),'new-label')): false
+      (contains(keys(labels),'manual-label')): false

--- a/tests/e2e/pod-annotations-change-collector/00-assert-deployment-with-pod-annotations.yaml
+++ b/tests/e2e/pod-annotations-change-collector/00-assert-deployment-with-pod-annotations.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-collector
+spec:
+  template:
+    metadata:
+      annotations:
+        first-annotation: "true"

--- a/tests/e2e/pod-annotations-change-collector/00-install-collector-with-pod-annotations.yaml
+++ b/tests/e2e/pod-annotations-change-collector/00-install-collector-with-pod-annotations.yaml
@@ -1,0 +1,23 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: deployment
+spec:
+  mode: deployment
+  podAnnotations:
+    first-annotation: "true"
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+    processors: {}
+
+    exporters:
+      debug: {}
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]

--- a/tests/e2e/pod-annotations-change-collector/01-assert-deployment-with-empty-pod-annotations.yaml
+++ b/tests/e2e/pod-annotations-change-collector/01-assert-deployment-with-empty-pod-annotations.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-collector
+spec:
+  template:
+    metadata:
+      (contains(keys(annotations), 'first-annotation')): false

--- a/tests/e2e/pod-annotations-change-collector/01-install-collector-with-empty-pod-annotations.yaml
+++ b/tests/e2e/pod-annotations-change-collector/01-install-collector-with-empty-pod-annotations.yaml
@@ -1,0 +1,22 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: deployment
+spec:
+  mode: deployment
+  podAnnotations: {}
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+    processors: {}
+
+    exporters:
+      debug: {}
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]

--- a/tests/e2e/pod-annotations-change-collector/02-assert-deployment-with-new-pod-annotations.yaml
+++ b/tests/e2e/pod-annotations-change-collector/02-assert-deployment-with-new-pod-annotations.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-collector
+spec:
+  template:
+    metadata:
+      (contains(keys(annotations), 'first-annotation')): false
+      annotations:
+        second-annotation: "true"

--- a/tests/e2e/pod-annotations-change-collector/02-install-collector-with-new-pod-annotations.yaml
+++ b/tests/e2e/pod-annotations-change-collector/02-install-collector-with-new-pod-annotations.yaml
@@ -1,0 +1,23 @@
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: deployment
+spec:
+  mode: deployment
+  podAnnotations:
+    second-annotation: "true"
+  config:
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+    processors: {}
+
+    exporters:
+      debug: {}
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]

--- a/tests/e2e/pod-annotations-change-collector/chainsaw-test.yaml
+++ b/tests/e2e/pod-annotations-change-collector/chainsaw-test.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: pod-annotations-change-collector
+spec:
+  steps:
+    - name: step-00
+      description: collector with spec.podAnnotations entries
+      try:
+        - apply:
+            file: 00-install-collector-with-pod-annotations.yaml
+        - assert:
+            file: 00-assert-deployment-with-pod-annotations.yaml
+
+    - name: step-01
+      description: spec.podAnnotations emptied, entries must be removed from the pod template
+      try:
+        - update:
+            file: 01-install-collector-with-empty-pod-annotations.yaml
+        - assert:
+            file: 01-assert-deployment-with-empty-pod-annotations.yaml
+
+    - name: step-02
+      description: spec.podAnnotations replaced, old entries must be gone from the pod template
+      try:
+        - update:
+            file: 02-install-collector-with-new-pod-annotations.yaml
+        - assert:
+            file: 02-assert-deployment-with-new-pod-annotations.yaml


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue. -->
Fixing a bug of spec.podAnnotations entries could never be deleted: once an annotation was set on the CR and reconciled into the managed workloads, removing it from the CR had no effect, because mutatePodTemplate merged the desired annotations/labels into the existing pod template (merge-only semantics) and there was no way to distinguish operator-managed entries from externally added ones.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #2795 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
