### PR TITLE
Add support for Kubernetes 1.36

### DIFF
--- a/.chloggen/k8s-1.36-support.yaml
+++ b/.chloggen/k8s-1.36-support.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for Kubernetes 1.36
+
+# One or more tracking issues related to the change
+issues: [5354]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -69,7 +69,7 @@ jobs:
         # should be compatible with them.
         kube-version:
         - "1.25"
-        - "1.35"
+        - "1.36"
         group:
         - e2e
         - e2e-automatic-rbac

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         kube-version:
           - "1.25"
-          - "1.35"
+          - "1.36"
 
     steps:
 

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ endif
 
 START_KIND_CLUSTER ?= true
 
-KUBE_VERSION ?= 1.35
+KUBE_VERSION ?= 1.36
 KIND_CONFIG ?= kind-$(KUBE_VERSION).yaml
 KIND_CLUSTER_NAME ?= "otel-operator"
 CHAINSAW_SELECTOR := $(shell [ "$(shell printf '%s\n' "$(KUBE_VERSION)" "1.29" | sort -V | head -n1)" = "1.29" ] && echo "--selector sidecar=native" || echo "--selector sidecar=legacy")

--- a/kind-1.36.yaml
+++ b/kind-1.36.yaml
@@ -1,0 +1,20 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: dual
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP


### PR DESCRIPTION
Following up on the discussion in #5448 (release v0.157.0 prep), this adds Kubernetes 1.36 support as a separate PR, mirroring the approach taken for 1.35 in #4582 and 1.34 in #4416.

Kubernetes 1.36 is now released and upstream-supported (current maintained minors: 1.34, 1.35, 1.36), so per the operator's compatibility policy this support should be added.

## Changes
- `.github/workflows/e2e-reusable.yaml`: bump the highest K8s version in the e2e matrix from `1.35` to `1.36` (the `1.25` floor is unchanged).
- `.github/workflows/scorecard.yaml`: bump the highest K8s version from `1.35` to `1.36`.
- `Makefile`: default `KUBE_VERSION` from `1.35` to `1.36`.
- `kind-1.36.yaml`: new kind cluster config using `kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5`.

## Notes
- The compatibility matrix in `docs/getting-started/compatibility.md` is intentionally **not** touched here; it is updated during release prep (see RELEASE.md). If this PR merges before #5448, the v0.157.0 row there will be rebased to `v1.25 to v1.36`.
- No change to `tests/e2e-crd-validations/sidecar/chainsaw-test.yaml` is needed. The CEL validation error message format changed in Kubernetes 1.35 (object-typed fields now omit the value/type, via [kubernetes/kubernetes#132798](https://github.com/kubernetes/kubernetes/pull/132798) and the follow-up that omits the value type) and is **unchanged in 1.36**, so the existing `minorVersion >= 35` branch already covers 1.36.

Refs #5354