### PR TITLE
Add e2e tests comparing target allocator with prometheus-operator

### DIFF
--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -75,6 +75,7 @@ jobs:
         - e2e-automatic-rbac
         - e2e-autoscale
         - e2e-clusterobservability
+        - e2e-collector-metrics
         - e2e-instrumentation-default
         - e2e-instrumentation
         - e2e-no-crds

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,10 @@ run:
   concurrency: 3
   issues-exit-code: 1
   tests: true
+  # Include the e2e test suites and their helpers (internal/testing/e2e,
+  # tests/e2e-*); without the tag they would be silently skipped.
+  build-tags:
+    - e2e
 
 linters:
   # all available settings of specific linters

--- a/Makefile
+++ b/Makefile
@@ -615,6 +615,14 @@ e2e-ta-standalone: kustomize gotestsum
 	KUSTOMIZE=$(KUSTOMIZE) \
 	$(GOTESTSUM) --junitfile ./.testresults/e2e/e2e-ta-standalone.xml -- -tags e2e -count=1 -timeout 10m ./tests/e2e-ta-standalone/...
 
+# Go-based full-deployment e2e (operator -> collector + target allocator) with
+# semantic metric checks. Deploys via the operator, so run `make prepare-e2e`
+# first. PoC of an e2e-framework + terratest harness for complex Go assertions.
+.PHONY: e2e-collector-metrics
+e2e-collector-metrics: gotestsum
+	@mkdir -p ./.testresults/e2e
+	$(GOTESTSUM) --junitfile ./.testresults/e2e/e2e-collector-metrics.xml -- -tags e2e -count=1 -timeout 15m ./tests/e2e-collector-metrics/...
+
 # Prepare environment for e2e tests
 .PHONY: prepare-e2e
 prepare-e2e: chainsaw set-image-controller add-image-targetallocator add-image-opampbridge start-kind cert-manager install-metrics-server install-gateway-api-crds install-targetallocator-prometheus-crds load-image-all deploy

--- a/Makefile
+++ b/Makefile
@@ -615,9 +615,8 @@ e2e-ta-standalone: kustomize gotestsum
 	KUSTOMIZE=$(KUSTOMIZE) \
 	$(GOTESTSUM) --junitfile ./.testresults/e2e/e2e-ta-standalone.xml -- -tags e2e -count=1 -timeout 10m ./tests/e2e-ta-standalone/...
 
-# Go-based full-deployment e2e (operator -> collector + target allocator) with
-# semantic metric checks. Deploys via the operator, so run `make prepare-e2e`
-# first. PoC of an e2e-framework + terratest harness for complex Go assertions.
+# End to end metrics collection test comparing against prometheus-operator.
+# Deploys via the operator, so run `make prepare-e2e` first.
 .PHONY: e2e-collector-metrics
 e2e-collector-metrics: gotestsum
 	@mkdir -p ./.testresults/e2e

--- a/go.mod
+++ b/go.mod
@@ -192,13 +192,8 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/arch v0.27.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-<<<<<<< HEAD
 	golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 // indirect
-	golang.org/x/mod v0.38.0 // indirect
-=======
-	golang.org/x/exp v0.0.0-20260611194520-c48552f49976 // indirect
-	golang.org/x/mod v0.37.0
->>>>>>> 16585e32 (Add e2e tests comparing target allocator with prometheus-operator)
+	golang.org/x/mod v0.38.0
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -192,8 +192,13 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/arch v0.27.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
+<<<<<<< HEAD
 	golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 // indirect
 	golang.org/x/mod v0.38.0 // indirect
+=======
+	golang.org/x/exp v0.0.0-20260611194520-c48552f49976 // indirect
+	golang.org/x/mod v0.37.0
+>>>>>>> 16585e32 (Add e2e tests comparing target allocator with prometheus-operator)
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
@@ -224,6 +229,7 @@ require (
 )
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.8 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.42.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.32.25 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFG
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0 h1:bXwSugBiSbgtz7rOtbfGf+woewp4f06orW9OP5BjHLA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0/go.mod h1:Y/HgrePTmGy9HjdSGTqZNa+apUpTVIEVKXJyARP2lrk=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1 h1:7CBQ+Ei8SP2c6ydQTGCCrS35bDxgTMfoP2miAwK++OU=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=

--- a/internal/testing/e2e/client.go
+++ b/internal/testing/e2e/client.go
@@ -4,25 +4,43 @@
 package e2e
 
 import (
+	"sync"
 	"testing"
 
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
+
+	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 )
 
 // fieldManager is the server-side-apply field owner used for every object this
 // framework applies.
 const fieldManager = "opentelemetry-operator-e2e"
 
+// Scheme returns the scheme the framework talks to the cluster with: the built-in
+// Kubernetes types plus the custom resources the e2e suites drive. Registering the
+// CRDs is what lets a test express a custom resource as a typed Go struct (see
+// ApplyObjects) instead of templated YAML.
+var Scheme = sync.OnceValue(func() *runtime.Scheme {
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(monitoringv1.AddToScheme(s))
+	utilruntime.Must(v1beta1.AddToScheme(s))
+	return s
+})
+
 // CRClient builds a controller-runtime client (typed + unstructured, with a dynamic
 // RESTMapper for CRDs) from the test's REST config. Exported so e2e test packages can
 // drive the typed/unstructured API directly while sharing one client construction path.
 func CRClient(t *testing.T, cfg *envconf.Config) crclient.Client {
 	t.Helper()
-	c, err := crclient.New(cfg.Client().RESTConfig(), crclient.Options{Scheme: clientgoscheme.Scheme})
+	c, err := crclient.New(cfg.Client().RESTConfig(), crclient.Options{Scheme: Scheme()})
 	require.NoError(t, err, "create controller-runtime client")
 	return c
 }

--- a/internal/testing/e2e/manifests.go
+++ b/internal/testing/e2e/manifests.go
@@ -11,9 +11,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -38,8 +35,11 @@ func ApplyObjects(ctx context.Context, t *testing.T, cfg *envconf.Config, ns str
 	t.Helper()
 	c := CRClient(t, cfg)
 	for _, obj := range objs {
-		obj.SetNamespace(ns)
-		u := toUnstructured(t, obj)
+		// Namespacing is applied to a copy: the caller's object (often a shared
+		// fixture built once per suite) must not be mutated.
+		namespaced := obj.DeepCopyObject().(crclient.Object)
+		namespaced.SetNamespace(ns)
+		u := toUnstructured(t, namespaced)
 		err := c.Apply(ctx, crclient.ApplyConfigurationFromUnstructured(u), crclient.FieldOwner(fieldManager), crclient.ForceOwnership)
 		require.NoError(t, err, "apply %s %q", u.GetKind(), u.GetName())
 	}
@@ -84,22 +84,5 @@ func applyManifests(ctx context.Context, t *testing.T, c crclient.Client, r io.R
 		}
 		err = c.Apply(ctx, crclient.ApplyConfigurationFromUnstructured(u), crclient.FieldOwner(fieldManager), crclient.ForceOwnership)
 		require.NoError(t, err, "apply %s %q", u.GetKind(), u.GetName())
-	}
-}
-
-// CreateNamespace creates ns.
-func CreateNamespace(ctx context.Context, t *testing.T, cfg *envconf.Config, ns string) {
-	t.Helper()
-	obj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
-	require.NoError(t, CRClient(t, cfg).Create(ctx, obj), "create namespace %s", ns)
-}
-
-// DeleteNamespace deletes ns (ignoring not-found), used for test cleanup.
-func DeleteNamespace(ctx context.Context, t *testing.T, cfg *envconf.Config, ns string) {
-	t.Helper()
-	obj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
-	err := CRClient(t, cfg).Delete(ctx, obj)
-	if !apierrors.IsNotFound(err) {
-		require.NoError(t, err, "delete namespace %s", ns)
 	}
 }

--- a/internal/testing/e2e/manifests.go
+++ b/internal/testing/e2e/manifests.go
@@ -15,8 +15,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
@@ -26,6 +28,38 @@ import (
 func Apply(ctx context.Context, t *testing.T, cfg *envconf.Config, ns, manifests string) {
 	t.Helper()
 	applyManifests(ctx, t, CRClient(t, cfg), strings.NewReader(manifests), ns)
+}
+
+// ApplyObjects server-side-applies typed objects into ns. It is the alternative to
+// Apply for resources a test needs to vary: rather than templating YAML, build the
+// object as a Go struct and set the fields that differ. Any type registered in Scheme
+// works, including custom resources such as ServiceMonitor or OpenTelemetryCollector.
+func ApplyObjects(ctx context.Context, t *testing.T, cfg *envconf.Config, ns string, objs ...crclient.Object) {
+	t.Helper()
+	c := CRClient(t, cfg)
+	for _, obj := range objs {
+		obj.SetNamespace(ns)
+		u := toUnstructured(t, obj)
+		err := c.Apply(ctx, crclient.ApplyConfigurationFromUnstructured(u), crclient.FieldOwner(fieldManager), crclient.ForceOwnership)
+		require.NoError(t, err, "apply %s %q", u.GetKind(), u.GetName())
+	}
+}
+
+// toUnstructured converts a typed object into an unstructured one carrying its
+// apiVersion/kind (typed structs leave TypeMeta empty), so it can go through the same
+// server-side-apply path as YAML manifests.
+func toUnstructured(t *testing.T, obj crclient.Object) *unstructured.Unstructured {
+	t.Helper()
+	gvk, err := apiutil.GVKForObject(obj, Scheme())
+	require.NoError(t, err, "look up GroupVersionKind for %T", obj)
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	require.NoError(t, err, "convert %T to unstructured", obj)
+	u := &unstructured.Unstructured{Object: raw}
+	u.SetGroupVersionKind(gvk)
+	// Typed structs always render a status; it is a subresource on every type these
+	// tests apply, so sending it would be at best ignored and at worst rejected.
+	unstructured.RemoveNestedField(u.Object, "status")
+	return u
 }
 
 // applyManifests SSA-applies each document from r. When forceNS is non-empty it is set

--- a/internal/testing/e2e/namespace.go
+++ b/internal/testing/e2e/namespace.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+// nsContextKey is the context key under which SetupNamespace stores the namespace.
+type nsContextKey struct{}
+
+// SetupNamespace creates a namespace named after the running test (see
+// NamespaceFromT), registers its deletion as test cleanup, and returns a context
+// carrying the namespace name — retrieve it with Namespace. Every test gets its own
+// namespace, which is what lets the manifests use fixed object names.
+func SetupNamespace(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	t.Helper()
+	ns := NamespaceFromT(t)
+	CreateNamespace(ctx, t, cfg, ns)
+	t.Cleanup(func() {
+		// The feature's context is already cancelled by the time cleanup runs.
+		DeleteNamespace(context.WithoutCancel(ctx), t, cfg, ns)
+	})
+	return context.WithValue(ctx, nsContextKey{}, ns)
+}
+
+// Namespace returns the namespace SetupNamespace stored in ctx, failing t when the
+// context does not carry one (i.e. the feature's Setup did not call SetupNamespace).
+func Namespace(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	ns, ok := ctx.Value(nsContextKey{}).(string)
+	require.True(t, ok, "no namespace in context: call e2e.SetupNamespace in the feature's Setup")
+	return ns
+}
+
+// CreateNamespace creates ns.
+func CreateNamespace(ctx context.Context, t *testing.T, cfg *envconf.Config, ns string) {
+	t.Helper()
+	obj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+	require.NoError(t, CRClient(t, cfg).Create(ctx, obj), "create namespace %s", ns)
+}
+
+// DeleteNamespace deletes ns (ignoring not-found), used for test cleanup.
+func DeleteNamespace(ctx context.Context, t *testing.T, cfg *envconf.Config, ns string) {
+	t.Helper()
+	obj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+	err := CRClient(t, cfg).Delete(ctx, obj)
+	if !apierrors.IsNotFound(err) {
+		require.NoError(t, err, "delete namespace %s", ns)
+	}
+}

--- a/internal/testing/e2e/prometheusoperator.go
+++ b/internal/testing/e2e/prometheusoperator.go
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/modfile"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+// EnsurePrometheusOperator installs prometheus-operator into the cluster if its
+// controller is not already running, so tests can use a Prometheus CR as a live
+// oracle. The version matches the prometheus-operator module this repo depends on
+// (see prometheusOperatorVersion). Idempotent: a no-op once installed. The release
+// bundle is fetched over the network and server-side-applied.
+func EnsurePrometheusOperator(ctx context.Context, t *testing.T, cfg *envconf.Config) {
+	t.Helper()
+	c := CRClient(t, cfg)
+	dep := &appsv1.Deployment{}
+	err := c.Get(ctx, crclient.ObjectKey{Namespace: "default", Name: "prometheus-operator"}, dep)
+	if err == nil {
+		return
+	}
+	if !apierrors.IsNotFound(err) {
+		require.NoError(t, err, "get prometheus-operator deployment")
+	}
+
+	url := "https://github.com/prometheus-operator/prometheus-operator/releases/download/" + prometheusOperatorVersion(t) + "/bundle.yaml"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	require.NoError(t, err, "request bundle")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "fetch bundle")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("fetch bundle: status %d", resp.StatusCode)
+	}
+	// The bundle mixes cluster-scoped (CRDs, RBAC) and namespaced (operator in
+	// default) objects, so its own namespaces are respected.
+	applyManifests(ctx, t, c, resp.Body, "")
+	WaitForDeployment(ctx, t, cfg, "default", "prometheus-operator", 3*time.Minute)
+}
+
+// prometheusOperatorVersion returns the prometheus-operator version this repo depends
+// on, read from go.mod, so the installed operator matches the API types and CRDs the
+// code is written against.
+func prometheusOperatorVersion(t *testing.T) string {
+	t.Helper()
+	const module = "github.com/prometheus-operator/prometheus-operator"
+	path := filepath.Join(RepoRoot(t), "go.mod")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "read go.mod")
+	f, err := modfile.Parse(path, data, nil)
+	require.NoError(t, err, "parse go.mod")
+	for _, r := range f.Require {
+		// Match the module's own require, not its /pkg/... submodules.
+		if r.Mod.Path == module {
+			return r.Mod.Version
+		}
+	}
+	t.Fatalf("module %s not found in go.mod", module)
+	return ""
+}

