### PR TITLE
Use published e2e test app images, build from source when they change

### DIFF
--- a/.github/workflows/e2e-reusable.yaml
+++ b/.github/workflows/e2e-reusable.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: ""
+      build-test-apps:
+        description: "Build the e2e test app images (tests/test-e2e-apps) from source instead of using the ones published from main. Pass true when the change set touches them, so incompatibilities with the tests surface before the merge publishes new images."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -44,7 +49,7 @@ jobs:
       run: make install-tools
 
     - name: Build test image archive
-      run: make container-image-archive IMAGE_ARCHIVE=${IMAGE_ARCHIVE_FILENAME} VERSION=${VERSION}
+      run: make container-image-archive IMAGE_ARCHIVE=${IMAGE_ARCHIVE_FILENAME} VERSION=${VERSION} BUILD_TEST_E2E_APPS=${{ inputs.build-test-apps }}
 
     - name: Upload test image archive
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,8 +10,53 @@ permissions:
   contents: read
 
 jobs:
+  # The e2e test app images are normally used as published from main. When this
+  # change set touches them, they must be built from source instead — otherwise
+  # incompatibilities between changed apps and the tests only surface after the
+  # merge publishes the new images. On detection failure, err on the side of
+  # building.
+  check-test-app-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.diff.outputs.build }}
+    steps:
+      # Deliberately no checkout: the compare API answers this in one request,
+      # where cloning the repo would fetch every file just to name-diff two trees.
+      - name: Check for e2e test app changes
+        id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
+          PREFIX: tests/test-e2e-apps/
+        run: |
+          set -uo pipefail
+          build=true
+          # A three-dot compare gives the changes the branch introduces, ignoring
+          # whatever landed on the base since it forked. On push, the merge base
+          # of before...after is before itself, so the same call fits both events.
+          if resp=$(gh api "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}"); then
+            # The endpoint caps `files` at 300 with no way to page further and no
+            # truncation flag, so a full page means "can't tell" -> build.
+            n=$(jq 'if (.files | type) == "array" then .files | length else -1 end' <<<"$resp")
+            if [ "${n:--1}" -ge 0 ] && [ "$n" -lt 300 ]; then
+              # Any jq failure leaves build=true rather than reading as "no match".
+              if touched=$(jq --arg p "$PREFIX" \
+                  '[.files[] | .filename, (.previous_filename // empty)]
+                   | any(startswith($p))' <<<"$resp"); then
+                [ "$touched" = true ] || build=false
+              fi
+            fi
+          fi
+          echo "Building e2e test apps from source: $build"
+          echo "build=$build" >> "$GITHUB_OUTPUT"
+
   run-e2e-tests:
+    needs: [ check-test-app-changes ]
     uses: ./.github/workflows/e2e-reusable.yaml
+    with:
+      build-test-apps: ${{ needs.check-test-app-changes.outputs.build == 'true' }}
 
   # This job is here to ensure the check has the right name we have set in Github's required checks.
   e2e-tests-check:

--- a/.github/workflows/publish-test-e2e-images.yaml
+++ b/.github/workflows/publish-test-e2e-images.yaml
@@ -20,7 +20,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The Go-based test apps have their own modules with unit tests; run them
+  # before publishing their images.
+  test-go-apps:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [ bridge-server ]
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "~1.26.6"
+          cache-dependency-path: tests/test-e2e-apps/${{ matrix.app }}/go.sum
+      - name: Vet and test
+        working-directory: tests/test-e2e-apps/${{ matrix.app }}
+        run: |
+          go vet ./...
+          go test ./...
   bridge-server:
+    needs: [ test-go-apps ]
     permissions: # required by the reusable workflow
       contents: read
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ config/rbac/extra-permissions-operator/
 config/rbac/certmanager-permissions/
 .testresults
 
+# locally-built test app binaries
+tests/test-e2e-apps/bridge-server/bridge-server
+
 # autoinstrumentation artifacts
 build
 node_modules

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,14 @@ TARGETALLOCATOR_IMG ?= ${IMG_PREFIX}/${TARGETALLOCATOR_IMG_REPO}:$(addprefix v,$
 OPERATOROPAMPBRIDGE_IMG_REPO ?= operator-opamp-bridge
 OPERATOROPAMPBRIDGE_IMG ?= ${IMG_PREFIX}/${OPERATOROPAMPBRIDGE_IMG_REPO}:$(addprefix v,${VERSION})
 
-BRIDGETESTSERVER_IMG_REPO ?= e2e-test-app-bridge-server
-BRIDGETESTSERVER_IMG ?= ${IMG_PREFIX}/${BRIDGETESTSERVER_IMG_REPO}:ve2e
+# E2E test app images (tests/test-e2e-apps). Their manifests reference the images
+# published from main (ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-*:main),
+# so the prefix is fixed and independent of IMG_PREFIX. Building locally tags images
+# exactly as the manifests reference them; loading them into kind then shadows the
+# registry versions, letting tests run against local changes before they are merged
+# and published.
+TEST_E2E_APPS_IMG_PREFIX ?= ghcr.io/open-telemetry/opentelemetry-operator
+TEST_E2E_APPS ?= apache-httpd bridge-server dotnet golang java metrics-basic-auth nodejs python
 
 COLLECTOR_IMG ?= ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:$(subst ",,$(OTELCOL_VERSION))
 
@@ -677,11 +683,17 @@ container-operator-opamp-bridge: GOOS = linux
 container-operator-opamp-bridge: operator-opamp-bridge
 	docker build --load -t ${OPERATOROPAMPBRIDGE_IMG} cmd/operator-opamp-bridge
 
-# Build bridge test server container image for e2e tests
-.PHONY: container-bridge-test-server
-container-bridge-test-server: GOOS = linux
-container-bridge-test-server:
-	docker build --load -t ${BRIDGETESTSERVER_IMG} tests/test-e2e-apps/bridge-server
+# Build every e2e test app image from tests/test-e2e-apps, tagged as the test
+# manifests reference them. The python app is built twice, matching the two
+# variants published from main (latest and oldest supported python).
+.PHONY: container-test-e2e-apps
+container-test-e2e-apps:
+	@for app in $(TEST_E2E_APPS); do \
+		echo "Building $(TEST_E2E_APPS_IMG_PREFIX)/e2e-test-app-$$app:main"; \
+		docker build --load -t $(TEST_E2E_APPS_IMG_PREFIX)/e2e-test-app-$$app:main tests/test-e2e-apps/$$app || exit 1; \
+	done
+	docker build --load -t $(TEST_E2E_APPS_IMG_PREFIX)/e2e-test-app-python:main-3.10 \
+		--build-arg BASE_IMAGE=docker.io/library/python:3.10-alpine tests/test-e2e-apps/python
 
 # Build must-gather container image
 .PHONY: container-must-gather
@@ -767,7 +779,7 @@ install-targetallocator-prometheus-crds:
 .PHONY: load-image-all
 load-image-all:
 ifeq ($(IMAGE_ARCHIVE),)
-	@make container load-image-operator load-image-target-allocator load-image-operator-opamp-bridge load-image-bridge-test-server
+	@make container load-image-operator load-image-target-allocator load-image-operator-opamp-bridge
 else
 	$(KIND) load --name $(KIND_CLUSTER_NAME) image-archive $(IMAGE_ARCHIVE)
 endif
@@ -791,10 +803,14 @@ else
 	$(MAKE) container-target-allocator-push
 endif
 
-# Load bridge test server image into kind cluster
-.PHONY: load-image-bridge-test-server
-load-image-bridge-test-server: container-bridge-test-server kind
-	$(KIND) load --name $(KIND_CLUSTER_NAME) docker-image ${BRIDGETESTSERVER_IMG}
+# Build all e2e test app images and load them into the kind cluster, shadowing the
+# published images the test manifests reference. Run this (or let CI run it) after
+# changing anything under tests/test-e2e-apps.
+.PHONY: load-image-test-e2e-apps
+load-image-test-e2e-apps: container-test-e2e-apps kind
+	$(KIND) load --name $(KIND_CLUSTER_NAME) docker-image \
+		$(foreach app,$(TEST_E2E_APPS),$(TEST_E2E_APPS_IMG_PREFIX)/e2e-test-app-$(app):main) \
+		$(TEST_E2E_APPS_IMG_PREFIX)/e2e-test-app-python:main-3.10
 
 # Load operator OpAMP bridge image into kind cluster
 .PHONY: load-image-operator-opamp-bridge
@@ -1178,9 +1194,15 @@ else
 	hack/create-release-issue.sh $(if $(RELEASE_VERSION),--version $(RELEASE_VERSION))
 endif
 
-# Create container image archive with all images
+# Create container image archive with all images. Set BUILD_TEST_E2E_APPS=true to
+# also build the e2e test app images from source and include them, so tests run
+# against local changes to tests/test-e2e-apps instead of the published images (CI
+# does this whenever those files change).
 container-image-archive: IMAGE_LIST_FILE = images-$(VERSION).txt
-container-image-archive: container container-target-allocator container-operator-opamp-bridge container-bridge-test-server container-instrumentation-all
+container-image-archive: container container-target-allocator container-operator-opamp-bridge container-instrumentation-all
+ifeq ($(BUILD_TEST_E2E_APPS),true)
+container-image-archive: container-test-e2e-apps
+endif
 ifeq ($(IMAGE_ARCHIVE),)
 	$(error "Use make container-image-archive IMAGE_ARCHIVE=<filename>")
 endif
@@ -1188,12 +1210,17 @@ endif
 	@echo "$(IMG)" >>$(IMAGE_LIST_FILE)
 	@echo "$(TARGETALLOCATOR_IMG)" >>$(IMAGE_LIST_FILE)
 	@echo "$(OPERATOROPAMPBRIDGE_IMG)" >>$(IMAGE_LIST_FILE)
-	@echo "$(BRIDGETESTSERVER_IMG)" >>$(IMAGE_LIST_FILE)
 	@echo "$(INSTRUMENTATION_JAVA_IMG)" >>$(IMAGE_LIST_FILE)
 	@echo "$(INSTRUMENTATION_NODEJS_IMG)" >>$(IMAGE_LIST_FILE)
 	@echo "$(INSTRUMENTATION_PYTHON_IMG)" >>$(IMAGE_LIST_FILE)
 	@echo "$(INSTRUMENTATION_DOTNET_IMG)" >>$(IMAGE_LIST_FILE)
 	@echo "$(INSTRUMENTATION_APACHE_HTTPD_IMG)" >>$(IMAGE_LIST_FILE)
+ifeq ($(BUILD_TEST_E2E_APPS),true)
+	@for app in $(TEST_E2E_APPS); do \
+		echo "$(TEST_E2E_APPS_IMG_PREFIX)/e2e-test-app-$$app:main" >>$(IMAGE_LIST_FILE); \
+	done
+	@echo "$(TEST_E2E_APPS_IMG_PREFIX)/e2e-test-app-python:main-3.10" >>$(IMAGE_LIST_FILE)
+endif
 	xargs -x -n 50 docker save -o "$(IMAGE_ARCHIVE)" <$(IMAGE_LIST_FILE)
 
 ##@ Validation

--- a/renovate.json
+++ b/renovate.json
@@ -290,6 +290,13 @@
       "schedule": ["on monday"]
     },
     {
+      "description": "Group all updates to the Go-based e2e test apps (module dependencies and base images) into a single weekly PR",
+      "matchManagers": ["gomod", "dockerfile"],
+      "matchFileNames": ["tests/test-e2e-apps/**"],
+      "groupName": "e2e test apps",
+      "schedule": ["on monday"]
+    },
+    {
       "matchManagers": ["regex"],
       "matchDatasources": ["docker"],
       "matchFileNames": [".github/workflows/publish-test-e2e-images.yaml"],

--- a/tests/e2e-instrumentation/instrumentation-apache-multicontainer/01-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-multicontainer/01-install-app.yaml
@@ -22,7 +22,6 @@ spec:
       containers:
         - name: myapp
           image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-apache-httpd:main
-          imagePullPolicy: Always
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/tests/e2e-instrumentation/instrumentation-apache-multicontainer/02-install-app.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-multicontainer/02-install-app.yaml
@@ -22,7 +22,6 @@ spec:
       containers:
         - name: myapp
           image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-apache-httpd:main
-          imagePullPolicy: Always
           ports:
             - containerPort: 8080
           readinessProbe:

--- a/tests/e2e-opampbridge/opampbridge/00-install.yaml
+++ b/tests/e2e-opampbridge/opampbridge/00-install.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: e2e-test-app-bridge-server
-          image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-bridge-server:ve2e
+          image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-bridge-server:main
           ports:
             - containerPort: 4320
             - containerPort: 4321

--- a/tests/e2e-opampbridge/standalone/00-install.yaml
+++ b/tests/e2e-opampbridge/standalone/00-install.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: e2e-test-app-bridge-server
-          image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-bridge-server:ve2e
+          image: ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-bridge-server:main
           ports:
             - containerPort: 4320
             - containerPort: 4321

--- a/tests/test-e2e-apps/README.md
+++ b/tests/test-e2e-apps/README.md
@@ -1,0 +1,34 @@
+# E2E test apps
+
+Container images used by the e2e test suites: sample workloads for the
+auto-instrumentation tests (`java`, `nodejs`, `python`, `dotnet`, `golang`,
+`apache-httpd`), a fake OpAMP server (`bridge-server`), and a scrape target
+with basic auth (`metrics-basic-auth`).
+
+## Image lifecycle
+
+Test manifests reference these images as published from `main`:
+`ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-<name>:main`
+(plus `e2e-test-app-python:main-3.10` for the oldest supported Python). The
+`publish-test-e2e-images` workflow builds and publishes them on merge; Go-based
+apps have unit tests that gate publishing.
+
+When a change set touches anything under `tests/test-e2e-apps/`, the published
+images do not include it yet — so the e2e workflow builds all app images from
+source (tagged exactly as the manifests reference them) and loads them into
+kind, shadowing the registry versions. That way incompatibilities between
+changed apps and the tests surface in PR CI, not after the merge. Detection is
+not fine-grained: any change under this directory rebuilds all the apps.
+
+To do the same locally after modifying an app:
+
+```bash
+make load-image-test-e2e-apps
+```
+
+Kubernetes only prefers the loaded image while the pull policy is
+`IfNotPresent` (the default for `:main`-tagged images) — don't set
+`imagePullPolicy: Always` on these images in test manifests.
+
+Dependency updates (Go modules and base images) for all apps are grouped by
+renovate into a single weekly PR.


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Test manifests now uniformly reference the e2e test app images published from main (ghcr.io/open-telemetry/opentelemetry-operator/e2e-test-app-*:main). A new load-image-test-e2e-apps target builds all of them from source with exactly those tags and loads them into kind, shadowing the registry images.

CI (the triggering e2e workflow) detects changes under tests/test-e2e-apps and passes build-test-apps to the reusable workflow, which then includes the locally-built apps in the test image archive. This surfaces incompatibilities between changed app images and the tests in PR CI instead of after the merge publishes the new images.

This replaces the bridge-server :ve2e tag, which forced a from-source build on every CI run and prepare-e2e regardless of changes. Also drop `imagePullPolicy: Always` from our own app images (it would bypass the shadow mechanism), gate publishing of the Go-based apps on their unit tests, and group renovate updates for the test apps into a single weekly PR (their Go modules were previously excluded from updates entirely).

