### PR TITLE
[Chore] Fix OBI smoke tests for OpenShift and multi-node clusters

### DIFF
--- a/tests/e2e/smoke-collector/smoke-collector-obi-unprivileged/01-install-app.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-obi-unprivileged/01-install-app.yaml
@@ -15,13 +15,13 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: mirror.gcr.io/library/nginx:stable
+          image: mirror.gcr.io/nginxinc/nginx-unprivileged:stable
           ports:
-            - containerPort: 80
+            - containerPort: 8080
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 3
             periodSeconds: 5
 ---
@@ -34,4 +34,4 @@ spec:
     app: obi-target
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8080

--- a/tests/e2e/smoke-collector/smoke-collector-obi-unprivileged/chainsaw-test.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-obi-unprivileged/chainsaw-test.yaml
@@ -7,12 +7,18 @@ metadata:
 # fine-grained Linux capabilities instead of a privileged container.
 # Validates that the operator reconciles the unprivileged CR into the
 # correct DaemonSet spec and that the OBI receiver produces traces.
+#
+# On OpenShift 4.x (kernel < 6.4), the base-6 capabilities are
+# insufficient for eBPF trace generation — the sk_msg/sockhash path is
+# disabled due to a kernel locking bug. The spec reconciliation is still
+# validated but the telemetry steps are skipped. See PR #5219 capability
+# findings for details.
 spec:
   bindings:
     - name: podLabelSelector
       value: app=obi-target
     - name: appPort
-      value: "80"
+      value: "8080"
     - name: appPath
       value: /
     - name: collectorLabelSelector
@@ -55,9 +61,6 @@ spec:
                 -n opentelemetry-operator-system | \
                 grep -o '"collector-image":"[^"]*"' | head -1 | \
                 grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-              # --collector-image may be pinned to a non-semver tag (e.g. a
-              # ":latest" dev build); fall back to "latest" so the test still
-              # gets a resolvable image instead of a version-less tag.
               printf '%s' "${VERSION:-latest}"
             outputs:
               - name: collectorVersion
@@ -83,14 +86,88 @@ spec:
         - assert:
             file: 01-assert.yaml
     - name: send-traffic
-      description: send HTTP traffic to the target workload
-      use:
-        template: ../../../step-templates/app-http-request.yaml
+      description: send HTTP traffic to the target workload (skipped on OpenShift with kernel < 6.4)
+      try:
+        - script:
+            env:
+              - name: POD_LABEL_SELECTOR
+                value: ($podLabelSelector)
+              - name: APP_PORT
+                value: ($appPort)
+              - name: APP_PATH
+                value: ($appPath)
+            timeout: 1m
+            content: |
+              ./check-ebpf-support.sh || exit 0
+              POD=$(kubectl get pod -n "$NAMESPACE" -l "$POD_LABEL_SELECTOR" -o jsonpath='{.items[0].metadata.name}')
+              kubectl get --raw "/api/v1/namespaces/$NAMESPACE/pods/$POD:$APP_PORT/proxy$APP_PATH"
     - name: wait-for-telemetry
-      description: wait for OBI traces in collector debug output
-      use:
-        template: ../../../step-templates/wait-for-telemetry.yaml
+      description: wait for OBI traces in any collector pod (skipped on OpenShift with kernel < 6.4)
+      try:
+        - script:
+            env:
+              - name: LABEL_SELECTOR
+                value: ($collectorLabelSelector)
+              - name: CONTAINER_NAME
+                value: ($containerName)
+              - name: RETRY_TIMEOUT
+                value: ($retryTimeout)
+              - name: RETRY_SLEEP
+                value: ($retrySleep)
+              - name: SEARCH_STRING
+                value: k8s.namespace.name
+            timeout: 5m
+            content: |
+              ./check-ebpf-support.sh || exit 0
+              START=$(date +%s)
+              while true; do
+                ELAPSED=$(( $(date +%s) - START ))
+                if [ "$ELAPSED" -ge "$RETRY_TIMEOUT" ]; then
+                  echo "ERROR: Timeout (${RETRY_TIMEOUT}s) — '$SEARCH_STRING' not found in any collector pod" >&2
+                  kubectl logs -n "$NAMESPACE" -l "$LABEL_SELECTOR" -c "$CONTAINER_NAME" --tail=20 --prefix >&2
+                  exit 1
+                fi
+                if kubectl logs -n "$NAMESPACE" -l "$LABEL_SELECTOR" -c "$CONTAINER_NAME" --tail=-1 2>/dev/null | grep -Fq "$SEARCH_STRING"; then
+                  echo "Found '$SEARCH_STRING' in collector logs (elapsed: ${ELAPSED}s)"
+                  exit 0
+                fi
+                echo "Attempt at ${ELAPSED}s: '$SEARCH_STRING' not yet in any collector pod logs" >&2
+                sleep "$RETRY_SLEEP"
+              done
+      catch:
+        - podLogs:
+            selector: ($catchPodLabelSelector)
+            container: ($catchContainer)
     - name: validate-collector-spans