--- a/internal/testing/e2e/prometheusoperator.go
+++ b/internal/testing/e2e/prometheusoperator.go
@@ -24,18 +24,28 @@ import (
 // oracle. The version matches the prometheus-operator module this repo depends on
 // (see prometheusOperatorVersion). Idempotent: a no-op once installed. The release
 // bundle is fetched over the network and server-side-applied.
+//
+// Availability is waited for on every path, not just after a fresh install: an
+// install left mid-rollout (or crash-looping) by a previous or concurrent run must
+// not let tests proceed against an operator that is not reconciling yet.
 func EnsurePrometheusOperator(ctx context.Context, t *testing.T, cfg *envconf.Config) {
 	t.Helper()
 	c := CRClient(t, cfg)
 	dep := &appsv1.Deployment{}
 	err := c.Get(ctx, crclient.ObjectKey{Namespace: "default", Name: "prometheus-operator"}, dep)
-	if err == nil {
-		return
-	}
-	if !apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
+		installPrometheusOperator(ctx, t, c)
+	} else {
 		require.NoError(t, err, "get prometheus-operator deployment")
 	}
+	// Returns almost immediately when the operator is already available.
+	WaitForDeployment(ctx, t, cfg, "default", "prometheus-operator", 3*time.Minute)
+}
 
