### PR TITLE
Seed scrape labels before relabel filtering in target allocator

### DIFF
--- a/.chloggen/ta-seeded-labels-relabel.yaml
+++ b/.chloggen/ta-seeded-labels-relabel.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Seed Prometheus's scrape labels (`job`, `__scheme__`, `__metrics_path__`, `__scrape_interval__`, `__scrape_timeout__`, `__param_*`) before relabel filtering, so keep/drop rules referencing them make the same decisions as Prometheus instead of silently dropping or over-allocating targets
+
+# One or more tracking issues related to the change
+issues: [5246]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The seeded labels also feed the target identity hash, matching Prometheus's post-relabel label partition more closely. With the `relabel-config` filter strategy enabled, existing targets are re-allocated once on upgrade because their hashes change. The served (pre-relabel) target labels are unchanged.

--- a/cmd/otel-allocator/internal/conformance/conformance_test.go
+++ b/cmd/otel-allocator/internal/conformance/conformance_test.go
@@ -36,9 +36,7 @@ var seededLabels = []string{
 
 // divergentFixtures are fixtures whose behavior is known to differ from raw
 // Prometheus. They are skipped until the allocator is fixed.
-var divergentFixtures = map[string]string{
-	"seeded-labels": "relabel rules referencing scrape-seeded labels diverge from Prometheus (regression of #4074); see testdata/gap-seeded-labels/",
-}
+var divergentFixtures = map[string]string{}
 
 // TestConformance runs every fixture under testdata/ through the target
 // allocator and compares against the committed promtool golden.

--- a/cmd/otel-allocator/internal/conformance/testdata/README.md
+++ b/cmd/otel-allocator/internal/conformance/testdata/README.md
@@ -39,7 +39,7 @@ For every fixture the suite compares the allocator's discovery+relabel result ag
 ## Known divergences
 
 Fixtures whose behavior currently differs from raw Prometheus are listed in
-`divergentFixtures` in `../conformance_test.go` and skipped with a reason. See `seeded-labels/` for an example (relabel rules on scrape-seeded labels).
+`divergentFixtures` in `../conformance_test.go` and skipped with a reason.
 
 ## Adding or updating a case
 

--- a/cmd/otel-allocator/internal/conformance/testdata/seeded-labels/prometheus.yaml
+++ b/cmd/otel-allocator/internal/conformance/testdata/seeded-labels/prometheus.yaml
@@ -1,9 +1,9 @@
-# SEEDING-GAP PROBES (documented divergence). Each job's relabel rule references
-# a label Prometheus seeds before relabeling (job, __scheme__, ...) but the
-# allocator's filter does not. Prometheus and the allocator therefore make
-# different keep/drop decisions. See KNOWN_DIVERGENCE.md.
+# SEEDED-LABEL PROBES (regression coverage for #5246). Each job's relabel rule
+# references a label Prometheus seeds before relabeling (job, __scheme__, ...).
+# The allocator seeds the same labels transiently for relabeling, so keep/drop
+# decisions must match Prometheus.
 scrape_configs:
-  # keep on `job`: Prometheus keeps (job is seeded), allocator drops -> silent loss.
+  # keep on `job`: Prometheus keeps (job is seeded); the allocator must too.
   - job_name: gap-keep-on-job
     static_configs:
       - targets: ['10.20.0.1:9100']
@@ -17,8 +17,8 @@ scrape_configs:
     relabel_configs:
       - {source_labels: [__scheme__], regex: 'http', action: keep}
 
-  # drop on `job`: opposite direction — Prometheus drops, allocator keeps
-  # (over-allocates; the collector re-relabels and drops, so less harmful).
+  # drop on `job`: opposite direction — Prometheus drops, and the allocator must
+  # drop too instead of over-allocating a target the collector later drops.
   - job_name: gap-drop-on-job
     static_configs:
       - targets: ['10.20.0.3:9100']

--- a/cmd/otel-allocator/internal/target/discovery.go
+++ b/cmd/otel-allocator/internal/target/discovery.go
@@ -41,6 +41,7 @@ type Discoverer struct {
 	mtxScrape                   sync.Mutex // Guards the fields below.
 	configsMap                  map[allocatorWatcher.EventSource][]*promconfig.ScrapeConfig
 	relabelCfg                  map[string][]*relabel.Config
+	scrapeSeeds                 map[string][]labels.Label
 	filterRelabelConfig         bool
 	scrapeConfigsHash           hash.Hash
 	scrapeConfigsUpdater        scrapeConfigsUpdater
@@ -107,6 +108,7 @@ func NewDiscoverer(
 		triggerReload:               make(chan struct{}, 1),
 		configsMap:                  make(map[allocatorWatcher.EventSource][]*promconfig.ScrapeConfig),
 		relabelCfg:                  make(map[string][]*relabel.Config),
+		scrapeSeeds:                 make(map[string][]labels.Label),
 		filterRelabelConfig:         filterStrategy == RelabelConfigFilterStrategy,
 		scrapeConfigsHash:           nil, // we want the first update to succeed even if the config is empty
 		scrapeConfigsUpdater:        scrapeConfigsUpdater,
@@ -128,6 +130,7 @@ func (m *Discoverer) ApplyConfig(source allocatorWatcher.EventSource, scrapeConf
 
 	discoveryCfg := make(map[string]discovery.Configs)
 	relabelCfg := make(map[string][]*relabel.Config)
+	scrapeSeeds := make(map[string][]labels.Label)
 
 	for _, configs := range m.configsMap {
 		for _, scrapeConfig := range configs {
@@ -139,6 +142,7 @@ func (m *Discoverer) ApplyConfig(source allocatorWatcher.EventSource, scrapeConf
 			// we leave relabelCfg empty so no relabeling/filtering is done during discovery.
 			if m.filterRelabelConfig {
 				relabelCfg[scrapeConfig.JobName] = addNoShardingConfig(scrapeConfig.RelabelConfigs)
+				scrapeSeeds[scrapeConfig.JobName] = scrapeConfigSeeds(scrapeConfig)
 			}
 		}
 	}
@@ -160,6 +164,7 @@ func (m *Discoverer) ApplyConfig(source allocatorWatcher.EventSource, scrapeConf
 
 	m.mtxScrape.Lock()
 	m.relabelCfg = relabelCfg
+	m.scrapeSeeds = scrapeSeeds
 	m.mtxScrape.Unlock()
 
 	return m.manager.ApplyConfig(discoveryCfg)
@@ -224,12 +229,13 @@ func (m *Discoverer) Reload() {
 	jobIndex := 0
 	for jobName, groups := range m.targetSets {
 		relabelCfg := m.relabelCfg[jobName]
+		seeds := m.scrapeSeeds[jobName]
 		wg.Add(1)
 		// Run the sync in parallel as these take a while and at high load can't catch up.
-		go func(idx int, jobName string, groups []*targetgroup.Group, relabelCfg []*relabel.Config) {
+		go func(idx int, jobName string, groups []*targetgroup.Group, relabelCfg []*relabel.Config, seeds []labels.Label) {
 			defer wg.Done()
-			jobResults[idx] = m.processTargetGroups(jobName, groups, relabelCfg)
-		}(jobIndex, jobName, groups, relabelCfg)
+			jobResults[idx] = m.processTargetGroups(jobName, groups, relabelCfg, seeds)
+		}(jobIndex, jobName, groups, relabelCfg, seeds)
 		jobIndex++
 	}
 	m.mtxScrape.Unlock()
@@ -251,7 +257,7 @@ func (m *Discoverer) Reload() {
 // by relabeling are excluded from the result, and for the targets that are kept the hash is
 // computed from the relabeled labels while the builder is still available, avoiding a later
 // recomputation.
-func (m *Discoverer) processTargetGroups(jobName string, groups []*targetgroup.Group, relabelCfg []*relabel.Config) []*Item {
+func (m *Discoverer) processTargetGroups(jobName string, groups []*targetgroup.Group, relabelCfg []*relabel.Config, seeds []labels.Label) []*Item {
 	// the builder for group labels
 	groupBuilder := labels.NewScratchBuilder(labelBuilderPreallocSize)
 
@@ -310,6 +316,15 @@ func (m *Discoverer) processTargetGroups(jobName string, groups []*targetgroup.G
 			// here, rather than lazily later.
 			relabelBuilder.Reset(itemLabels)
 			if len(relabelCfg) > 0 {
+				// Seed the labels Prometheus's scrape layer adds before relabeling
+				// (PopulateDiscoveredLabels), so keep/drop rules referencing them
+				// (e.g. job, __scheme__) behave the same as in Prometheus. Target and
+				// group labels take precedence, matching Prometheus.
+				for _, seed := range seeds {
+					if relabelBuilder.Get(seed.Name) == "" {
+						relabelBuilder.Set(seed.Name, seed.Value)
+					}
+				}
 				if keepTarget := relabel.ProcessBuilder(relabelBuilder, relabelCfg...); !keepTarget {
 					continue
 				}
@@ -324,6 +339,28 @@ func (m *Discoverer) processTargetGroups(jobName string, groups []*targetgroup.G
 }
 
 const disableShardingLabelName = "__tmp_disable_sharding"
+
+// scrapeConfigSeeds returns the labels Prometheus's scrape layer sets on every
+// target before relabeling (see PopulateDiscoveredLabels): the scrape config's
+// job, scheme, metrics path, interval, timeout, and query params. The allocator
+// applies them transiently for relabeling and hashing only; they are not part of
+// the served target labels, which the collector's Prometheus receiver seeds itself.
+func scrapeConfigSeeds(cfg *promconfig.ScrapeConfig) []labels.Label {
+	seeds := make([]labels.Label, 0, 5+len(cfg.Params))
+	seeds = append(seeds,
+		labels.Label{Name: model.JobLabel, Value: cfg.JobName},
+		labels.Label{Name: model.ScrapeIntervalLabel, Value: cfg.ScrapeInterval.String()},
+		labels.Label{Name: model.ScrapeTimeoutLabel, Value: cfg.ScrapeTimeout.String()},
+		labels.Label{Name: model.MetricsPathLabel, Value: cfg.MetricsPath},
+		labels.Label{Name: model.SchemeLabel, Value: cfg.Scheme},
+	)
+	for k, v := range cfg.Params {
+		if len(v) > 0 {
+			seeds = append(seeds, labels.Label{Name: model.ParamLabelPrefix + k, Value: v[0]})
+		}
+	}
+	return seeds
+}
 
 // addNoShardingConfig adds a relabel config to disable sharding for the given job. This is needed because the scrape
 // configs generated by prometheus-operator by default depend on a `SHARD` environment variable, even in non-sharded

--- a/cmd/otel-allocator/internal/target/discovery_test.go
+++ b/cmd/otel-allocator/internal/target/discovery_test.go
@@ -496,7 +496,7 @@ func TestProcessTargetGroups_StableLabelIterationOrder(t *testing.T) {
 	manager := discovery.NewManager(ctx, config.NopLogger, registry, sdMetrics)
 	d, err := NewDiscoverer(ctrl.Log.WithName("test"), manager, RelabelConfigFilterStrategy, scu, nil)
 	require.NoError(t, err)
-	results := d.processTargetGroups("test", groups, nil)
+	results := d.processTargetGroups("test", groups, nil, nil)
 	require.Len(t, results, 1)
 
 	i := 0
@@ -607,7 +607,7 @@ func TestProcessTargetGroupsRelabelFiltering(t *testing.T) {
 		},
 	}
 
-	got := d.processTargetGroups("test", groups, relabelCfg)
+	got := d.processTargetGroups("test", groups, relabelCfg, nil)
 	require.Len(t, got, 2)
 	gotURLs := []string{got[0].TargetURL, got[1].TargetURL}
 	slices.Sort(gotURLs)
@@ -615,6 +615,75 @@ func TestProcessTargetGroupsRelabelFiltering(t *testing.T) {
 	for _, item := range got {
 		assert.NotZero(t, item.hash, "kept targets should carry a precomputed hash")
 	}
+}
+
+// TestProcessTargetGroupsSeededLabels verifies that relabel rules referencing
+// labels Prometheus seeds before relabeling (job, __scheme__, ...) make the same
+// keep/drop decisions as Prometheus, and that the seeds neither leak into the
+// served labels nor override labels already present on the target.
+// Regression test for https://github.com/open-telemetry/opentelemetry-operator/issues/5246.
+func TestProcessTargetGroupsSeededLabels(t *testing.T) {
+	d := newTestDiscoverer(t, RelabelConfigFilterStrategy, nil)
+	scrapeCfg := &promconfig.ScrapeConfig{
+		JobName:        "seeded-job",
+		Scheme:         "http",
+		MetricsPath:    "/metrics",
+		ScrapeInterval: model.Duration(time.Minute),
+		ScrapeTimeout:  model.Duration(10 * time.Second),
+	}
+	seeds := scrapeConfigSeeds(scrapeCfg)
+	groups := []*targetgroup.Group{
+		{
+			Targets: []model.LabelSet{
+				{model.AddressLabel: "10.0.0.1:9090"},
+				// A target-provided scheme wins over the seeded one, matching Prometheus.
+				{model.AddressLabel: "10.0.0.2:9090", model.SchemeLabel: "https"},
+			},
+		},
+	}
+
+	t.Run("keep on seeded job label", func(t *testing.T) {
+		relabelCfg := []*relabel.Config{
+			{
+				SourceLabels: model.LabelNames{"job"},
+				Regex:        relabel.MustNewRegexp("seeded-job"),
+				Action:       relabel.Keep,
+			},
+		}
+		got := d.processTargetGroups("seeded-job", groups, relabelCfg, seeds)
+		require.Len(t, got, 2)
+		for _, item := range got {
+			assert.Empty(t, item.Labels.Get("job"), "seeds must not leak into the served labels")
+		}
+		byURL := map[string]*Item{got[0].TargetURL: got[0], got[1].TargetURL: got[1]}
+		assert.Empty(t, byURL["10.0.0.1:9090"].Labels.Get(model.SchemeLabel), "seeds must not leak into the served labels")
+		assert.Equal(t, "https", byURL["10.0.0.2:9090"].Labels.Get(model.SchemeLabel), "target-provided labels must be served verbatim")
+	})
+
+	t.Run("drop on seeded job label", func(t *testing.T) {
+		relabelCfg := []*relabel.Config{
+			{
+				SourceLabels: model.LabelNames{"job"},
+				Regex:        relabel.MustNewRegexp("seeded-job"),
+				Action:       relabel.Drop,
+			},
+		}
+		got := d.processTargetGroups("seeded-job", groups, relabelCfg, seeds)
+		assert.Empty(t, got)
+	})
+
+	t.Run("keep on seeded scheme label respects target precedence", func(t *testing.T) {
+		relabelCfg := []*relabel.Config{
+			{
+				SourceLabels: model.LabelNames{model.SchemeLabel},
+				Regex:        relabel.MustNewRegexp("http"),
+				Action:       relabel.Keep,
+			},
+		}
+		got := d.processTargetGroups("seeded-job", groups, relabelCfg, seeds)
+		require.Len(t, got, 1)
+		assert.Equal(t, "10.0.0.1:9090", got[0].TargetURL, "the https target must not match the seeded http scheme")
+	})
 }
 
 // TestProcessTargetGroupsNoRelabelConfig verifies that when there's no relabel config for a job,
@@ -631,7 +700,7 @@ func TestProcessTargetGroupsNoRelabelConfig(t *testing.T) {
 		},
 	}
 
-	got := d.processTargetGroups("test", groups, nil)
+	got := d.processTargetGroups("test", groups, nil, nil)
 	require.Len(t, got, 2)
 	for _, item := range got {
 		// The hash is computed at creation, from the same builder-based function whether or not
@@ -661,7 +730,7 @@ func TestProcessTargetGroupsDeduplicatesByHash(t *testing.T) {
 		},
 	}
 
-	got := d.processTargetGroups("test", groups, relabelCfg)
+	got := d.processTargetGroups("test", groups, relabelCfg, nil)
 	require.Len(t, got, 2)
 	assert.Equal(t, got[0].Hash(), got[1].Hash(), "targets identical after relabeling should share a hash")
 }


### PR DESCRIPTION
**Description:**

The target allocator applied `relabel_configs` to raw discovery labels, while Prometheus first seeds scrape labels (`job`, `__scheme__`, `__metrics_path__`, `__scrape_interval__`, `__scrape_timeout__`, `__param_*`) via `PopulateDiscoveredLabels`. Keep/drop rules referencing those labels therefore made inverted decisions in the allocator: `keep` rules silently dropped targets, `drop` rules kept them.

The fix mirrors Prometheus: per-job seed labels are computed in `ApplyConfig` and applied transiently to the relabel builder (target/group labels take precedence) before relabeling and identity hashing. Served (pre-relabel) target labels are unchanged — the collector's Prometheus receiver seeds those itself. The seeded labels also feed the identity hash, aligning the allocator's target-identity partition with Prometheus's post-relabel label partition.

This is deliberately scoped to the relabel-filtering path and complements #5018, which addresses the broader label-initialization gap in #4074. With the `relabel-config` filter strategy enabled, existing targets are re-allocated once on upgrade because their hashes change (noted in the changelog entry).

**Link to tracking Issue(s):**

- Resolves: #5246

**Testing:**

- Unskips the `seeded-labels` conformance fixture; full differential suite passes 19/19 against promtool goldens.
- Adds `TestProcessTargetGroupsSeededLabels` (keep/drop on `job`, keep on `__scheme__` with target-label precedence, no seed leakage into served labels).
- `go test ./cmd/otel-allocator/...` — all packages pass; golangci-lint clean.

**Documentation:** n/a