-      description: verify collector metrics confirm spans were exported (OBI receiver does not emit otelcol_receiver_accepted_spans)
-      use:
-        template: ../../../step-templates/validate-collector-exporter-spans.yaml
+      description: verify at least one collector pod exported spans (skipped on OpenShift with kernel < 6.4)
+      try:
+        - script:
+            env:
+              - name: COLLECTOR_LABEL_SELECTOR
+                value: ($collectorLabelSelector)
+              - name: METRICS_PORT
+                value: ($collectorMetricsPort)
+            shell: /bin/bash
+            timeout: 2m
+            content: |
+              ./check-ebpf-support.sh || exit 0
+              PODS=$(kubectl get pod -n "$NAMESPACE" -l "$COLLECTOR_LABEL_SELECTOR" -o jsonpath='{.items[*].metadata.name}')
+              for i in {1..12}; do
+                for POD in $PODS; do
+                  if metrics=$(kubectl get --raw "/api/v1/namespaces/$NAMESPACE/pods/$POD:$METRICS_PORT/proxy/metrics" 2>/dev/null); then
+                    SPANS=$(echo "$metrics" | grep '^otelcol_exporter_sent_spans' | awk '{print $2}' | head -1)
+                    if [ -n "$SPANS" ] && [ "$SPANS" != "0" ]; then
+                      echo "otelcol_exporter_sent_spans = $SPANS (pod: $POD)"
+                      exit 0
+                    fi
+                  fi
+                done
+                echo "Attempt $i: no collector pod has sent_spans > 0 yet" >&2
+                sleep 5
+              done
+              echo "FAIL: no collector pod exported spans after 12 attempts" >&2
+              exit 1
+      catch:
+        - podLogs:
+            selector: ($catchPodLabelSelector)
+            container: ($catchContainer)

--- a/tests/e2e/smoke-collector/smoke-collector-obi-unprivileged/check-ebpf-support.sh
+++ b/tests/e2e/smoke-collector/smoke-collector-obi-unprivileged/check-ebpf-support.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Returns 0 if unprivileged eBPF tracing is expected to work, 1 if not.
+# On non-OpenShift (kind), eBPF always works with the base-6 capabilities.
+# On OpenShift, kernel >= 6.4 is required for the sk_msg/sockhash path
+# that avoids SYS_ADMIN. Older kernels (5.14 on RHEL 9 / OCP 4.x) cannot
+# use unprivileged eBPF tracing.
+if ! kubectl api-resources --api-group=security.openshift.io -o name 2>/dev/null | grep -q securitycontextconstraints; then
+  exit 0
+fi
+KERNEL=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.kernelVersion}')
+MAJOR=$(echo "$KERNEL" | cut -d. -f1)
+MINOR=$(echo "$KERNEL" | cut -d. -f2)
+if [ "$MAJOR" -gt 6 ] || { [ "$MAJOR" -eq 6 ] && [ "$MINOR" -ge 4 ]; }; then
+  exit 0
+fi
+echo "SKIP: OpenShift kernel $KERNEL < 6.4 — unprivileged eBPF tracing not supported"
+exit 1

--- a/tests/e2e/smoke-collector/smoke-collector-obi/01-install-app.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-obi/01-install-app.yaml
@@ -15,13 +15,13 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: mirror.gcr.io/library/nginx:stable
+          image: mirror.gcr.io/nginxinc/nginx-unprivileged:stable
           ports:
-            - containerPort: 80
+            - containerPort: 8080
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 3
             periodSeconds: 5
 ---
@@ -34,4 +34,4 @@ spec:
     app: obi-target
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8080

--- a/tests/e2e/smoke-collector/smoke-collector-obi/chainsaw-test.yaml
+++ b/tests/e2e/smoke-collector/smoke-collector-obi/chainsaw-test.yaml
@@ -7,12 +7,17 @@ metadata:
 # privileged securityContext, hostPID, and user-managed RBAC. Validates that
 # the operator reconciles the CR into the correct DaemonSet spec and that the
 # OBI receiver successfully produces traces from a target workload.
+#
+# OBI uses eBPF to instrument processes at the kernel level, so traces only
+# appear in the collector pod running on the same node as the target workload.
+# The telemetry steps check ALL collector pods (not just the first) to handle
+# multi-node clusters correctly.
 spec:
   bindings:
     - name: podLabelSelector
       value: app=obi-target
     - name: appPort
-      value: "80"
+      value: "8080"
     - name: appPath
       value: /
     - name: collectorLabelSelector
@@ -55,9 +60,6 @@ spec:
                 -n opentelemetry-operator-system | \
                 grep -o '"collector-image":"[^"]*"' | head -1 | \
                 grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-              # --collector-image may be pinned to a non-semver tag (e.g. a
-              # ":latest" dev build); fall back to "latest" so the test still
-              # gets a resolvable image instead of a version-less tag.
               printf '%s' "${VERSION:-latest}"
             outputs:
               - name: collectorVersion
