### PR TITLE
Bump Go toolchain to 1.26.5

### DIFF
--- a/cmd/otel-allocator/integrationtest/go.mod
+++ b/cmd/otel-allocator/integrationtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/integrationtest
 
-go 1.26.3
+go 1.26.5
 
 // This is a separate module so the collector + prometheus receiver dependency
 // graph stays out of the target allocator binary's module. It imports the target

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-operator
 
-go 1.26.3
+go 1.26.5
 
 retract v1.51.0
 

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,18 @@
     },
     {
       "customType": "regex",
+      "description": "Update Go toolchain version in go.mod files",
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "go",
+      "fileMatch": [
+        "(^|/)go\\.mod$"
+      ],
+      "matchStrings": [
+        "\\ngo (?<currentValue>\\d+\\.\\d+\\.\\d+)\\n"
+      ]
+    },
+    {
+      "customType": "regex",
       "description" : "Update tool versions in the Makefile and Github Actions",
       "fileMatch": [
         "(^|/)Makefile$",
@@ -96,6 +108,16 @@
       "matchFileNames": [".github/workflows/*.yaml", ".github/workflows/*.yml"],
       "separateMinorPatch": true,
       "commitMessageTopic": "go version in CI"
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "matchManagers": ["regex"],
+      "matchFileNames": ["**/go.mod"],
+      "separateMinorPatch": true,
+      "matchUpdateTypes": ["patch"],
+      "groupName": "go toolchain in go.mod",
+      "commitMessageTopic": "Go toolchain version in go.mod",
+      "postUpdateOptions": ["gomodTidy"]
     },
     {
       "matchManagers": ["regex"],


### PR DESCRIPTION
## Summary
- Bumps Go toolchain from 1.26.3 to 1.26.5 in `go.mod` and `cmd/otel-allocator/integrationtest/go.mod` (CVE-2026-39822, CVE-2026-42505)
- Adds a Renovate custom manager to automatically open PRs for future Go patch version bumps in `go.mod` files. Minor version bumps are left for manual upgrade.