### PR TITLE
fix(auto-instrumentation): default OTEL_METRICS_EXPORTER to otlp for Node.js

### DIFF
--- a/.chloggen/fix-nodejs-metrics-exporter-default.yaml
+++ b/.chloggen/fix-nodejs-metrics-exporter-default.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: auto-instrumentation
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Default `OTEL_METRICS_EXPORTER` to `otlp` for Node.js auto-instrumentation so metrics are exported without extra configuration.
+
+# One or more tracking issues related to the change
+issues: [3768]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The Node.js SDK only initializes its metrics pipeline when a metric reader is configured, and the
+  webhook was not setting one. As a result, metrics silently stopped being exported for anyone relying
+  on the previous default behavior. The webhook now sets `OTEL_METRICS_EXPORTER=otlp` by default,
+  matching the existing behavior for Python auto-instrumentation, unless the user already set it.

--- a/internal/instrumentation/nodejs.go
+++ b/internal/instrumentation/nodejs.go
@@ -74,26 +74,32 @@ func injectNodeJSSDK(nodeJSSpec v1alpha1.NodeJS, pod *corev1.Pod, containers []*
 }
 
 func getDefaultNodeJSEnvVars(container *corev1.Container) []corev1.EnvVar {
+	var envVars []corev1.EnvVar
+
 	idx := getIndexOfEnv(container.Env, envNodeOptions)
 	if idx == -1 {
-		return []corev1.EnvVar{
-			{
-				Name:  envNodeOptions,
-				Value: nodeRequireArgument,
-			},
-		}
-	} else if idx > -1 {
-		// Don't modify NODE_OPTIONS if it uses ValueFrom
-		if container.Env[idx].ValueFrom != nil {
-			return []corev1.EnvVar{}
-		}
-		// NODE_OPTIONS is set, append the required argument
-		return []corev1.EnvVar{
-			{
-				Name:  envNodeOptions,
-				Value: container.Env[idx].Value + nodeRequireArgument,
-			},
-		}
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envNodeOptions,
+			Value: nodeRequireArgument,
+		})
+	} else if container.Env[idx].ValueFrom == nil {
+		// NODE_OPTIONS is set, append the required argument.
+		// Don't modify NODE_OPTIONS if it uses ValueFrom.
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envNodeOptions,
+			Value: container.Env[idx].Value + nodeRequireArgument,
+		})
 	}
-	return []corev1.EnvVar{}
+
+	// Set OTEL_METRICS_EXPORTER to otlp if not set by the user. The Node.js SDK only
+	// initializes the metrics SDK when a metric reader is configured, so without this
+	// default, metrics are silently dropped.
+	if getIndexOfEnv(container.Env, envOtelMetricsExporter) == -1 {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envOtelMetricsExporter,
+			Value: "otlp",
+		})
+	}
+
+	return envVars
 }

--- a/internal/instrumentation/nodejs_test.go
+++ b/internal/instrumentation/nodejs_test.go
@@ -67,6 +67,10 @@ func TestInjectNodeJSSDK(t *testing.T) {
 									Name:  "NODE_OPTIONS",
 									Value: " --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js",
 								},
+								{
+									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
+								},
 							},
 						},
 					},
@@ -127,6 +131,10 @@ func TestInjectNodeJSSDK(t *testing.T) {
 								{
 									Name:  "NODE_OPTIONS",
 									Value: "-Dbaz=bar" + " --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js",
+								},
+								{
+									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
 								},
 							},
 						},
@@ -214,6 +222,10 @@ func TestInjectNodeJSSDK(t *testing.T) {
 								{
 									Name:  "NODE_OPTIONS",
 									Value: " --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js",
+								},
+								{
+									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
 								},
 							},
 						},

--- a/internal/instrumentation/podmutator_test.go
+++ b/internal/instrumentation/podmutator_test.go
@@ -831,6 +831,10 @@ func TestMutatePod(t *testing.T) {
 									Value: nodeRequireArgument,
 								},
 								{
+									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
+								},
+								{
 									Name:  "OTEL_SERVICE_NAME",
 									Value: "app",
 								},
@@ -1023,6 +1027,10 @@ func TestMutatePod(t *testing.T) {
 									Value: nodeRequireArgument,
 								},
 								{
+									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
+								},
+								{
 									Name:  "OTEL_SERVICE_NAME",
 									Value: "app1",
 								},
@@ -1104,6 +1112,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:  "NODE_OPTIONS",
 									Value: nodeRequireArgument,
