### PR TITLE
fix(opamp): rebuild applied collector keys from cluster state on bridge restart

### DIFF
--- a/.chloggen/opamp-bridge-rebuild-applied-keys.yaml
+++ b/.chloggen/opamp-bridge-rebuild-applied-keys.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: opamp
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rebuild the OpAMP Bridge's applied-keys tracking from cluster state on startup, so a remote config that drops a collector after a bridge restart correctly deletes it.
+
+# One or more tracking issues related to the change
+issues: [5445]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/operator-opamp-bridge/internal/agent/agent.go
+++ b/cmd/operator-opamp-bridge/internal/agent/agent.go
@@ -198,6 +198,11 @@ func (agent *Agent) Start() error {
 		return err
 	}
 	agent.startTime = startTime
+
+	if err = agent.rebuildAppliedKeys(); err != nil {
+		return fmt.Errorf("failed to rebuild applied keys from cluster state: %w", err)
+	}
+
 	settings := types.StartSettings{
 		OpAMPServerURL: agent.config.Endpoint,
 		Header:         agent.config.Headers.ToHTTPHeader(),
@@ -386,6 +391,25 @@ func (agent *Agent) initMeter(settings *protobufs.TelemetryConnectionSettings) {
 		agent.metricReporter.Shutdown()
 	}
 	agent.metricReporter = reporter
+}
+
+// rebuildAppliedKeys reconstructs appliedKeys from the collectors currently in the cluster. appliedKeys
+// only lives in memory, so without this a restart forgets every key the bridge previously applied and a
+// later remote config that drops one of those keys never triggers the corresponding delete.
+func (agent *Agent) rebuildAppliedKeys() error {
+	instances, err := agent.applier.ListInstances()
+	if err != nil {
+		return err
+	}
+	for _, instance := range instances {
+		if !instance.IsManaged() || instance.GetDeletionTimestamp() != nil {
+			continue
+		}
+		for key := range instance.GetConfigMap() {
+			agent.appliedKeys[key] = true
+		}
+	}
+	return nil
 }
 
 // applyRemoteConfig receives a remote configuration from a remote server of the following form:

--- a/cmd/operator-opamp-bridge/internal/agent/agent_test.go
+++ b/cmd/operator-opamp-bridge/internal/agent/agent_test.go
@@ -1445,6 +1445,61 @@ func TestAgent_Start_RegistersOnCommand(t *testing.T) {
 	assert.NotNil(t, mockClient.settings.Callbacks.OnCommand, "OnCommand callback must be registered")
 }
 
