### PR TITLE
fix outdated TargetAllocator replicas HA comment

### DIFF
--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -308,8 +308,8 @@ type PortsSpec struct {
 // OpenTelemetryTargetAllocator defines the configurations for the Prometheus target allocator.
 type OpenTelemetryTargetAllocator struct {
 	// Replicas is the number of pod instances for the underlying TargetAllocator. This should only be set to a value
-	// other than 1 if a strategy that allows for high availability is chosen. Currently, the only allocation strategy
-	// that can be run in a high availability mode is consistent-hashing.
+	// other than 1 if a strategy that allows for high availability is chosen. Currently, the allocation strategies
+	// that can be run in a high availability mode are consistent-hashing and per-node.
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 	// NodeSelector to schedule OpenTelemetry TargetAllocator pods.

--- a/apis/v1beta1/opentelemetrycollector_types.go
+++ b/apis/v1beta1/opentelemetrycollector_types.go
@@ -160,8 +160,8 @@ type OpenTelemetryCollectorSpec struct {
 // OpenTelemetryCollector spec.
 type TargetAllocatorEmbedded struct {
 	// Replicas is the number of pod instances for the underlying TargetAllocator. This should only be set to a value
-	// other than 1 if a strategy that allows for high availability is chosen. Currently, the only allocation strategy
-	// that can be run in a high availability mode is consistent-hashing.
+	// other than 1 if a strategy that allows for high availability is chosen. Currently, the allocation strategies
+	// that can be run in a high availability mode are consistent-hashing and per-node.
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 	// NodeSelector to schedule OpenTelemetry TargetAllocator pods.

--- a/docs/api/opentelemetrycollectors.md
+++ b/docs/api/opentelemetrycollectors.md
@@ -11426,8 +11426,8 @@ All CR instances which the ServiceAccount has access to will be retrieved. This 
         <td>integer</td>
         <td>
           Replicas is the number of pod instances for the underlying TargetAllocator. This should only be set to a value
-other than 1 if a strategy that allows for high availability is chosen. Currently, the only allocation strategy
-that can be run in a high availability mode is consistent-hashing.<br/>
+other than 1 if a strategy that allows for high availability is chosen. Currently, the allocation strategies
+that can be run in a high availability mode are consistent-hashing and per-node.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>
@@ -32398,8 +32398,8 @@ All CR instances which the ServiceAccount has access to will be retrieved. This 
         <td>integer</td>
         <td>
           Replicas is the number of pod instances for the underlying TargetAllocator. This should only be set to a value
-other than 1 if a strategy that allows for high availability is chosen. Currently, the only allocation strategy
-that can be run in a high availability mode is consistent-hashing.<br/>
+other than 1 if a strategy that allows for high availability is chosen. Currently, the allocation strategies
+that can be run in a high availability mode are consistent-hashing and per-node.<br/>
           <br/>
             <i>Format</i>: int32<br/>
         </td>


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The Replicas field comment in apis/v1alpha1/opentelemetrycollector_types.go and apis/v1beta1/opentelemetrycollector_types.go stated that consistent-hashing is the only TargetAllocator allocation strategy that can run in high availability mode. This is outdated: per-node allocation is stateless and deterministic, and has been supported with multiple replicas since PodDisruptionBudget support was added in #2932 (v0.103.0), as confirmed in #2900. 

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #4407

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
