### PR TITLE
clusterobservability: reconcile managed resource updates

### DIFF
--- a/.chloggen/clusterobservability-managed-resource-updates.yaml
+++ b/.chloggen/clusterobservability-managed-resource-updates.yaml
@@ -1,0 +1,13 @@
+change_type: bug_fix
+
+component: cluster-observability
+
+note: Keep ClusterObservability managed resources up to date
+
+issues: [5450]
+
+subtext: |
+  Apply exporter configuration changes to both managed Collectors and propagate
+  updated default Collector and auto-instrumentation images after operator
+  upgrades. Preserve unrelated metadata and avoid updates caused only by
+  API-server defaults.

--- a/docs/collector/cluster-observability.md
+++ b/docs/collector/cluster-observability.md
@@ -133,6 +133,22 @@ sequenceDiagram
     Controller->>Controller: Reconcile Changes
 ```
 
+The controller rebuilds desired state on every reconciliation. When the
+`ClusterObservability` spec changes, it updates both managed
+`OpenTelemetryCollector` resources and the managed `Instrumentation` resource.
+Their respective controllers perform workload rollouts, while instrumentation
+changes apply to newly created pods.
+
+### Operator upgrades
+
+The generated collectors use the manager's
+`clusterobservability-collector-image` value explicitly. When a new operator
+version starts, its informer initially enqueues existing
+`ClusterObservability` resources. Rebuilding desired state propagates a changed
+collector image to both child collectors even though the parent generation is
+unchanged. The collector controller then performs the normal DaemonSet and
+StatefulSet rollouts.
+
 ## Feature Gate
 
 ClusterObservability is controlled by the `operator.clusterobservability` feature gate:

--- a/internal/controllers/clusterobservability_controller.go
+++ b/internal/controllers/clusterobservability_controller.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -33,6 +34,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/clusterobservability"
 	coStatus "github.com/open-telemetry/opentelemetry-operator/internal/status/clusterobservability"
+	"github.com/open-telemetry/opentelemetry-operator/internal/webhook"
 )
 
 // ClusterObservabilityReconciler reconciles a ClusterObservability object.
@@ -52,6 +54,8 @@ type ClusterObservabilityReconcilerParams struct {
 	Log      logr.Logger
 	Config   config.Config
 }
+
+const clusterObservabilityResourceOwnerKey = ".metadata.owner"
 
 func (r *ClusterObservabilityReconciler) getParams(instance v1alpha1.ClusterObservability) manifests.Params {
 	return manifests.Params{
@@ -118,19 +122,8 @@ func (r *ClusterObservabilityReconciler) Reconcile(ctx context.Context, req ctrl
 		return coStatus.HandleReconcileStatus(ctx, log, params, errors.New("multiple ClusterObservability resources detected"))
 	}
 
-	// TODO: Add upgrade support
+	// Rebuild desired state on every reconcile so manager defaults propagate after upgrades.
 	// TODO: Support management state like OpenTelemetryCollector
-
-	configChanged, configErr := coStatus.DetectConfigChanges(&instance)
-	if configErr != nil {
-		log.Error(configErr, "failed to detect config changes")
-	}
-
-	if configChanged {
-		log.Info("Configuration changes detected - triggering full reconciliation")
-		r.recorder.Eventf(&instance, nil, corev1.EventTypeNormal, "ConfigChanged", "ConfigChanged",
-			"Collector configuration has changed, updating managed resources")
-	}
 
 	// Add finalizer to ensure proper resource cleanup
 	if !controllerutil.ContainsFinalizer(&instance, v1alpha1.ClusterObservabilityFinalizer) {
@@ -165,124 +158,65 @@ func (r *ClusterObservabilityReconciler) Reconcile(ctx context.Context, req ctrl
 		}
 	}
 
-	// Handle OpenTelemetry CRs - their controllers manage the underlying resources
-	for _, crObj := range openTelemetryCRs {
-		if err := r.reconcileOpenTelemetryResource(ctx, log, crObj); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile OpenTelemetry CR %s: %w", crObj.GetObjectKind(), err)
-		}
-	}
-
-	// Handle Unstructured objects (like OpenShift SCC) separately to avoid deep copy issues
+	// Prerequisites such as the OpenShift SCC must exist before child controllers
+	// can create their workloads.
 	for _, unstructuredObj := range unstructuredObjects {
 		if err := r.reconcileUnstructuredResource(ctx, log, unstructuredObj); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to reconcile unstructured resource %s: %w", unstructuredObj.GetName(), err)
 		}
 	}
-	// Handle regular Kubernetes resources (currently none - OpenTelemetry CRs handle their own resources)
-	if len(regularObjects) > 0 {
-		ownedObjects, err := r.findClusterObservabilityOwnedObjects(ctx, params)
-		if err != nil {
-			return ctrl.Result{}, err
+	for _, crObj := range openTelemetryCRs {
+		if err := r.defaultOpenTelemetryResource(ctx, log, crObj); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to default desired %T %s: %w", crObj, client.ObjectKeyFromObject(crObj), err)
 		}
-		err = reconcileDesiredObjects(ctx, r.Client, log, &params.ClusterObservability, params.Scheme, regularObjects, ownedObjects)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+	}
+
+	ownedObjects, err := r.findClusterObservabilityOwnedObjects(ctx, params)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	managedObjects := append(openTelemetryCRs, regularObjects...)
+	if err := reconcileDesiredObjects(ctx, r.Client, log, &params.ClusterObservability, params.Scheme, managedObjects, ownedObjects); err != nil {
+		return ctrl.Result{}, err
 	}
 	return coStatus.HandleReconcileStatus(ctx, log, params, nil)
 }
 
-// reconcileOpenTelemetryResource creates/updates OpenTelemetry CRs.
-// Their respective controllers handle the underlying Kubernetes resources.
-// TODO: fix issue with resourceVersion becoming stale due to updates from OpenTelemetryCollector/Instrumentation controllers.
-func (r *ClusterObservabilityReconciler) reconcileOpenTelemetryResource(ctx context.Context, log logr.Logger, desired client.Object) error {
-	key := client.ObjectKeyFromObject(desired)
-
-	var existing client.Object
-	switch desired.(type) {
+func (r *ClusterObservabilityReconciler) defaultOpenTelemetryResource(
+	ctx context.Context,
+	log logr.Logger,
+	desired client.Object,
+) error {
+	switch resource := desired.(type) {
 	case *v1beta1.OpenTelemetryCollector:
-		existing = &v1beta1.OpenTelemetryCollector{}
+		// Default is nil-safe without the optional admission and event collaborators.
+		defaulter := webhook.NewCollectorWebhook(log, r.scheme, r.config, nil, nil, nil, nil, nil)
+		if err := defaulter.Default(ctx, resource); err != nil {
+			return err
+		}
+		return normalizeCollectorConfigForAPI(resource)
 	case *v1alpha1.Instrumentation:
-		existing = &v1alpha1.Instrumentation{}
+		defaulter := webhook.NewInstrumentationWebhook(log, r.scheme, r.config)
+		return defaulter.Default(ctx, resource)
 	default:
 		return fmt.Errorf("unsupported CRD type: %T", desired)
 	}
+}
 
-	getErr := r.Get(ctx, key, existing)
-
-	if getErr != nil {
-		if apierrors.IsNotFound(getErr) {
-			if createErr := r.Create(ctx, desired); createErr != nil {
-				return fmt.Errorf("failed to create %s %s: %w", desired.GetObjectKind().GroupVersionKind().Kind, key, createErr)
-			}
-			log.Info("Created CR", "kind", desired.GetObjectKind().GroupVersionKind().Kind, "name", key.Name, "namespace", key.Namespace)
-			return nil
-		}
-		return fmt.Errorf("failed to get %s %s: %w", desired.GetObjectKind().GroupVersionKind().Kind, key, getErr)
+// normalizeCollectorConfigForAPI round-trips opaque values through JSON so
+// webhook defaults use the same dynamic types as API-server values.
+func normalizeCollectorConfigForAPI(resource *v1beta1.OpenTelemetryCollector) error {
+	// AnyConfig's custom marshaler has a pointer receiver.
+	configJSON, err := json.Marshal(&resource.Spec.Config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal desired collector config: %w", err)
 	}
-	switch existingCRD := existing.(type) {
-	case *v1beta1.OpenTelemetryCollector:
-		desiredCRD := desired.(*v1beta1.OpenTelemetryCollector)
-		if !apiequality.Semantic.DeepEqual(existingCRD.Spec, desiredCRD.Spec) {
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				latest := &v1beta1.OpenTelemetryCollector{}
-				if err := r.Get(ctx, key, latest); err != nil {
-					return err
-				}
-
-				// Only update if still different (another controller might have updated it)
-				if apiequality.Semantic.DeepEqual(latest.Spec, desiredCRD.Spec) {
-					log.Info("OpenTelemetryCollector already matches desired state", "name", key.Name, "namespace", key.Namespace)
-					return nil
-				}
-
-				// Update the latest version with our desired changes
-				latest.Spec = desiredCRD.Spec
-				latest.Labels = desiredCRD.Labels
-				latest.Annotations = desiredCRD.Annotations
-
-				return r.Update(ctx, latest)
-			})
-			if err != nil {
-				return fmt.Errorf("failed to update OpenTelemetryCollector %s: %w", key, err)
-			}
-
-			log.Info("Updated OpenTelemetryCollector", "name", key.Name, "namespace", key.Namespace)
-		}
-
-	case *v1alpha1.Instrumentation:
-		desiredCRD := desired.(*v1alpha1.Instrumentation)
-		if !apiequality.Semantic.DeepEqual(existingCRD.Spec, desiredCRD.Spec) {
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				latest := &v1alpha1.Instrumentation{}
-				if err := r.Get(ctx, key, latest); err != nil {
-					return err
-				}
-
-				// Only update if still different (another controller might have updated it)
-				if apiequality.Semantic.DeepEqual(latest.Spec, desiredCRD.Spec) {
-					log.Info("Instrumentation already matches desired state", "name", key.Name, "namespace", key.Namespace)
-					return nil
-				}
-
-				// Update the latest version with our desired changes
-				latest.Spec = desiredCRD.Spec
-				latest.Labels = desiredCRD.Labels
-				latest.Annotations = desiredCRD.Annotations
-
-				return r.Update(ctx, latest)
-			})
-			if err != nil {
-				return fmt.Errorf("failed to update Instrumentation %s: %w", key, err)
-			}
-
-			log.Info("Updated Instrumentation", "name", key.Name, "namespace", key.Namespace)
-		}
-
-	default:
-		return fmt.Errorf("unsupported CRD type: %T", existing)
+	var normalized v1beta1.Config
+	if err := json.Unmarshal(configJSON, &normalized); err != nil {
+		return fmt.Errorf("failed to normalize desired collector config: %w", err)
 	}
-
+	resource.Spec.Config = normalized
 	return nil
 }
 
@@ -290,6 +224,10 @@ func (r *ClusterObservabilityReconciler) reconcileOpenTelemetryResource(ctx cont
 // without deep copy issues that occur with complex nested data.
 func (r *ClusterObservabilityReconciler) reconcileUnstructuredResource(ctx context.Context, log logr.Logger, obj client.Object) error {
 	unstructuredObj := obj.(*unstructured.Unstructured)
+	normalizedDesired, err := normalizeUnstructuredForAPI(unstructuredObj)
+	if err != nil {
+		return fmt.Errorf("failed to normalize unstructured resource %s: %w", unstructuredObj.GetName(), err)
+	}
 
 	// Create a new Unstructured object for fetching existing resource
 	// This avoids deep copy issues with the desired object
@@ -304,18 +242,37 @@ func (r *ClusterObservabilityReconciler) reconcileUnstructuredResource(ctx conte
 
 	if apierrors.IsNotFound(getErr) {
 		// Create new resource
-		if createErr := r.Create(ctx, unstructuredObj); createErr != nil {
+		if createErr := r.Create(ctx, normalizedDesired); createErr != nil {
 			return fmt.Errorf("failed to create unstructured resource %s: %w", unstructuredObj.GetName(), createErr)
 		}
 		log.Info("Created unstructured resource",
 			"kind", unstructuredObj.GetKind(),
 			"name", unstructuredObj.GetName())
-		// Check if update is needed by comparing specs
-	} else if !apiequality.Semantic.DeepEqual(existing.Object, unstructuredObj.Object) {
-		unstructuredObj.SetResourceVersion(existing.GetResourceVersion())
-		if updateErr := r.Update(ctx, unstructuredObj); updateErr != nil {
-			return fmt.Errorf("failed to update unstructured resource %s: %w", unstructuredObj.GetName(), updateErr)
+		return nil
+	}
+
+	updated := false
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &unstructured.Unstructured{}
+		latest.SetGroupVersionKind(unstructuredObj.GroupVersionKind())
+		if err := r.Get(ctx, key, latest); err != nil {
+			return err
 		}
+
+		candidate := latest.DeepCopy()
+		applyDesiredUnstructuredResource(candidate, normalizedDesired)
+		if apiequality.Semantic.DeepEqual(latest.Object, candidate.Object) {
+			return nil
+		}
+		if err := r.Update(ctx, candidate); err != nil {
+			return err
+		}
+		updated = true
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to update unstructured resource %s: %w", unstructuredObj.GetName(), err)
+	}
+	if updated {
 		log.Info("Updated unstructured resource",
 			"kind", unstructuredObj.GetKind(),
 			"name", unstructuredObj.GetName())
@@ -324,10 +281,49 @@ func (r *ClusterObservabilityReconciler) reconcileUnstructuredResource(ctx conte
 	return nil
 }
 
+func normalizeUnstructuredForAPI(resource *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	data, err := json.Marshal(resource.Object)
+	if err != nil {
+		return nil, err
+	}
+	normalized := &unstructured.Unstructured{}
+	if err := json.Unmarshal(data, normalized); err != nil {
+		return nil, err
+	}
+	normalized.SetGroupVersionKind(resource.GroupVersionKind())
+	return normalized, nil
+}
+
+func applyDesiredUnstructuredResource(existing, desired *unstructured.Unstructured) {
+	if desiredLabels := desired.GetLabels(); len(desiredLabels) > 0 {
+		labels := maps.Clone(existing.GetLabels())
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		maps.Copy(labels, desiredLabels)
+		existing.SetLabels(labels)
+	}
+
+	if desiredAnnotations := desired.GetAnnotations(); len(desiredAnnotations) > 0 {
+		annotations := maps.Clone(existing.GetAnnotations())
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		maps.Copy(annotations, desiredAnnotations)
+		existing.SetAnnotations(annotations)
+	}
+
+	for key, value := range desired.Object {
+		if key == "apiVersion" || key == "kind" || key == "metadata" {
+			continue
+		}
+		existing.Object[key] = runtime.DeepCopyJSONValue(value)
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterObservabilityReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	err := r.SetupCaches(mgr)
-	if err != nil {
+	if err := r.SetupCaches(mgr.GetCache()); err != nil {
 		return err
 	}
 
@@ -346,27 +342,22 @@ func (r *ClusterObservabilityReconciler) SetupWithManager(mgr ctrl.Manager) erro
 	return builder.Complete(r)
 }
 
-// SetupCaches sets up field indexing for efficient owned object queries.
-func (r *ClusterObservabilityReconciler) SetupCaches(mgr ctrl.Manager) error {
-	const clusterObservabilityResourceOwnerKey = ".metadata.owner"
-
-	ownedResources := r.GetOwnedResourceTypes()
-	for _, resource := range ownedResources {
-		if err := mgr.GetCache().IndexField(context.Background(), resource, clusterObservabilityResourceOwnerKey, func(rawObj client.Object) []string {
-			owner := metav1.GetControllerOf(rawObj)
-			if owner == nil {
-				return nil
-			}
-			// Make sure it's a ClusterObservability
-			if owner.APIVersion != v1alpha1.GroupVersion.String() || owner.Kind != "ClusterObservability" {
-				return nil
-			}
-			return []string{owner.Name}
-		}); err != nil {
+// SetupCaches indexes resources by their ClusterObservability controller owner.
+func (r *ClusterObservabilityReconciler) SetupCaches(indexer client.FieldIndexer) error {
+	for _, resource := range r.GetOwnedResourceTypes() {
+		if err := indexer.IndexField(context.Background(), resource, clusterObservabilityResourceOwnerKey, clusterObservabilityOwnerName); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func clusterObservabilityOwnerName(rawObj client.Object) []string {
+	owner := metav1.GetControllerOf(rawObj)
+	if owner == nil || owner.APIVersion != v1alpha1.GroupVersion.String() || owner.Kind != "ClusterObservability" {
+		return nil
+	}
+	return []string{owner.Name}
 }
 
 // findClusterObservabilityForNamespace finds ClusterObservability instances when namespaces change.
@@ -535,24 +526,19 @@ func (*ClusterObservabilityReconciler) GetOwnedResourceTypes() []client.Object {
 	}
 }
 
-// findClusterObservabilityOwnedObjects finds OpenTelemetry CRs owned by ClusterObservability for cleanup.
 func (r *ClusterObservabilityReconciler) findClusterObservabilityOwnedObjects(ctx context.Context, params manifests.Params) (map[types.UID]client.Object, error) {
-	const clusterObservabilityResourceOwnerKey = ".metadata.owner"
 	ownedObjects := map[types.UID]client.Object{}
-
 	listOpts := []client.ListOption{
 		client.InNamespace(params.ClusterObservability.Namespace),
 		client.MatchingFields{clusterObservabilityResourceOwnerKey: params.ClusterObservability.Name},
 	}
 
-	ownedObjectTypes := r.GetOwnedResourceTypes()
-	for _, objectType := range ownedObjectTypes {
-		objs, err := getList(ctx, r.Client, objectType, listOpts...)
+	for _, objectType := range r.GetOwnedResourceTypes() {
+		objects, err := getList(ctx, r.Client, objectType, listOpts...)
 		if err != nil {
 			return nil, err
 		}
-		maps.Copy(ownedObjects, objs)
+		maps.Copy(ownedObjects, objects)
 	}
-
 	return ownedObjects, nil
 }

--- a/internal/controllers/clusterobservability_controller_test.go
+++ b/internal/controllers/clusterobservability_controller_test.go
@@ -109,7 +109,7 @@ func TestClusterObservabilitySpecUpdateReconcilesManagedResources(t *testing.T) 
 	assert.Equal(t, reconciled.Generation, reconciled.Status.ObservedGeneration)
 }
 
-func TestClusterObservabilityManagedResourcesAreStableAndFollowOperatorImage(t *testing.T) {
+func TestClusterObservabilityManagedResourcesAreStableAndFollowOperatorDefaults(t *testing.T) {
 	ctx := context.Background()
 	key := types.NamespacedName{Name: "cluster-obs", Namespace: "observability"}
 	instance := &v1alpha1.ClusterObservability{
@@ -145,10 +145,9 @@ func TestClusterObservabilityManagedResourcesAreStableAndFollowOperatorImage(t *
 		Build()
 
 	oldImage := "registry.example.com/otelcol-k8s:old"
-	oldJavaImage := "registry.example.com/autoinstrumentation-java:old"
 	initialConfig := operatorconfig.New()
 	initialConfig.ClusterObservabilityCollectorImage = oldImage
-	initialConfig.AutoInstrumentationJavaImage = oldJavaImage
+	oldInstrumentationImages := setAutoInstrumentationImages(&initialConfig, "old")
 	reconciler := NewClusterObservabilityReconciler(ClusterObservabilityReconcilerParams{
 		Client:   cli,
 		Recorder: events.NewFakeRecorder(20),
@@ -169,7 +168,7 @@ func TestClusterObservabilityManagedResourcesAreStableAndFollowOperatorImage(t *
 	}
 	instrumentation := &v1alpha1.Instrumentation{}
 	require.NoError(t, cli.Get(ctx, client.ObjectKey(key), instrumentation))
-	assert.Equal(t, oldJavaImage, instrumentation.Spec.Java.Image)
+	assertAutoInstrumentationImages(t, instrumentation, oldInstrumentationImages)
 	stale := &v1alpha1.Instrumentation{ObjectMeta: metav1.ObjectMeta{
 		Name: "stale", Namespace: key.Namespace, UID: types.UID("stale-instrumentation-uid"),
 	}}
@@ -193,12 +192,11 @@ func TestClusterObservabilityManagedResourcesAreStableAndFollowOperatorImage(t *
 	assert.True(t, apierrors.IsNotFound(cli.Get(ctx, client.ObjectKeyFromObject(stale), &v1alpha1.Instrumentation{})))
 
 	// A new manager configuration simulates an operator upgrade. The parent CR
-	// generation is unchanged, but the new operand image must still propagate.
+	// generation is unchanged, but the new operand images must still propagate.
 	newImage := "registry.example.com/otelcol-k8s:new"
-	newJavaImage := "registry.example.com/autoinstrumentation-java:new"
 	upgradedConfig := initialConfig
 	upgradedConfig.ClusterObservabilityCollectorImage = newImage
-	upgradedConfig.AutoInstrumentationJavaImage = newJavaImage
+	newInstrumentationImages := setAutoInstrumentationImages(&upgradedConfig, "new")
 	upgradedReconciler := NewClusterObservabilityReconciler(ClusterObservabilityReconcilerParams{
 		Client:   cli,
 		Recorder: events.NewFakeRecorder(20),
@@ -223,12 +221,45 @@ func TestClusterObservabilityManagedResourcesAreStableAndFollowOperatorImage(t *
 	assert.Equal(t, "true", agent.Labels["opentelemetry.io/opamp-reporting"])
 	assert.Equal(t, "preserved", agent.Annotations["example.com/external-metadata"])
 	require.NoError(t, cli.Get(ctx, client.ObjectKey(key), instrumentation))
-	assert.Equal(t, newJavaImage, instrumentation.Spec.Java.Image)
+	assertAutoInstrumentationImages(t, instrumentation, newInstrumentationImages)
 
 	reconciled := &v1alpha1.ClusterObservability{}
 	require.NoError(t, cli.Get(ctx, key, reconciled))
 	assert.Equal(t, int64(1), reconciled.Generation)
 	assert.Equal(t, reconciled.Generation, reconciled.Status.ObservedGeneration)
+}
+
+func setAutoInstrumentationImages(cfg *operatorconfig.Config, tag string) map[string]string {
+	images := map[string]string{
+		"apache-httpd": "registry.example.com/autoinstrumentation-apache-httpd:" + tag,
+		"dotnet":       "registry.example.com/autoinstrumentation-dotnet:" + tag,
+		"go":           "registry.example.com/autoinstrumentation-go:" + tag,
+		"java":         "registry.example.com/autoinstrumentation-java:" + tag,
+		"nginx":        "registry.example.com/autoinstrumentation-nginx:" + tag,
+		"nodejs":       "registry.example.com/autoinstrumentation-nodejs:" + tag,
+		"python":       "registry.example.com/autoinstrumentation-python:" + tag,
+	}
+	cfg.AutoInstrumentationApacheHttpdImage = images["apache-httpd"]
+	cfg.AutoInstrumentationDotNetImage = images["dotnet"]
+	cfg.AutoInstrumentationGoImage = images["go"]
+	cfg.AutoInstrumentationJavaImage = images["java"]
+	cfg.AutoInstrumentationNginxImage = images["nginx"]
+	cfg.AutoInstrumentationNodeJSImage = images["nodejs"]
+	cfg.AutoInstrumentationPythonImage = images["python"]
+	return images
+}
+
+func assertAutoInstrumentationImages(t *testing.T, instrumentation *v1alpha1.Instrumentation, expected map[string]string) {
+	t.Helper()
+	assert.Equal(t, expected, map[string]string{
+		"apache-httpd": instrumentation.Spec.ApacheHttpd.Image,
+		"dotnet":       instrumentation.Spec.DotNet.Image,
+		"go":           instrumentation.Spec.Go.Image,
+		"java":         instrumentation.Spec.Java.Image,
+		"nginx":        instrumentation.Spec.Nginx.Image,
+		"nodejs":       instrumentation.Spec.NodeJS.Image,
+		"python":       instrumentation.Spec.Python.Image,
+	})
 }
 
 func TestClusterObservabilityCreatesOpenShiftSCCBeforeCollectors(t *testing.T) {

--- a/internal/controllers/clusterobservability_controller_test.go
+++ b/internal/controllers/clusterobservability_controller_test.go
@@ -1,0 +1,378 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/openshift"
+	operatorconfig "github.com/open-telemetry/opentelemetry-operator/internal/config"
+)
+
+func TestClusterObservabilitySpecUpdateReconcilesManagedResources(t *testing.T) {
+	ctx := context.Background()
+	key := types.NamespacedName{Name: "cluster-obs", Namespace: "observability"}
+	initialExporter := v1alpha1.OTLPHTTPExporter{
+		Endpoint: "https://old.example.com:4318",
+		Timeout:  "30s",
+	}
+	initialExporterConfig := map[string]any{
+		"endpoint": "https://old.example.com:4318",
+		"timeout":  "30s",
+	}
+	instance := &v1alpha1.ClusterObservability{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.GroupVersion.String(),
+			Kind:       "ClusterObservability",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       key.Name,
+			Namespace:  key.Namespace,
+			UID:        types.UID("cluster-observability-uid"),
+			Generation: 1,
+		},
+		Spec: v1alpha1.ClusterObservabilitySpec{
+			Exporter: initialExporter,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	cli := newClusterObservabilityFakeClientBuilder(scheme).
+		WithStatusSubresource(&v1alpha1.ClusterObservability{}).
+		WithObjects(instance).
+		Build()
+	reconciler := NewClusterObservabilityReconciler(ClusterObservabilityReconcilerParams{
+		Client:   cli,
+		Recorder: events.NewFakeRecorder(20),
+		Scheme:   scheme,
+		Log:      logr.Discard(),
+		Config:   operatorconfig.New(),
+	})
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assertManagedCollectorExporter(t, ctx, cli, key.Namespace, key.Name+"-agent", initialExporterConfig)
+	assertManagedCollectorExporter(t, ctx, cli, key.Namespace, key.Name+"-cluster", initialExporterConfig)
+
+	updatedExporter := v1alpha1.OTLPHTTPExporter{
+		Endpoint:    "https://new.example.com:4318",
+		Timeout:     "45s",
+		Compression: "none",
+	}
+	updatedExporterConfig := map[string]any{
+		"endpoint":    "https://new.example.com:4318",
+		"timeout":     "45s",
+		"compression": "none",
+	}
+	updated := &v1alpha1.ClusterObservability{}
+	require.NoError(t, cli.Get(ctx, key, updated))
+	updated.Spec.Exporter = updatedExporter
+	// The fake client does not increment metadata.generation automatically.
+	updated.Generation++
+	require.NoError(t, cli.Update(ctx, updated))
+
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assertManagedCollectorExporter(t, ctx, cli, key.Namespace, key.Name+"-agent", updatedExporterConfig)
+	assertManagedCollectorExporter(t, ctx, cli, key.Namespace, key.Name+"-cluster", updatedExporterConfig)
+
+	instrumentation := &v1alpha1.Instrumentation{}
+	require.NoError(t, cli.Get(ctx, client.ObjectKey(key), instrumentation))
+	assert.Equal(t, "http://$(OTEL_NODE_IP):4318", instrumentation.Spec.Endpoint)
+
+	reconciled := &v1alpha1.ClusterObservability{}
+	require.NoError(t, cli.Get(ctx, key, reconciled))
+	assert.Equal(t, reconciled.Generation, reconciled.Status.ObservedGeneration)
+}
+
+func TestClusterObservabilityManagedResourcesAreStableAndFollowOperatorImage(t *testing.T) {
+	ctx := context.Background()
+	key := types.NamespacedName{Name: "cluster-obs", Namespace: "observability"}
+	instance := &v1alpha1.ClusterObservability{
+		TypeMeta: metav1.TypeMeta{APIVersion: v1alpha1.GroupVersion.String(), Kind: "ClusterObservability"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       key.Name,
+			Namespace:  key.Namespace,
+			UID:        types.UID("cluster-observability-uid"),
+			Generation: 1,
+		},
+		Spec: v1alpha1.ClusterObservabilitySpec{
+			Exporter: v1alpha1.OTLPHTTPExporter{Endpoint: "https://example.com:4318"},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	var childUpdates []string
+	cli := newClusterObservabilityFakeClientBuilder(scheme).
+		WithStatusSubresource(&v1alpha1.ClusterObservability{}).
+		WithObjects(instance).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				switch obj.(type) {
+				case *v1beta1.OpenTelemetryCollector, *v1alpha1.Instrumentation:
+					childUpdates = append(childUpdates, fmt.Sprintf("%T/%s", obj, obj.GetName()))
+				}
+				return cli.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	oldImage := "registry.example.com/otelcol-k8s:old"
+	oldJavaImage := "registry.example.com/autoinstrumentation-java:old"
+	initialConfig := operatorconfig.New()
+	initialConfig.ClusterObservabilityCollectorImage = oldImage
+	initialConfig.AutoInstrumentationJavaImage = oldJavaImage
+	reconciler := NewClusterObservabilityReconciler(ClusterObservabilityReconcilerParams{
+		Client:   cli,
+		Recorder: events.NewFakeRecorder(20),
+		Scheme:   scheme,
+		Log:      logr.Discard(),
+		Config:   initialConfig,
+	})
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	for _, name := range []string{key.Name + "-agent", key.Name + "-cluster"} {
+		collector := &v1beta1.OpenTelemetryCollector{}
+		require.NoError(t, cli.Get(ctx, client.ObjectKey{Namespace: key.Namespace, Name: name}, collector))
+		assert.Equal(t, oldImage, collector.Spec.Image)
+		assert.Equal(t, v1beta1.UpgradeStrategyAutomatic, collector.Spec.UpgradeStrategy)
+		assert.Equal(t, v1beta1.ManagementStateManaged, collector.Spec.ManagementState)
+		assert.NotEmpty(t, collector.Spec.Config.Exporters.Object["otlp_http"])
+	}
+	instrumentation := &v1alpha1.Instrumentation{}
+	require.NoError(t, cli.Get(ctx, client.ObjectKey(key), instrumentation))
+	assert.Equal(t, oldJavaImage, instrumentation.Spec.Java.Image)
+	stale := &v1alpha1.Instrumentation{ObjectMeta: metav1.ObjectMeta{
+		Name: "stale", Namespace: key.Namespace, UID: types.UID("stale-instrumentation-uid"),
+	}}
+	require.NoError(t, ctrl.SetControllerReference(instance, stale, scheme))
+	require.NoError(t, cli.Create(ctx, stale))
+
+	agent := &v1beta1.OpenTelemetryCollector{}
+	require.NoError(t, cli.Get(ctx, client.ObjectKey{Namespace: key.Namespace, Name: key.Name + "-agent"}, agent))
+	agent.Labels["opentelemetry.io/opamp-reporting"] = "true"
+	if agent.Annotations == nil {
+		agent.Annotations = map[string]string{}
+	}
+	agent.Annotations["example.com/external-metadata"] = "preserved"
+	require.NoError(t, cli.Update(ctx, agent))
+	childUpdates = nil
+
+	// A no-op reconciliation must not rewrite webhook-defaulted child CRs.
+	_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Empty(t, childUpdates)
+	assert.True(t, apierrors.IsNotFound(cli.Get(ctx, client.ObjectKeyFromObject(stale), &v1alpha1.Instrumentation{})))
+
+	// A new manager configuration simulates an operator upgrade. The parent CR
+	// generation is unchanged, but the new operand image must still propagate.
+	newImage := "registry.example.com/otelcol-k8s:new"
+	newJavaImage := "registry.example.com/autoinstrumentation-java:new"
+	upgradedConfig := initialConfig
+	upgradedConfig.ClusterObservabilityCollectorImage = newImage
+	upgradedConfig.AutoInstrumentationJavaImage = newJavaImage
+	upgradedReconciler := NewClusterObservabilityReconciler(ClusterObservabilityReconcilerParams{
+		Client:   cli,
+		Recorder: events.NewFakeRecorder(20),
+		Scheme:   scheme,
+		Log:      logr.Discard(),
+		Config:   upgradedConfig,
+	})
+	_, err = upgradedReconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{
+		"*v1beta1.OpenTelemetryCollector/cluster-obs-agent",
+		"*v1beta1.OpenTelemetryCollector/cluster-obs-cluster",
+		"*v1alpha1.Instrumentation/cluster-obs",
+	}, childUpdates)
+
+	for _, name := range []string{key.Name + "-agent", key.Name + "-cluster"} {
+		collector := &v1beta1.OpenTelemetryCollector{}
+		require.NoError(t, cli.Get(ctx, client.ObjectKey{Namespace: key.Namespace, Name: name}, collector))
+		assert.Equal(t, newImage, collector.Spec.Image)
+	}
+	require.NoError(t, cli.Get(ctx, client.ObjectKey{Namespace: key.Namespace, Name: key.Name + "-agent"}, agent))
+	assert.Equal(t, "true", agent.Labels["opentelemetry.io/opamp-reporting"])
+	assert.Equal(t, "preserved", agent.Annotations["example.com/external-metadata"])
+	require.NoError(t, cli.Get(ctx, client.ObjectKey(key), instrumentation))
+	assert.Equal(t, newJavaImage, instrumentation.Spec.Java.Image)
+
+	reconciled := &v1alpha1.ClusterObservability{}
+	require.NoError(t, cli.Get(ctx, key, reconciled))
+	assert.Equal(t, int64(1), reconciled.Generation)
+	assert.Equal(t, reconciled.Generation, reconciled.Status.ObservedGeneration)
+}
+
+func TestClusterObservabilityCreatesOpenShiftSCCBeforeCollectors(t *testing.T) {
+	ctx := context.Background()
+	key := types.NamespacedName{Name: "cluster-obs", Namespace: "observability"}
+	instance := &v1alpha1.ClusterObservability{
+		TypeMeta: metav1.TypeMeta{APIVersion: v1alpha1.GroupVersion.String(), Kind: "ClusterObservability"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       key.Name,
+			Namespace:  key.Namespace,
+			UID:        types.UID("cluster-observability-uid"),
+			Generation: 1,
+		},
+		Spec: v1alpha1.ClusterObservabilitySpec{
+			Exporter: v1alpha1.OTLPHTTPExporter{Endpoint: "https://example.com:4318"},
+		},
+	}
+
+	sccGVK := schema.GroupVersionKind{Group: "security.openshift.io", Version: "v1", Kind: "SecurityContextConstraints"}
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	scheme.AddKnownTypeWithName(sccGVK, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(sccGVK.GroupVersion().WithKind(sccGVK.Kind+"List"), &unstructured.UnstructuredList{})
+
+	var created []string
+	cli := newClusterObservabilityFakeClientBuilder(scheme).
+		WithStatusSubresource(&v1alpha1.ClusterObservability{}).
+		WithObjects(instance).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				switch obj := obj.(type) {
+				case *unstructured.Unstructured:
+					created = append(created, obj.GetKind())
+				case *v1beta1.OpenTelemetryCollector:
+					created = append(created, "OpenTelemetryCollector/"+obj.Name)
+				}
+				return cli.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	cfg := operatorconfig.New()
+	cfg.OpenShiftRoutesAvailability = openshift.RoutesAvailable
+	reconciler := NewClusterObservabilityReconciler(ClusterObservabilityReconcilerParams{
+		Client: cli, Recorder: events.NewFakeRecorder(10), Scheme: scheme, Log: logr.Discard(), Config: cfg,
+	})
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(created), 3)
+	assert.Equal(t, "SecurityContextConstraints", created[0])
+	assert.Equal(t, "OpenTelemetryCollector/cluster-obs-agent", created[1])
+	assert.Equal(t, "OpenTelemetryCollector/cluster-obs-cluster", created[2])
+}
+
+func TestApplyDesiredUnstructuredResourceDoesNotAddEmptyMetadataMaps(t *testing.T) {
+	existing := &unstructured.Unstructured{Object: map[string]any{"metadata": map[string]any{"name": "example"}}}
+	desired := existing.DeepCopy()
+
+	applyDesiredUnstructuredResource(existing, desired)
+
+	assert.Nil(t, existing.GetLabels())
+	assert.Nil(t, existing.GetAnnotations())
+}
+
+func TestReconcileUnstructuredResourceAvoidsNoOpUpdates(t *testing.T) {
+	ctx := context.Background()
+	gvk := schema.GroupVersionKind{Group: "security.openshift.io", Version: "v1", Kind: "SecurityContextConstraints"}
+	desired := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "security.openshift.io/v1",
+		"kind":       "SecurityContextConstraints",
+		"metadata": map[string]any{
+			"name":        "cluster-obs-agent-hostaccess",
+			"labels":      map[string]any{"app.kubernetes.io/managed-by": "opentelemetry-operator"},
+			"annotations": map[string]any{"kubernetes.io/description": "managed"},
+		},
+		"priority":         float64(10),
+		"allowHostNetwork": true,
+	}}
+	desired.SetGroupVersionKind(gvk)
+	existing := desired.DeepCopy()
+	existing.SetResourceVersion("1")
+	existing.SetUID(types.UID("scc-uid"))
+	existing.SetLabels(map[string]string{
+		"app.kubernetes.io/managed-by": "opentelemetry-operator",
+		"example.com/external":         "preserved",
+	})
+	existing.SetAnnotations(map[string]string{
+		"kubernetes.io/description": "managed",
+		"example.com/external":      "preserved",
+	})
+	existing.Object["groups"] = []any{}
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})
+	updates := 0
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				updates++
+				return cli.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	reconciler := NewClusterObservabilityReconciler(ClusterObservabilityReconcilerParams{Client: cli, Scheme: scheme, Log: logr.Discard()})
+
+	require.NoError(t, reconciler.reconcileUnstructuredResource(ctx, logr.Discard(), desired))
+	assert.Zero(t, updates)
+
+	desired.Object["priority"] = float64(20)
+	require.NoError(t, reconciler.reconcileUnstructuredResource(ctx, logr.Discard(), desired))
+	assert.Equal(t, 1, updates)
+
+	updated := &unstructured.Unstructured{}
+	updated.SetGroupVersionKind(gvk)
+	require.NoError(t, cli.Get(ctx, client.ObjectKeyFromObject(existing), updated))
+	assert.Equal(t, int64(20), updated.Object["priority"])
+	assert.Equal(t, []any{}, updated.Object["groups"])
+	assert.Equal(t, "preserved", updated.GetLabels()["example.com/external"])
+	assert.Equal(t, "preserved", updated.GetAnnotations()["example.com/external"])
+}
+
+func assertManagedCollectorExporter(
+	t *testing.T,
+	ctx context.Context,
+	cli client.Client,
+	namespace string,
+	name string,
+	want map[string]any,
+) {
+	t.Helper()
+
+	collector := &v1beta1.OpenTelemetryCollector{}
+	require.NoError(t, cli.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, collector))
+	assert.Equal(t, want, collector.Spec.Config.Exporters.Object["otlp_http"])
+}
+
+func newClusterObservabilityFakeClientBuilder(scheme *runtime.Scheme) *fake.ClientBuilder {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithIndex(&v1beta1.OpenTelemetryCollector{}, clusterObservabilityResourceOwnerKey, clusterObservabilityOwnerName).
+		WithIndex(&v1alpha1.Instrumentation{}, clusterObservabilityResourceOwnerKey, clusterObservabilityOwnerName)
+}

--- a/internal/controllers/clusterobservability_reconcile_envtest_test.go
+++ b/internal/controllers/clusterobservability_reconcile_envtest_test.go
@@ -1,0 +1,128 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/tools/events"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
+	operatorconfig "github.com/open-telemetry/opentelemetry-operator/internal/config"
+	"github.com/open-telemetry/opentelemetry-operator/internal/controllers"
+)
+
+func TestClusterObservabilityNoOpReconcilePreservesStructuralDefaults(t *testing.T) {
+	ctx := context.Background()
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "co-api-defaults-" + utilrand.String(8)}}
+	require.NoError(t, k8sClient.Create(ctx, namespace))
+	key := types.NamespacedName{Name: "cluster-obs", Namespace: namespace.Name}
+	instance := &v1alpha1.ClusterObservability{
+		TypeMeta: metav1.TypeMeta{APIVersion: v1alpha1.GroupVersion.String(), Kind: "ClusterObservability"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
+		Spec: v1alpha1.ClusterObservabilitySpec{
+			Exporter: v1alpha1.OTLPHTTPExporter{Endpoint: "https://example.com:4318"},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, instance))
+	t.Cleanup(func() {
+		for _, child := range []client.Object{
+			&v1beta1.OpenTelemetryCollector{ObjectMeta: metav1.ObjectMeta{Name: key.Name + "-agent", Namespace: key.Namespace}},
+			&v1beta1.OpenTelemetryCollector{ObjectMeta: metav1.ObjectMeta{Name: key.Name + "-cluster", Namespace: key.Namespace}},
+			&v1alpha1.Instrumentation{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}},
+		} {
+			_ = client.IgnoreNotFound(k8sClient.Delete(context.Background(), child))
+		}
+		current := &v1alpha1.ClusterObservability{}
+		if getErr := k8sClient.Get(context.Background(), key, current); getErr == nil {
+			current.Finalizers = nil
+			_ = k8sClient.Update(context.Background(), current)
+			_ = k8sClient.Delete(context.Background(), current)
+		}
+		_ = client.IgnoreNotFound(k8sClient.Delete(context.Background(), namespace))
+	})
+
+	testCache, err := cache.New(restCfg, cache.Options{Scheme: testScheme})
+	require.NoError(t, err)
+	cacheCtx, cancelCache := context.WithCancel(context.Background())
+	t.Cleanup(cancelCache)
+	indexer := controllers.NewClusterObservabilityReconciler(controllers.ClusterObservabilityReconcilerParams{})
+	require.NoError(t, indexer.SetupCaches(testCache))
+	go func() {
+		_ = testCache.Start(cacheCtx)
+	}()
+	syncCtx, cancelSync := context.WithTimeout(ctx, 10*time.Second)
+	t.Cleanup(cancelSync)
+	require.True(t, testCache.WaitForCacheSync(syncCtx))
+	cachedClient, err := client.New(restCfg, client.Options{
+		Scheme: testScheme,
+		Cache:  &client.CacheOptions{Reader: testCache},
+	})
+	require.NoError(t, err)
+
+	reconciler := controllers.NewClusterObservabilityReconciler(controllers.ClusterObservabilityReconcilerParams{
+		Client:   cachedClient,
+		Recorder: events.NewFakeRecorder(20),
+		Scheme:   testScheme,
+		Log:      logr.Discard(),
+		Config:   operatorconfig.New(),
+	})
+	req := ctrl.Request{NamespacedName: key}
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	managedResources := []client.Object{
+		&v1beta1.OpenTelemetryCollector{ObjectMeta: metav1.ObjectMeta{Name: key.Name + "-agent", Namespace: key.Namespace}},
+		&v1beta1.OpenTelemetryCollector{ObjectMeta: metav1.ObjectMeta{Name: key.Name + "-cluster", Namespace: key.Namespace}},
+		&v1alpha1.Instrumentation{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}},
+	}
+	require.Eventually(t, func() bool {
+		for _, resource := range managedResources {
+			current := resource.DeepCopyObject().(client.Object)
+			if err := cachedClient.Get(ctx, client.ObjectKeyFromObject(resource), current); err != nil {
+				return false
+			}
+		}
+		return true
+	}, 10*time.Second, 50*time.Millisecond)
+
+	before := map[client.ObjectKey]string{}
+	for _, resource := range managedResources {
+		current := resource.DeepCopyObject().(client.Object)
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(resource), current))
+		owner := metav1.GetControllerOf(current)
+		require.NotNil(t, owner)
+		assert.Equal(t, key.Name, owner.Name)
+		if collector, ok := current.(*v1beta1.OpenTelemetryCollector); ok {
+			assert.NotEmpty(t, collector.Spec.Config.Exporters.Object["otlp_http"])
+			assert.Equal(t, 3, collector.Spec.ConfigVersions)
+		}
+		before[client.ObjectKeyFromObject(resource)] = current.GetResourceVersion()
+	}
+
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	for _, resource := range managedResources {
+		current := resource.DeepCopyObject().(client.Object)
+		resourceKey := client.ObjectKeyFromObject(resource)
+		require.NoError(t, k8sClient.Get(ctx, resourceKey, current))
+		assert.Equal(t, before[resourceKey], current.GetResourceVersion(), "no-op reconcile updated %T %s", current, resourceKey)
+	}
+}

--- a/internal/controllers/clusterobservability_reconcile_envtest_test.go
+++ b/internal/controllers/clusterobservability_reconcile_envtest_test.go
@@ -96,7 +96,7 @@ func TestClusterObservabilityNoOpReconcilePreservesStructuralDefaults(t *testing
 	require.Eventually(t, func() bool {
 		for _, resource := range managedResources {
 			current := resource.DeepCopyObject().(client.Object)
-			if err := cachedClient.Get(ctx, client.ObjectKeyFromObject(resource), current); err != nil {
+			if getErr := cachedClient.Get(ctx, client.ObjectKeyFromObject(resource), current); getErr != nil {
 				return false
 			}
 		}

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -217,6 +217,10 @@ func TestMain(m *testing.M) {
 		fmt.Printf("failed to SetupWebhookWithManager: %v", err)
 		os.Exit(1)
 	}
+	if err = wh.SetupInstrumentationWebhook(mgr, config.New()); err != nil {
+		fmt.Printf("failed to SetupWebhookWithManager: %v", err)
+		os.Exit(1)
+	}
 	if err = wh.SetupOpAMPBridgeWebhook(mgr, config.New()); err != nil {
 		fmt.Printf("failed to SetupWebhookWithManager: %v", err)
 		os.Exit(1)

--- a/internal/manifests/clusterobservability/clusterobservability.go
+++ b/internal/manifests/clusterobservability/clusterobservability.go
@@ -107,16 +107,6 @@ func buildAgentCollector(params manifests.Params, distro config.DistroProvider) 
 			Name:      agentCollectorName,
 			Namespace: co.Namespace,
 			Labels:    labels,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         co.APIVersion,
-					Kind:               co.Kind,
-					Name:               co.Name,
-					UID:                co.UID,
-					Controller:         new(true),
-					BlockOwnerDeletion: new(true),
-				},
-			},
 		},
 		Spec: v1beta1.OpenTelemetryCollectorSpec{
 			Mode:   v1beta1.ModeDaemonSet,
@@ -173,16 +163,6 @@ func buildClusterCollector(params manifests.Params) (*v1beta1.OpenTelemetryColle
 			Name:      clusterCollectorName,
 			Namespace: co.Namespace,
 			Labels:    clusterLabels,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         co.APIVersion,
-					Kind:               co.Kind,
-					Name:               co.Name,
-					UID:                co.UID,
-					Controller:         new(true),
-					BlockOwnerDeletion: new(true),
-				},
-			},
 		},
 		Spec: v1beta1.OpenTelemetryCollectorSpec{
 			Mode:   v1beta1.ModeStatefulSet,
@@ -234,16 +214,6 @@ func buildInstrumentations(params manifests.Params) ([]client.Object, error) {
 			Name:      co.Name,
 			Namespace: co.Namespace,
 			Labels:    instrumentationLabels,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         co.APIVersion,
-					Kind:               co.Kind,
-					Name:               co.Name,
-					UID:                co.UID,
-					Controller:         new(true),
-					BlockOwnerDeletion: new(true),
-				},
-			},
 		},
 		Spec: v1alpha1.InstrumentationSpec{
 			Exporter: v1alpha1.Exporter{

--- a/internal/manifests/clusterobservability/openshift_scc.go
+++ b/internal/manifests/clusterobservability/openshift_scc.go
@@ -75,8 +75,6 @@ func buildOpenShiftSCC(params manifests.Params) []client.Object {
 			"defaultAddCapabilities":   []string{},
 			"requiredDropCapabilities": []string{"ALL"},
 			"seccompProfiles":          []string{"runtime/default"},
-			"allowedUnsafeSysctls":     []string{},
-			"forbiddenSysctls":         []string{},
 			"volumes": []string{
 				"configMap",
 				"downwardAPI",

--- a/internal/manifests/mutate.go
+++ b/internal/manifests/mutate.go
@@ -23,6 +23,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 )
 
@@ -55,6 +56,8 @@ var ImmutableChangeErr *ImmutableFieldChangeErr
 // - Route
 // - Secret
 // - TargetAllocator
+// - OpenTelemetryCollector
+// - Instrumentation
 // - HTTPRoute
 // In order for the operator to reconcile other types, they must be added here.
 // The function returned takes no arguments but instead uses the existing and desired inputs here. Existing is expected
@@ -192,6 +195,16 @@ func MutateFuncFor(existing, desired client.Object) controllerutil.MutateFn {
 			wantTa := desired.(*v1alpha1.TargetAllocator)
 			mutateTargetAllocator(ta, wantTa)
 
+		case *v1beta1.OpenTelemetryCollector:
+			collector := existing
+			wantCollector := desired.(*v1beta1.OpenTelemetryCollector)
+			mutateOpenTelemetryCollector(collector, wantCollector)
+
+		case *v1alpha1.Instrumentation:
+			instrumentation := existing
+			wantInstrumentation := desired.(*v1alpha1.Instrumentation)
+			mutateInstrumentation(instrumentation, wantInstrumentation)
+
 		default:
 			t := reflect.TypeOf(existing).String()
 			return fmt.Errorf("missing mutate implementation for resource type: %s", t)
@@ -297,6 +310,63 @@ func mutateTargetAllocator(existing, desired *v1alpha1.TargetAllocator) {
 	existing.Annotations = desired.Annotations
 	existing.Labels = desired.Labels
 	existing.Spec = desired.Spec
+}
+
+func mutateOpenTelemetryCollector(existing, desired *v1beta1.OpenTelemetryCollector) {
+	normalizedDesired := desired.DeepCopy()
+	preserveCollectorStructuralDefaults(existing, normalizedDesired)
+	existing.Spec = normalizedDesired.Spec
+}
+
+func mutateInstrumentation(existing, desired *v1alpha1.Instrumentation) {
+	existing.Spec = desired.Spec
+}
+
+// Keep this list aligned with Collector CRD defaults. The no-op reconcile envtest
+// exercises these defaults after an API-server round trip.
+func preserveCollectorStructuralDefaults(existing, desired *v1beta1.OpenTelemetryCollector) {
+	if desired.Spec.ConfigVersions == 0 {
+		desired.Spec.ConfigVersions = existing.Spec.ConfigVersions
+	}
+	if desired.Spec.IpFamilyPolicy == nil {
+		desired.Spec.IpFamilyPolicy = existing.Spec.IpFamilyPolicy
+	}
+
+	desiredTA := &desired.Spec.TargetAllocator
+	existingTA := existing.Spec.TargetAllocator
+	if desiredTA.AllocationStrategy == "" {
+		desiredTA.AllocationStrategy = existingTA.AllocationStrategy
+	}
+	if desiredTA.FilterStrategy == "" {
+		desiredTA.FilterStrategy = existingTA.FilterStrategy
+	}
+	if desiredTA.CollectorNotReadyGracePeriod == nil {
+		desiredTA.CollectorNotReadyGracePeriod = existingTA.CollectorNotReadyGracePeriod
+	}
+	if desiredTA.CollectorTargetReloadInterval == nil {
+		desiredTA.CollectorTargetReloadInterval = existingTA.CollectorTargetReloadInterval
+	}
+	if desiredTA.PrometheusCR.ScrapeInterval == nil {
+		desiredTA.PrometheusCR.ScrapeInterval = existingTA.PrometheusCR.ScrapeInterval
+	}
+	if desiredTA.PrometheusCR.EvaluationInterval == nil {
+		desiredTA.PrometheusCR.EvaluationInterval = existingTA.PrometheusCR.EvaluationInterval
+	}
+	if desiredTA.PrometheusCR.PodMonitorNamespaceSelector == nil {
+		desiredTA.PrometheusCR.PodMonitorNamespaceSelector = existingTA.PrometheusCR.PodMonitorNamespaceSelector
+	}
+	if desiredTA.PrometheusCR.ServiceMonitorNamespaceSelector == nil {
+		desiredTA.PrometheusCR.ServiceMonitorNamespaceSelector = existingTA.PrometheusCR.ServiceMonitorNamespaceSelector
+	}
+	if desiredTA.PrometheusCR.ScrapeConfigNamespaceSelector == nil {
+		desiredTA.PrometheusCR.ScrapeConfigNamespaceSelector = existingTA.PrometheusCR.ScrapeConfigNamespaceSelector
+	}
+	if desiredTA.PrometheusCR.ProbeNamespaceSelector == nil {
+		desiredTA.PrometheusCR.ProbeNamespaceSelector = existingTA.PrometheusCR.ProbeNamespaceSelector
+	}
+	if desiredTA.Mtls != nil && desiredTA.Mtls.UseCertManager == nil && existingTA.Mtls != nil {
+		desiredTA.Mtls.UseCertManager = existingTA.Mtls.UseCertManager
+	}
 }
 
 func mutateService(existing, desired *corev1.Service) {

--- a/internal/manifests/mutate_test.go
+++ b/internal/manifests/mutate_test.go
@@ -5,6 +5,7 @@ package manifests
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,8 +14,70 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests/manifestutils"
 )
+
+func TestMutateOpenTelemetryCollectorPreservesAPIServerDefaults(t *testing.T) {
+	ipFamilyPolicy := corev1.IPFamilyPolicySingleStack
+	useCertManager := true
+	existing := &v1beta1.OpenTelemetryCollector{
+		Spec: v1beta1.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{
+				Image:          "collector:old",
+				IpFamilyPolicy: &ipFamilyPolicy,
+			},
+			ConfigVersions: 3,
+			TargetAllocator: v1beta1.TargetAllocatorEmbedded{
+				AllocationStrategy:            v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
+				FilterStrategy:                v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
+				CollectorNotReadyGracePeriod:  &metav1.Duration{Duration: 30 * time.Second},
+				CollectorTargetReloadInterval: &metav1.Duration{Duration: 30 * time.Second},
+				Mtls:                          &v1beta1.TargetAllocatorMTLS{UseCertManager: &useCertManager},
+				PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
+					ScrapeInterval:                  &metav1.Duration{Duration: 30 * time.Second},
+					EvaluationInterval:              &metav1.Duration{Duration: 30 * time.Second},
+					PodMonitorNamespaceSelector:     &metav1.LabelSelector{},
+					ServiceMonitorNamespaceSelector: &metav1.LabelSelector{},
+					ScrapeConfigNamespaceSelector:   &metav1.LabelSelector{},
+					ProbeNamespaceSelector:          &metav1.LabelSelector{},
+				},
+			},
+		},
+	}
+	desired := &v1beta1.OpenTelemetryCollector{
+		Spec: v1beta1.OpenTelemetryCollectorSpec{
+			OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{Image: "collector:new"},
+			TargetAllocator:           v1beta1.TargetAllocatorEmbedded{Mtls: &v1beta1.TargetAllocatorMTLS{}},
+		},
+	}
+	defaulted := existing.DeepCopy()
+	desiredBefore := desired.DeepCopy()
+
+	require.NoError(t, MutateFuncFor(existing, desired)())
+
+	assert.Equal(t, "collector:new", existing.Spec.Image)
+	assert.Equal(t, defaulted.Spec.ConfigVersions, existing.Spec.ConfigVersions)
+	assert.Equal(t, defaulted.Spec.IpFamilyPolicy, existing.Spec.IpFamilyPolicy)
+	assert.Equal(t, defaulted.Spec.TargetAllocator, existing.Spec.TargetAllocator)
+	assert.Equal(t, desiredBefore, desired)
+}
+
+func TestMutateInstrumentationCopiesDesiredSpec(t *testing.T) {
+	existing := &v1alpha1.Instrumentation{Spec: v1alpha1.InstrumentationSpec{
+		Exporter: v1alpha1.Exporter{Endpoint: "http://old:4318"},
+	}}
+	desired := &v1alpha1.Instrumentation{Spec: v1alpha1.InstrumentationSpec{
+		Exporter: v1alpha1.Exporter{Endpoint: "http://new:4318"},
+	}}
+	desiredBefore := desired.DeepCopy()
+
+	require.NoError(t, MutateFuncFor(existing, desired)())
+
+	assert.Equal(t, desired.Spec, existing.Spec)
+	assert.Equal(t, desiredBefore, desired)
+}
 
 func TestMutateServiceAccount(t *testing.T) {
 	existing := corev1.ServiceAccount{

--- a/internal/status/clusterobservability/handle.go
+++ b/internal/status/clusterobservability/handle.go
@@ -430,37 +430,6 @@ func updateConfigVersions(co *v1alpha1.ClusterObservability) error {
 	return nil
 }
 
-// DetectConfigChanges returns true if the config versions in the status differ from current embedded configs.
-// This is used to trigger reconciliation when operator is upgraded with new configs.
-func DetectConfigChanges(co *v1alpha1.ClusterObservability) (bool, error) {
-	if co.Status.ConfigVersions == nil {
-		// First time - consider it a change
-		return true, nil
-	}
-
-	configLoader := config.NewConfigLoader()
-	currentVersions, err := configLoader.GetAllConfigVersions()
-	if err != nil {
-		return false, fmt.Errorf("failed to get current config versions: %w", err)
-	}
-
-	// Check if any versions differ
-	for versionKey, currentVersion := range currentVersions {
-		if existingVersion, exists := co.Status.ConfigVersions[versionKey]; !exists || configLoader.CompareConfigVersions(existingVersion, currentVersion) {
-			return true, nil
-		}
-	}
-
-	// Check if any old versions are no longer present (distro removed)
-	for versionKey := range co.Status.ConfigVersions {
-		if _, exists := currentVersions[versionKey]; !exists {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
 // findCondition finds a condition by type in the conditions slice.
 func findCondition(conditions []v1alpha1.ClusterObservabilityCondition, condType v1alpha1.ClusterObservabilityConditionType) *v1alpha1.ClusterObservabilityCondition {
 	for i := range conditions {

--- a/tests/e2e-clusterobservability/smoke-clusterobservability/01-assert-clusterobservability-update.yaml
+++ b/tests/e2e-clusterobservability/smoke-clusterobservability/01-assert-clusterobservability-update.yaml
@@ -1,0 +1,47 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: ClusterObservability
+metadata:
+  name: cluster-obs
+status:
+  observedGeneration: 2
+  phase: Ready
+  (conditions[?type == 'Configured']):
+  - status: "True"
+  (conditions[?type == 'Ready']):
+  - status: "True"
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: cluster-obs-agent
+spec:
+  config:
+    exporters:
+      otlp_http:
+        endpoint: http://sink-collector:4318
+        timeout: 45s
+        sending_queue:
+          enabled: true
+          queue_size: 2048
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: cluster-obs-cluster
+spec:
+  config:
+    exporters:
+      otlp_http:
+        endpoint: http://sink-collector:4318
+        timeout: 45s
+        sending_queue:
+          enabled: true
+          queue_size: 2048
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: cluster-obs
+spec:
+  exporter:
+    endpoint: http://$(OTEL_NODE_IP):4318

--- a/tests/e2e-clusterobservability/smoke-clusterobservability/01-update-clusterobservability.yaml
+++ b/tests/e2e-clusterobservability/smoke-clusterobservability/01-update-clusterobservability.yaml
@@ -1,0 +1,11 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: ClusterObservability
+metadata:
+  name: cluster-obs
+spec:
+  exporter:
+    endpoint: http://sink-collector:4318
+    timeout: 45s
+    sending_queue:
+      enabled: true
+      queue_size: 2048

--- a/tests/e2e-clusterobservability/smoke-clusterobservability/02-assert-telemetry-flow.yaml
+++ b/tests/e2e-clusterobservability/smoke-clusterobservability/02-assert-telemetry-flow.yaml
@@ -25,8 +25,24 @@ spec:
           fi
           sleep 2
         done
+        sent_logs() {
+          METRICS=$(kubectl get --raw \
+            "/api/v1/namespaces/$NAMESPACE/pods/$CLUSTER_POD:8888/proxy/metrics" \
+            2>/dev/null) || return 1
+          printf '%s\n' "$METRICS" \
+            | awk '/^otelcol_exporter_sent_log_records(\{| )/ { total += $NF } END { print total + 0 }'
+        }
         # Ensure the whole-second Event timestamp is after the receiver start time.
         sleep 2
+        for i in $(seq 1 30); do
+          if BASELINE=$(sent_logs); then
+            break
+          fi
+          if [ "$i" -eq 30 ]; then
+            echo "ERROR: Collector telemetry endpoint is unavailable"; exit 1
+          fi
+          sleep 1
+        done
         kubectl apply -f - <<EOF
         apiVersion: events.k8s.io/v1
         kind: Event
@@ -45,6 +61,20 @@ spec:
           kind: Namespace
           name: default
         EOF
+        for i in $(seq 1 30); do
+          if ! CURRENT=$(sent_logs); then
+            sleep 1
+            continue
+          fi
+          if awk -v current="$CURRENT" -v baseline="$BASELINE" \
+            'BEGIN { exit !(current > baseline) }'; then
+            exit 0
+          fi
+          if [ "$i" -eq 30 ]; then
+            echo "ERROR: k8s_events telemetry did not reach the sink"; exit 1
+          fi
+          sleep 1
+        done
   - script:
       env:
       - name: LABEL_SELECTOR
@@ -55,12 +85,14 @@ spec:
         value: "480"
       - name: RETRY_SLEEP
         value: "10"
+      - name: ACCUMULATE_SEARCH_RESULTS
+        value: "true"
       # One signal unique to each bundled receiver:
       #   - kubeletstats (agent):   k8s.node.cpu.usage
       #   - hostmetrics (agent):    system.cpu.time
       #   - k8s_cluster  (cluster): k8s.deployment.available
       #   - filelog (agent):        unique probe body + log.file.path
-      #   - k8s_events (cluster):    unique Event note
+      #   - k8s_events (cluster):   unique Event note
       - name: SEARCH_STRINGS_ENV
         value: |
           k8s.node.cpu.usage

--- a/tests/e2e-clusterobservability/smoke-clusterobservability/chainsaw-test.yaml
+++ b/tests/e2e-clusterobservability/smoke-clusterobservability/chainsaw-test.yaml
@@ -34,6 +34,12 @@ spec:
     try:
     - assert:
         file: 01-assert-collectors.yaml
+  - name: Update ClusterObservability
+    try:
+    - apply:
+        file: 01-update-clusterobservability.yaml
+    - assert:
+        file: 01-assert-clusterobservability-update.yaml
   - name: Assert telemetry reaches the sink
     use:
       template: 02-assert-telemetry-flow.yaml

--- a/tests/test-e2e-apps/scripts/check_pod_logs.sh
+++ b/tests/test-e2e-apps/scripts/check_pod_logs.sh
@@ -8,6 +8,7 @@ CONTAINER_NAME=${CONTAINER_NAME} # Read from env
 RETRY_TIMEOUT=${RETRY_TIMEOUT:-120} # Read from env, default 120
 RETRY_SLEEP=${RETRY_SLEEP:-5}    # Read from env, default 5
 SEARCH_STRINGS_INPUT=${SEARCH_STRINGS_ENV} # Read the delimited string from env
+ACCUMULATE_SEARCH_RESULTS=${ACCUMULATE_SEARCH_RESULTS:-false}
 
 # --- Input Validation ---
 if [[ -z "$LABEL_SELECTOR" ]]; then
@@ -36,6 +37,7 @@ if [[ ${#SEARCH_STRINGS[@]} -eq 0 ]]; then
   echo "ERROR: Failed to parse any search strings from SEARCH_STRINGS_ENV."
   exit 1
 fi
+TOTAL_SEARCH_STRINGS=${#SEARCH_STRINGS[@]}
 # --- End Configuration Processing ---
 
 
@@ -126,10 +128,14 @@ while true; do
         fi
     done
 
+    if [ "$ACCUMULATE_SEARCH_RESULTS" = true ]; then
+        SEARCH_STRINGS=("${MISSING_STRINGS_THIS_ATTEMPT[@]}")
+    fi
+
     # 4. Evaluate outcome of this attempt
     if [ "$ALL_FOUND_THIS_ATTEMPT" = true ]; then
         echo "-----------------------------------------------------"
-        echo "Success: All ${#SEARCH_STRINGS[@]} strings found simultaneously in container '$CONTAINER_NAME' of pod '$POD'."
+        echo "Success: All $TOTAL_SEARCH_STRINGS strings found in container '$CONTAINER_NAME' of pod '$POD'."
         echo "-----------------------------------------------------"
         exit 0 # Successful exit!
     else


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`ClusterObservability` creates managed Collector and Instrumentation resources, but changes to the parent or operator defaults were not reliably propagated after creation.

This change:

- reconciles the desired child resources on every parent reconciliation
- applies defaults before comparing resources, avoiding unnecessary updates
- preserves labels and annotations not owned by this controller
- propagates Collector and Instrumentation image changes after an operator upgrade

Before comparing a generated collector with the live resource, the controller copies values that k8s added from the CRD schema into the generated object. This keeps an unchanged Collector from being written again on every reconciliation. Server-Side Apply could remove the need to account for these defaulted fields explicitly by letting k8s track which fields `ClusterObservability` owns. That broader reconciliation change will be evaluated separately.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #5450

**Testing:** <Describe what testing was performed and which tests were added.>
- Add unit tests, update scenario to chainsaw e2e tests
- Verified exporter updates, telemetry delivery, operator image-default propagation, OpenShift SCC/TLS behavior, and clean no-op reconciliation

**Documentation:** <Describe the documentation added.>
Updated `docs/collector/cluster-observability.md`