@@ -87,10 +89,70 @@ spec:
       use:
         template: ../../../step-templates/app-http-request.yaml
     - name: wait-for-telemetry
-      description: wait for OBI traces in collector debug output
-      use:
-        template: ../../../step-templates/wait-for-telemetry.yaml
+      description: wait for OBI traces in any collector pod (DaemonSet — traces only appear on the target's node)
+      try:
+        - script:
+            env:
+              - name: LABEL_SELECTOR
+                value: ($collectorLabelSelector)
+              - name: CONTAINER_NAME
+                value: ($containerName)
+              - name: RETRY_TIMEOUT
+                value: ($retryTimeout)
+              - name: RETRY_SLEEP
+                value: ($retrySleep)
+              - name: SEARCH_STRING
+                value: k8s.namespace.name
+            timeout: 5m
+            content: |
+              START=$(date +%s)
+              while true; do
+                ELAPSED=$(( $(date +%s) - START ))
+                if [ "$ELAPSED" -ge "$RETRY_TIMEOUT" ]; then
+                  echo "ERROR: Timeout (${RETRY_TIMEOUT}s) — '$SEARCH_STRING' not found in any collector pod" >&2
+                  kubectl logs -n "$NAMESPACE" -l "$LABEL_SELECTOR" -c "$CONTAINER_NAME" --tail=20 --prefix >&2
+                  exit 1
+                fi
+                if kubectl logs -n "$NAMESPACE" -l "$LABEL_SELECTOR" -c "$CONTAINER_NAME" --tail=-1 2>/dev/null | grep -Fq "$SEARCH_STRING"; then
+                  echo "Found '$SEARCH_STRING' in collector logs (elapsed: ${ELAPSED}s)"
+                  exit 0
+                fi
+                echo "Attempt at ${ELAPSED}s: '$SEARCH_STRING' not yet in any collector pod logs" >&2
+                sleep "$RETRY_SLEEP"
+              done
+      catch:
+        - podLogs:
+            selector: ($catchPodLabelSelector)
+            container: ($catchContainer)
     - name: validate-collector-spans
-      description: verify collector metrics confirm spans were exported (OBI receiver does not emit otelcol_receiver_accepted_spans)
-      use:
-        template: ../../../step-templates/validate-collector-exporter-spans.yaml
+      description: verify at least one collector pod exported spans (OBI traces land on the target's node only)
+      try:
+        - script:
+            env:
+              - name: COLLECTOR_LABEL_SELECTOR
+                value: ($collectorLabelSelector)
+              - name: METRICS_PORT
+                value: ($collectorMetricsPort)
+            shell: /bin/bash
+            timeout: 2m
+            content: |
+              PODS=$(kubectl get pod -n "$NAMESPACE" -l "$COLLECTOR_LABEL_SELECTOR" -o jsonpath='{.items[*].metadata.name}')
+              for i in {1..12}; do
+                for POD in $PODS; do
+                  if metrics=$(kubectl get --raw "/api/v1/namespaces/$NAMESPACE/pods/$POD:$METRICS_PORT/proxy/metrics" 2>/dev/null); then
+                    SPANS=$(echo "$metrics" | grep '^otelcol_exporter_sent_spans' | awk '{print $2}' | head -1)
+                    if [ -n "$SPANS" ] && [ "$SPANS" != "0" ]; then
+                      echo "otelcol_exporter_sent_spans = $SPANS (pod: $POD)"
+                      exit 0
+                    fi
+                  fi
+                done
+                echo "Attempt $i: no collector pod has sent_spans > 0 yet" >&2
+                sleep 5
+              done
+              echo "FAIL: no collector pod exported spans after 12 attempts" >&2
+              exit 1
+      catch:
+        - podLogs:
+            selector: ($catchPodLabelSelector)
+            container: ($catchContainer)


### PR DESCRIPTION
## Summary

- Use `nginx-unprivileged:stable` on port 8080 instead of `nginx:stable` on port 80 in OBI target workloads. Standard nginx binds port 80, which fails on OpenShift where the restricted SCC runs containers with a random non-root UID.
- Inline telemetry steps (`wait-for-telemetry`, `validate-collector-spans`) to check **all** DaemonSet collector pods instead of only the first. OBI eBPF traces only appear in the collector pod on the same node as the target workload, so picking `items[0]` is flaky on multi-node clusters.
- For the unprivileged OBI test, skip telemetry steps on OpenShift with kernel < 6.4 (OCP 4.x / RHEL 9) where the base-6 capabilities are insufficient for the sk_msg/sockhash eBPF path. Spec reconciliation (DaemonSet, RBAC, CR status) is still validated on all platforms.

## Test plan

- [x] `smoke-collector-obi` passes on OpenShift 4.x (3-node cluster, kernel 5.14)
- [x] `smoke-collector-obi-unprivileged` passes on OpenShift 4.x — spec reconciliation validated, telemetry steps correctly skipped with kernel < 6.4
- [x] Both tests pass when run in parallel
- [x] Verify tests still pass on kind (single-node, kernel >= 6.4 — telemetry steps should run fully)