### PR TITLE
[Chore] Fix DaemonSet hostNetwork e2e test failures on OpenShift

### DIFF
--- a/tests/e2e-instrumentation/instrumentation-apache-httpd/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-httpd/chainsaw-test.yaml
@@ -59,6 +59,18 @@ spec:
   - name: Check the instrumented app has sent the telemetry data successfully
     use:
       template: ../../step-templates/validate-collector-spans.yaml
+  - name: Setup SCC for DaemonSet hostNetwork
+    try:
+    - script:
+        timeout: 1m
+        content: |
+          if kubectl api-resources --api-group=security.openshift.io -o name 2>/dev/null | grep -q securitycontextconstraints; then
+            echo "OpenShift detected — creating SCC for hostNetwork"
+            kubectl apply -f scc.yaml
+            oc adm policy add-scc-to-user daemonset-with-hostport -z daemonset-collector -n $NAMESPACE
+          else
+            echo "Not OpenShift — skipping SCC setup"
+          fi
   - name: Switch to node-IP exporter endpoint
     try:
     - apply:
@@ -113,10 +125,18 @@ spec:
         bindings:
           - name: collectorLabelSelector
             value: app.kubernetes.io/name=daemonset-collector
-  - name: Check telemetry data via node-IP endpoint
+  - name: Check the DaemonSet collector has sent the telemetry data successfully
     use:
       template: ../../step-templates/validate-collector-spans.yaml
       with:
         bindings:
           - name: collectorLabelSelector
             value: app.kubernetes.io/name=daemonset-collector
+  - name: Cleanup SCC
+    try:
+    - script:
+        timeout: 1m
+        content: |
+          if kubectl api-resources --api-group=security.openshift.io -o name 2>/dev/null | grep -q securitycontextconstraints; then
+            kubectl delete scc daemonset-with-hostport --ignore-not-found
+          fi

--- a/tests/e2e-instrumentation/instrumentation-apache-httpd/scc.yaml
+++ b/tests/e2e-instrumentation/instrumentation-apache-httpd/scc.yaml
@@ -1,0 +1,23 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: daemonset-with-hostport
+  annotations:
+    kubernetes.io/description: 'Allows DaemonSets to bind to a well-known host port'
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+allowHostPorts: true
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: false
+volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI

--- a/tests/e2e-instrumentation/instrumentation-nginx/chainsaw-test.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx/chainsaw-test.yaml
@@ -60,6 +60,18 @@ spec:
   - name: Check the instrumented app has sent the telemetry data successfully
     use:
       template: ../../step-templates/validate-collector-spans.yaml
+  - name: Setup SCC for DaemonSet hostNetwork
+    try:
+    - script:
+        timeout: 1m
+        content: |
+          if kubectl api-resources --api-group=security.openshift.io -o name 2>/dev/null | grep -q securitycontextconstraints; then
+            echo "OpenShift detected — creating SCC for hostNetwork"
+            kubectl apply -f scc.yaml
+            oc adm policy add-scc-to-user daemonset-with-hostport -z daemonset-collector -n $NAMESPACE
+          else
+            echo "Not OpenShift — skipping SCC setup"
+          fi
   - name: Switch to node-IP exporter endpoint
     try:
     - apply:
@@ -114,10 +126,18 @@ spec:
         bindings:
           - name: collectorLabelSelector
             value: app.kubernetes.io/name=daemonset-collector
-  - name: Check telemetry data via node-IP endpoint
+  - name: Check the DaemonSet collector has sent the telemetry data successfully
     use:
       template: ../../step-templates/validate-collector-spans.yaml
       with:
         bindings:
           - name: collectorLabelSelector
             value: app.kubernetes.io/name=daemonset-collector
+  - name: Cleanup SCC
+    try:
+    - script:
+        timeout: 1m
+        content: |
+          if kubectl api-resources --api-group=security.openshift.io -o name 2>/dev/null | grep -q securitycontextconstraints; then
+            kubectl delete scc daemonset-with-hostport --ignore-not-found
+          fi

--- a/tests/e2e-instrumentation/instrumentation-nginx/scc.yaml
+++ b/tests/e2e-instrumentation/instrumentation-nginx/scc.yaml
@@ -1,0 +1,23 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: daemonset-with-hostport
+  annotations:
+    kubernetes.io/description: 'Allows DaemonSets to bind to a well-known host port'
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+allowHostPorts: true
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: false
+volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI

--- a/tests/step-templates/validate-collector-spans.yaml
+++ b/tests/step-templates/validate-collector-spans.yaml
@@ -4,44 +4,60 @@ metadata:
   name: validate-collector-spans
 spec:
   try:
-    - command:
-        entrypoint: kubectl
+    - script:
         env:
           - name: COLLECTOR_LABEL_SELECTOR
             value: ($collectorLabelSelector)
-        args:
-          - get
-          - pod
-          - -n
-          - ${NAMESPACE}
-          - -l
-          - ${COLLECTOR_LABEL_SELECTOR}
-          - -o
-          - jsonpath={.items[0].metadata.name}
-        outputs:
-          - name: collectorPodName
-            value: ($stdout)
-    - script:
-        env:
-          - name: podName
-            value: ($collectorPodName)
           - name: metricsPort
             value: ($collectorMetricsPort)
         shell: /bin/bash
