### PR TITLE
Fix clusterobservability test flakiness

### DIFF
--- a/tests/e2e-clusterobservability/smoke-clusterobservability/02-assert-telemetry-flow.yaml
+++ b/tests/e2e-clusterobservability/smoke-clusterobservability/02-assert-telemetry-flow.yaml
@@ -15,13 +15,19 @@ spec:
         CLUSTER_POD=$(kubectl get pod -n "$NAMESPACE" \
           -l app.kubernetes.io/name=cluster-obs-cluster \
           -o jsonpath='{.items[0].metadata.name}')
+        # Wait for the k8s_events receiver to log its startup message.
+        # Match both compact JSON ("k8s_events") and console format with spaces.
+        # The check is advisory — if the log line is absent after 60s (e.g. due
+        # to a version-dependent format change) we proceed rather than failing
+        # hard; the sink-log check below will catch any missing signal.
         for i in $(seq 1 30); do
           if kubectl logs "$CLUSTER_POD" -n "$NAMESPACE" \
-            | grep -q 'Started collecting.*"otelcol.component.id": "k8s_events"'; then
+            | grep -qE '"k8s_events".*[Ss]tart|[Ss]tart.*"k8s_events"'; then
+            echo "k8s_events receiver startup confirmed"
             break
           fi
           if [ "$i" -eq 30 ]; then
-            echo "ERROR: k8s_events receiver did not start"; exit 1
+            echo "WARNING: k8s_events receiver startup log not found after 60s; proceeding anyway"
           fi
           sleep 2
         done

--- a/tests/e2e-clusterobservability/smoke-clusterobservability/04-assert-component-health.yaml
+++ b/tests/e2e-clusterobservability/smoke-clusterobservability/04-assert-component-health.yaml
@@ -31,7 +31,23 @@ spec:
               return 1
             fi
 
-            logs=$(kubectl logs "$pod" -n "$NAMESPACE" --all-containers)
+            # Only check logs after the startup grace period to avoid flagging
+            # transient errors (e.g. k8s_api detector timeout, initial OTLP
+            # export retries) that resolve on their own within seconds.
+            POD_START_TS=$(kubectl get pod "$pod" -n "$NAMESPACE" \
+              -o jsonpath='{.status.startTime}')
+            POD_START_EPOCH=$(date -d "$POD_START_TS" +%s)
+            NOW_EPOCH=$(date +%s)
+            POD_AGE=$((NOW_EPOCH - POD_START_EPOCH))
+            STARTUP_GRACE=120
+            if [ "$POD_AGE" -gt "$STARTUP_GRACE" ]; then
+              SINCE_SECS=$((POD_AGE - STARTUP_GRACE))
+              logs=$(kubectl logs "$pod" -n "$NAMESPACE" --all-containers \
+                --since="${SINCE_SECS}s")
+            else
+              echo "Pod $pod is ${POD_AGE}s old (grace period ${STARTUP_GRACE}s); skipping error log check"
+              logs=""
+            fi
             warnings=$(printf '%s\n' "$logs" | grep -Ei \
               '(^|[[:space:]])warn(ing)?([[:space:]:]|$)|"level"[[:space:]]*:[[:space:]]*"warn(ing)?"' || true)
             if [ -n "$warnings" ]; then

--- a/tests/e2e-clusterobservability/smoke-clusterobservability/04-assert-component-health.yaml
+++ b/tests/e2e-clusterobservability/smoke-clusterobservability/04-assert-component-health.yaml
@@ -31,23 +31,7 @@ spec:
               return 1
             fi
 
-            # Only check logs after the startup grace period to avoid flagging
-            # transient errors (e.g. k8s_api detector timeout, initial OTLP
-            # export retries) that resolve on their own within seconds.
-            POD_START_TS=$(kubectl get pod "$pod" -n "$NAMESPACE" \
-              -o jsonpath='{.status.startTime}')
-            POD_START_EPOCH=$(date -d "$POD_START_TS" +%s)
-            NOW_EPOCH=$(date +%s)
-            POD_AGE=$((NOW_EPOCH - POD_START_EPOCH))
-            STARTUP_GRACE=120
-            if [ "$POD_AGE" -gt "$STARTUP_GRACE" ]; then
-              SINCE_SECS=$((POD_AGE - STARTUP_GRACE))
-              logs=$(kubectl logs "$pod" -n "$NAMESPACE" --all-containers \
-                --since="${SINCE_SECS}s")
-            else
-              echo "Pod $pod is ${POD_AGE}s old (grace period ${STARTUP_GRACE}s); skipping error log check"
-              logs=""
-            fi
+            logs=$(kubectl logs "$pod" -n "$NAMESPACE" --all-containers)
             warnings=$(printf '%s\n' "$logs" | grep -Ei \
               '(^|[[:space:]])warn(ing)?([[:space:]:]|$)|"level"[[:space:]]*:[[:space:]]*"warn(ing)?"' || true)
             if [ -n "$warnings" ]; then
@@ -56,8 +40,13 @@ spec:
               printf '%s\n' "$warnings" | sed -n '1,20p'
             fi
 
+            # Kubelet stats scrape failures are acceptable: the kubelet endpoint
+            # can be transiently busy on CI, and the telemetry flow assertions
+            # (k8s.node.cpu.usage appearing at the sink) confirm recovery.
+            ACCEPTABLE_ERRORS='call to /stats/summary endpoint failed|call to /pods endpoint failed'
             errors=$(printf '%s\n' "$logs" | grep -Ei \
-              '(^|[[:space:]])(error|dpanic|panic|fatal)([[:space:]:]|$)|"level"[[:space:]]*:[[:space:]]*"(error|dpanic|panic|fatal)"' || true)
+              '(^|[[:space:]])(error|dpanic|panic|fatal)([[:space:]:]|$)|"level"[[:space:]]*:[[:space:]]*"(error|dpanic|panic|fatal)"' | \
+              grep -Ev "$ACCEPTABLE_ERRORS" || true)
             if [ -n "$errors" ]; then
               echo "ERROR: error-level logs from $pod:"
               echo "$errors"


### PR DESCRIPTION
Make sure transient errors that sometimes happen in kind on GHA runners don't lead to test failures. See https://github.com/open-telemetry/opentelemetry-operator/actions/runs/32717495596/job/97403312789 for example.
