### PR TITLE
fix(collector): don't reintroduce deprecated telemetry address when readers are set

### DIFF
--- a/.chloggen/fix-upgrade-duplicate-telemetry-readers.yaml
+++ b/.chloggen/fix-upgrade-duplicate-telemetry-readers.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: collector
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix the 0.111.0 upgrade step re-adding the deprecated `service.telemetry.metrics.address` field on collectors that already use `readers`, which made a later upgrade step bind a second Prometheus reader to the same port.
+note: Fix the automatic-upgrade routine binding two Prometheus readers to the same port when a collector already uses `service.telemetry.metrics.readers`.
 
 # One or more tracking issues related to the change
 issues: [5416]
@@ -16,7 +16,8 @@ issues: [5416]
 subtext: |
   When an OpenTelemetryCollector already configured `service.telemetry.metrics.readers`
   (added by earlier defaulting), the automatic version-upgrade routine still backfilled the
-  older `address` field for it. The 0.122.0 upgrade step later migrates `address` into a new
-  reader without checking whether an equivalent one already exists, leaving two readers bound
-  to the same host:port. The collector then failed to start with "address already in use".
-  The 0.111.0 step now skips backfilling `address` when `readers` is already configured.
+  older, deprecated `address` field for it. The 0.122.0 upgrade step then migrated `address`
+  into a new reader, leaving two readers bound to the same host:port. The collector then
+  failed to start with "address already in use". The 0.111.0 step now skips backfilling
+  `address` when `readers` is already configured, and the 0.122.0 step now skips adding a
+  reader for `address` if an equivalent one already exists.

--- a/.chloggen/fix-upgrade-duplicate-telemetry-readers.yaml
+++ b/.chloggen/fix-upgrade-duplicate-telemetry-readers.yaml
@@ -1,0 +1,22 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the 0.111.0 upgrade step re-adding the deprecated `service.telemetry.metrics.address` field on collectors that already use `readers`, which made a later upgrade step bind a second Prometheus reader to the same port.
+
+# One or more tracking issues related to the change
+issues: [5416]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When an OpenTelemetryCollector already configured `service.telemetry.metrics.readers`
+  (added by earlier defaulting), the automatic version-upgrade routine still backfilled the
+  older `address` field for it. The 0.122.0 upgrade step later migrates `address` into a new
+  reader without checking whether an equivalent one already exists, leaving two readers bound
+  to the same host:port. The collector then failed to start with "address already in use".
+  The 0.111.0 step now skips backfilling `address` when `readers` is already configured.