+// installPrometheusOperator fetches the release bundle matching the module version
+// and server-side-applies it.
+func installPrometheusOperator(ctx context.Context, t *testing.T, c crclient.Client) {
+	t.Helper()
 	url := "https://github.com/prometheus-operator/prometheus-operator/releases/download/" + prometheusOperatorVersion(t) + "/bundle.yaml"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	require.NoError(t, err, "request bundle")
@@ -48,7 +58,6 @@ func EnsurePrometheusOperator(ctx context.Context, t *testing.T, cfg *envconf.Co
 	// The bundle mixes cluster-scoped (CRDs, RBAC) and namespaced (operator in
 	// default) objects, so its own namespaces are respected.
 	applyManifests(ctx, t, c, resp.Body, "")
-	WaitForDeployment(ctx, t, cfg, "default", "prometheus-operator", 3*time.Minute)
 }
 
 // prometheusOperatorVersion returns the prometheus-operator version this repo depends

--- a/internal/testing/e2e/promql.go
+++ b/internal/testing/e2e/promql.go
@@ -11,25 +11,64 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
-// PromTarget identifies a Prometheus backend by its in-namespace Service and port.
-type PromTarget struct {
-	Service string
-	Port    int
+const (
+	// defaultPromTimeout bounds how long the retrying query helpers wait for a check
+	// to pass — long enough for a freshly deployed pipeline to scrape and export.
+	defaultPromTimeout = 2 * time.Minute
+	// defaultPromInterval is the delay between attempts of the retrying query helpers.
+	defaultPromInterval = 2 * time.Second
+)
+
+// Prom is a handle to a Prometheus backend reachable through the API server's
+// service proxy (which works for headless Services, so no port-forward is needed).
+// It carries everything that stays constant for a test — the environment plus the
+// namespace, Service and port of the backend — so assertions only name the query.
+type Prom struct {
+	cfg       *envconf.Config
+	namespace string
+	service   string
+	port      int
+
+	once  sync.Once
+	cs    *kubernetes.Clientset
+	csErr error
 }
 
-// queryProm runs an instant PromQL query against a Prometheus Service via the API
-// server's service proxy (works for headless Services, so no port-forward is needed).
-func queryProm(ctx context.Context, cs *kubernetes.Clientset, ns string, target PromTarget, query string) (model.Vector, error) {
-	raw, err := cs.CoreV1().Services(ns).
-		ProxyGet("http", target.Service, strconv.Itoa(target.Port), "/api/v1/query", map[string]string{"query": query}).
+// NewProm returns a handle to the Prometheus served by the named Service and port in
+// namespace. Build it once the namespace is known (see Namespace) and reuse it for
+// every assertion against that backend.
+func NewProm(cfg *envconf.Config, namespace, service string, port int) *Prom {
+	return &Prom{cfg: cfg, namespace: namespace, service: service, port: port}
+}
+
+// clientSet lazily builds (and caches) the clientset used for the service proxy. It
+// returns the error instead of failing the test because it runs inside retry loops.
+func (p *Prom) clientSet() (*kubernetes.Clientset, error) {
+	p.once.Do(func() { p.cs, p.csErr = clientSet(p.cfg) })
+	return p.cs, p.csErr
+}
+
+// Query runs a single instant PromQL query and decodes the result vector. It does not
+// retry — use Eventually for assertions that have to wait for data to arrive.
+func (p *Prom) Query(ctx context.Context, t *testing.T, query string) (model.Vector, error) {
+	t.Helper()
+	cs, err := p.clientSet()
+	if err != nil {
+		return nil, fmt.Errorf("create clientset: %w", err)
+	}
+	raw, err := cs.CoreV1().Services(p.namespace).
+		ProxyGet("http", p.service, strconv.Itoa(p.port), "/api/v1/query", map[string]string{"query": query}).
 		DoRaw(ctx)
 	if err != nil {
 		return nil, err
@@ -37,81 +76,21 @@ func queryProm(ctx context.Context, cs *kubernetes.Clientset, ns string, target 
 	return parsePromVector(raw)
 }
 
-// parsePromVector decodes a Prometheus instant-query JSON response into a model.Vector.
-func parsePromVector(raw []byte) (model.Vector, error) {
-	var resp struct {
-		Status string `json:"status"`
-		Error  string `json:"error"`
-		Data   struct {
-			ResultType string `json:"resultType"`
-			Result     []struct {
-				Metric map[string]string `json:"metric"`
-				Value  []any             `json:"value"`
-			} `json:"result"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(raw, &resp); err != nil {
-		return nil, fmt.Errorf("decode prometheus response: %w", err)
-	}
-	if resp.Status != "success" {
-		return nil, fmt.Errorf("prometheus query failed: %s", resp.Error)
-	}
-	if resp.Data.ResultType != "vector" {
-		return nil, fmt.Errorf("query returned %q, want a vector", resp.Data.ResultType)
-	}
-	var vec model.Vector
-	for _, r := range resp.Data.Result {
-		metric := model.Metric{}
-		for k, v := range r.Metric {
-			metric[model.LabelName(k)] = model.LabelValue(v)
-		}
-		var val model.SampleValue
-		if len(r.Value) == 2 {
-			s, _ := r.Value[1].(string)
-			f, err := strconv.ParseFloat(s, 64)
-			if err != nil {
-				return nil, fmt.Errorf("parse sample value %q: %w", s, err)
-			}
-			val = model.SampleValue(f)
-		}
-		vec = append(vec, &model.Sample{Metric: metric, Value: val})
-	}
-	return vec, nil
-}
-
-// eventuallyInterval is the delay between eventually's attempts.
-const eventuallyInterval = 2 * time.Second
-
-// eventually retries fn until it returns nil, ctx is done, or attempts are exhausted.
-func eventually(ctx context.Context, t *testing.T, desc string, attempts int, fn func() error) {
+// Eventually runs an instant query and retries until check passes. The check is plain
+// Go over a model.Vector — assert on values and labels of the queried series. On
+// timeout the test fails with the last query or check error.
+func (p *Prom) Eventually(ctx context.Context, t *testing.T, query string, check func(model.Vector) error) {
 	t.Helper()
-	var err error
-	for range attempts {
-		if err = fn(); err == nil {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		vec, err := p.Query(ctx, t, query)
+		if err != nil {
+			c.Errorf("promql %s: %v", query, err)
 			return
 		}
-		select {
-		case <-ctx.Done():
-			t.Fatalf("%s: %v (last error: %v)", desc, ctx.Err(), err)
-		case <-time.After(eventuallyInterval):
+		if err := check(vec); err != nil {
+			c.Errorf("promql %s: %v", query, err)
 		}
-	}
-	t.Fatalf("%s: gave up after %d attempts: %v", desc, attempts, err)
-}
-
-// EventuallyPromQL runs an instant query against a Prometheus Service and retries until
-// check passes. The check is plain Go over a model.Vector — assert on values and labels
-// of the queried series.
-func EventuallyPromQL(ctx context.Context, t *testing.T, cfg *envconf.Config, ns string, target PromTarget, query string, check func(model.Vector) error) {
-	t.Helper()
-	cs := ClientSet(t, cfg)
-	eventually(ctx, t, "promql: "+query, 60, func() error {
-		vec, err := queryProm(ctx, cs, ns, target, query)
-		if err != nil {
-			return err
-		}
-		return check(vec)
-	})
+	}, defaultPromTimeout, defaultPromInterval)
 }
 
 // Differential describes a SameLabelsAcross comparison: partition the result of
@@ -136,65 +115,64 @@ type Differential struct {
 // partitions are present and they agree.
 //
 // Query `up` to compare pure target identity.
-func SameLabelsAcross(ctx context.Context, t *testing.T, cfg *envconf.Config, ns string, target PromTarget, d Differential) {
+func (p *Prom) SameLabelsAcross(ctx context.Context, t *testing.T, d Differential) {
 	t.Helper()
-	cs := ClientSet(t, cfg)
-	drop := map[string]bool{"__name__": true, d.PartitionLabel: true}
-	for _, l := range d.Ignore {
-		drop[l] = true
-	}
-
 	desc := fmt.Sprintf("differential %q across %q", d.Query, d.PartitionLabel)
-	eventually(ctx, t, desc, 60, func() error {
-		vec, err := queryProm(ctx, cs, ns, target, d.Query)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		vec, err := p.Query(ctx, t, d.Query)
 		if err != nil {
-			return err
+			c.Errorf("%s: %v", desc, err)
+			return
 		}
-		parts := map[string]map[string]bool{} // partition value -> set of canonical label-sets
-		for _, s := range vec {
-			pv := string(s.Metric[model.LabelName(d.PartitionLabel)])
-			labels := map[string]string{}
-			for k, v := range s.Metric {
-				if drop[string(k)] {
-					continue
-				}
-				labels[string(k)] = string(v)
-			}
-			if parts[pv] == nil {
-				parts[pv] = map[string]bool{}
-			}
-			parts[pv][canonicalLabels(labels)] = true
+		if err := samePartitionLabels(vec, d); err != nil {
+			c.Errorf("%s: %v", desc, err)
 		}
-		if len(parts) < d.WantPartitions {
-			return fmt.Errorf("waiting for %d partitions of %q, have %d: %v", d.WantPartitions, d.PartitionLabel, len(parts), slices.Sorted(maps.Keys(parts)))
-		}
-		var refName string
-		var ref map[string]bool
-		for name, set := range parts {
-			if ref == nil {
-				refName, ref = name, set
-				continue
-			}
-			if diff := diffSets(ref, set); diff != "" {
-				return fmt.Errorf("label sets differ between %s=%q (A) and %s=%q (B):\n%s", d.PartitionLabel, refName, d.PartitionLabel, name, diff)
-			}
-		}
-		return nil
-	})
+	}, defaultPromTimeout, defaultPromInterval)
 }
 
-// canonicalLabels renders a label set as a single deterministic string (labels sorted
-// by name, each rendered as name="value") so that label sets can be used as map keys
-// and compared for set membership.
-func canonicalLabels(m map[string]string) string {
-	var b strings.Builder
-	for i, k := range slices.Sorted(maps.Keys(m)) {
-		if i > 0 {
-			b.WriteByte(',')
-		}
-		fmt.Fprintf(&b, "%s=%q", k, m[k])
+// samePartitionLabels is the pure check behind SameLabelsAcross: it partitions vec by
+// d.PartitionLabel and returns nil when at least d.WantPartitions partitions are
+// present and all of them carry the same set of label-sets.
+func samePartitionLabels(vec model.Vector, d Differential) error {
+	drop := map[model.LabelName]bool{model.MetricNameLabel: true, model.LabelName(d.PartitionLabel): true}
+	for _, l := range d.Ignore {
+		drop[model.LabelName(l)] = true
 	}
-	return b.String()
+
+	parts := map[string]map[string]bool{} // partition value -> set of canonical label-sets
+	for _, s := range vec {
+		pv := string(s.Metric[model.LabelName(d.PartitionLabel)])
+		if parts[pv] == nil {
+			parts[pv] = map[string]bool{}
+		}
+		parts[pv][canonicalLabels(s.Metric, drop)] = true
+	}
+	if len(parts) < d.WantPartitions {
+		return fmt.Errorf("waiting for %d partitions of %q, have %d: %v", d.WantPartitions, d.PartitionLabel, len(parts), slices.Sorted(maps.Keys(parts)))
+	}
+	// Compare against the lexically first partition so the message is deterministic.
+	names := slices.Sorted(maps.Keys(parts))
+	refName := names[0]
+	for _, name := range names[1:] {
+		if diff := diffSets(parts[refName], parts[name]); diff != "" {
+			return fmt.Errorf("label sets differ between %s=%q (A) and %s=%q (B):\n%s", d.PartitionLabel, refName, d.PartitionLabel, name, diff)
+		}
+	}
+	return nil
+}
+
+// canonicalLabels renders a sample's labels, minus the dropped ones, as a single
+// deterministic string (`{name="value", ...}`, sorted by label name) so that label
+// sets can be used as map keys and compared for set membership.
+func canonicalLabels(metric model.Metric, drop map[model.LabelName]bool) string {
+	ls := make(model.LabelSet, len(metric))
+	for k, v := range metric {
+		if drop[k] {
+			continue
+		}
+		ls[k] = v
+	}
+	return ls.String()
 }
 
 // diffSets returns a human-readable description of the symmetric difference between
@@ -219,10 +197,38 @@ func diffSets(a, b map[string]bool) string {
 	slices.Sort(onlyB)
 	var sb strings.Builder
 	for _, s := range onlyA {
-		fmt.Fprintf(&sb, "  only in A: {%s}\n", s)
+		fmt.Fprintf(&sb, "  only in A: %s\n", s)
 	}
 	for _, s := range onlyB {
-		fmt.Fprintf(&sb, "  only in B: {%s}\n", s)
+		fmt.Fprintf(&sb, "  only in B: %s\n", s)
 	}
 	return sb.String()
+}
+
+// parsePromVector decodes a Prometheus instant-query JSON response into a
+// model.Vector, leaving the sample decoding (label sets, timestamps, native
+// histograms) to prometheus/common's own unmarshaller.
+func parsePromVector(raw []byte) (model.Vector, error) {
+	var resp struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+		Data   struct {
+			ResultType string          `json:"resultType"`
+			Result     json.RawMessage `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("decode prometheus response: %w", err)
+	}
+	if resp.Status != "success" {
+		return nil, fmt.Errorf("prometheus query failed: %s", resp.Error)
+	}
+	if resp.Data.ResultType != "vector" {
+		return nil, fmt.Errorf("query returned %q, want a vector", resp.Data.ResultType)
+	}
+	var vec model.Vector
+	if err := json.Unmarshal(resp.Data.Result, &vec); err != nil {
+		return nil, fmt.Errorf("decode prometheus vector: %w", err)
+	}
+	return vec, nil
 }

--- a/internal/testing/e2e/promql.go
+++ b/internal/testing/e2e/promql.go
@@ -1,0 +1,228 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+// PromTarget identifies a Prometheus backend by its in-namespace Service and port.
+type PromTarget struct {
+	Service string
+	Port    int
+}
+
+// queryProm runs an instant PromQL query against a Prometheus Service via the API
+// server's service proxy (works for headless Services, so no port-forward is needed).
+func queryProm(ctx context.Context, cs *kubernetes.Clientset, ns string, target PromTarget, query string) (model.Vector, error) {
+	raw, err := cs.CoreV1().Services(ns).
+		ProxyGet("http", target.Service, strconv.Itoa(target.Port), "/api/v1/query", map[string]string{"query": query}).
+		DoRaw(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return parsePromVector(raw)
+}
+
+// parsePromVector decodes a Prometheus instant-query JSON response into a model.Vector.
+func parsePromVector(raw []byte) (model.Vector, error) {
+	var resp struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []any             `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("decode prometheus response: %w", err)
+	}
+	if resp.Status != "success" {
+		return nil, fmt.Errorf("prometheus query failed: %s", resp.Error)
+	}
+	if resp.Data.ResultType != "vector" {
+		return nil, fmt.Errorf("query returned %q, want a vector", resp.Data.ResultType)
+	}
+	var vec model.Vector
+	for _, r := range resp.Data.Result {
+		metric := model.Metric{}
+		for k, v := range r.Metric {
+			metric[model.LabelName(k)] = model.LabelValue(v)
+		}
+		var val model.SampleValue
+		if len(r.Value) == 2 {
+			s, _ := r.Value[1].(string)
+			f, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return nil, fmt.Errorf("parse sample value %q: %w", s, err)
+			}
+			val = model.SampleValue(f)
+		}
+		vec = append(vec, &model.Sample{Metric: metric, Value: val})
+	}
+	return vec, nil
+}
+
+// eventuallyInterval is the delay between eventually's attempts.
+const eventuallyInterval = 2 * time.Second
+
+// eventually retries fn until it returns nil, ctx is done, or attempts are exhausted.
+func eventually(ctx context.Context, t *testing.T, desc string, attempts int, fn func() error) {
+	t.Helper()
+	var err error
+	for range attempts {
+		if err = fn(); err == nil {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("%s: %v (last error: %v)", desc, ctx.Err(), err)
+		case <-time.After(eventuallyInterval):
+		}
+	}
+	t.Fatalf("%s: gave up after %d attempts: %v", desc, attempts, err)
+}
+
+// EventuallyPromQL runs an instant query against a Prometheus Service and retries until
+// check passes. The check is plain Go over a model.Vector — assert on values and labels
+// of the queried series.
+func EventuallyPromQL(ctx context.Context, t *testing.T, cfg *envconf.Config, ns string, target PromTarget, query string, check func(model.Vector) error) {
+	t.Helper()
+	cs := ClientSet(t, cfg)
+	eventually(ctx, t, "promql: "+query, 60, func() error {
+		vec, err := queryProm(ctx, cs, ns, target, query)
+		if err != nil {
+			return err
+		}
+		return check(vec)
+	})
+}
+
+// Differential describes a SameLabelsAcross comparison: partition the result of
+// Query by the value of PartitionLabel, require at least WantPartitions distinct
+// partitions, and ignore the labels in Ignore (they legitimately differ between
+// pipelines).
+type Differential struct {
+	Query          string
+	PartitionLabel string
+	WantPartitions int
+	Ignore         []string
+}
+
+// SameLabelsAcross is a differential within one Prometheus: it queries a single
+// backend, partitions the result series by the value of d.PartitionLabel, and asserts
+// every partition exposes the same set of label-sets (after dropping the partition
+// label and any ignored labels). Use it to compare two pipelines that write to one
+// Prometheus distinguished by a label — e.g. the target allocator pipeline
+// (pipeline=ta) versus prometheus-operator scraping the same target natively
+// (pipeline=oracle). Identical sets mean the allocator labeled the target exactly as
+// prometheus-operator does. It retries until at least d.WantPartitions distinct
+// partitions are present and they agree.
+//
+// Query `up` to compare pure target identity.
+func SameLabelsAcross(ctx context.Context, t *testing.T, cfg *envconf.Config, ns string, target PromTarget, d Differential) {
+	t.Helper()
+	cs := ClientSet(t, cfg)
+	drop := map[string]bool{"__name__": true, d.PartitionLabel: true}
+	for _, l := range d.Ignore {
+		drop[l] = true
+	}
+
+	desc := fmt.Sprintf("differential %q across %q", d.Query, d.PartitionLabel)
+	eventually(ctx, t, desc, 60, func() error {
+		vec, err := queryProm(ctx, cs, ns, target, d.Query)
+		if err != nil {
+			return err
+		}
+		parts := map[string]map[string]bool{} // partition value -> set of canonical label-sets
+		for _, s := range vec {
+			pv := string(s.Metric[model.LabelName(d.PartitionLabel)])
+			labels := map[string]string{}
+			for k, v := range s.Metric {
+				if drop[string(k)] {
+					continue
+				}
+				labels[string(k)] = string(v)
+			}
+			if parts[pv] == nil {
+				parts[pv] = map[string]bool{}
+			}
+			parts[pv][canonicalLabels(labels)] = true
+		}
+		if len(parts) < d.WantPartitions {
+			return fmt.Errorf("waiting for %d partitions of %q, have %d: %v", d.WantPartitions, d.PartitionLabel, len(parts), slices.Sorted(maps.Keys(parts)))
+		}
+		var refName string
+		var ref map[string]bool
+		for name, set := range parts {
+			if ref == nil {
+				refName, ref = name, set
+				continue
+			}
+			if diff := diffSets(ref, set); diff != "" {
+				return fmt.Errorf("label sets differ between %s=%q (A) and %s=%q (B):\n%s", d.PartitionLabel, refName, d.PartitionLabel, name, diff)
+			}
+		}
+		return nil
+	})
+}
+
+// canonicalLabels renders a label set as a single deterministic string (labels sorted
+// by name, each rendered as name="value") so that label sets can be used as map keys
+// and compared for set membership.
+func canonicalLabels(m map[string]string) string {
+	var b strings.Builder
+	for i, k := range slices.Sorted(maps.Keys(m)) {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, "%s=%q", k, m[k])
+	}
+	return b.String()
+}
+
+// diffSets returns a human-readable description of the symmetric difference between
+// two sets of canonical label-sets — the members only in a ("only in A") and only in
+// b ("only in B"). It returns the empty string when the sets are equal.
+func diffSets(a, b map[string]bool) string {
+	var onlyA, onlyB []string
+	for k := range a {
+		if !b[k] {
+			onlyA = append(onlyA, k)
+		}
+	}
+	for k := range b {
+		if !a[k] {
+			onlyB = append(onlyB, k)
+		}
+	}
+	if len(onlyA) == 0 && len(onlyB) == 0 {
+		return ""
+	}
+	slices.Sort(onlyA)
+	slices.Sort(onlyB)
+	var sb strings.Builder
+	for _, s := range onlyA {
+		fmt.Fprintf(&sb, "  only in A: {%s}\n", s)
+	}
+	for _, s := range onlyB {
+		fmt.Fprintf(&sb, "  only in B: {%s}\n", s)
+	}
+	return sb.String()
+}

--- a/internal/testing/e2e/promql_test.go
+++ b/internal/testing/e2e/promql_test.go
@@ -1,0 +1,193 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePromVector(t *testing.T) {
+	t.Run("decodes samples with metric and value", func(t *testing.T) {
+		vec, err := parsePromVector([]byte(`{
+			"status": "success",
+			"data": {
+				"resultType": "vector",
+				"result": [
+					{"metric": {"__name__": "up", "job": "sample-app"}, "value": [1700000000.5, "1"]},
+					{"metric": {"__name__": "up", "job": "other"}, "value": [1700000000.5, "0"]}
+				]
+			}
+		}`))
+		require.NoError(t, err)
+		require.Len(t, vec, 2)
+		assert.Equal(t, model.LabelValue("sample-app"), vec[0].Metric["job"])
+		assert.Equal(t, model.SampleValue(1), vec[0].Value)
+		assert.Equal(t, model.Time(1700000000500), vec[0].Timestamp)
+		assert.Equal(t, model.SampleValue(0), vec[1].Value)
+	})
+
+	t.Run("decodes an empty result", func(t *testing.T) {
+		vec, err := parsePromVector([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+		require.NoError(t, err)
+		assert.Empty(t, vec)
+	})
+
+	t.Run("reports a query error", func(t *testing.T) {
+		_, err := parsePromVector([]byte(`{"status":"error","errorType":"bad_data","error":"invalid parameter"}`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid parameter")
+	})
+
+	t.Run("rejects a non-vector result type", func(t *testing.T) {
+		_, err := parsePromVector([]byte(`{"status":"success","data":{"resultType":"matrix","result":[]}}`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `"matrix"`)
+	})
+
+	t.Run("rejects malformed JSON", func(t *testing.T) {
+		_, err := parsePromVector([]byte(`not json`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode prometheus response")
+	})
+
+	t.Run("rejects a malformed result", func(t *testing.T) {
+		_, err := parsePromVector([]byte(`{"status":"success","data":{"resultType":"vector","result":{}}}`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode prometheus vector")
+	})
+}
+
+func TestCanonicalLabels(t *testing.T) {
+	metric := model.Metric{
+		"__name__": "up",
+		"pipeline": "ta",
+		"job":      "sample-app",
+		"instance": "10.0.0.1:8080",
+		"pod":      "sample-app-abc",
+	}
+
+	t.Run("renders sorted and drops nothing by default", func(t *testing.T) {
+		assert.Equal(t,
+			`{__name__="up", instance="10.0.0.1:8080", job="sample-app", pipeline="ta", pod="sample-app-abc"}`,
+			canonicalLabels(metric, nil))
+	})
+
+	t.Run("drops the requested labels", func(t *testing.T) {
+		drop := map[model.LabelName]bool{"__name__": true, "pipeline": true, "pod": true}
+		assert.Equal(t, `{instance="10.0.0.1:8080", job="sample-app"}`, canonicalLabels(metric, drop))
+	})
+
+	t.Run("label order in the sample does not affect the rendering", func(t *testing.T) {
+		assert.Equal(t,
+			canonicalLabels(model.Metric{"b": "2", "a": "1"}, nil),
+			canonicalLabels(model.Metric{"a": "1", "b": "2"}, nil))
+	})
+
+	t.Run("renders an all-dropped label set as the empty set", func(t *testing.T) {
+		assert.Equal(t, "{}", canonicalLabels(model.Metric{"job": "x"}, map[model.LabelName]bool{"job": true}))
+	})
+}
+
+func TestDiffSets(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		a, b map[string]bool
+		want string
+	}{
+		{
+			name: "equal sets have no diff",
+			a:    map[string]bool{`{job="a"}`: true, `{job="b"}`: true},
+			b:    map[string]bool{`{job="b"}`: true, `{job="a"}`: true},
+			want: "",
+		},
+		{
+			name: "both empty",
+			a:    map[string]bool{},
+			b:    map[string]bool{},
+			want: "",
+		},
+		{
+			name: "member only in A",
+			a:    map[string]bool{`{job="a"}`: true, `{job="b"}`: true},
+			b:    map[string]bool{`{job="a"}`: true},
+			want: "  only in A: {job=\"b\"}\n",
+		},
+		{
+			name: "member only in B",
+			a:    map[string]bool{`{job="a"}`: true},
+			b:    map[string]bool{`{job="a"}`: true, `{job="b"}`: true},
+			want: "  only in B: {job=\"b\"}\n",
+		},
+		{
+			name: "both sides, rendered in sorted order",
+			a:    map[string]bool{`{job="a2"}`: true, `{job="a1"}`: true},
+			b:    map[string]bool{`{job="b2"}`: true, `{job="b1"}`: true},
+			want: "  only in A: {job=\"a1\"}\n  only in A: {job=\"a2\"}\n  only in B: {job=\"b1\"}\n  only in B: {job=\"b2\"}\n",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, diffSets(tt.a, tt.b))
+		})
+	}
+}
+
+func TestSamePartitionLabels(t *testing.T) {
+	// Two pipelines scraping the same two targets, agreeing on every label except
+	// the partition label itself.
+	agreeing := model.Vector{
+		sample(1, "__name__", "up", "pipeline", "ta", "job", "sample-app", "instance", "a:8080"),
+		sample(1, "__name__", "up", "pipeline", "ta", "job", "sample-app", "instance", "b:8080"),
+		sample(1, "__name__", "up", "pipeline", "oracle", "job", "sample-app", "instance", "a:8080"),
+		sample(1, "__name__", "up", "pipeline", "oracle", "job", "sample-app", "instance", "b:8080"),
+	}
+	d := Differential{Query: "up", PartitionLabel: "pipeline", WantPartitions: 2}
+
+	t.Run("passes when the partitions agree", func(t *testing.T) {
+		require.NoError(t, samePartitionLabels(agreeing, d))
+	})
+
+	t.Run("waits for the wanted number of partitions", func(t *testing.T) {
+		err := samePartitionLabels(agreeing[:2], d)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "waiting for 2 partitions")
+		assert.Contains(t, err.Error(), "[ta]")
+	})
+
+	t.Run("reports a diverging label", func(t *testing.T) {
+		diverging := model.Vector{
+			sample(1, "__name__", "up", "pipeline", "ta", "job", "sample-app", "instance", "a:8080"),
+			sample(1, "__name__", "up", "pipeline", "oracle", "job", "sample-app", "instance", "a:8080", "container", "app"),
+		}
+		err := samePartitionLabels(diverging, d)
+		require.Error(t, err)
+		// Partitions are compared in sorted order, so "oracle" is the reference (A).
+		assert.Contains(t, err.Error(), `pipeline="oracle" (A)`)
+		assert.Contains(t, err.Error(), `pipeline="ta" (B)`)
+		assert.Contains(t, err.Error(), `only in A: {container="app", instance="a:8080", job="sample-app"}`)
+		assert.Contains(t, err.Error(), `only in B: {instance="a:8080", job="sample-app"}`)
+	})
+
+	t.Run("ignored labels may differ", func(t *testing.T) {
+		diverging := model.Vector{
+			sample(1, "__name__", "up", "pipeline", "ta", "job", "sample-app", "endpoint", "metrics"),
+			sample(1, "__name__", "up", "pipeline", "oracle", "job", "sample-app", "endpoint", "http-metrics"),
+		}
+		require.Error(t, samePartitionLabels(diverging, d))
+		ignoring := d
+		ignoring.Ignore = []string{"endpoint"}
+		require.NoError(t, samePartitionLabels(diverging, ignoring))
+	})
+
+	t.Run("the metric name never counts as a difference", func(t *testing.T) {
+		renamed := model.Vector{
+			sample(1, "__name__", "up", "pipeline", "ta", "job", "sample-app"),
+			sample(1, "__name__", "up_total", "pipeline", "oracle", "job", "sample-app"),
+		}
+		require.NoError(t, samePartitionLabels(renamed, d))
+	})
+}

--- a/internal/testing/e2e/series.go
+++ b/internal/testing/e2e/series.go
@@ -1,0 +1,85 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/prometheus/common/model"
+)
+
+// Series is an expected Prometheus series for HasSeries. A sample matches when it
+// carries every label in Labels (exact value), carries every label in Present (any
+// value), carries no label in Absent, and — when Value is non-nil — its value
+// satisfies it. When Exact is true the sample must carry EXACTLY the union of Labels
+// and Present and nothing else, which pins a target's complete label set while still
+// allowing non-deterministic values (e.g. a pod name) via Present.
+//
+// Absent and Exact are how a test proves target labeling: a static scrape config
+// must carry no Kubernetes service-discovery labels, while a ServiceMonitor target
+// must carry exactly the relabeled identity the allocator generated.
+type Series struct {
+	Labels  map[string]string
+	Present []string
+	Absent  []string
+	Exact   bool
+	Value   func(model.SampleValue) bool
+}
+
+// HasSeries returns a PromQL check (for EventuallyPromQL) that passes when some
+// sample in the result vector matches want.
+func HasSeries(want Series) func(model.Vector) error {
+	return func(v model.Vector) error {
+		for _, s := range v {
+			if seriesMatches(want, s) {
+				return nil
+			}
+		}
+		return fmt.Errorf("no sample matched labels=%v absent=%v among %d samples: %v",
+			want.Labels, want.Absent, len(v), v)
+	}
+}
+
+func seriesMatches(want Series, s *model.Sample) bool {
+	for k, val := range want.Labels {
+		if string(s.Metric[model.LabelName(k)]) != val {
+			return false
+		}
+	}
+	for _, k := range want.Present {
+		if _, ok := s.Metric[model.LabelName(k)]; !ok {
+			return false
+		}
+	}
+	for _, k := range want.Absent {
+		if _, ok := s.Metric[model.LabelName(k)]; ok {
+			return false
+		}
+	}
+	if want.Exact {
+		allowed := map[string]bool{"__name__": true}
+		for k := range want.Labels {
+			allowed[k] = true
+		}
+		for _, k := range want.Present {
+			allowed[k] = true
+		}
+		for k := range s.Metric {
+			if !allowed[string(k)] {
+				return false
+			}
+		}
+	}
+	return want.Value == nil || want.Value(s.Value)
+}
+
+// Equals matches a sample value exactly.
+func Equals(want model.SampleValue) func(model.SampleValue) bool {
+	return func(got model.SampleValue) bool { return got == want }
+}
+
+// AtLeast matches a sample value >= want.
+func AtLeast(want model.SampleValue) func(model.SampleValue) bool {
+	return func(got model.SampleValue) bool { return got >= want }
+}

--- a/internal/testing/e2e/series.go
+++ b/internal/testing/e2e/series.go
@@ -5,6 +5,9 @@ package e2e
 
 import (
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
 	"github.com/prometheus/common/model"
 )
@@ -27,7 +30,36 @@ type Series struct {
 	Value   func(model.SampleValue) bool
 }
 
-// HasSeries returns a PromQL check (for EventuallyPromQL) that passes when some
+// String renders every clause of the matcher, so a failure message says which
+// conditions the samples were judged against — not just some of them.
+func (s Series) String() string {
+	var clauses []string
+	if len(s.Labels) > 0 {
+		pairs := make([]string, 0, len(s.Labels))
+		for _, k := range slices.Sorted(maps.Keys(s.Labels)) {
+			pairs = append(pairs, fmt.Sprintf("%s=%q", k, s.Labels[k]))
+		}
+		clauses = append(clauses, "labels{"+strings.Join(pairs, ", ")+"}")
+	}
+	if len(s.Present) > 0 {
+		clauses = append(clauses, fmt.Sprintf("present%v", s.Present))
+	}
+	if len(s.Absent) > 0 {
+		clauses = append(clauses, fmt.Sprintf("absent%v", s.Absent))
+	}
+	if s.Exact {
+		clauses = append(clauses, "exact")
+	}
+	if s.Value != nil {
+		clauses = append(clauses, "value predicate")
+	}
+	if len(clauses) == 0 {
+		return "Series{any sample}"
+	}
+	return "Series{" + strings.Join(clauses, ", ") + "}"
+}
+
+// HasSeries returns a PromQL check (for Prom.Eventually) that passes when some
 // sample in the result vector matches want.
 func HasSeries(want Series) func(model.Vector) error {
 	return func(v model.Vector) error {
@@ -36,8 +68,7 @@ func HasSeries(want Series) func(model.Vector) error {
 				return nil
 			}
 		}
-		return fmt.Errorf("no sample matched labels=%v absent=%v among %d samples: %v",
-			want.Labels, want.Absent, len(v), v)
+		return fmt.Errorf("no sample matched %s among %d samples: %v", want, len(v), v)
 	}
 }
 

--- a/internal/testing/e2e/series_test.go
+++ b/internal/testing/e2e/series_test.go
@@ -1,0 +1,183 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sample builds a sample with the given value and labels, e.g.
+// sample(1, "__name__", "up", "job", "sample-app").
+func sample(value model.SampleValue, labels ...string) *model.Sample {
+	metric := model.Metric{}
+	for i := 0; i < len(labels); i += 2 {
+		metric[model.LabelName(labels[i])] = model.LabelValue(labels[i+1])
+	}
+	return &model.Sample{Metric: metric, Value: value}
+}
+
+func TestSeriesMatches(t *testing.T) {
+	up := sample(1, "__name__", "up", "job", "sample-app", "instance", "sample-app:8080", "pod", "sample-app-abc")
+
+	for _, tt := range []struct {
+		name  string
+		want  Series
+		s     *model.Sample
+		match bool
+	}{
+		{
+			name:  "empty matcher matches anything",
+			want:  Series{},
+			s:     up,
+			match: true,
+		},
+		{
+			name:  "labels match on exact value",
+			want:  Series{Labels: map[string]string{"job": "sample-app"}},
+			s:     up,
+			match: true,
+		},
+		{
+			name:  "labels reject a different value",
+			want:  Series{Labels: map[string]string{"job": "other"}},
+			s:     up,
+			match: false,
+		},
+		{
+			name:  "labels treat a missing label as the empty value",
+			want:  Series{Labels: map[string]string{"namespace": ""}},
+			s:     sample(1, "job", "sample-app"),
+			match: true,
+		},
+		{
+			name:  "present matches any value",
+			want:  Series{Present: []string{"pod", "instance"}},
+			s:     up,
+			match: true,
+		},
+		{
+			name:  "present rejects a missing label",
+			want:  Series{Present: []string{"container"}},
+			s:     up,
+			match: false,
+		},
+		{
+			name:  "absent matches when the label is missing",
+			want:  Series{Absent: []string{"container"}},
+			s:     up,
+			match: true,
+		},
+		{
+			name:  "absent rejects a present label",
+			want:  Series{Absent: []string{"pod"}},
+			s:     up,
+			match: false,
+		},
+		{
+			name:  "exact allows only labels, present and __name__",
+			want:  Series{Labels: map[string]string{"job": "sample-app"}, Present: []string{"instance", "pod"}, Exact: true},
+			s:     up,
+			match: true,
+		},
+		{
+			name:  "exact rejects an extra label",
+			want:  Series{Labels: map[string]string{"job": "sample-app"}, Present: []string{"instance"}, Exact: true},
+			s:     up,
+			match: false,
+		},
+		{
+			name:  "exact tolerates a sample without __name__",
+			want:  Series{Labels: map[string]string{"job": "sample-app"}, Exact: true},
+			s:     sample(1, "job", "sample-app"),
+			match: true,
+		},
+		{
+			name:  "value predicate accepts a matching value",
+			want:  Series{Value: Equals(1)},
+			s:     up,
+			match: true,
+		},
+		{
+			name:  "value predicate rejects a different value",
+			want:  Series{Value: Equals(0)},
+			s:     up,
+			match: false,
+		},
+		{
+			name:  "at least accepts a greater value",
+			want:  Series{Value: AtLeast(1)},
+			s:     sample(7, "job", "sample-app"),
+			match: true,
+		},
+		{
+			name:  "at least rejects a smaller value",
+			want:  Series{Value: AtLeast(10)},
+			s:     sample(7, "job", "sample-app"),
+			match: false,
+		},
+		{
+			name: "clauses combine",
+			want: Series{
+				Labels:  map[string]string{"job": "sample-app"},
+				Present: []string{"pod"},
+				Absent:  []string{"container"},
+				Value:   Equals(1),
+			},
+			s:     up,
+			match: true,
+		},
+		{
+			name: "one failing clause fails the whole matcher",
+			want: Series{
+				Labels:  map[string]string{"job": "sample-app"},
+				Present: []string{"pod"},
+				Absent:  []string{"instance"},
+			},
+			s:     up,
+			match: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.match, seriesMatches(tt.want, tt.s))
+		})
+	}
+}
+
+func TestHasSeries(t *testing.T) {
+	up := sample(1, "__name__", "up", "job", "sample-app")
+
+	t.Run("passes when one sample of the vector matches", func(t *testing.T) {
+		check := HasSeries(Series{Labels: map[string]string{"job": "sample-app"}})
+		require.NoError(t, check(model.Vector{sample(0, "job", "other"), up}))
+	})
+
+	t.Run("reports every clause of the matcher", func(t *testing.T) {
+		check := HasSeries(Series{
+			Labels:  map[string]string{"job": "sample-app"},
+			Present: []string{"pod"},
+			Absent:  []string{"container"},
+			Exact:   true,
+			Value:   Equals(1),
+		})
+		err := check(model.Vector{up})
+		require.Error(t, err)
+		// A failure caused by Present/Exact/Value must not read as a label mismatch.
+		assert.Contains(t, err.Error(), `labels{job="sample-app"}`)
+		assert.Contains(t, err.Error(), "present[pod]")
+		assert.Contains(t, err.Error(), "absent[container]")
+		assert.Contains(t, err.Error(), "exact")
+		assert.Contains(t, err.Error(), "value predicate")
+		assert.Contains(t, err.Error(), "among 1 samples")
+	})
+
+	t.Run("empty matcher against an empty vector", func(t *testing.T) {
+		err := HasSeries(Series{})(model.Vector{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Series{any sample}")
+	})
+}

--- a/tests/e2e-collector-metrics/README.md
+++ b/tests/e2e-collector-metrics/README.md
@@ -1,0 +1,123 @@
+# Go full-deployment e2e
+
+Full-deployment e2e tests written in Go for cases that need **semantic checks** —
+"the target got discovered and labeled correctly, end to end" — which are painful in
+chainsaw/bash + `jq`.
+
+Each test deploys through the **operator** (an `OpenTelemetryCollector` CR with the
+target allocator + prometheus receiver), scrapes a sample app, exports OTLP to a
+prometheus-operator-managed **Prometheus**, and asserts on the resulting target
+labels over **PromQL** — all in typed Go.
+
+```
+sample-app ──scrape──▶ collector (TA + prometheus receiver) ──OTLP──▶ Prometheus ◀──PromQL── test
+```
+
+## What it validates
+
+The focus is **target labeling, end to end** — that a target discovered and
+relabeled by the allocator ends up with the labels Prometheus would give it — not
+metric values or sample structure. Two suites cover the allocator's two discovery
+paths:
+
+| Suite | Path | Key assertion |
+|---|---|---|
+| `TestServiceMonitorDifferential` | `prometheusCR` (ServiceMonitor) | **live differential vs prometheus-operator** (see below) — the allocator must label a ServiceMonitor target *identically* to prometheus-operator scraping it natively. |
+| `TestRawScrapeConfigMetrics` | raw `scrape_configs` (`static_configs`) | the static target carries *exactly* `job`/`instance` and no service-discovery labels (`Exact`). |
+
+### The ServiceMonitor differential
+
+A single prometheus-operator-managed `Prometheus` runs with the OTLP receiver enabled
+and `translation_strategy: NoTranslation`. The same instance plays both roles:
+
+```
+                      ┌──────────── ServiceMonitor (sample app) ────────────┐
+   sm-ta  ──▶ collector (TA) ──scrape──▶ ──OTLP──▶  Prometheus  ◀──scrape── sm-oracle
+                                                    (one instance)
+            series get pipeline="ta"                series get pipeline="oracle"
+```
+
+Both pipelines scrape the **same pod** and write to the **same Prometheus**,
+distinguished only by a `pipeline` label (`ta` vs `oracle`) added by an otherwise
+identical ServiceMonitor. `fw.SameLabelsAcross(prom, "up", "pipeline", 2)` then asserts
+that, after dropping `pipeline`, the two partitions carry the **same target label
+set**. Because `NoTranslation` makes the OTLP round-trip label-preserving, any
+divergence — the allocator dropping, adding or rewriting a target label relative to
+prometheus-operator — fails the differential. prometheus-operator is the oracle, so
+this directly tests the allocator as a prometheus-operator compatibility layer.
+
+## Design
+
+Same module as the operator; gated by `//go:build e2e`; run as a normal Go test
+against a kind cluster — no chainsaw. The reusable framework lives in
+[`internal/testing/e2e`](../../internal/testing/e2e) and uses only libraries the
+operator already depends on, so the e2e tests add **nothing** to its module footprint:
+
+| Concern | Library | Used for |
+|---|---|---|
+| Lifecycle | `sigs.k8s.io/e2e-framework` | `env`/`features`, typed resource waits |
+| Cluster ops | controller-runtime + client-go | server-side-apply manifests (unstructured), namespaces, RBAC |
+| PromQL | API server **service proxy** + `common/model` | query Prometheus with no port-forward; typed results |
+
+Framework helpers, imported under the package's own name `e2e`:
+
+- `e2e.Apply(ctx, t, cfg, ns, manifests)` — server-side-applies multi-doc YAML as
+  unstructured objects (no scheme registration needed for the CRDs).
+- `e2e.CreateNamespace` / `e2e.DeleteNamespace` / `e2e.WaitForStatefulSet` / `e2e.WaitForDeployment`.
+- `e2e.EnsurePrometheusOperator(ctx, t, cfg)` — idempotently installs prometheus-operator
+  (version read from `go.mod`) so a `Prometheus` CR can be used as a live oracle.
+- `e2e.BindTargetAllocatorClusterRole(ctx, t, cfg, ns, sa)` — apply the project's
+  shipped ClusterRole (`config/target-allocator/clusterrole.yaml`) and bind it to the
+  named ServiceAccount (the allocator's or the oracle Prometheus's).
+- `e2e.SameLabelsAcross(ctx, t, cfg, ns, prom, query, partitionLabel, wantPartitions, ignore...)`
+  — the **differential**: query one Prometheus (`e2e.PromTarget{Service, Port}`),
+  partition the result by `partitionLabel`, and assert every partition carries the same
+  target label set (dropping `partitionLabel` + `ignore`), retrying until
+  `wantPartitions` are present and agree.
+- `e2e.EventuallyPromQL(ctx, t, cfg, ns, prom, query, check)` — query Prometheus over the
+  service proxy, retry until `check(model.Vector) error` passes.
+- `e2e.HasSeries(e2e.Series{Labels, Present, Absent, Exact, Value})` — a `check` for a
+  single series: `Labels` (exact value), `Present` (any value), `Absent` (must not
+  exist), `Exact` (carry *only* `Labels`∪`Present`, nothing else — pins a complete
+  target identity while allowing a dynamic pod/instance), and an optional `Value`
+  predicate (`e2e.Equals` / `e2e.AtLeast`).
+
+Manifests live in `testdata/` and are `go:embed`-ed, with parameters rendered via
+`text/template`. A test (`metrics_test.go`) is then just a `features.Feature`: deploy
+sample app + oracle Prometheus + collector + RBAC → wait → assert with
+`SameLabelsAcross` (differential) and/or `EventuallyPromQL` + `HasSeries` (exact identity).
+
+## Running
+
+```bash
+make prepare-e2e            # deploys the operator into kind (shared with the chainsaw e2e)
+make e2e-collector-metrics  # runs this Go suite
+```
+
+The suite installs prometheus-operator itself (idempotently, via
+`fw.EnsurePrometheusOperator`) on first run, so no extra prep step is needed — but it
+fetches the release bundle over the network.
+
+## Notes
+
+- **Oracle backend:** a single prometheus-operator-managed `Prometheus` per test,
+  with `enableOTLPReceiver: true` and `otlp.translationStrategy: NoTranslation` so OTLP
+  target labels are stored byte-for-byte; `tsdb.outOfOrderTimeWindow` absorbs the
+  reordering of OTLP export batches. Its ServiceAccount reuses the shipped
+  target-allocator ClusterRole for discovery. This replaces the previously hand-rolled
+  Prometheus Deployments.
+- **prometheus-operator install** needs network access to fetch the
+  `${PrometheusOperatorVersion}/bundle.yaml`; it is applied server-side (the CRDs are
+  too large for client-side apply) and left in place (idempotent across runs).
+- **Target allocator RBAC:** the operator does **not** auto-create the allocator's
+  RBAC — the permissions a target allocator needs depend on what the user asks it to
+  discover (pods, endpoints, ServiceMonitors, …). So the test grants it explicitly,
+  reusing the project's shipped ClusterRole (`config/target-allocator/clusterrole.yaml`,
+  which covers both core discovery and the Prometheus CRDs). Without it the allocator
+  can't list collector pods or ServiceMonitors, allocates no targets, nothing scraped.
+- **No traffic needed:** the assertions use `up` and the always-present `version`
+  gauge, so the tests need no load against the sample app.
+- Images (prometheus-operator, `prom/prometheus`, `quay.io/brancz/prometheus-example-app`)
+  are pulled from the internet — load them into kind for hermetic/offline runs.
+- The framework is backend-agnostic; `EventuallyPromQL` is one query helper —
+  add others (range queries, alerts) as suites need them.

--- a/tests/e2e-collector-metrics/README.md
+++ b/tests/e2e-collector-metrics/README.md
@@ -1,34 +1,33 @@
-# Go full-deployment e2e
+# Collector metrics e2e
 
-Full-deployment e2e tests written in Go for cases that need **semantic checks** —
-"the target got discovered and labeled correctly, end to end" — which are painful in
-chainsaw/bash + `jq`.
-
-Each test deploys through the **operator** (an `OpenTelemetryCollector` CR with the
-target allocator + prometheus receiver), scrapes a sample app, exports OTLP to a
-prometheus-operator-managed **Prometheus**, and asserts on the resulting target
-labels over **PromQL** — all in typed Go.
+End-to-end tests for how the target allocator labels targets. Each test deploys an
+`OpenTelemetryCollector` CR (target allocator + prometheus receiver) through the
+operator, scrapes a sample app, exports OTLP to a prometheus-operator-managed
+Prometheus, and asserts on the resulting target labels over PromQL:
 
 ```
 sample-app ──scrape──▶ collector (TA + prometheus receiver) ──OTLP──▶ Prometheus ◀──PromQL── test
 ```
 
+The tests are plain Go tests built on the helpers in
+[`internal/testing/e2e`](../../internal/testing/e2e).
+
 ## What it validates
 
-The focus is **target labeling, end to end** — that a target discovered and
-relabeled by the allocator ends up with the labels Prometheus would give it — not
-metric values or sample structure. Two suites cover the allocator's two discovery
-paths:
+The focus is target labeling, end to end — a target discovered and relabeled by the
+allocator must end up with the labels Prometheus would give it — not metric values or
+sample structure. The two tests cover the allocator's two discovery paths:
 
-| Suite | Path | Key assertion |
+| Test | Path | Key assertion |
 |---|---|---|
-| `TestServiceMonitorDifferential` | `prometheusCR` (ServiceMonitor) | **live differential vs prometheus-operator** (see below) — the allocator must label a ServiceMonitor target *identically* to prometheus-operator scraping it natively. |
-| `TestRawScrapeConfigMetrics` | raw `scrape_configs` (`static_configs`) | the static target carries *exactly* `job`/`instance` and no service-discovery labels (`Exact`). |
+| `TestServiceMonitorDifferential` | `prometheusCR` (ServiceMonitor) | live differential vs prometheus-operator (see below): the allocator must label a ServiceMonitor target *identically* to prometheus-operator scraping it natively. |
+| `TestRawScrapeConfigMetrics` | raw `scrape_configs` (`static_configs`) | the static target carries *exactly* `job`/`instance` and no service-discovery labels. |
 
 ### The ServiceMonitor differential
 
 A single prometheus-operator-managed `Prometheus` runs with the OTLP receiver enabled
-and `translation_strategy: NoTranslation`. The same instance plays both roles:
+and `translation_strategy: NoTranslation`, so OTLP target labels are stored
+byte-for-byte. The same instance plays both roles:
 
 ```
                       ┌──────────── ServiceMonitor (sample app) ────────────┐
@@ -37,100 +36,34 @@ and `translation_strategy: NoTranslation`. The same instance plays both roles:
             series get pipeline="ta"                series get pipeline="oracle"
 ```
 
-Both pipelines scrape the **same pod** and write to the **same Prometheus**,
-distinguished only by a `pipeline` label (`ta` vs `oracle`) added by an otherwise
-identical ServiceMonitor. `prom.SameLabelsAcross(ctx, t, e2e.Differential{Query: "up",
-PartitionLabel: "pipeline", WantPartitions: 2})` then asserts that, after dropping
-`pipeline`, the two partitions carry the **same target label
-set**. Because `NoTranslation` makes the OTLP round-trip label-preserving, any
-divergence — the allocator dropping, adding or rewriting a target label relative to
-prometheus-operator — fails the differential. prometheus-operator is the oracle, so
-this directly tests the allocator as a prometheus-operator compatibility layer.
-
-## Design
-
-Same module as the operator; gated by `//go:build e2e`; run as a normal Go test
-against a kind cluster — no chainsaw. The reusable framework lives in
-[`internal/testing/e2e`](../../internal/testing/e2e) and uses only libraries the
-operator already depends on, so the e2e tests add **nothing** to its module footprint:
-
-| Concern | Library | Used for |
-|---|---|---|
-| Lifecycle | `sigs.k8s.io/e2e-framework` | `env`/`features`, typed resource waits |
-| Cluster ops | controller-runtime + client-go | server-side-apply manifests (unstructured), namespaces, RBAC |
-| PromQL | API server **service proxy** + `common/model` | query Prometheus with no port-forward; typed results |
-
-Framework helpers, imported under the package's own name `e2e`:
-
-- `e2e.Apply(ctx, t, cfg, ns, manifests)` — server-side-applies multi-doc YAML as
-  unstructured objects (no scheme registration needed for the CRDs).
-- `e2e.ApplyObjects(ctx, t, cfg, ns, objs...)` — server-side-applies **typed** objects,
-  for the resources a test needs to vary (here: the two ServiceMonitors).
-- `e2e.SetupNamespace(ctx, t, cfg)` — creates a namespace named after the test,
-  registers its deletion as cleanup, and returns a context carrying its name;
-  `e2e.Namespace(t, ctx)` reads it back inside the assessments.
-- `e2e.CreateNamespace` / `e2e.DeleteNamespace` / `e2e.WaitForStatefulSet` / `e2e.WaitForDeployment`.
-- `e2e.EnsurePrometheusOperator(ctx, t, cfg)` — idempotently installs prometheus-operator
-  (version read from `go.mod`) so a `Prometheus` CR can be used as a live oracle.
-- `e2e.BindTargetAllocatorClusterRole(ctx, t, cfg, ns, sa)` — apply the project's
-  shipped ClusterRole (`config/target-allocator/clusterrole.yaml`) and bind it to the
-  named ServiceAccount (the allocator's or the oracle Prometheus's).
-- `e2e.NewProm(cfg, ns, service, port)` — a handle to a Prometheus reachable over the
-  API server's service proxy (no port-forward). It carries the namespace/Service/port,
-  so assertions only name the query:
-  - `prom.Query(ctx, t, query)` — one instant query, no retry.
-  - `prom.Eventually(ctx, t, query, check)` — retry the query until
-    `check(model.Vector) error` passes (`require.EventuallyWithT` under the hood).
-  - `prom.SameLabelsAcross(ctx, t, e2e.Differential{Query, PartitionLabel, WantPartitions, Ignore})`
-    — the **differential**: partition the result by `PartitionLabel` and assert every
-    partition carries the same target label set (dropping `PartitionLabel` + `Ignore`),
-    retrying until `WantPartitions` are present and agree.
-- `e2e.HasSeries(e2e.Series{Labels, Present, Absent, Exact, Value})` — a `check` for a
-  single series: `Labels` (exact value), `Present` (any value), `Absent` (must not
-  exist), `Exact` (carry *only* `Labels`∪`Present`, nothing else — pins a complete
-  target identity while allowing a dynamic pod/instance), and an optional `Value`
-  predicate (`e2e.Equals` / `e2e.AtLeast`).
-
-Manifests live in `testdata/` and are `go:embed`-ed. They are static: every test runs
-in its own namespace, so object names can be fixed, and the one object that genuinely
-differs between the two pipelines (the `ServiceMonitor`) is built as a typed Go struct
-and applied with `ApplyObjects`. A test (`metrics_test.go`) is then just a
-`features.Feature`: deploy sample app + oracle Prometheus + collector + RBAC → wait →
-assert with `SameLabelsAcross` (differential) and/or `Eventually` + `HasSeries`
-(exact identity).
+Both pipelines scrape the same pod and write to the same Prometheus, distinguished
+only by a `pipeline` label added by an otherwise identical ServiceMonitor. The test
+asserts that, after dropping `pipeline`, both partitions carry the same target label
+set. Any divergence — the allocator dropping, adding or rewriting a target label
+relative to prometheus-operator — fails the differential. prometheus-operator is the
+oracle: this directly tests the allocator as a prometheus-operator compatibility
+layer.
 
 ## Running
 
 ```bash
-make prepare-e2e            # deploys the operator into kind (shared with the chainsaw e2e)
-make e2e-collector-metrics  # runs this Go suite
+make prepare-e2e            # build the operator and deploy it into kind
+make e2e-collector-metrics  # run this suite
 ```
 
-The suite installs prometheus-operator itself (idempotently, via
-`e2e.EnsurePrometheusOperator`) on first run, so no extra prep step is needed — but it
-fetches the release bundle over the network.
+The suite installs prometheus-operator itself (idempotently, pinned to the version in
+`go.mod`) so it can use a `Prometheus` CR as the oracle. That bundle and the test
+images (`quay.io/prometheus/prometheus`, `quay.io/brancz/prometheus-example-app`) are
+fetched from the internet.
 
 ## Notes
 
-- **Oracle backend:** a single prometheus-operator-managed `Prometheus` per test,
-  with `enableOTLPReceiver: true` and `otlp.translationStrategy: NoTranslation` so OTLP
-  target labels are stored byte-for-byte; `tsdb.outOfOrderTimeWindow` absorbs the
-  reordering of OTLP export batches. Its ServiceAccount reuses the shipped
-  target-allocator ClusterRole for discovery.
-- **prometheus-operator install** needs network access to fetch the
-  `${PrometheusOperatorVersion}/bundle.yaml`; it is applied server-side (the CRDs are
-  too large for client-side apply) and left in place (idempotent across runs).
-- **Target allocator RBAC:** the operator does **not** auto-create the allocator's
-  RBAC — the permissions a target allocator needs depend on what the user asks it to
-  discover (pods, endpoints, ServiceMonitors, …). So the test grants it explicitly,
-  reusing the project's shipped ClusterRole (`config/target-allocator/clusterrole.yaml`,
-  which covers both core discovery and the Prometheus CRDs). Without it the allocator
-  can't list collector pods or ServiceMonitors, allocates no targets, nothing scraped.
-- **No traffic needed:** the assertions use `up` and the always-present `version`
-  gauge, so the tests need no load against the sample app.
-- Images (prometheus-operator, `quay.io/prometheus/prometheus` — deployed by
-  prometheus-operator from the `Prometheus` CR — and
-  `quay.io/brancz/prometheus-example-app`) are pulled from the internet; load them into
-  kind for hermetic/offline runs.
-- The framework is backend-agnostic; `Prom.Eventually` is one query helper —
-  add others (range queries, alerts) as suites need them.
+- The operator does not auto-create the target allocator's RBAC — the permissions
+  depend on what the allocator is asked to discover — so each test binds the project's
+  shipped ClusterRole (`config/target-allocator/clusterrole.yaml`) to the allocator's
+  (and the oracle's) ServiceAccount explicitly. Without it, the allocator discovers
+  nothing and nothing is scraped.
+- The assertions use `up` and the sample app's always-present `version` gauge, so the
+  tests need no traffic against the app.
+- `tsdb.outOfOrderTimeWindow` on the oracle Prometheus absorbs the reordering of OTLP
+  export batches.

--- a/tests/e2e-collector-metrics/README.md
+++ b/tests/e2e-collector-metrics/README.md
@@ -53,7 +53,7 @@ make e2e-collector-metrics  # run this suite
 
 The suite installs prometheus-operator itself (idempotently, pinned to the version in
 `go.mod`) so it can use a `Prometheus` CR as the oracle. That bundle and the test
-images (`quay.io/prometheus/prometheus`, `quay.io/brancz/prometheus-example-app`) are
+images (`quay.io/prometheus/prometheus`, `quay.io/prometheus/node-exporter`) are
 fetched from the internet.
 
 ## Notes
@@ -63,7 +63,7 @@ fetched from the internet.
   shipped ClusterRole (`config/target-allocator/clusterrole.yaml`) to the allocator's
   (and the oracle's) ServiceAccount explicitly. Without it, the allocator discovers
   nothing and nothing is scraped.
-- The assertions use `up` and the sample app's always-present `version` gauge, so the
-  tests need no traffic against the app.
+- The assertions use `up` and the sample app's always-present
+  `node_exporter_build_info` gauge, so the tests need no traffic against the app.
 - `tsdb.outOfOrderTimeWindow` on the oracle Prometheus absorbs the reordering of OTLP
   export batches.

--- a/tests/e2e-collector-metrics/README.md
+++ b/tests/e2e-collector-metrics/README.md
@@ -39,8 +39,9 @@ and `translation_strategy: NoTranslation`. The same instance plays both roles:
 
 Both pipelines scrape the **same pod** and write to the **same Prometheus**,
 distinguished only by a `pipeline` label (`ta` vs `oracle`) added by an otherwise
-identical ServiceMonitor. `fw.SameLabelsAcross(prom, "up", "pipeline", 2)` then asserts
-that, after dropping `pipeline`, the two partitions carry the **same target label
+identical ServiceMonitor. `prom.SameLabelsAcross(ctx, t, e2e.Differential{Query: "up",
+PartitionLabel: "pipeline", WantPartitions: 2})` then asserts that, after dropping
+`pipeline`, the two partitions carry the **same target label
 set**. Because `NoTranslation` makes the OTLP round-trip label-preserving, any
 divergence — the allocator dropping, adding or rewriting a target label relative to
 prometheus-operator — fails the differential. prometheus-operator is the oracle, so
@@ -63,29 +64,40 @@ Framework helpers, imported under the package's own name `e2e`:
 
 - `e2e.Apply(ctx, t, cfg, ns, manifests)` — server-side-applies multi-doc YAML as
   unstructured objects (no scheme registration needed for the CRDs).
+- `e2e.ApplyObjects(ctx, t, cfg, ns, objs...)` — server-side-applies **typed** objects,
+  for the resources a test needs to vary (here: the two ServiceMonitors).
+- `e2e.SetupNamespace(ctx, t, cfg)` — creates a namespace named after the test,
+  registers its deletion as cleanup, and returns a context carrying its name;
+  `e2e.Namespace(t, ctx)` reads it back inside the assessments.
 - `e2e.CreateNamespace` / `e2e.DeleteNamespace` / `e2e.WaitForStatefulSet` / `e2e.WaitForDeployment`.
 - `e2e.EnsurePrometheusOperator(ctx, t, cfg)` — idempotently installs prometheus-operator
   (version read from `go.mod`) so a `Prometheus` CR can be used as a live oracle.
 - `e2e.BindTargetAllocatorClusterRole(ctx, t, cfg, ns, sa)` — apply the project's
   shipped ClusterRole (`config/target-allocator/clusterrole.yaml`) and bind it to the
   named ServiceAccount (the allocator's or the oracle Prometheus's).
-- `e2e.SameLabelsAcross(ctx, t, cfg, ns, prom, query, partitionLabel, wantPartitions, ignore...)`
-  — the **differential**: query one Prometheus (`e2e.PromTarget{Service, Port}`),
-  partition the result by `partitionLabel`, and assert every partition carries the same
-  target label set (dropping `partitionLabel` + `ignore`), retrying until
-  `wantPartitions` are present and agree.
-- `e2e.EventuallyPromQL(ctx, t, cfg, ns, prom, query, check)` — query Prometheus over the
-  service proxy, retry until `check(model.Vector) error` passes.
+- `e2e.NewProm(cfg, ns, service, port)` — a handle to a Prometheus reachable over the
+  API server's service proxy (no port-forward). It carries the namespace/Service/port,
+  so assertions only name the query:
+  - `prom.Query(ctx, t, query)` — one instant query, no retry.
+  - `prom.Eventually(ctx, t, query, check)` — retry the query until
+    `check(model.Vector) error` passes (`require.EventuallyWithT` under the hood).
+  - `prom.SameLabelsAcross(ctx, t, e2e.Differential{Query, PartitionLabel, WantPartitions, Ignore})`
+    — the **differential**: partition the result by `PartitionLabel` and assert every
+    partition carries the same target label set (dropping `PartitionLabel` + `Ignore`),
+    retrying until `WantPartitions` are present and agree.
 - `e2e.HasSeries(e2e.Series{Labels, Present, Absent, Exact, Value})` — a `check` for a
   single series: `Labels` (exact value), `Present` (any value), `Absent` (must not
   exist), `Exact` (carry *only* `Labels`∪`Present`, nothing else — pins a complete
   target identity while allowing a dynamic pod/instance), and an optional `Value`
   predicate (`e2e.Equals` / `e2e.AtLeast`).
 
-Manifests live in `testdata/` and are `go:embed`-ed, with parameters rendered via
-`text/template`. A test (`metrics_test.go`) is then just a `features.Feature`: deploy
-sample app + oracle Prometheus + collector + RBAC → wait → assert with
-`SameLabelsAcross` (differential) and/or `EventuallyPromQL` + `HasSeries` (exact identity).
+Manifests live in `testdata/` and are `go:embed`-ed. They are static: every test runs
+in its own namespace, so object names can be fixed, and the one object that genuinely
+differs between the two pipelines (the `ServiceMonitor`) is built as a typed Go struct
+and applied with `ApplyObjects`. A test (`metrics_test.go`) is then just a
+`features.Feature`: deploy sample app + oracle Prometheus + collector + RBAC → wait →
+assert with `SameLabelsAcross` (differential) and/or `Eventually` + `HasSeries`
+(exact identity).
 
 ## Running
 
@@ -95,7 +107,7 @@ make e2e-collector-metrics  # runs this Go suite
 ```
 
 The suite installs prometheus-operator itself (idempotently, via
-`fw.EnsurePrometheusOperator`) on first run, so no extra prep step is needed — but it
+`e2e.EnsurePrometheusOperator`) on first run, so no extra prep step is needed — but it
 fetches the release bundle over the network.
 
 ## Notes
@@ -104,8 +116,7 @@ fetches the release bundle over the network.
   with `enableOTLPReceiver: true` and `otlp.translationStrategy: NoTranslation` so OTLP
   target labels are stored byte-for-byte; `tsdb.outOfOrderTimeWindow` absorbs the
   reordering of OTLP export batches. Its ServiceAccount reuses the shipped
-  target-allocator ClusterRole for discovery. This replaces the previously hand-rolled
-  Prometheus Deployments.
+  target-allocator ClusterRole for discovery.
 - **prometheus-operator install** needs network access to fetch the
   `${PrometheusOperatorVersion}/bundle.yaml`; it is applied server-side (the CRDs are
   too large for client-side apply) and left in place (idempotent across runs).
@@ -117,7 +128,9 @@ fetches the release bundle over the network.
   can't list collector pods or ServiceMonitors, allocates no targets, nothing scraped.
 - **No traffic needed:** the assertions use `up` and the always-present `version`
   gauge, so the tests need no load against the sample app.
-- Images (prometheus-operator, `prom/prometheus`, `quay.io/brancz/prometheus-example-app`)
-  are pulled from the internet — load them into kind for hermetic/offline runs.
-- The framework is backend-agnostic; `EventuallyPromQL` is one query helper —
+- Images (prometheus-operator, `quay.io/prometheus/prometheus` — deployed by
+  prometheus-operator from the `Prometheus` CR — and
+  `quay.io/brancz/prometheus-example-app`) are pulled from the internet; load them into
+  kind for hermetic/offline runs.
+- The framework is backend-agnostic; `Prom.Eventually` is one query helper —
   add others (range queries, alerts) as suites need them.

--- a/tests/e2e-collector-metrics/metrics_test.go
+++ b/tests/e2e-collector-metrics/metrics_test.go
@@ -163,8 +163,8 @@ func TestServiceMonitorDifferential(t *testing.T) {
 			prom(t, ctx, cfg).SameLabelsAcross(ctx, t, e2e.Differential{Query: `up`, PartitionLabel: pipelineLabel, WantPartitions: 2})
 			return ctx
 		}).
-		Assess("a scraped series matches prometheus-operator end-to-end (version)", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			prom(t, ctx, cfg).SameLabelsAcross(ctx, t, e2e.Differential{Query: `version`, PartitionLabel: pipelineLabel, WantPartitions: 2})
+		Assess("a scraped series matches prometheus-operator end-to-end (build_info)", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			prom(t, ctx, cfg).SameLabelsAcross(ctx, t, e2e.Differential{Query: `node_exporter_build_info`, PartitionLabel: pipelineLabel, WantPartitions: 2})
 			return ctx
 		}).
 		Feature()
@@ -182,7 +182,7 @@ func TestRawScrapeConfigMetrics(t *testing.T) {
 		Assess("the static target carries exactly job/instance and no service-discovery labels", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			prom(t, ctx, cfg).Eventually(ctx, t, fmt.Sprintf(`up{job=%q}`, sampleApp),
 				e2e.HasSeries(e2e.Series{
-					Labels: map[string]string{"job": sampleApp, "instance": sampleApp + ":8080"},
+					Labels: map[string]string{"job": sampleApp, "instance": sampleApp + ":9100"},
 					Exact:  true,
 				}))
 			return ctx

--- a/tests/e2e-collector-metrics/metrics_test.go
+++ b/tests/e2e-collector-metrics/metrics_test.go
@@ -108,9 +108,12 @@ func TestMain(m *testing.M) {
 	os.Exit(testenv.Run(m))
 }
 
-type nsKey struct{}
-
-func ns(ctx context.Context) string { return ctx.Value(nsKey{}).(string) }
+// prom returns a handle to the test's oracle Prometheus. It is built per assertion
+// rather than per package because the namespace is only known once setup ran.
+func prom(t *testing.T, ctx context.Context, cfg *envconf.Config) *e2e.Prom {
+	t.Helper()
+	return e2e.NewProm(cfg, e2e.Namespace(t, ctx), promSvc, promPort)
+}
 
 // setup ensures prometheus-operator is installed, then deploys the sample app, the
 // oracle Prometheus (+ RBAC), any extra objects (e.g. ServiceMonitors), the collector
@@ -119,9 +122,8 @@ func setup(collectorManifest string, extra ...crclient.Object) features.Func {
 	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 		e2e.EnsurePrometheusOperator(ctx, t, cfg)
 
-		namespace := e2e.NamespaceFromT(t)
-		e2e.CreateNamespace(ctx, t, cfg, namespace)
-		t.Cleanup(func() { e2e.DeleteNamespace(context.WithoutCancel(ctx), t, cfg, namespace) })
+		ctx = e2e.SetupNamespace(ctx, t, cfg)
+		namespace := e2e.Namespace(t, ctx)
 
 		e2e.Apply(ctx, t, cfg, namespace, sampleAppManifest)
 		e2e.Apply(ctx, t, cfg, namespace, oraclePrometheusManifest)
@@ -135,7 +137,7 @@ func setup(collectorManifest string, extra ...crclient.Object) features.Func {
 		// StatefulSet; the operator reconciles the collector CR into <name>-collector.
 		e2e.WaitForStatefulSet(ctx, t, cfg, namespace, oracleSTS, 1, 3*time.Minute)
 		e2e.WaitForStatefulSet(ctx, t, cfg, namespace, collectorSTS, 1, 5*time.Minute)
-		return context.WithValue(ctx, nsKey{}, namespace)
+		return ctx
 	}
 }
 
@@ -144,26 +146,25 @@ func setup(collectorManifest string, extra ...crclient.Object) features.Func {
 // scrape the same pod and write to the same Prometheus, distinguished by a `pipeline`
 // label, so any divergence in target labeling fails the differential.
 func TestServiceMonitorDifferential(t *testing.T) {
-	prom := e2e.PromTarget{Service: promSvc, Port: promPort}
-
 	feat := features.New("ServiceMonitor targets labeled identically to prometheus-operator").
 		Setup(setup(smCollectorManifest, serviceMonitor(pipelineTA), serviceMonitor(pipelineProm))).
 		Assess("the allocator path really went through ServiceMonitor relabeling", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ns := e2e.Namespace(t, ctx)
 			// Guards the differential against a vacuous pass: the TA series must carry
 			// the prometheus-operator relabeling output, not be empty/trivial.
-			e2e.EventuallyPromQL(ctx, t, cfg, ns(ctx), prom, fmt.Sprintf(`up{%s=%q}`, pipelineLabel, pipelineTA),
+			prom(t, ctx, cfg).Eventually(ctx, t, fmt.Sprintf(`up{%s=%q}`, pipelineLabel, pipelineTA),
 				e2e.HasSeries(e2e.Series{
-					Labels:  map[string]string{"service": sampleApp, "namespace": ns(ctx)},
+					Labels:  map[string]string{"service": sampleApp, "namespace": ns},
 					Present: []string{"endpoint", "pod", "container"},
 				}))
 			return ctx
 		}).
 		Assess("target identity matches prometheus-operator (up)", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			e2e.SameLabelsAcross(ctx, t, cfg, ns(ctx), prom, e2e.Differential{Query: `up`, PartitionLabel: pipelineLabel, WantPartitions: 2})
+			prom(t, ctx, cfg).SameLabelsAcross(ctx, t, e2e.Differential{Query: `up`, PartitionLabel: pipelineLabel, WantPartitions: 2})
 			return ctx
 		}).
 		Assess("a scraped series matches prometheus-operator end-to-end (version)", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			e2e.SameLabelsAcross(ctx, t, cfg, ns(ctx), prom, e2e.Differential{Query: `version`, PartitionLabel: pipelineLabel, WantPartitions: 2})
+			prom(t, ctx, cfg).SameLabelsAcross(ctx, t, e2e.Differential{Query: `version`, PartitionLabel: pipelineLabel, WantPartitions: 2})
 			return ctx
 		}).
 		Feature()
@@ -176,12 +177,10 @@ func TestServiceMonitorDifferential(t *testing.T) {
 // carrying exactly the scrape config's identity (job/instance) and no
 // service-discovery labels.
 func TestRawScrapeConfigMetrics(t *testing.T) {
-	prom := e2e.PromTarget{Service: promSvc, Port: promPort}
-
 	feat := features.New("raw scrape_configs carry exactly the static identity").
 		Setup(setup(rawCollectorManifest)).
 		Assess("the static target carries exactly job/instance and no service-discovery labels", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			e2e.EventuallyPromQL(ctx, t, cfg, ns(ctx), prom, fmt.Sprintf(`up{job=%q}`, sampleApp),
+			prom(t, ctx, cfg).Eventually(ctx, t, fmt.Sprintf(`up{job=%q}`, sampleApp),
 				e2e.HasSeries(e2e.Series{
 					Labels: map[string]string{"job": sampleApp, "instance": sampleApp + ":8080"},
 					Exact:  true,

--- a/tests/e2e-collector-metrics/metrics_test.go
+++ b/tests/e2e-collector-metrics/metrics_test.go
@@ -1,0 +1,194 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build e2e
+
+package collectormetrics
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/open-telemetry/opentelemetry-operator/internal/testing/e2e"
+)
+
+// These tests validate that the target allocator labels targets correctly, end to
+// end. A collector (TA + prometheus receiver) is deployed through the operator,
+// scrapes a sample app, and exports OTLP into a single prometheus-operator-managed
+// Prometheus running with translation_strategy: NoTranslation (so target labels cross
+// the OTLP boundary byte-for-byte). We assert purely on target labels:
+//
+//   - ServiceMonitor (prometheusCR) path: a live differential. The SAME Prometheus
+//     both receives the TA pipeline (pipeline=ta) and natively scrapes the same pod
+//     via prometheus-operator (pipeline=oracle). The two must carry identical target
+//     labels — the allocator must label a ServiceMonitor target exactly as
+//     prometheus-operator does.
+//   - raw scrape_configs path: the static target carries exactly job/instance and no
+//     service-discovery labels.
+
+const (
+	sampleApp = "sample-app"          // the scraped workload (Deployment + Service)
+	promSvc   = "prometheus-operated" // headless Service prometheus-operator creates for the Prometheus pods
+	promPort  = 9090
+
+	oracleName = "oracle"            // name of the oracle Prometheus CR and its ServiceAccount
+	oracleSTS  = "prometheus-oracle" // StatefulSet prometheus-operator derives from the oracle Prometheus
+
+	// The collector CR carries the same name in every test — each test runs in its
+	// own namespace — and the operator derives the collector StatefulSet and the
+	// target allocator ServiceAccount from it.
+	collectorName = "otel"
+	collectorSTS  = collectorName + "-collector"
+	collectorSA   = collectorName + "-targetallocator"
+
+	groupLabel    = "group"    // ServiceMonitor label that each side's selector matches on
+	pipelineLabel = "pipeline" // label that distinguishes the pipelines in one Prometheus
+	pipelineTA    = "ta"       // TA pipeline: collector(TA) -> OTLP -> Prometheus
+	pipelineProm  = "oracle"   // oracle pipeline: prometheus-operator native scrape
+)
+
+// The manifests are static. Nothing here is templated: names can be fixed because
+// every test runs in its own namespace, and the one object that genuinely differs
+// between the two pipelines is built as a typed object instead (see serviceMonitor).
+var (
+	//go:embed testdata/sample-app.yaml
+	sampleAppManifest string
+	//go:embed testdata/oracle-prometheus.yaml
+	oraclePrometheusManifest string
+	//go:embed testdata/collector-sm.yaml
+	smCollectorManifest string
+	//go:embed testdata/collector-raw.yaml
+	rawCollectorManifest string
+)
+
+// serviceMonitor builds the ServiceMonitor for one pipeline: it selects the sample
+// app's Service and its named `metrics` port, labels itself so that pipeline's
+// selector picks it up, and relabels every target with a constant `pipeline` label so
+// the two pipelines can be told apart in one Prometheus.
+func serviceMonitor(pipeline string) *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "sm-" + pipeline,
+			Labels: map[string]string{groupLabel: pipeline},
+		},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Selector: metav1.LabelSelector{MatchLabels: map[string]string{"app": sampleApp}},
+			Endpoints: []monitoringv1.Endpoint{{
+				Port:     "metrics",
+				Interval: "5s",
+				RelabelConfigs: []monitoringv1.RelabelConfig{{
+					TargetLabel: pipelineLabel,
+					Replacement: new(pipeline),
+				}},
+			}},
+		},
+	}
+}
+
+var testenv env.Environment
+
+func TestMain(m *testing.M) {
+	cfg, err := envconf.NewFromFlags()
+	if err != nil {
+		log.Fatalf("failed to parse e2e flags: %v", err)
+	}
+	testenv = env.NewWithConfig(cfg)
+	os.Exit(testenv.Run(m))
+}
+
+type nsKey struct{}
+
+func ns(ctx context.Context) string { return ctx.Value(nsKey{}).(string) }
+
+// setup ensures prometheus-operator is installed, then deploys the sample app, the
+// oracle Prometheus (+ RBAC), any extra objects (e.g. ServiceMonitors), the collector
+// CR (+ RBAC), waits for readiness, and stashes the namespace in the context.
+func setup(collectorManifest string, extra ...crclient.Object) features.Func {
+	return func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		e2e.EnsurePrometheusOperator(ctx, t, cfg)
+
+		namespace := e2e.NamespaceFromT(t)
+		e2e.CreateNamespace(ctx, t, cfg, namespace)
+		t.Cleanup(func() { e2e.DeleteNamespace(context.WithoutCancel(ctx), t, cfg, namespace) })
+
+		e2e.Apply(ctx, t, cfg, namespace, sampleAppManifest)
+		e2e.Apply(ctx, t, cfg, namespace, oraclePrometheusManifest)
+		e2e.BindTargetAllocatorClusterRole(ctx, t, cfg, namespace, oracleName)
+		e2e.ApplyObjects(ctx, t, cfg, namespace, extra...)
+		e2e.Apply(ctx, t, cfg, namespace, collectorManifest)
+		e2e.BindTargetAllocatorClusterRole(ctx, t, cfg, namespace, collectorSA)
+
+		e2e.WaitForDeployment(ctx, t, cfg, namespace, sampleApp, 2*time.Minute)
+		// prometheus-operator reconciles the Prometheus CR into the prometheus-oracle
+		// StatefulSet; the operator reconciles the collector CR into <name>-collector.
+		e2e.WaitForStatefulSet(ctx, t, cfg, namespace, oracleSTS, 1, 3*time.Minute)
+		e2e.WaitForStatefulSet(ctx, t, cfg, namespace, collectorSTS, 1, 5*time.Minute)
+		return context.WithValue(ctx, nsKey{}, namespace)
+	}
+}
+
+// TestServiceMonitorDifferential is the headline test: the target allocator must
+// label a ServiceMonitor target exactly as prometheus-operator does. Both pipelines
+// scrape the same pod and write to the same Prometheus, distinguished by a `pipeline`
+// label, so any divergence in target labeling fails the differential.
+func TestServiceMonitorDifferential(t *testing.T) {
+	prom := e2e.PromTarget{Service: promSvc, Port: promPort}
+
+	feat := features.New("ServiceMonitor targets labeled identically to prometheus-operator").
+		Setup(setup(smCollectorManifest, serviceMonitor(pipelineTA), serviceMonitor(pipelineProm))).
+		Assess("the allocator path really went through ServiceMonitor relabeling", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// Guards the differential against a vacuous pass: the TA series must carry
+			// the prometheus-operator relabeling output, not be empty/trivial.
+			e2e.EventuallyPromQL(ctx, t, cfg, ns(ctx), prom, fmt.Sprintf(`up{%s=%q}`, pipelineLabel, pipelineTA),
+				e2e.HasSeries(e2e.Series{
+					Labels:  map[string]string{"service": sampleApp, "namespace": ns(ctx)},
+					Present: []string{"endpoint", "pod", "container"},
+				}))
+			return ctx
+		}).
+		Assess("target identity matches prometheus-operator (up)", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			e2e.SameLabelsAcross(ctx, t, cfg, ns(ctx), prom, e2e.Differential{Query: `up`, PartitionLabel: pipelineLabel, WantPartitions: 2})
+			return ctx
+		}).
+		Assess("a scraped series matches prometheus-operator end-to-end (version)", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			e2e.SameLabelsAcross(ctx, t, cfg, ns(ctx), prom, e2e.Differential{Query: `version`, PartitionLabel: pipelineLabel, WantPartitions: 2})
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}
+
+// TestRawScrapeConfigMetrics validates the target allocator's raw scrape_configs
+// path: a static_configs target is allocated, scraped, exported OTLP and arrives
+// carrying exactly the scrape config's identity (job/instance) and no
+// service-discovery labels.
+func TestRawScrapeConfigMetrics(t *testing.T) {
+	prom := e2e.PromTarget{Service: promSvc, Port: promPort}
+
+	feat := features.New("raw scrape_configs carry exactly the static identity").
+		Setup(setup(rawCollectorManifest)).
+		Assess("the static target carries exactly job/instance and no service-discovery labels", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			e2e.EventuallyPromQL(ctx, t, cfg, ns(ctx), prom, fmt.Sprintf(`up{job=%q}`, sampleApp),
+				e2e.HasSeries(e2e.Series{
+					Labels: map[string]string{"job": sampleApp, "instance": sampleApp + ":8080"},
+					Exact:  true,
+				}))
+			return ctx
+		}).
+		Feature()
+
+	testenv.Test(t, feat)
+}

--- a/tests/e2e-collector-metrics/testdata/collector-raw.yaml
+++ b/tests/e2e-collector-metrics/testdata/collector-raw.yaml
@@ -1,0 +1,28 @@
+# A collector whose target allocator scrapes the sample app via a raw static_configs
+# scrape config (no Kubernetes service discovery), exporting OTLP to the oracle
+# Prometheus.
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+spec:
+  mode: statefulset
+  targetAllocator:
+    enabled: true
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: sample-app
+              scrape_interval: 5s
+              static_configs:
+                - targets: ['sample-app:8080']
+    exporters:
+      otlphttp:
+        endpoint: http://prometheus-operated:9090/api/v1/otlp
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [otlphttp]

--- a/tests/e2e-collector-metrics/testdata/collector-raw.yaml
+++ b/tests/e2e-collector-metrics/testdata/collector-raw.yaml
@@ -17,7 +17,7 @@ spec:
             - job_name: sample-app
               scrape_interval: 5s
               static_configs:
-                - targets: ['sample-app:8080']
+                - targets: ['sample-app:9100']
     exporters:
       otlphttp:
         endpoint: http://prometheus-operated:9090/api/v1/otlp

--- a/tests/e2e-collector-metrics/testdata/collector-sm.yaml
+++ b/tests/e2e-collector-metrics/testdata/collector-sm.yaml
@@ -1,0 +1,29 @@
+# A collector whose target allocator discovers targets via prometheusCR, selecting
+# only the ServiceMonitors of the `ta` pipeline, and exports OTLP to the oracle
+# Prometheus.
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+spec:
+  mode: statefulset
+  targetAllocator:
+    enabled: true
+    prometheusCR:
+      enabled: true
+      scrapeInterval: 5s
+      serviceMonitorSelector:
+        matchLabels: {group: ta}
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs: []
+    exporters:
+      otlphttp:
+        endpoint: http://prometheus-operated:9090/api/v1/otlp
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [otlphttp]

--- a/tests/e2e-collector-metrics/testdata/oracle-prometheus.yaml
+++ b/tests/e2e-collector-metrics/testdata/oracle-prometheus.yaml
@@ -1,0 +1,28 @@
+# A prometheus-operator-managed Prometheus with the OTLP receiver enabled and
+# translation_strategy: NoTranslation (so OTLP target labels are stored byte-for-byte).
+# It is both the OTLP sink for the collector and the native scraper of the oracle
+# ServiceMonitors. outOfOrderTimeWindow absorbs the
+# reordering of OTLP export batches. Its ServiceAccount is granted discovery RBAC by
+# the test (BindTargetAllocatorClusterRole).
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: oracle}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata: {name: oracle}
+spec:
+  serviceAccountName: oracle
+  replicas: 1
+  enableOTLPReceiver: true
+  otlp:
+    translationStrategy: NoTranslation
+  tsdb:
+    outOfOrderTimeWindow: 30m
+  scrapeInterval: 5s
+  scrapeTimeout: 5s
+  # Scrapes the `oracle` pipeline's ServiceMonitors natively. Tests that create
+  # none (the raw scrape_configs test) simply match nothing, leaving this a pure
+  # OTLP sink.
+  serviceMonitorSelector:
+    matchLabels: {group: oracle}

--- a/tests/e2e-collector-metrics/testdata/sample-app.yaml
+++ b/tests/e2e-collector-metrics/testdata/sample-app.yaml
@@ -1,0 +1,23 @@
+# brancz/prometheus-example-app: exposes a `version` gauge and (the synthetic) `up`
+# per scrape — enough to assert on target labels without any traffic. The Service port
+# is named `metrics` so a ServiceMonitor endpoint can target it.
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: sample-app, labels: {app: sample-app}}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: sample-app}}
+  template:
+    metadata: {labels: {app: sample-app}}
+    spec:
+      containers:
+        - name: app
+          image: quay.io/brancz/prometheus-example-app:v0.5.0
+          ports: [{containerPort: 8080, name: metrics}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: sample-app, labels: {app: sample-app}}
+spec:
+  selector: {app: sample-app}
+  ports: [{port: 8080, targetPort: 8080, name: metrics}]

--- a/tests/e2e-collector-metrics/testdata/sample-app.yaml
+++ b/tests/e2e-collector-metrics/testdata/sample-app.yaml
@@ -1,6 +1,8 @@
-# brancz/prometheus-example-app: exposes a `version` gauge and (the synthetic) `up`
-# per scrape — enough to assert on target labels without any traffic. The Service port
-# is named `metrics` so a ServiceMonitor endpoint can target it.
+# The scraped workload: node-exporter, from the Prometheus org. Chosen because the
+# image is multi-arch — including s390x and ppc64le, which downstream CI runs these
+# tests on — and because it exposes a constant `node_exporter_build_info` gauge, so
+# target labels can be asserted on without generating any traffic against the app.
+# The port is named `metrics` so a ServiceMonitor endpoint can target it by name.
 apiVersion: apps/v1
 kind: Deployment
 metadata: {name: sample-app, labels: {app: sample-app}}
@@ -12,12 +14,12 @@ spec:
     spec:
       containers:
         - name: app
-          image: quay.io/brancz/prometheus-example-app:v0.5.0
-          ports: [{containerPort: 8080, name: metrics}]
+          image: quay.io/prometheus/node-exporter:v1.10.2
+          ports: [{containerPort: 9100, name: metrics}]
 ---
 apiVersion: v1
 kind: Service
 metadata: {name: sample-app, labels: {app: sample-app}}
 spec:
   selector: {app: sample-app}
-  ports: [{port: 8080, targetPort: 8080, name: metrics}]
+  ports: [{port: 9100, targetPort: 9100, name: metrics}]

--- a/tests/e2e-ta-standalone/helpers_test.go
+++ b/tests/e2e-ta-standalone/helpers_test.go
@@ -227,7 +227,6 @@ configMapGenerator:
 	// The standalone TA needs the project's target-allocator ClusterRole bound to its
 	// ServiceAccount; the operator does not create this RBAC for a standalone TA.
 	e2e.BindTargetAllocatorClusterRole(ctx, t, cfg, ns, "target-allocator")
-
 }
 
 func deployCollectors(t *testing.T, ctx context.Context, cfg *envconf.Config, ns string, replicas int32) {

--- a/tests/e2e-ta-standalone/helpers_test.go
+++ b/tests/e2e-ta-standalone/helpers_test.go
@@ -79,28 +79,16 @@ func TestMain(m *testing.M) {
 // Namespace lifecycle
 // ---------------------------------------------------------------------------
 
-// nsContextKey is the context key used to store the per-feature namespace name.
-type nsContextKey struct{}
-
-// nsFromCtx retrieves the per-feature namespace stored by setupTestNamespace.
-func nsFromCtx(ctx context.Context) string {
-	return ctx.Value(nsContextKey{}).(string)
-}
-
 // setupTestNamespace creates a unique namespace for the current test feature, stores
 // its name in the context, registers a t.Cleanup for teardown, and returns the updated
 // context and namespace name. Cluster RBAC is created (and cleaned up) per binding by
 // e2e.BindTargetAllocatorClusterRole, so namespace teardown only removes the namespace.
 func setupTestNamespace(ctx context.Context, t *testing.T, cfg *envconf.Config) (nsCtx context.Context, ns string) {
 	t.Helper()
-	ns = e2e.NamespaceFromT(t)
-	e2e.CreateNamespace(ctx, t, cfg, ns)
+	nsCtx = e2e.SetupNamespace(ctx, t, cfg)
+	ns = e2e.Namespace(t, nsCtx)
 	t.Logf("created namespace %s", ns)
-	t.Cleanup(func() {
-		e2e.DeleteNamespace(context.WithoutCancel(ctx), t, cfg, ns)
-		t.Logf("cleaned up namespace %s", ns)
-	})
-	return context.WithValue(ctx, nsContextKey{}, ns), ns
+	return nsCtx, ns
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e-ta-standalone/prometheuscr_test.go
+++ b/tests/e2e-ta-standalone/prometheuscr_test.go
@@ -85,7 +85,7 @@ func TestPrometheusCRTargetAllocator(t *testing.T) {
 			})
 		}).
 		Assess("ServiceMonitor, PodMonitor and ScrapeConfig targets discovered", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			ns := nsFromCtx(ctx)
+			ns := e2e.Namespace(t, ctx)
 			state := ctx.Value(promCRStateKey{}).(promCRState)
 			proxyBase := taProxyBase(ns)
 
@@ -101,7 +101,7 @@ func TestPrometheusCRTargetAllocator(t *testing.T) {
 			return ctx
 		}).
 		Assess("ServiceMonitor targets disappear after deletion", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			ns := nsFromCtx(ctx)
+			ns := e2e.Namespace(t, ctx)
 			state := ctx.Value(promCRStateKey{}).(promCRState)
 			proxyBase := taProxyBase(ns)
 

--- a/tests/e2e-ta-standalone/standalone_test.go
+++ b/tests/e2e-ta-standalone/standalone_test.go
@@ -52,7 +52,7 @@ func TestStandaloneTargetAllocator(t *testing.T) {
 			return ctx
 		}).
 		Assess("scale up preserves consistency", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			ns := nsFromCtx(ctx)
+			ns := e2e.Namespace(t, ctx)
 			initialAssignment := ctx.Value(initialAssignmentKey{}).(map[string][]string)
 
 			scaleStatefulSet(t, ctx, cfg, ns, "collector", 3)
@@ -66,7 +66,7 @@ func TestStandaloneTargetAllocator(t *testing.T) {
 			return ctx
 		}).
 		Assess("scale down reassigns targets", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			ns := nsFromCtx(ctx)
+			ns := e2e.Namespace(t, ctx)
 
 			scaleStatefulSet(t, ctx, cfg, ns, "collector", 2)
 			e2e.WaitForStatefulSet(ctx, t, cfg, ns, "collector", 2, testTimeout)
@@ -77,7 +77,7 @@ func TestStandaloneTargetAllocator(t *testing.T) {
 			return ctx
 		}).
 		Assess("HTTP API contract", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			ns := nsFromCtx(ctx)
+			ns := e2e.Namespace(t, ctx)
 			proxyBase := taProxyBase(ns)
 
 			body := kubectlGetRaw(t, ctx, cfg, proxyBase+"/jobs")


### PR DESCRIPTION
**Description:**

Add an e2e test directly comparing the output of prometheus-operator and target allocator with otel collector, on the same application and ServiceMonitor/scrape config.

The test installs prometheus-operator and creates a Prometheus resource. This resource is used to collect data for a ServiceMonitor and for a raw scrape config natively. Then, we also create an OpenTelemetryCollector with a target allocator, scraping the same data based on the same ServiceMonitor and scrape config, and exporting to the Prometheus using its otlp endpoint.

We collect the data, and then assert that the labels are the same in Prometheus for both ingest methods.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/5242

**Testing:**

This is a test, but the added utilities in the e2e package do have their own unit tests.

**Documentation:**

Added a short README explaining the architecture.
