### PR TITLE
Promote the operator.collector.usedefaulttelemetryshape feature gate to stable

### DIFF
--- a/.chloggen/promote-default-telemetry-shape-gate-to-stable.yaml
+++ b/.chloggen/promote-default-telemetry-shape-gate-to-stable.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "promote the operator.collector.usedefaulttelemetryshape feature gate to stable, so the operator-injected Prometheus telemetry reader always uses collector defaults for without_type_suffix, without_units, and without_scope_info"
+
+# One or more tracking issues related to the change
+issues: [5075]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The gate is now stable and can no longer be disabled. Users wanting the
+  pre-v0.154.0 metric name shape should explicitly set
+  `without_type_suffix`, `without_units`, and `without_scope_info` to `false`
+  in their collector configuration. The gate will be removed in a future release.

--- a/internal/otelconfig/config.go
+++ b/internal/otelconfig/config.go
@@ -496,10 +496,8 @@ func ServiceApplyDefaults(s *v1beta1.Service, logger logr.Logger) ([]v1beta1.Eve
 }
 
 // AddPrometheusMetricsEndpoint creates a MetricReader with a Prometheus pull exporter.
-// By default (operator.collector.usedefaulttelemetryshape beta gate enabled) the
-// reader carries no overrides, so the collector's defaults for without_type_suffix,
-// without_units, and without_scope_info apply. Disabling the gate explicitly sets
-// all three to false to preserve the pre-v0.154.0 metric name shape. See #5075.
+// The reader carries no overrides, so the collector's defaults for without_type_suffix,
+// without_units, and without_scope_info apply. See #5075.
 func AddPrometheusMetricsEndpoint(host string, port int32) otelConfig.MetricReader {
 	portInt := int(port)
 	prom := &otelConfig.Prometheus{

--- a/internal/otelconfig/config_test.go
+++ b/internal/otelconfig/config_test.go
@@ -15,12 +15,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	colfeaturegate "go.opentelemetry.io/collector/featuregate"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
-	"github.com/open-telemetry/opentelemetry-operator/pkg/featuregate"
 )
 
 func TestConfigFiles(t *testing.T) {
@@ -1553,20 +1551,8 @@ func TestTelemetryIncompleteConfigAppliesDefaults(t *testing.T) {
 	require.Nil(t, telemetry.Metrics.Readers[0].Pull.Exporter.Prometheus.WithoutScopeInfo)
 }
 
-// withTelemetryShapeGate temporarily flips the operator.collector.usedefaulttelemetryshape
-// gate to the given value for the duration of the test and restores it on cleanup.
-func withTelemetryShapeGate(t *testing.T, enabled bool) {
-	t.Helper()
-	registry := colfeaturegate.GlobalRegistry()
-	original := featuregate.UseCollectorDefaultTelemetryShape.IsEnabled()
-	require.NoError(t, registry.Set(featuregate.UseCollectorDefaultTelemetryShape.ID(), enabled))
-	t.Cleanup(func() {
-		require.NoError(t, registry.Set(featuregate.UseCollectorDefaultTelemetryShape.ID(), original))
-	})
-}
-
-// Default behavior (beta gate enabled): the injected reader carries no shape overrides,
-// so the collector's defaults apply.
+// The operator.collector.usedefaulttelemetryshape gate is stable (always on):
+// the injected reader carries no shape overrides, so the collector's defaults apply.
 func TestAddPrometheusMetricsEndpointUsesCollectorDefaultsByDefault(t *testing.T) {
 	reader := AddPrometheusMetricsEndpoint("0.0.0.0", 8888)
 	require.NotNil(t, reader.Pull)
@@ -1576,21 +1562,4 @@ func TestAddPrometheusMetricsEndpointUsesCollectorDefaultsByDefault(t *testing.T
 	require.Nil(t, reader.Pull.Exporter.Prometheus.WithoutTypeSuffix)
 	require.Nil(t, reader.Pull.Exporter.Prometheus.WithoutUnits)
 	require.Nil(t, reader.Pull.Exporter.Prometheus.WithoutScopeInfo)
-}
-
-// Opt-out behavior: when the gate is disabled, the operator pins all three
-// fields to false to preserve the pre-v0.154.0 metric name shape.
-func TestAddPrometheusMetricsEndpointPreservesShapeWhenGateDisabled(t *testing.T) {
-	withTelemetryShapeGate(t, false)
-
-	reader := AddPrometheusMetricsEndpoint("0.0.0.0", 8888)
-	require.NotNil(t, reader.Pull.Exporter.Prometheus)
-	require.Equal(t, "0.0.0.0", *reader.Pull.Exporter.Prometheus.Host)
-	require.Equal(t, 8888, *reader.Pull.Exporter.Prometheus.Port)
-	require.NotNil(t, reader.Pull.Exporter.Prometheus.WithoutTypeSuffix)
-	require.False(t, *reader.Pull.Exporter.Prometheus.WithoutTypeSuffix)
-	require.NotNil(t, reader.Pull.Exporter.Prometheus.WithoutUnits)
-	require.False(t, *reader.Pull.Exporter.Prometheus.WithoutUnits)
-	require.NotNil(t, reader.Pull.Exporter.Prometheus.WithoutScopeInfo)
-	require.False(t, *reader.Pull.Exporter.Prometheus.WithoutScopeInfo)
 }

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -52,18 +52,19 @@ var (
 		featuregate.WithRegisterDescription("enables the ClusterObservability controller for managed observability deployment"),
 		featuregate.WithRegisterFromVersion("v0.134.0"),
 	)
-	// UseCollectorDefaultTelemetryShape, when enabled (default at beta), makes
+	// UseCollectorDefaultTelemetryShape, when enabled (stable, always on), makes
 	// the operator-injected Prometheus telemetry reader use collector defaults
 	// for without_type_suffix, without_units, and without_scope_info — metric
 	// names emitted by operator-managed collectors no longer carry type
-	// suffixes, units, or scope_info. When disabled, the operator explicitly
-	// sets all three to false to preserve the pre-v0.154.0 metric name shape.
+	// suffixes, units, or scope_info. Users wanting the pre-v0.154.0 metric name
+	// shape must explicitly set all three to false under spec.config.service.telemetry.
 	// See open-telemetry/opentelemetry-operator#5075.
 	UseCollectorDefaultTelemetryShape = featuregate.GlobalRegistry().MustRegister(
 		"operator.collector.usedefaulttelemetryshape",
-		featuregate.StageBeta,
-		featuregate.WithRegisterDescription("when enabled (default), the operator-injected Prometheus telemetry reader uses collector defaults for without_type_suffix/without_units/without_scope_info. When disabled, the operator explicitly sets all three to false to preserve the pre-v0.154.0 metric name shape."),
+		featuregate.StageStable,
+		featuregate.WithRegisterDescription("when enabled, the operator-injected Prometheus telemetry reader uses collector defaults for without_type_suffix/without_units/without_scope_info. Users wanting the pre-v0.154.0 metric name shape must explicitly set all three to false in the collector configuration."),
 		featuregate.WithRegisterFromVersion("v0.152.0"),
+		featuregate.WithRegisterToVersion("v0.160.0"),
 	)
 )
 


### PR DESCRIPTION
**Description:**

It's been in beta for a few releases.

**Link to tracking Issue(s):**

- Relates: https://github.com/open-telemetry/opentelemetry-operator/issues/5075