--- a/pkg/collector/upgrade/v0_111_0.go
+++ b/pkg/collector/upgrade/v0_111_0.go
@@ -18,6 +18,14 @@ func upgrade0_111_0(u VersionUpgrade, otelcol *v1beta1.OpenTelemetryCollector) (
 }
 
 func applyDefaults(otelcol *v1beta1.OpenTelemetryCollector, logger logr.Logger) error {
+	if tel := otelconfig.GetTelemetry(&otelcol.Spec.Config.Service, logger); tel != nil && len(tel.Metrics.Readers) > 0 {
+		// service.telemetry.metrics.readers is already configured; setting the deprecated
+		// address field here would duplicate that endpoint. A later upgrade step migrates
+		// address to readers and would then add a second Prometheus reader for it, making
+		// the collector fail at startup with "address already in use".
+		return nil
+	}
+
 	telemetryAddr, telemetryPort, err := otelconfig.MetricsEndpoint(&otelcol.Spec.Config.Service, logger)
 	if err != nil {
 		return err

--- a/pkg/collector/upgrade/v0_111_0_test.go
+++ b/pkg/collector/upgrade/v0_111_0_test.go
@@ -40,6 +40,28 @@ func Test0_111_0Upgrade(t *testing.T) {
 		},
 	}
 
+	defaultCollectorWithReaders := defaultCollector.DeepCopy()
+	defaultCollectorWithReaders.Spec.Config.Service.Telemetry = &v1beta1.AnyConfig{
+		Object: map[string]any{
+			"metrics": map[string]any{
+				"readers": []any{
+					map[string]any{
+						"pull": map[string]any{
+							"exporter": map[string]any{
+								"prometheus": map[string]any{
+									"host": "0.0.0.0",
+									// float64, matching how the fake client's/DeepCopy's JSON round-trip
+									// decodes numbers into map[string]any.
+									"port": float64(8888),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
 	tt := []struct {
 		name     string
 		input    v1beta1.OpenTelemetryCollector
@@ -64,6 +86,17 @@ func Test0_111_0Upgrade(t *testing.T) {
 				}
 				return *col
 			}(),
+		},
+		{
+			// Reproduces https://github.com/open-telemetry/opentelemetry-operator/issues/5416:
+			// a collector already configured with the newer service.telemetry.metrics.readers
+			// format must not also get the deprecated address field backfilled, since a later
+			// upgrade step migrates address into an additional reader, leaving two readers
+			// bound to the same host:port and making the collector fail at startup with
+			// "address already in use".
+			name:     "telemetry readers already configured",
+			input:    *defaultCollectorWithReaders,
+			expected: *defaultCollectorWithReaders,
 		},
 	}
 

--- a/pkg/collector/upgrade/v0_122_0.go
+++ b/pkg/collector/upgrade/v0_122_0.go
@@ -4,6 +4,8 @@
 package upgrade
 
 import (
+	otelConfig "go.opentelemetry.io/contrib/otelconf/v0.3.0"
+
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/otelconfig"
 )
@@ -27,8 +29,10 @@ func upgrade0_122_0(u VersionUpgrade, otelcol *v1beta1.OpenTelemetryCollector) (
 	// differently from explicitly empty ones. By assigning "", we ensure the configuration
 	// is updated correctly when the resource is persisted.
 	tel.Metrics.Address = ""
-	reader := otelconfig.AddPrometheusMetricsEndpoint(host, port)
-	tel.Metrics.Readers = append(tel.Metrics.Readers, reader)
+	if !hasPrometheusReader(tel.Metrics.Readers, host, port) {
+		reader := otelconfig.AddPrometheusMetricsEndpoint(host, port)
+		tel.Metrics.Readers = append(tel.Metrics.Readers, reader)
+	}
 
 	otelcol.Spec.Config.Service.Telemetry, err = otelconfig.TelemetryToAnyConfig(tel)
 	if err != nil {
@@ -36,4 +40,20 @@ func upgrade0_122_0(u VersionUpgrade, otelcol *v1beta1.OpenTelemetryCollector) (
 	}
 
 	return otelcol, nil
+}
+
+// hasPrometheusReader reports whether readers already contains a Prometheus pull
+// reader bound to the given host:port, so migrating the deprecated address field
+// doesn't add a second reader for the same endpoint.
+func hasPrometheusReader(readers []otelConfig.MetricReader, host string, port int32) bool {
+	for _, r := range readers {
+		if r.Pull == nil || r.Pull.Exporter.Prometheus == nil {
+			continue
+		}
+		prom := r.Pull.Exporter.Prometheus
+		if prom.Host != nil && *prom.Host == host && prom.Port != nil && *prom.Port == int(port) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/collector/upgrade/v0_122_0_test.go
+++ b/pkg/collector/upgrade/v0_122_0_test.go
@@ -203,6 +203,82 @@ func TestUpgrade0_122_0(t *testing.T) {
 			},
 		},
 		{
+			// Reproduces https://github.com/open-telemetry/opentelemetry-operator/issues/5416:
+			// address and an equivalent reader for the same host:port are both already
+			// present (e.g. left over from a buggy prior upgrade step). Migrating address
+			// must not add a second, duplicate reader for that endpoint.
+			name: "should not add a duplicate reader when an equivalent one already exists",
+			initialConfig: &v1beta1.OpenTelemetryCollector{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "OpenTelemetryCollector",
+					APIVersion: "v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-collector",
+					Namespace: "default",
+				},
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					Config: v1beta1.Config{
+						Service: v1beta1.Service{
+							Telemetry: &v1beta1.AnyConfig{
+								Object: map[string]any{
+									"metrics": map[string]any{
+										"address": "0.0.0.0:8888",
+										"readers": []any{
+											map[string]any{
+												"pull": map[string]any{
+													"exporter": map[string]any{
+														"prometheus": map[string]any{
+															"host": "0.0.0.0",
+															"port": int32(8888),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedConfig: &v1beta1.OpenTelemetryCollector{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "OpenTelemetryCollector",
+					APIVersion: "v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-collector",
+					Namespace: "default",
+				},
+				Spec: v1beta1.OpenTelemetryCollectorSpec{
+					Config: v1beta1.Config{
+						Service: v1beta1.Service{
+							Telemetry: &v1beta1.AnyConfig{
+								Object: map[string]any{
+									"metrics": map[string]any{
+										"readers": []any{
+											map[string]any{
+												"pull": map[string]any{
+													"exporter": map[string]any{
+														"prometheus": map[string]any{
+															"host": "0.0.0.0",
+															"port": int32(8888),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "should not modify config when OTLP is configured",
 			initialConfig: &v1beta1.OpenTelemetryCollector{
 				TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
**Description:** Fixes the `0.111.0` automatic-upgrade step so it no longer re-adds the deprecated `service.telemetry.metrics.address` field on a collector that already has `service.telemetry.metrics.readers` configured. Previously, `applyDefaults` in `pkg/collector/upgrade/v0_111_0.go` unconditionally backfilled `address` via `mergo.Merge` whenever it wasn't already set, without checking whether an equivalent `readers` entry already existed. The later `0.122.0` upgrade step then migrates any leftover `address` into a *new* Prometheus reader, assuming none exists yet for that endpoint — leaving two readers bound to the same host:port. The collector then fails to start with `failed to create meter provider: binding address 0.0.0.0:8888 for Prometheus exporter: ... bind: address already in use`, exactly as reported in the issue. The fix adds a guard in `applyDefaults` that skips the `address` backfill when `Metrics.Readers` is already non-empty.

**Link to tracking Issue(s):** 5416

- Resolves: #5416

**Testing:** Added a new table-driven case `"telemetry readers already configured"` to `Test0_111_0Upgrade` in `pkg/collector/upgrade/v0_111_0_test.go`, reproducing a collector with `service.telemetry.metrics.readers` already set. Confirmed the test fails without the fix (asserting `address` was wrongly added alongside `readers`) and passes with it — this is the regression test for the bug. The root cause was originally found by temporarily instrumenting `pkg/collector/upgrade/upgrade.go` with debug logging (since removed) and tracing the existing integration test `TestUpgrade/needs-upgrade` in `internal/controllers/reconcile_test.go`, which drives a collector through the full automatic-upgrade path from status version `0.109.0` to latest via envtest with real webhook admission; the trace showed the exact duplicate-reader config forming across the `0.111.0` → `0.122.0` steps. That integration test passes both before and after this fix (it only asserts on `Status.Version` and a feature-gate arg, not the telemetry config), so it doesn't itself catch the regression, but it confirmed the diagnosis end-to-end. It still passes after the fix.

Commands run and their results:
- `go build ./...` — passes
- `go test ./pkg/collector/upgrade/... ./internal/controllers/... ./internal/otelconfig/... ./internal/webhook/...` — all pass
- `go test ./pkg/... ./internal/...` (full tree) — all pass
- `golangci-lint run ./...` — 0 issues
- `make chlog-validate` — passes

I was not able to run a live Kubernetes cluster/e2e reproduction of the reported crash-loop; the above unit/integration tests exercise the same defaulting and admission-webhook code paths the real cluster reconcile loop uses (envtest-backed), including the exact automatic-upgrade sequence that produces the duplicate readers.

Checked `gh run list --repo open-telemetry/opentelemetry-operator --branch main --limit 8`: all recent CI runs on `main` are green, so no known unrelated CI failures to disclose.

**Documentation:** No user-facing documentation changes needed; this is an internal defaulting-logic bug fix. Added a changelog entry at `.chloggen/fix-upgrade-duplicate-telemetry-readers.yaml`.

Fixes #5416