### PR TITLE
[Nightly Build] Fallback to latest collector image for OBI tests

### DIFF
--- a/tests/e2e-openshift/export-to-cluster-logging-lokistack/chainsaw-test.yaml
+++ b/tests/e2e-openshift/export-to-cluster-logging-lokistack/chainsaw-test.yaml
@@ -14,7 +14,10 @@ spec:
             -n opentelemetry-operator-system | \
             grep -o '"collector-image":"[^"]*"' | head -1 | \
             grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-          printf '%s' "$VERSION"
+          # --collector-image may be pinned to a non-semver tag (e.g. a
+          # ":latest" dev build); fall back to "latest" so the test still
+          # gets a resolvable image instead of a version-less tag.
+          printf '%s' "${VERSION:-latest}"
         outputs:
           - name: collectorVersion
             value: ($stdout)

--- a/tests/e2e/smoke-collector/smoke-collector-obi-unprivileged/chainsaw-test.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-obi-unprivileged/chainsaw-test.yaml
@@ -55,7 +55,10 @@ spec:
                 -n opentelemetry-operator-system | \
                 grep -o '"collector-image":"[^"]*"' | head -1 | \
                 grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-              printf '%s' "$VERSION"
+              # --collector-image may be pinned to a non-semver tag (e.g. a
+              # ":latest" dev build); fall back to "latest" so the test still
+              # gets a resolvable image instead of a version-less tag.
+              printf '%s' "${VERSION:-latest}"
             outputs:
               - name: collectorVersion
                 value: ($stdout)

--- a/tests/e2e/smoke-collector/smoke-collector-obi/chainsaw-test.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-obi/chainsaw-test.yaml
@@ -55,7 +55,10 @@ spec:
                 -n opentelemetry-operator-system | \
                 grep -o '"collector-image":"[^"]*"' | head -1 | \
                 grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-              printf '%s' "$VERSION"
+              # --collector-image may be pinned to a non-semver tag (e.g. a
+              # ":latest" dev build); fall back to "latest" so the test still
+              # gets a resolvable image instead of a version-less tag.
+              printf '%s' "${VERSION:-latest}"
             outputs:
               - name: collectorVersion
                 value: ($stdout)


### PR DESCRIPTION
Same issue as #5344.


- Resolves: #5391 

**Testing:**
```bash
make prepare-e2e
make add-image-collector COLLECTOR_IMG=otel/opentelemetry-collector-contrib-dev:latest deploy

./bin/chainsaw test --test-dir ./tests/e2e/smoke-collector/smoke-collector-obi
./bin/chainsaw test --test-dir ./tests/e2e/smoke-collector/smoke-collector-obi-unprivileged
```

**Documentation:** N/A