+// TestAgent_Start_RebuildsAppliedKeysAcrossRestart reproduces
+// https://github.com/open-telemetry/opentelemetry-operator/issues/5445: a bridge restart used to forget
+// which collectors it had previously applied, so a later remote config that dropped one of those keys
+// never deleted the collector. It also verifies reporting-only collectors, which the bridge never applied,
+// are left alone.
+func TestAgent_Start_RebuildsAppliedKeysAcrossRestart(t *testing.T) {
+	const reportingCollectorName = "reporting-only"
+
+	managedCollector := v1beta1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testCollectorName,
+			Namespace: testNamespace,
+			Labels:    map[string]string{operator.ManagedLabelKey: "true"},
+		},
+	}
+	reportingCollector := v1beta1.OpenTelemetryCollector{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      reportingCollectorName,
+			Namespace: testNamespace,
+			Labels:    map[string]string{operator.ReportingLabelKey: "true"},
+		},
+	}
+	collectorList := &v1beta1.OpenTelemetryCollectorList{
+		Items: []v1beta1.OpenTelemetryCollector{managedCollector, reportingCollector},
+	}
+
+	mockClient := &mockOpampClient{}
+	conf := config.NewConfig(logr.Discard())
+	conf.Capabilities = map[config.Capability]bool{"AcceptsRemoteConfig": true}
+	applier := getFakeApplier(t, conf, collectorList)
+	agent := NewAgent(logr.Discard(), applier, conf, mockClient, newMockProxy(nil, nil, nil))
+
+	require.NoError(t, agent.Start(), "should be able to start agent")
+	defer agent.Shutdown()
+
+	require.Contains(t, agent.appliedKeys, testCollectorKey, "restart should rebuild the previously applied managed collector's key")
+	require.NotContains(t, agent.appliedKeys, testNamespace+"/"+reportingCollectorName, "reporting-only collectors were never applied and must not be tracked as applied")
+
+	// Simulate a remote config that no longer references the managed collector.
+	agent.onMessage(context.Background(), &types.MessageData{
+		RemoteConfig: &protobufs.AgentRemoteConfig{
+			Config:     &protobufs.AgentConfigMap{ConfigMap: map[string]*protobufs.AgentConfigFile{}},
+			ConfigHash: []byte("empty-config"),
+		},
+	})
+
+	deletedInstance, err := applier.GetInstance(testCollectorName, testNamespace)
+	require.NoError(t, err)
+	assert.Nil(t, deletedInstance, "collector previously applied before the restart should now be deleted")
+
+	stillReportingInstance, err := applier.GetInstance(reportingCollectorName, testNamespace)
+	require.NoError(t, err)
+	assert.NotNil(t, stillReportingInstance, "reporting-only collector must not be deleted")
+}
+
 func getMessageDataFromConfigFile(filemap map[string]string) (*types.MessageData, error) {
 	toReturn := &types.MessageData{}
 	if filemap == nil {

--- a/cmd/operator-opamp-bridge/internal/operator/client.go
+++ b/cmd/operator-opamp-bridge/internal/operator/client.go
@@ -327,8 +327,6 @@ func (c Client) generateCollectorHealth(selectorLabels map[string]string, namesp
 func (c Client) listOpenTelemetryCollectors() ([]CRDInstance, error) {
 	ctx := context.Background()
 
-	var instances []v1beta1.OpenTelemetryCollector
-
 	labelSelector := labels.NewSelector()
 	requirement, err := labels.NewRequirement(ManagedLabelKey, selection.In, []string{c.name, "true"})
 	if err != nil {
@@ -341,7 +339,6 @@ func (c Client) listOpenTelemetryCollectors() ([]CRDInstance, error) {
 	if err != nil {
 		return nil, err
 	}
-	instances = append(instances, managedCollectors.Items...)
 
 	reportingCollectorLabelMatcher := client.MatchingLabels{ReportingLabelKey: "true"}
 	reportingCollectors := v1beta1.OpenTelemetryCollectorList{}
@@ -349,16 +346,17 @@ func (c Client) listOpenTelemetryCollectors() ([]CRDInstance, error) {
 	if err != nil {
 		return nil, err
 	}
-	instances = append(instances, reportingCollectors.Items...)
 
-	for i := range instances {
-		instances[i].SetManagedFields(nil)
-		setTypedMeta(&instances[i])
+	result := make([]CRDInstance, 0, len(managedCollectors.Items)+len(reportingCollectors.Items))
+	for i := range managedCollectors.Items {
+		managedCollectors.Items[i].SetManagedFields(nil)
+		setTypedMeta(&managedCollectors.Items[i])
+		result = append(result, newCRDInstance(managedCollectors.Items[i], true))
 	}
-
-	result := make([]CRDInstance, len(instances))
-	for i := range instances {
-		result[i] = newCRDInstance(instances[i])
+	for i := range reportingCollectors.Items {
+		reportingCollectors.Items[i].SetManagedFields(nil)
+		setTypedMeta(&reportingCollectors.Items[i])
+		result = append(result, newCRDInstance(reportingCollectors.Items[i], false))
 	}
 	return result, nil
 }

--- a/cmd/operator-opamp-bridge/internal/operator/crd_instance.go
+++ b/cmd/operator-opamp-bridge/internal/operator/crd_instance.go
@@ -17,11 +17,12 @@ var _ CollectorInstance = CRDInstance{}
 
 // CRDInstance wraps an OpenTelemetryCollector CRD to implement CollectorInstance.
 type CRDInstance struct {
-	Col v1beta1.OpenTelemetryCollector
+	Col     v1beta1.OpenTelemetryCollector
+	managed bool
 }
 
-func newCRDInstance(col v1beta1.OpenTelemetryCollector) CRDInstance {
-	return CRDInstance{Col: col}
+func newCRDInstance(col v1beta1.OpenTelemetryCollector, managed bool) CRDInstance {
+	return CRDInstance{Col: col, managed: managed}
 }
 
 func (c CRDInstance) GetName() string {
@@ -34,6 +35,12 @@ func (c CRDInstance) GetNamespace() string {
 
 func (c CRDInstance) GetDeletionTimestamp() *metav1.Time {
 	return c.Col.GetDeletionTimestamp()
+}
+
+// IsManaged reports whether the bridge applies remote config to this collector, as opposed to it only
+// being reporting-only (labeled with ReportingLabelKey but not ManagedLabelKey).
+func (c CRDInstance) IsManaged() bool {
+	return c.managed
 }
 
 // selectorLabels returns the collector's status selector, or the operator's standard collector labels as a fallback.

--- a/cmd/operator-opamp-bridge/internal/operator/instance.go
+++ b/cmd/operator-opamp-bridge/internal/operator/instance.go
@@ -31,4 +31,8 @@ type CollectorInstance interface {
 	GetNamespace() string
 	GetDeletionTimestamp() *metav1.Time
 	GetConfigMap() map[string]ConfigFile
+
+	// IsManaged reports whether the bridge owns this instance's lifecycle (apply/delete), as opposed to
+	// only reporting its status upstream without ever having applied config to it.
+	IsManaged() bool
 }

--- a/cmd/operator-opamp-bridge/internal/standalone/configmap_instance.go
+++ b/cmd/operator-opamp-bridge/internal/standalone/configmap_instance.go
@@ -37,3 +37,9 @@ func (*standaloneCollectorInstance) GetDeletionTimestamp() *metav1.Time {
 func (p *standaloneCollectorInstance) GetConfigMap() map[string]operator.ConfigFile {
 	return p.configMap
 }
+
+// IsManaged always returns true: standalone mode has no reporting-only concept, so every instance
+// returned by ListInstances is one the bridge applies remote config to.
+func (*standaloneCollectorInstance) IsManaged() bool {
+	return true
+}


### PR DESCRIPTION
**Description:** The OpAMP Bridge tracks which collector remote-config keys it has applied in an in-memory map (`Agent.appliedKeys`). This map is only ever created empty and is never rebuilt from cluster state, so after a bridge restart the bridge forgets about every collector it previously applied. Deletion is computed as the set difference between `appliedKeys` and the keys in an incoming remote config, so right after a restart there is nothing to diff against — a later remote config that drops a previously-applied collector never deletes it.

This change rebuilds `appliedKeys` from the cluster on `Agent.Start()` by listing the collectors the bridge currently manages and seeding their keys. Reporting-only collectors (labeled `opentelemetry.io/opamp-reporting: true` but not `opentelemetry.io/opamp-managed`) are explicitly excluded from this rebuild, since the bridge never applies config to them and must not delete them.

**Link to tracking Issue(s):** 5445

- Resolves: #5445

**Testing:** Added `TestAgent_Start_RebuildsAppliedKeysAcrossRestart` in `cmd/operator-opamp-bridge/internal/agent/agent_test.go`, which seeds a fake Kubernetes client with a previously-applied managed collector and an unrelated reporting-only collector, starts a fresh `Agent` (simulating a post-restart process), and asserts that a subsequent remote config which omits the managed collector deletes it while leaving the reporting-only collector untouched. I confirmed this test fails without the fix (`appliedKeys` stays empty after `Start()`) and passes with it, by temporarily stashing only the `agent.go` change and re-running the test.

Ran from `cmd/operator-opamp-bridge/` (its own Go module):
- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — all packages pass
- `golangci-lint run ./...` — 0 issues
- `gofmt -l` on changed files — clean

I did not run the e2e OpAMP bridge suite (`make e2e-opampbridge`) against a live cluster; the fix and its regression test are scoped to the in-process `Agent`/`ConfigApplier` logic, which the added unit test exercises directly against a fake Kubernetes client covering the exact reported scenario.

**Documentation:** No user-facing documentation changes; this is an internal bug fix to bridge restart behavior. Added a changelog entry at `.chloggen/opamp-bridge-rebuild-applied-keys.yaml`.

Fixes #5445