+								},
+								{
+									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
 								},
 								{
 									Name:  "OTEL_SERVICE_NAME",
@@ -4046,6 +4058,10 @@ func TestMutatePod(t *testing.T) {
 									Value: nodeRequireArgument,
 								},
 								{
+									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
+								},
+								{
 									Name:  "OTEL_SERVICE_NAME",
 									Value: "nodejs1",
 								},
@@ -4107,6 +4123,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:  "NODE_OPTIONS",
 									Value: nodeRequireArgument,
+								},
+								{
+									Name:  "OTEL_METRICS_EXPORTER",
+									Value: "otlp",
 								},
 								{
 									Name:  "OTEL_SERVICE_NAME",

--- a/internal/instrumentation/sdk_test.go
+++ b/internal/instrumentation/sdk_test.go
@@ -1105,6 +1105,10 @@ func TestInjectNodeJS(t *testing.T) {
 							Value: nodeRequireArgument,
 						},
 						{
+							Name:  "OTEL_METRICS_EXPORTER",
+							Value: "otlp",
+						},
+						{
 							Name:  "OTEL_SERVICE_NAME",
 							Value: "app",
 						},

--- a/tests/e2e-instrumentation/instrumentation-nodejs/00-install-instrumentation.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs/00-install-instrumentation.yaml
@@ -14,8 +14,6 @@ spec:
       value: always_on
     - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
       value: "true"
-    - name: OTEL_METRICS_EXPORTER
-      value: otlp
   exporter:
     endpoint: http://deployment-collector:4318
   propagators:

--- a/tests/e2e-instrumentation/instrumentation-nodejs/01-assert.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nodejs/01-assert.yaml
@@ -30,10 +30,10 @@ spec:
       value: always_on
     - name: SPLUNK_TRACE_RESPONSE_HEADER_ENABLED
       value: "true"
-    - name: OTEL_METRICS_EXPORTER
-      value: otlp
     - name: NODE_OPTIONS
       value: ' --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
+    - name: OTEL_METRICS_EXPORTER
+      value: otlp
     - name: OTEL_SERVICE_NAME
       value: my-nodejs
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME

--- a/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/01-assert.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-multi-multicontainer/01-assert.yaml
@@ -135,6 +135,8 @@ spec:
       value: "0.85"
     - name: NODE_OPTIONS
       value: ' --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
+    - name: OTEL_METRICS_EXPORTER
+      value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://deployment-collector:4317
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME

--- a/tests/e2e-multi-instrumentation/instrumentation-single-instr-first-container/01-assert.yaml
+++ b/tests/e2e-multi-instrumentation/instrumentation-single-instr-first-container/01-assert.yaml
@@ -26,6 +26,8 @@ spec:
       value: "0.85"
     - name: NODE_OPTIONS
       value: ' --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js'
+    - name: OTEL_METRICS_EXPORTER
+      value: otlp
     - name: OTEL_EXPORTER_OTLP_ENDPOINT
       value: http://deployment-collector:4317
     - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME


### PR DESCRIPTION
**Description:** The Node.js SDK only initializes its metrics pipeline when a metric reader is configured. Since the operator's Node.js auto-instrumentation webhook wasn't setting one (or the corresponding env var), metrics silently stopped being exported for anyone using Node.js auto-instrumentation and relying on the previous default behavior, even though traces and logs continued to work. This change defaults `OTEL_METRICS_EXPORTER` to `otlp` in `getDefaultNodeJSEnvVars` (`internal/instrumentation/nodejs.go`) when the user hasn't already set that env var on the container, mirroring the default already applied for Python auto-instrumentation in `getDefaultPythonEnvVars` (`internal/instrumentation/python.go`).

**Link to tracking Issue(s):**

- Resolves: #3768

**Testing:** Updated unit test expectations in `nodejs_test.go`, `sdk_test.go`, and `podmutator_test.go` to assert `OTEL_METRICS_EXPORTER=otlp` is injected by default and left untouched when already set by the user. Confirmed the tests are meaningful by temporarily reverting only `nodejs.go` (keeping the updated tests) and verifying `TestInjectNodeJS`, `TestInjectNodeJSSDK`, and `TestMutatePod` fail without the fix and pass with it restored. Ran and passed `go build ./...`, `go test ./internal/instrumentation/...`, `gofmt -l internal/instrumentation/nodejs.go internal/instrumentation/nodejs_test.go internal/instrumentation/podmutator_test.go internal/instrumentation/sdk_test.go`, `go vet ./internal/instrumentation/...`, and `make chlog-validate`.

**Documentation:** No documentation changes were required; this restores previous default behavior for Node.js metrics export.

---
AI assistance: this change was drafted with Claude Code.

Fixes #3768