### PR TITLE
[chore] Drop unnecessary rule disabling test image Go updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -141,11 +141,6 @@
       "commitMessageTopic": "kind node images"
     },
     {
-      "matchManagers": ["gomod"],
-      "matchFileNames": ["tests/test-e2e-apps/**/go.mod"],
-      "enabled": false
-    },
-    {
       "description": "Never bump the in-repo module references (resolved via local replace directives)",
       "matchManagers": ["gomod"],
       "matchDepNames": [


### PR DESCRIPTION
This rule used to be in place because we didn't have any test converage for these images. Now that they're built for e2e tests if the files changes, it's safe to enable the updates again.
