### PR TITLE
Fix disabling target filtering for target allocator

### DIFF
--- a/.chloggen/target-allocator-filter-strategy-none.yaml
+++ b/.chloggen/target-allocator-filter-strategy-none.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: target allocator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `none` as an explicit filter strategy and preserve explicitly configured empty strategies.
+
+# One or more tracking issues related to the change
+issues: [5444]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The Go type of `TargetAllocatorSpec.FilterStrategy` changed to a pointer so typed clients can
+  distinguish an unset strategy from an explicitly configured value. The legacy empty value remains
+  accepted as an alias for disabling filtering, but new configurations should use `none`.

--- a/.chloggen/target-allocator-filter-strategy-none.yaml
+++ b/.chloggen/target-allocator-filter-strategy-none.yaml
@@ -17,3 +17,5 @@ subtext: |
   The Go type of `TargetAllocatorSpec.FilterStrategy` changed to a pointer so typed clients can
   distinguish an unset strategy from an explicitly configured value. The legacy empty value remains
   accepted as an alias for disabling filtering, but new configurations should use `none`.
+  The Target Allocator now rejects any other value of `filter_strategy` on startup, and normalizes
+  the empty value to `none` when loading its configuration.

--- a/apis/v1alpha1/targetallocator_types.go
+++ b/apis/v1alpha1/targetallocator_types.go
@@ -59,11 +59,13 @@ type TargetAllocatorSpec struct {
 	// +kubebuilder:default:=consistent-hashing
 	AllocationStrategy v1beta1.TargetAllocatorAllocationStrategy `json:"allocationStrategy,omitempty"`
 	// FilterStrategy determines how to filter targets before allocating them among the collectors.
-	// The only current option is relabel-config (drops targets based on prom relabel_config).
+	// The current options are relabel-config (drops targets based on Prometheus relabel_config)
+	// and none (disables filtering).
+	// For backward compatibility, an empty string also disables filtering, but none should be used.
 	// The default is relabel-config.
 	// +optional
 	// +kubebuilder:default:=relabel-config
-	FilterStrategy v1beta1.TargetAllocatorFilterStrategy `json:"filterStrategy,omitempty"`
+	FilterStrategy *v1beta1.TargetAllocatorFilterStrategy `json:"filterStrategy,omitempty"`
 	// GlobalConfig configures the global configuration for Prometheus
 	// For more info, see https://prometheus.io/docs/prometheus/latest/configuration/configuration/#configuration-file.
 	GlobalConfig v1beta1.AnyConfig `json:"global,omitempty"`

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1682,6 +1682,11 @@ func (in *TargetAllocatorList) DeepCopyObject() runtime.Object {
 func (in *TargetAllocatorSpec) DeepCopyInto(out *TargetAllocatorSpec) {
 	*out = *in
 	in.OpenTelemetryCommonFields.DeepCopyInto(&out.OpenTelemetryCommonFields)
+	if in.FilterStrategy != nil {
+		in, out := &in.FilterStrategy, &out.FilterStrategy
+		*out = new(v1beta1.TargetAllocatorFilterStrategy)
+		**out = **in
+	}
 	in.GlobalConfig.DeepCopyInto(&out.GlobalConfig)
 	if in.ScrapeConfigs != nil {
 		in, out := &in.ScrapeConfigs, &out.ScrapeConfigs

--- a/apis/v1beta1/opentelemetrycollector_types.go
+++ b/apis/v1beta1/opentelemetrycollector_types.go
@@ -178,7 +178,9 @@ type TargetAllocatorEmbedded struct {
 	// +kubebuilder:default:=consistent-hashing
 	AllocationStrategy TargetAllocatorAllocationStrategy `json:"allocationStrategy,omitempty"`
 	// FilterStrategy determines how to filter targets before allocating them among the collectors.
-	// The only current option is relabel-config (drops targets based on prom relabel_config).
+	// The current options are relabel-config (drops targets based on Prometheus relabel_config)
+	// and none (disables filtering).
+	// For backward compatibility, an empty string also disables filtering, but none should be used.
 	// The default is relabel-config.
 	// +optional
 	// +kubebuilder:default:=relabel-config

--- a/apis/v1beta1/targetallocator_types.go
+++ b/apis/v1beta1/targetallocator_types.go
@@ -114,7 +114,7 @@ type (
 	// +kubebuilder:validation:Enum=least-weighted;consistent-hashing;per-node
 	TargetAllocatorAllocationStrategy string
 	// TargetAllocatorFilterStrategy represent a filtering strategy for targets before they are assigned to collectors
-	// +kubebuilder:validation:Enum="";relabel-config
+	// +kubebuilder:validation:Enum="";none;relabel-config
 	TargetAllocatorFilterStrategy string
 )
 
@@ -130,4 +130,7 @@ const (
 
 	// TargetAllocatorFilterStrategyRelabelConfig targets will be consistently drops targets based on the relabel_config.
 	TargetAllocatorFilterStrategyRelabelConfig TargetAllocatorFilterStrategy = "relabel-config"
+
+	// TargetAllocatorFilterStrategyNone disables filtering of targets before they are assigned to collectors.
+	TargetAllocatorFilterStrategyNone TargetAllocatorFilterStrategy = "none"
 )

--- a/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -8203,6 +8203,7 @@ spec:
                     default: relabel-config
                     enum:
                     - ""
+                    - none
                     - relabel-config
                     type: string
                   image:

--- a/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
@@ -1331,6 +1331,7 @@ spec:
                 default: relabel-config
                 enum:
                 - ""
+                - none
                 - relabel-config
                 type: string
               global:

--- a/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -8202,6 +8202,7 @@ spec:
                     default: relabel-config
                     enum:
                     - ""
+                    - none
                     - relabel-config
                     type: string
                   image:

--- a/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
@@ -1331,6 +1331,7 @@ spec:
                 default: relabel-config
                 enum:
                 - ""
+                - none
                 - relabel-config
                 type: string
               global:

--- a/cmd/otel-allocator/benchmark_test.go
+++ b/cmd/otel-allocator/benchmark_test.go
@@ -186,9 +186,9 @@ func createTestDiscoverer(allocationStrategy string, relabelConfig map[string][]
 
 	// Enable relabel-config filtering only when there are configs to apply, so the no-relabel
 	// benchmark measures the unfiltered path.
-	filterStrategy := ""
+	filterStrategy := config.FilterStrategyNone
 	if len(relabelConfig) > 0 {
-		filterStrategy = target.RelabelConfigFilterStrategy
+		filterStrategy = config.FilterStrategyRelabelConfig
 	}
 	targetDiscoverer, err := target.NewDiscoverer(logger, discoveryManager, filterStrategy, srv, allocator.SetTargets)
 	if err != nil {

--- a/cmd/otel-allocator/integrationtest/harness.go
+++ b/cmd/otel-allocator/integrationtest/harness.go
@@ -92,7 +92,7 @@ func startTargetAllocator(t *testing.T, scrapeConfigs []*promconfig.ScrapeConfig
 	// Keep the production discovery path (discoverer.Run + reloader), just with a
 	// short reload interval so the test does not wait on the 5s default debounce.
 	// Relabel filtering now happens inside discovery (selected by the filter strategy).
-	discoverer, err := target.NewDiscoverer(log, discoveryManager, target.RelabelConfigFilterStrategy, srv, alloc.SetTargets, target.WithReloadInterval(10*time.Millisecond))
+	discoverer, err := target.NewDiscoverer(log, discoveryManager, taconfig.FilterStrategyRelabelConfig, srv, alloc.SetTargets, target.WithReloadInterval(10*time.Millisecond))
 	require.NoError(t, err)
 
 	errs := make(chan error, 3)

--- a/cmd/otel-allocator/internal/config/config.go
+++ b/cmd/otel-allocator/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -43,9 +44,38 @@ const (
 	DefaultConfigFilePath               string         = "/conf/targetallocator.yaml"
 	DefaultCRScrapeInterval             model.Duration = model.Duration(time.Second * 30)
 	DefaultAllocationStrategy                          = "consistent-hashing"
-	DefaultFilterStrategy                              = "relabel-config"
 	DefaultCollectorNotReadyGracePeriod                = 30 * time.Second
 )
+
+// FilterStrategy determines whether, and how, the Target Allocator filters targets before
+// allocating them among the collectors.
+type FilterStrategy string
+
+const (
+	// FilterStrategyRelabelConfig drops targets based on the scrape config's relabel_configs,
+	// as they are discovered.
+	FilterStrategyRelabelConfig FilterStrategy = "relabel-config"
+	// FilterStrategyNone disables target filtering.
+	FilterStrategyNone FilterStrategy = "none"
+	// FilterStrategyUnset is the empty value, kept for backward compatibility with configurations
+	// which disabled filtering that way. It normalizes to FilterStrategyNone on config load.
+	FilterStrategyUnset FilterStrategy = ""
+
+	// DefaultFilterStrategy is used if no filter strategy is set in the configuration.
+	DefaultFilterStrategy = FilterStrategyRelabelConfig
+)
+
+// validFilterStrategies are all the values the filter_strategy option accepts.
+var validFilterStrategies = []FilterStrategy{FilterStrategyRelabelConfig, FilterStrategyNone, FilterStrategyUnset}
+
+// normalize resolves the deprecated empty value to the equivalent explicit strategy. Any other
+// value is returned as-is, so that invalid ones can be rejected by ValidateConfig.
+func (f FilterStrategy) normalize() FilterStrategy {
+	if f == FilterStrategyUnset {
+		return FilterStrategyNone
+	}
+	return f
+}
 
 var DefaultKubeConfigFilePath = filepath.Join(homedir.HomeDir(), ".kube", "config")
 
@@ -69,7 +99,7 @@ type Config struct {
 	PromConfig                   *promconfig.Config    `yaml:"config"`
 	AllocationStrategy           string                `yaml:"allocation_strategy,omitempty"`
 	AllocationFallbackStrategy   string                `yaml:"allocation_fallback_strategy,omitempty"`
-	FilterStrategy               string                `yaml:"filter_strategy,omitempty"`
+	FilterStrategy               FilterStrategy        `yaml:"filter_strategy,omitempty"`
 	PrometheusCR                 PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
 	HTTPS                        HTTPSServerConfig     `yaml:"https,omitempty"`
 	Telemetry                    TelemetryConfig       `yaml:"telemetry,omitempty"`
@@ -504,6 +534,8 @@ func Load(args []string) (*Config, error) {
 		return nil, err
 	}
 
+	config.FilterStrategy = config.FilterStrategy.normalize()
+
 	return &config, nil
 }
 
@@ -518,6 +550,9 @@ func ValidateConfig(config *Config) error {
 	}
 	if len(config.PrometheusCR.AllowNamespaces) != 0 && len(config.PrometheusCR.DenyNamespaces) != 0 {
 		return errors.New("only one of allowNamespaces or denyNamespaces can be set")
+	}
+	if !slices.Contains(validFilterStrategies, config.FilterStrategy) {
+		return fmt.Errorf("invalid filter strategy %q, must be one of: %s, %s", config.FilterStrategy, FilterStrategyRelabelConfig, FilterStrategyNone)
 	}
 	return validateTelemetry(config.Telemetry)
 }

--- a/cmd/otel-allocator/internal/config/config_test.go
+++ b/cmd/otel-allocator/internal/config/config_test.go
@@ -862,6 +862,42 @@ func TestValidateConfig(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name: "empty filter strategy",
+			fileConfig: Config{
+				PromConfig:         &promconfig.Config{ScrapeConfigs: []*promconfig.ScrapeConfig{{}}},
+				CollectorNamespace: "default",
+				FilterStrategy:     FilterStrategyUnset,
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "none filter strategy",
+			fileConfig: Config{
+				PromConfig:         &promconfig.Config{ScrapeConfigs: []*promconfig.ScrapeConfig{{}}},
+				CollectorNamespace: "default",
+				FilterStrategy:     FilterStrategyNone,
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "relabel-config filter strategy",
+			fileConfig: Config{
+				PromConfig:         &promconfig.Config{ScrapeConfigs: []*promconfig.ScrapeConfig{{}}},
+				CollectorNamespace: "default",
+				FilterStrategy:     FilterStrategyRelabelConfig,
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "invalid filter strategy",
+			fileConfig: Config{
+				PromConfig:         &promconfig.Config{ScrapeConfigs: []*promconfig.ScrapeConfig{{}}},
+				CollectorNamespace: "default",
+				FilterStrategy:     "not-a-strategy",
+			},
+			expectedErr: errors.New(`invalid filter strategy "not-a-strategy", must be one of: relabel-config, none`),
+		},
+		{
 			name: "both allowNamespaces and denyNamespaces set",
 			fileConfig: Config{
 				PrometheusCR: PrometheusCRConfig{
@@ -1217,5 +1253,35 @@ kube_config_file_path: "` + kubeConfigPath + `"
 		assert.Equal(t, testNamespace, config.CollectorNamespace, "Env var should override config file for namespace")
 		assert.Equal(t, cliListenAddr, config.ListenAddr, "CLI should override config file for listen address")
 		assert.True(t, config.PrometheusCR.Enabled, "CLI should override config file for prometheus CR enabled")
+	})
+
+	t.Run("filter strategy is normalized on load", func(t *testing.T) {
+		for _, tc := range []struct {
+			name     string
+			value    string
+			expected FilterStrategy
+		}{
+			{name: "unset", value: "", expected: DefaultFilterStrategy},
+			{name: "empty", value: `filter_strategy: ""`, expected: FilterStrategyNone},
+			{name: "none", value: "filter_strategy: none", expected: FilterStrategyNone},
+			{name: "relabel-config", value: "filter_strategy: relabel-config", expected: FilterStrategyRelabelConfig},
+			{name: "invalid values are left for validation", value: "filter_strategy: invalid", expected: "invalid"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				tempDir := t.TempDir()
+				kubeConfigPath := createDummyKubeConfig(t, tempDir)
+				configPath := filepath.Join(tempDir, "config.yaml")
+				require.NoError(t, os.WriteFile(configPath, []byte(tc.value+"\n"), 0o600))
+
+				args := []string{
+					"--" + configFilePathFlagName + "=" + configPath,
+					"--" + kubeConfigPathFlagName + "=" + kubeConfigPath,
+				}
+
+				config, err := Load(args)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, config.FilterStrategy)
+			})
+		}
 	})
 }

--- a/cmd/otel-allocator/internal/conformance/pipeline.go
+++ b/cmd/otel-allocator/internal/conformance/pipeline.go
@@ -82,9 +82,9 @@ func runAllocatorPipeline(t *testing.T, promYAML string) map[targetKey][]allocat
 	}
 
 	// Pass 1: filtering off — all discovered targets, post-merge / pre-relabel.
-	allItems := runDiscovery(t, tsets, "", nil)
+	allItems := runDiscovery(t, tsets, config.FilterStrategyNone, nil)
 	// Pass 2: filtering on — the survivors, carrying the relabel identity hash.
-	kept := runDiscovery(t, tsets, target.RelabelConfigFilterStrategy, cfg.ScrapeConfigs)
+	kept := runDiscovery(t, tsets, config.FilterStrategyRelabelConfig, cfg.ScrapeConfigs)
 
 	// Index survivors by (job, full pre-relabel label-set hash) — not by address, so
 	// targets that share a pre-relabel address are not confused. The Item carries the
@@ -117,7 +117,7 @@ func runAllocatorPipeline(t *testing.T, promYAML string) map[targetKey][]allocat
 //
 // Target sets are injected directly via UpdateTsets, so no real service discovery
 // runs — a fake discovery manager stands in for the real one.
-func runDiscovery(t *testing.T, tsets map[string][]*targetgroup.Group, filterStrategy string, scrapeConfigs []*promconfig.ScrapeConfig) []*target.Item {
+func runDiscovery(t *testing.T, tsets map[string][]*targetgroup.Group, filterStrategy config.FilterStrategy, scrapeConfigs []*promconfig.ScrapeConfig) []*target.Item {
 	t.Helper()
 	var captured []*target.Item
 	d, err := target.NewDiscoverer(logr.Discard(), fakeDiscoveryManager{}, filterStrategy, nil, func(items []*target.Item) {

--- a/cmd/otel-allocator/internal/target/discovery.go
+++ b/cmd/otel-allocator/internal/target/discovery.go
@@ -24,15 +24,11 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/config"
 	allocatorWatcher "github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/internal/watcher"
 )
 
 const labelBuilderPreallocSize = 100
-
-// RelabelConfigFilterStrategy is the filter strategy that drops targets while they are being
-// created, based on the scrape config's relabel_configs. It's the only filtering strategy
-// currently supported; any other value disables target filtering.
-const RelabelConfigFilterStrategy = "relabel-config"
 
 type Discoverer struct {
 	log                         logr.Logger
@@ -81,7 +77,7 @@ type discoveryManager interface {
 func NewDiscoverer(
 	log logr.Logger,
 	manager discoveryManager,
-	filterStrategy string,
+	filterStrategy config.FilterStrategy,
 	scrapeConfigsUpdater scrapeConfigsUpdater,
 	setTargets func(targets []*Item),
 	opts ...DiscovererOption,
@@ -109,7 +105,7 @@ func NewDiscoverer(
 		configsMap:                  make(map[allocatorWatcher.EventSource][]*promconfig.ScrapeConfig),
 		relabelCfg:                  make(map[string][]*relabel.Config),
 		scrapeSeeds:                 make(map[string][]labels.Label),
-		filterRelabelConfig:         filterStrategy == RelabelConfigFilterStrategy,
+		filterRelabelConfig:         filterStrategy == config.FilterStrategyRelabelConfig,
 		scrapeConfigsHash:           nil, // we want the first update to succeed even if the config is empty
 		scrapeConfigsUpdater:        scrapeConfigsUpdater,
 		processTargetsCallBack:      setTargets,

--- a/cmd/otel-allocator/internal/target/discovery_test.go
+++ b/cmd/otel-allocator/internal/target/discovery_test.go
@@ -772,7 +772,7 @@ func TestReloadAppliesRelabelFilteringWhenEnabled(t *testing.T) {
 // disables filtering during discovery: targets are kept even if relabel_configs would drop them.
 func TestReloadSkipsRelabelFilteringWhenDisabled(t *testing.T) {
 	var got []*Item
-	d := newTestDiscoverer(t, "", func(targets []*Item) { got = targets })
+	d := newTestDiscoverer(t, "none", func(targets []*Item) { got = targets })
 
 	scrapeConfigs := []*promconfig.ScrapeConfig{
 		{

--- a/cmd/otel-allocator/internal/target/discovery_test.go
+++ b/cmd/otel-allocator/internal/target/discovery_test.go
@@ -64,7 +64,7 @@ func TestDiscovery(t *testing.T) {
 	require.NoError(t, err)
 	d := discovery.NewManager(ctx, config.NopLogger, registry, sdMetrics)
 	results := make(chan []string)
-	manager, err := NewDiscoverer(ctrl.Log.WithName("test"), d, RelabelConfigFilterStrategy, scu, func(targets []*Item) {
+	manager, err := NewDiscoverer(ctrl.Log.WithName("test"), d, config.FilterStrategyRelabelConfig, scu, func(targets []*Item) {
 		var result []string
 		for _, t := range targets {
 			result = append(result, t.TargetURL)
@@ -312,7 +312,7 @@ func TestDiscovery_ScrapeConfigHashing(t *testing.T) {
 	sdMetrics, err := discovery.CreateAndRegisterSDMetrics(registry)
 	require.NoError(t, err)
 	d := discovery.NewManager(ctx, config.NopLogger, registry, sdMetrics)
-	manager, err := NewDiscoverer(ctrl.Log.WithName("test"), d, RelabelConfigFilterStrategy, scu, nil)
+	manager, err := NewDiscoverer(ctrl.Log.WithName("test"), d, config.FilterStrategyRelabelConfig, scu, nil)
 	require.NoError(t, err)
 
 	for _, tc := range tests {
@@ -403,7 +403,7 @@ func TestDiscoveryTargetHashing(t *testing.T) {
 	require.NoError(t, err)
 	d := discovery.NewManager(ctx, config.NopLogger, registry, sdMetrics)
 	results := make(chan []*Item)
-	manager, err := NewDiscoverer(ctrl.Log.WithName("test"), d, RelabelConfigFilterStrategy, scu, func(targets []*Item) {
+	manager, err := NewDiscoverer(ctrl.Log.WithName("test"), d, config.FilterStrategyRelabelConfig, scu, func(targets []*Item) {
 		var result []*Item
 		result = append(result, targets...)
 		results <- result
@@ -450,7 +450,7 @@ func TestDiscovery_NoConfig(t *testing.T) {
 	sdMetrics, err := discovery.CreateAndRegisterSDMetrics(registry)
 	require.NoError(t, err)
 	d := discovery.NewManager(ctx, config.NopLogger, registry, sdMetrics)
-	manager, err := NewDiscoverer(ctrl.Log.WithName("test"), d, RelabelConfigFilterStrategy, scu, nil)
+	manager, err := NewDiscoverer(ctrl.Log.WithName("test"), d, config.FilterStrategyRelabelConfig, scu, nil)
 	require.NoError(t, err)
 	defer close(manager.close)
 	defer cancelFunc()
@@ -494,7 +494,7 @@ func TestProcessTargetGroups_StableLabelIterationOrder(t *testing.T) {
 	sdMetrics, err := discovery.CreateAndRegisterSDMetrics(registry)
 	require.NoError(t, err)
 	manager := discovery.NewManager(ctx, config.NopLogger, registry, sdMetrics)
-	d, err := NewDiscoverer(ctrl.Log.WithName("test"), manager, RelabelConfigFilterStrategy, scu, nil)
+	d, err := NewDiscoverer(ctrl.Log.WithName("test"), manager, config.FilterStrategyRelabelConfig, scu, nil)
 	require.NoError(t, err)
 	results := d.processTargetGroups("test", groups, nil, nil)
 	require.Len(t, results, 1)
@@ -545,7 +545,7 @@ func BenchmarkApplyScrapeConfig(b *testing.B) {
 	sdMetrics, err := discovery.CreateAndRegisterSDMetrics(registry)
 	require.NoError(b, err)
 	d := discovery.NewManager(ctx, config.NopLogger, registry, sdMetrics)
-	manager, err := NewDiscoverer(ctrl.Log.WithName("test"), d, RelabelConfigFilterStrategy, scu, nil)
+	manager, err := NewDiscoverer(ctrl.Log.WithName("test"), d, config.FilterStrategyRelabelConfig, scu, nil)
 	require.NoError(b, err)
 
 	b.ResetTimer()
@@ -573,7 +573,7 @@ func (m *mockScrapeConfigUpdater) UpdateScrapeConfigResponse(cfg map[string]*pro
 	return nil
 }
 
-func newTestDiscoverer(t testing.TB, filterStrategy string, setTargets func([]*Item)) *Discoverer {
+func newTestDiscoverer(t testing.TB, filterStrategy config.FilterStrategy, setTargets func([]*Item)) *Discoverer {
 	t.Helper()
 	registry := prometheus.NewRegistry()
 	sdMetrics, err := discovery.CreateAndRegisterSDMetrics(registry)
@@ -588,7 +588,7 @@ func newTestDiscoverer(t testing.TB, filterStrategy string, setTargets func([]*I
 // created: targets dropped by a keep/drop action are excluded, and kept targets carry a
 // precomputed hash derived from the relabeled labels.
 func TestProcessTargetGroupsRelabelFiltering(t *testing.T) {
-	d := newTestDiscoverer(t, RelabelConfigFilterStrategy, nil)
+	d := newTestDiscoverer(t, config.FilterStrategyRelabelConfig, nil)
 	groups := []*targetgroup.Group{
 		{
 			Labels: model.LabelSet{"job": "test"},
@@ -623,7 +623,7 @@ func TestProcessTargetGroupsRelabelFiltering(t *testing.T) {
 // served labels nor override labels already present on the target.
 // Regression test for https://github.com/open-telemetry/opentelemetry-operator/issues/5246.
 func TestProcessTargetGroupsSeededLabels(t *testing.T) {
-	d := newTestDiscoverer(t, RelabelConfigFilterStrategy, nil)
+	d := newTestDiscoverer(t, config.FilterStrategyRelabelConfig, nil)
 	scrapeCfg := &promconfig.ScrapeConfig{
 		JobName:        "seeded-job",
 		Scheme:         "http",
@@ -689,7 +689,7 @@ func TestProcessTargetGroupsSeededLabels(t *testing.T) {
 // TestProcessTargetGroupsNoRelabelConfig verifies that when there's no relabel config for a job,
 // all targets are kept and the hash is still computed from the labels at creation time.
 func TestProcessTargetGroupsNoRelabelConfig(t *testing.T) {
-	d := newTestDiscoverer(t, RelabelConfigFilterStrategy, nil)
+	d := newTestDiscoverer(t, config.FilterStrategyRelabelConfig, nil)
 	groups := []*targetgroup.Group{
 		{
 			Labels: model.LabelSet{"job": "test"},
@@ -713,7 +713,7 @@ func TestProcessTargetGroupsNoRelabelConfig(t *testing.T) {
 // TestProcessTargetGroupsDeduplicatesByHash verifies that targets which become identical after
 // relabeling share the same hash, so the allocator deduplicates them.
 func TestProcessTargetGroupsDeduplicatesByHash(t *testing.T) {
-	d := newTestDiscoverer(t, RelabelConfigFilterStrategy, nil)
+	d := newTestDiscoverer(t, config.FilterStrategyRelabelConfig, nil)
 	groups := []*targetgroup.Group{
 		{
 			Labels: model.LabelSet{"job": "test"},
@@ -739,7 +739,7 @@ func TestProcessTargetGroupsDeduplicatesByHash(t *testing.T) {
 // targets according to the scrape config's relabel_configs when the filter strategy is enabled.
 func TestReloadAppliesRelabelFilteringWhenEnabled(t *testing.T) {
 	var got []*Item
-	d := newTestDiscoverer(t, RelabelConfigFilterStrategy, func(targets []*Item) { got = targets })
+	d := newTestDiscoverer(t, config.FilterStrategyRelabelConfig, func(targets []*Item) { got = targets })
 
 	scrapeConfigs := []*promconfig.ScrapeConfig{
 		{
@@ -772,7 +772,7 @@ func TestReloadAppliesRelabelFilteringWhenEnabled(t *testing.T) {
 // disables filtering during discovery: targets are kept even if relabel_configs would drop them.
 func TestReloadSkipsRelabelFilteringWhenDisabled(t *testing.T) {
 	var got []*Item
-	d := newTestDiscoverer(t, "none", func(targets []*Item) { got = targets })
+	d := newTestDiscoverer(t, config.FilterStrategyNone, func(targets []*Item) { got = targets })
 
 	scrapeConfigs := []*promconfig.ScrapeConfig{
 		{

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -8189,6 +8189,7 @@ spec:
                     default: relabel-config
                     enum:
                     - ""
+                    - none
                     - relabel-config
                     type: string
                   image:

--- a/config/crd/bases/opentelemetry.io_targetallocators.yaml
+++ b/config/crd/bases/opentelemetry.io_targetallocators.yaml
@@ -1329,6 +1329,7 @@ spec:
                 default: relabel-config
                 enum:
                 - ""
+                - none
                 - relabel-config
                 type: string
               global:

--- a/docs/api/opentelemetrycollectors.md
+++ b/docs/api/opentelemetrycollectors.md
@@ -32333,10 +32333,12 @@ consumed in the config file for the TargetAllocator.<br/>
         <td>enum</td>
         <td>
           FilterStrategy determines how to filter targets before allocating them among the collectors.
-The only current option is relabel-config (drops targets based on prom relabel_config).
+The current options are relabel-config (drops targets based on Prometheus relabel_config)
+and none (disables filtering).
+For backward compatibility, an empty string also disables filtering, but none should be used.
 The default is relabel-config.<br/>
           <br/>
-            <i>Enum</i>: , relabel-config<br/>
+            <i>Enum</i>: , none, relabel-config<br/>
             <i>Default</i>: relabel-config<br/>
         </td>
         <td>false</td>

--- a/docs/api/targetallocators.md
+++ b/docs/api/targetallocators.md
@@ -172,10 +172,12 @@ The default is 30s, which means that if a collector becomes not Ready, the targe
         <td>enum</td>
         <td>
           FilterStrategy determines how to filter targets before allocating them among the collectors.
-The only current option is relabel-config (drops targets based on prom relabel_config).
+The current options are relabel-config (drops targets based on Prometheus relabel_config)
+and none (disables filtering).
+For backward compatibility, an empty string also disables filtering, but none should be used.
 The default is relabel-config.<br/>
           <br/>
-            <i>Enum</i>: , relabel-config<br/>
+            <i>Enum</i>: , none, relabel-config<br/>
             <i>Default</i>: relabel-config<br/>
         </td>
         <td>false</td>

--- a/docs/target-allocator/README.md
+++ b/docs/target-allocator/README.md
@@ -24,7 +24,7 @@ The Target Allocator uses a configuration file (by default under `/conf/targetal
 | `config`                           | Prometheus configuration block                                                |                                               |                      |
 | `allocation_strategy`              | Allocation strategy to apply to job assignments                               | `consistent-hashing`                          |                      |
 | `allocation_fallback_strategy`     | Fallback allocation strategy for job assignments                              |                                               |                      |
-| `filter_strategy`                  | Filter strategy to apply to metrics                                           | `relabel-config`                              |                      |
+| `filter_strategy`                  | Filter strategy to apply to metrics (`relabel-config` or `none`)               | `relabel-config`                              |                      |
 | `prometheus_cr`                    | Whether to watch Prometheus Custom Resources                                  |                                               |                      |
 | `https`                            | Whether to expose the target allocator endpoint over https                    |                                               |                      |
 | `allow_insecure_auth_secrets`      | Serve auth secret values over plain HTTP without mTLS                         | `false`                                       | `ALLOW_INSECURE_AUTH_SECRETS` |

--- a/internal/controllers/reconcile_test.go
+++ b/internal/controllers/reconcile_test.go
@@ -113,6 +113,8 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 	updatedRouteParams.Spec.Ingress.Type = v1beta1.IngressTypeRoute
 	updatedRouteParams.Spec.Ingress.Route.Termination = v1beta1.TLSRouteTerminationTypeInsecure
 	updatedRouteParams.Spec.Ingress.Hostname = expectHostname
+	noneFilterStrategyParams := testCollectorAssertNoErr(t, "test-stateful-ta-none-filter", baseTaImage, promFile)
+	noneFilterStrategyParams.Spec.TargetAllocator.FilterStrategy = v1beta1.TargetAllocatorFilterStrategyNone
 	deletedParams := testCollectorWithMode(t, "test2", v1beta1.ModeDeployment)
 	now := metav1.NewTime(time.Now())
 	deletedParams.DeletionTimestamp = &now
@@ -517,6 +519,7 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 							exists, err = populateObjectIfExists(t, &actual, namespacedObjectName(params.Name, params.Namespace))
 							require.NoError(t, err)
 							require.True(t, exists)
+							relabelConfigFilterStrategy := v1beta1.TargetAllocatorFilterStrategyRelabelConfig
 							expected := v1alpha1.TargetAllocator{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      params.Name,
@@ -528,7 +531,7 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 								Spec: v1alpha1.TargetAllocatorSpec{
 									OpenTelemetryCommonFields: v1beta1.OpenTelemetryCommonFields{},
 									AllocationStrategy:        "consistent-hashing",
-									FilterStrategy:            "relabel-config",
+									FilterStrategy:            &relabelConfigFilterStrategy,
 									PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
 										ScrapeInterval:         &metav1.Duration{Duration: time.Second * 30},
 										ServiceMonitorSelector: &metav1.LabelSelector{},
@@ -576,6 +579,29 @@ func TestOpenTelemetryCollectorReconciler_Reconcile(t *testing.T) {
 							require.NoError(t, err)
 							require.True(t, exists)
 							assert.Equal(t, actual.Spec.Image, updatedTaImage)
+						},
+					},
+					wantErr:     assert.NoError,
+					validateErr: assert.NoError,
+				},
+			},
+		},
+		{
+			name: "stateful collector with target allocator filtering disabled",
+			args: args{
+				params: noneFilterStrategyParams,
+			},
+			want: []want{
+				{
+					result: controllerruntime.Result{},
+					checks: []check[v1beta1.OpenTelemetryCollector]{
+						func(t *testing.T, params v1beta1.OpenTelemetryCollector) {
+							actual := v1alpha1.TargetAllocator{}
+							exists, err := populateObjectIfExists(t, &actual, namespacedObjectName(params.Name, params.Namespace))
+							require.NoError(t, err)
+							require.True(t, exists)
+							require.NotNil(t, actual.Spec.FilterStrategy)
+							assert.Equal(t, v1beta1.TargetAllocatorFilterStrategyNone, *actual.Spec.FilterStrategy)
 						},
 					},
 					wantErr:     assert.NoError,

--- a/internal/manifests/collector/targetallocator.go
+++ b/internal/manifests/collector/targetallocator.go
@@ -19,6 +19,7 @@ func TargetAllocator(params manifests.Params) (*v1alpha1.TargetAllocator, error)
 	if !taSpec.Enabled {
 		return nil, nil
 	}
+	filterStrategy := taSpec.FilterStrategy
 
 	// setting all the labels normally here leads to some undesirable results, like the name label being wrong
 	// instead, only set managed-by and leave everything else as-is
@@ -57,7 +58,7 @@ func TargetAllocator(params manifests.Params) (*v1alpha1.TargetAllocator, error)
 				PodDisruptionBudget:       taSpec.PodDisruptionBudget,
 			},
 			AllocationStrategy:           taSpec.AllocationStrategy,
-			FilterStrategy:               taSpec.FilterStrategy,
+			FilterStrategy:               &filterStrategy,
 			PrometheusCR:                 taSpec.PrometheusCR,
 			Observability:                taSpec.Observability,
 			AllowInsecureAuthSecrets:     taSpec.AllowInsecureAuthSecrets,

--- a/internal/manifests/collector/targetallocator_test.go
+++ b/internal/manifests/collector/targetallocator_test.go
@@ -4,6 +4,7 @@
 package collector
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -45,6 +46,8 @@ func TestTargetAllocator(t *testing.T) {
 	privileged := true
 	runAsUser := int64(1337)
 	runasGroup := int64(1338)
+	emptyFilterStrategy := v1beta1.TargetAllocatorFilterStrategy("")
+	relabelConfigFilterStrategy := v1beta1.TargetAllocatorFilterStrategyRelabelConfig
 
 	testCases := []struct {
 		name    string
@@ -76,7 +79,8 @@ func TestTargetAllocator(t *testing.T) {
 			want: &v1alpha1.TargetAllocator{
 				ObjectMeta: expectedObjectMetadata,
 				Spec: v1alpha1.TargetAllocatorSpec{
-					GlobalConfig: v1beta1.AnyConfig{},
+					FilterStrategy: &emptyFilterStrategy,
+					GlobalConfig:   v1beta1.AnyConfig{},
 				},
 			},
 		},
@@ -265,7 +269,7 @@ func TestTargetAllocator(t *testing.T) {
 						},
 					},
 					AllocationStrategy: v1beta1.TargetAllocatorAllocationStrategyConsistentHashing,
-					FilterStrategy:     v1beta1.TargetAllocatorFilterStrategyRelabelConfig,
+					FilterStrategy:     &relabelConfigFilterStrategy,
 					PrometheusCR: v1beta1.TargetAllocatorPrometheusCR{
 						Enabled:        true,
 						ScrapeInterval: &metav1.Duration{Duration: time.Second},
@@ -295,6 +299,48 @@ func TestTargetAllocator(t *testing.T) {
 			actual, err := TargetAllocator(params)
 			assert.Equal(t, testCase.wantErr, err)
 			assert.Equal(t, testCase.want, actual)
+		})
+	}
+}
+
+func TestTargetAllocatorPreservesExplicitFilterStrategy(t *testing.T) {
+	testCases := []struct {
+		name           string
+		filterStrategy v1beta1.TargetAllocatorFilterStrategy
+	}{
+		{
+			name:           "none",
+			filterStrategy: v1beta1.TargetAllocatorFilterStrategyNone,
+		},
+		{
+			name:           "legacy empty value",
+			filterStrategy: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			targetAllocator, err := TargetAllocator(manifests.Params{
+				OtelCol: v1beta1.OpenTelemetryCollector{
+					Spec: v1beta1.OpenTelemetryCollectorSpec{
+						TargetAllocator: v1beta1.TargetAllocatorEmbedded{
+							Enabled:        true,
+							FilterStrategy: testCase.filterStrategy,
+						},
+					},
+				},
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.filterStrategy, *targetAllocator.Spec.FilterStrategy)
+
+			encoded, err := json.Marshal(targetAllocator)
+			assert.NoError(t, err)
+			var object map[string]any
+			assert.NoError(t, json.Unmarshal(encoded, &object))
+			spec := object["spec"].(map[string]any)
+			value, present := spec["filterStrategy"]
+			assert.True(t, present)
+			assert.Equal(t, string(testCase.filterStrategy), value)
 		})
 	}
 }

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -83,7 +83,11 @@ func ConfigMap(params Params) (*corev1.ConfigMap, error) {
 		taConfig["allocation_fallback_strategy"] = v1beta1.TargetAllocatorAllocationStrategyConsistentHashing
 	}
 
-	taConfig["filter_strategy"] = taSpec.FilterStrategy
+	filterStrategy := v1beta1.TargetAllocatorFilterStrategyRelabelConfig
+	if taSpec.FilterStrategy != nil {
+		filterStrategy = *taSpec.FilterStrategy
+	}
+	taConfig["filter_strategy"] = filterStrategy
 
 	if taSpec.PrometheusCR.Enabled {
 		prometheusCRConfig := map[any]any{

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -63,6 +63,44 @@ filter_strategy: relabel-config
 		assert.Equal(t, expectedLabels, actual.Labels)
 		assert.Equal(t, expectedData[targetAllocatorFilename], actual.Data[targetAllocatorFilename])
 	})
+	t.Run("should render filter strategies", func(t *testing.T) {
+		noneFilterStrategy := v1beta1.TargetAllocatorFilterStrategyNone
+		emptyFilterStrategy := v1beta1.TargetAllocatorFilterStrategy("")
+		testCases := []struct {
+			name           string
+			filterStrategy *v1beta1.TargetAllocatorFilterStrategy
+			expected       string
+		}{
+			{
+				name:           "none",
+				filterStrategy: &noneFilterStrategy,
+				expected:       "filter_strategy: none\n",
+			},
+			{
+				name:           "legacy empty value",
+				filterStrategy: &emptyFilterStrategy,
+				expected:       "filter_strategy: \"\"\n",
+			},
+			{
+				name:           "unset",
+				filterStrategy: nil,
+				expected:       "filter_strategy: relabel-config\n",
+			},
+		}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				targetAllocator := targetAllocatorInstance()
+				targetAllocator.Spec.FilterStrategy = testCase.filterStrategy
+				actual, err := ConfigMap(Params{
+					Collector:       collectorInstance(),
+					TargetAllocator: targetAllocator,
+				})
+				require.NoError(t, err)
+				assert.Contains(t, actual.Data[targetAllocatorFilename], testCase.expected)
+			})
+		}
+	})
 	t.Run("should return target allocator config map without collector", func(t *testing.T) {
 		expectedData := map[string]string{
 			targetAllocatorFilename: `allocation_strategy: consistent-hashing

--- a/tests/e2e-targetallocator-cr/targetallocator-label/00-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/00-assert.yaml
@@ -38,6 +38,7 @@ apiVersion: v1
 data:
   targetallocator.yaml: |
     allocation_strategy: consistent-hashing
+    collector_not_ready_grace_period: 30s
     collector_selector: null
     filter_strategy: none
 kind: ConfigMap

--- a/tests/e2e-targetallocator-cr/targetallocator-label/00-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/00-assert.yaml
@@ -39,7 +39,7 @@ data:
   targetallocator.yaml: |
     allocation_strategy: consistent-hashing
     collector_selector: null
-    filter_strategy: ""
+    filter_strategy: none
 kind: ConfigMap
 metadata:
   name: ta-targetallocator

--- a/tests/e2e-targetallocator-cr/targetallocator-label/00-install.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/00-install.yaml
@@ -4,6 +4,7 @@ kind: TargetAllocator
 metadata:
   name: ta
 spec:
+  filterStrategy: none
 ---
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
@@ -27,4 +28,3 @@ spec:
         metrics:
           receivers: [prometheus]
           exporters: [debug]
-

--- a/tests/e2e-targetallocator-cr/targetallocator-label/03-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/03-assert.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 data:
   targetallocator.yaml: |
     allocation_strategy: consistent-hashing
+    collector_not_ready_grace_period: 30s
     collector_selector: null
     filter_strategy: none
 kind: ConfigMap

--- a/tests/e2e-targetallocator-cr/targetallocator-label/03-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-label/03-assert.yaml
@@ -4,7 +4,7 @@ data:
   targetallocator.yaml: |
     allocation_strategy: consistent-hashing
     collector_selector: null
-    filter_strategy: ""
+    filter_strategy: none
 kind: ConfigMap
 metadata:
   name: ta-targetallocator

--- a/tests/e2e/smoke-collector/smoke-targetallocator/00-install.yaml
+++ b/tests/e2e/smoke-collector/smoke-targetallocator/00-install.yaml
@@ -30,4 +30,5 @@ spec:
   mode: statefulset
   targetAllocator:
     enabled: true
+    filterStrategy: none
     serviceAccount: ta

--- a/tests/e2e/smoke-collector/smoke-targetallocator/01-change-ta-config.yaml
+++ b/tests/e2e/smoke-collector/smoke-targetallocator/01-change-ta-config.yaml
@@ -6,6 +6,7 @@ spec:
   mode: statefulset
   targetAllocator:
     enabled: true
+    filterStrategy: none
     serviceAccount: ta
     prometheusCR:
       enabled: true

--- a/tests/e2e/smoke-collector/smoke-targetallocator/chainsaw-test.yaml
+++ b/tests/e2e/smoke-collector/smoke-targetallocator/chainsaw-test.yaml
@@ -57,7 +57,7 @@ spec:
                         static_configs:
                           - targets:
                               - 0.0.0.0:8888
-                  filter_strategy: relabel-config
+                  filter_strategy: none
   - name: step-01
     try:
     - apply:


### PR DESCRIPTION
**Description:**

The value intended to disable target filtering - `filterStrategy: ""` was lost during reconciliation. When the operator instantiates the TargetAllocator CR as a Go struct, the empty string is treated as no value, which falls back to the default after admission. 

Add a new, explicit `none` value while keeping the empty one for compatibility and fix the serialization. Fixing requires making the field a pointer and take `nil` as "no value".  This is a breaking change in the Go API, but not the CRD.

I've also made the target allocator config file parsing stricter. It now only accepts `""`, `none` and `relabel-config` as values and fails validation otherwise.

**Link to tracking Issue(s):**

- Resolves: https://github.com/open-telemetry/opentelemetry-operator/issues/5444

**Testing:**

Unit tests and an addition to the smoke e2e test.