-        timeout: 60s
+        timeout: 120s
         content: |
-          # Add retry logic for metrics collection to handle timing issues
-          for i in {1..12}; do
-            echo "Attempt $i: Fetching metrics from pod ${podName}..." >&2
-            if metrics_output=$(kubectl get --raw /api/v1/namespaces/$NAMESPACE/pods/${podName}:${metricsPort}/proxy/metrics 2>/dev/null); then
-              echo "Successfully fetched metrics on attempt $i" >&2
-              echo "$metrics_output"
-              exit 0
+          PODS=$(kubectl get pods -n "$NAMESPACE" -l "$COLLECTOR_LABEL_SELECTOR" \
+            -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+          if [ -z "$PODS" ]; then
+            echo "ERROR: No pods found matching '$COLLECTOR_LABEL_SELECTOR'" >&2
+            exit 1
+          fi
+
+          FIRST_POD=$(echo "$PODS" | head -1)
+          HOST_NETWORK=$(kubectl get pod -n "$NAMESPACE" "$FIRST_POD" \
+            -o jsonpath='{.spec.hostNetwork}')
+
+          fetch_metrics() {
+            local pod=$1
+            if [ "$HOST_NETWORK" = "true" ]; then
+              local lport=$((30000 + RANDOM % 10000))
+              kubectl port-forward -n "$NAMESPACE" "pod/${pod}" "${lport}:${metricsPort}" &>/dev/null &
+              local pf=$!
+              sleep 2
+              local out
+              out=$(curl -sf "http://localhost:${lport}/metrics" 2>/dev/null)
+              local rc=$?
+              kill $pf 2>/dev/null; wait $pf 2>/dev/null
+              [ $rc -ne 0 ] && return 1
+              echo "$out"
+            else
+              kubectl get --raw \
+                "/api/v1/namespaces/$NAMESPACE/pods/${pod}:${metricsPort}/proxy/metrics" 2>/dev/null
             fi
-            echo "Failed to fetch metrics, retrying in 5 seconds..." >&2
+          }
+
+          for attempt in {1..12}; do
+            for POD in $PODS; do
+              metrics_output=$(fetch_metrics "$POD") || continue
+              sent=$(echo "$metrics_output" | grep '^otelcol_exporter_sent_spans{' | awk '{s+=$NF} END {print s+0}')
+              if [ "$sent" -gt 0 ]; then
+                echo "Found spans on pod $POD (sent=$sent) on attempt $attempt" >&2
+                echo "$metrics_output"
+                exit 0
+              fi
+              echo "Pod $POD has no span data yet (sent=$sent)" >&2
+            done
+            echo "Attempt $attempt: No pod has span data yet, retrying in 5s..." >&2
             sleep 5
           done
-          echo "Failed to fetch metrics after 12 attempts (60 seconds)" >&2
+          echo "Failed to find spans after 12 attempts" >&2
           exit 1
         outputs:
           - name: metrics

--- a/tests/test-e2e-apps/scripts/check_pod_logs.sh
+++ b/tests/test-e2e-apps/scripts/check_pod_logs.sh
@@ -48,24 +48,15 @@ echo "Searching for ${#SEARCH_STRINGS[@]} strings:"
 printf "  - '%s'\n" "${SEARCH_STRINGS[@]}" # Print strings for verification, quoting them
 
 
-# --- Get Initial Pod Name ---
-echo "Finding target pod..."
-# Ensure kubectl uses the namespace chainsaw provides. Use --request-timeout for robustness.
-PODS_JSONPATH_OUTPUT=$(kubectl get pods -n "$NAMESPACE" -l "$LABEL_SELECTOR" --request-timeout=10s -o jsonpath='{.items[0].metadata.name}')
-KUBECTL_GET_EXIT_CODE=$?
-if [ $KUBECTL_GET_EXIT_CODE -ne 0 ]; then
-    echo "ERROR: Failed to run initial kubectl get pods (Exit Code: $KUBECTL_GET_EXIT_CODE). Is kubectl configured correctly for namespace '$NAMESPACE'?"
-    exit 1
-fi
-# Handle case where no pod is found gracefully
-if [[ -z "$PODS_JSONPATH_OUTPUT" ]]; then
+# --- Verify Matching Pods Exist ---
+echo "Finding target pods..."
+POD_COUNT=$(kubectl get pods -n "$NAMESPACE" -l "$LABEL_SELECTOR" --request-timeout=10s -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -c . || true)
+if [ "$POD_COUNT" -eq 0 ]; then
     echo "ERROR: No pods found with label '$LABEL_SELECTOR' in namespace '$NAMESPACE'"
     exit 1
 fi
-# Assuming only one pod matches, if multiple could match, logic needs adjustment
-POD=$PODS_JSONPATH_OUTPUT
-echo "Target Pod: $POD"
-# --- End Get Initial Pod Name ---
+echo "Found $POD_COUNT pod(s) matching '$LABEL_SELECTOR'"
+# --- End Verify Matching Pods Exist ---
 
 # --- Main Retry Loop ---
 START_TIME=$(date +%s)
@@ -78,29 +69,27 @@ while true; do
     # 1. Check for Timeout
     if [ "$ELAPSED_TIME" -ge "$RETRY_TIMEOUT" ]; then
         echo "-----------------------------------------------------"
-        echo "ERROR: Timeout ($RETRY_TIMEOUT seconds) reached. Not all required strings were found in container '$CONTAINER_NAME' of pod '$POD'."
-        # Attempt to print last known missing strings, might be empty if loop never found anything
+        echo "ERROR: Timeout ($RETRY_TIMEOUT seconds) reached. Not all required strings were found in container '$CONTAINER_NAME' of pods matching '$LABEL_SELECTOR'."
         if [[ ${#MISSING_STRINGS_THIS_ATTEMPT[@]} -gt 0 ]]; then
             echo "Last known missing strings:"
             printf "  - '%s'\n" "${MISSING_STRINGS_THIS_ATTEMPT[@]}"
         fi
-        # Display last few lines of logs for debugging
-        echo "Last 20 lines of logs from $POD/$CONTAINER_NAME:"
-        kubectl logs "$POD" -n "$NAMESPACE" -c "$CONTAINER_NAME" --tail=20 || echo "  (failed to retrieve final logs)"
+        echo "Last 20 lines of logs from matching pods:"
+        kubectl logs -n "$NAMESPACE" -l "$LABEL_SELECTOR" -c "$CONTAINER_NAME" --tail=20 || echo "  (failed to retrieve final logs)"
         echo "-----------------------------------------------------"
         exit 1
     fi
 
-    # echo "-----------------------------------------------------" # Reduced verbosity
-    echo "Attempting log check on $POD/$CONTAINER_NAME (Elapsed: ${ELAPSED_TIME}s / ${RETRY_TIMEOUT}s)"
+    echo "Attempting log check on pods matching '$LABEL_SELECTOR' / $CONTAINER_NAME (Elapsed: ${ELAPSED_TIME}s / ${RETRY_TIMEOUT}s)"
 
-    # 2. Get Logs for this attempt from the SPECIFIC container
-    # Using --tail=-1 to get all logs. Consider limiting if logs are huge and only recent ones matter.
-    LOGS=$(kubectl logs "$POD" -n "$NAMESPACE" -c "$CONTAINER_NAME" --tail=-1 --request-timeout=10s)
+    # 2. Get Logs from ALL pods matching the label selector.
+    # This is essential for DaemonSets where spans land on the node-local pod,
+    # which may not be the first pod returned by kubectl.
+    LOGS=$(kubectl logs -n "$NAMESPACE" -l "$LABEL_SELECTOR" -c "$CONTAINER_NAME" --tail=-1 --request-timeout=10s)
     KUBECTL_LOGS_EXIT_CODE=$?
 
     if [ $KUBECTL_LOGS_EXIT_CODE -ne 0 ]; then
-         echo "Warning: Failed to get logs for container '$CONTAINER_NAME' in pod '$POD' (Exit code: $KUBECTL_LOGS_EXIT_CODE). Retrying after sleep..."
+         echo "Warning: Failed to get logs for container '$CONTAINER_NAME' in pods matching '$LABEL_SELECTOR' (Exit code: $KUBECTL_LOGS_EXIT_CODE). Retrying after sleep..."
          sleep "$RETRY_SLEEP"
          continue # Go to next loop iteration
     fi
@@ -129,7 +118,7 @@ while true; do
     # 4. Evaluate outcome of this attempt
     if [ "$ALL_FOUND_THIS_ATTEMPT" = true ]; then
         echo "-----------------------------------------------------"
-        echo "Success: All ${#SEARCH_STRINGS[@]} strings found simultaneously in container '$CONTAINER_NAME' of pod '$POD'."
+        echo "Success: All ${#SEARCH_STRINGS[@]} strings found in container '$CONTAINER_NAME' of pods matching '$LABEL_SELECTOR'."
         echo "-----------------------------------------------------"
         exit 0 # Successful exit!
     else


### PR DESCRIPTION
## Summary
- Add SCC setup for `instrumentation-nginx` and `instrumentation-apache-httpd` tests that create DaemonSet collectors with `hostNetwork: true` on OpenShift
- Fix `check_pod_logs.sh` to search logs from ALL matching pods (not just `.items[0]`), since DaemonSet spans land on the node-local pod
- Update `validate-collector-spans.yaml` to fall back to `kubectl port-forward` + `curl` for metrics fetching when `hostNetwork` is detected (kube-proxy is unreachable), and iterate over all pods to find the one with non-zero span data

## Test plan
- [x] `instrumentation-nginx` — verified passing on OCP 4.22 (3-node cluster)
- [x] `instrumentation-apache-httpd` — verified passing on OCP 4.22 (3-node cluster)
- [x] Deployment-mode collector validation still uses kube-proxy (no regression)
- [x] DaemonSet-mode metrics validation via port-forward finds the correct pod with span data