### PR TITLE
fix: reconcile operator NetworkPolicy when API server IPs change

### DIFF
--- a/.chloggen/fix-reconcile-operator-networkpolicy-on-ip-change.yaml
+++ b/.chloggen/fix-reconcile-operator-networkpolicy-on-ip-change.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: operator
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reconcile operator NetworkPolicy when API server IPs change by watching EndpointSlices.
+
+# One or more tracking issues related to the change
+issues: [5559]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -411,6 +411,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - gateway.networking.k8s.io
           resources:

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -411,6 +411,7 @@ spec:
           verbs:
           - get
           - list
+          - watch
         - apiGroups:
           - gateway.networking.k8s.io
           resources:

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -375,6 +375,7 @@ func enableOperatorNetworkPolicy(cfg config.Config, clientset kubernetes.Interfa
 	}
 
 	var policyOpts []operatornetworkpolicy.Option
+	policyOpts = append(policyOpts, operatornetworkpolicy.WithLogger(ctrl.Log.WithName("operator-networkpolicy")))
 	policyOpts = append(policyOpts, operatornetworkpolicy.WithOperatorNamespace(operatorNamespace))
 	policyOpts = append(policyOpts, operatornetworkpolicy.WithOperatorPodName(operatorPodName))
 	policyOpts = append(policyOpts, operatornetworkpolicy.WithAPIServerPort(cfg.Internal.KubeAPIServerPort))

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -119,6 +119,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - gateway.networking.k8s.io
   resources:

--- a/internal/controllers/opentelemetrycollector_controller.go
+++ b/internal/controllers/opentelemetrycollector_controller.go
@@ -265,7 +265,7 @@ func NewReconciler(p Params) *OpenTelemetryCollectorReconciler {
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;create;update
-// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list
+// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;podmonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete

--- a/internal/operatornetworkpolicy/operatornetworkpolicy.go
+++ b/internal/operatornetworkpolicy/operatornetworkpolicy.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,10 +193,14 @@ func (n *networkPolicy) handleEndpointSliceEvent(ctx context.Context, ownerRef [
 	}
 
 	n.logger.Info("API server IPs changed, updating NetworkPolicy", "oldIPs", n.apiServerIPs, "newIPs", newIPs)
+
+	oldIPs := n.apiServerIPs
 	n.apiServerIPs = newIPs
 
 	if err := n.createOrUpdateNetworkPolicy(ctx, ownerRef); err != nil {
 		n.logger.Error(err, "Failed to update NetworkPolicy after IP change")
+		// Revert in-memory state so the next event retries the update.
+		n.apiServerIPs = oldIPs
 	}
 }
 
@@ -385,19 +388,6 @@ func (n *networkPolicy) operatorDeployment(ctx context.Context) (*appsv1.Deploym
 		return nil, fmt.Errorf("failed to get operator Deployment %q: %w", depRef.Name, err)
 	}
 	return dep, nil
-}
-
-// extractIPsFromEndpointSlice extracts endpoint addresses from an EndpointSlice.
-func extractIPsFromEndpointSlice(obj interface{}) []string {
-	es, ok := obj.(*discoveryv1.EndpointSlice)
-	if !ok {
-		return nil
-	}
-	var ips []string
-	for _, endpoint := range es.Endpoints {
-		ips = append(ips, endpoint.Addresses...)
-	}
-	return ips
 }
 
 func (*networkPolicy) NeedLeaderElection() bool {

--- a/internal/operatornetworkpolicy/operatornetworkpolicy.go
+++ b/internal/operatornetworkpolicy/operatornetworkpolicy.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"sort"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -160,13 +159,13 @@ func (n *networkPolicy) watchEndpointSlices(ctx context.Context, ownerRef []meta
 	informer := factory.Discovery().V1().EndpointSlices().Informer()
 
 	handler := cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(_ any) {
 			n.handleEndpointSliceEvent(ctx, ownerRef)
 		},
-		UpdateFunc: func(_, _ interface{}) {
+		UpdateFunc: func(_, _ any) {
 			n.handleEndpointSliceEvent(ctx, ownerRef)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(_ any) {
 			n.handleEndpointSliceEvent(ctx, ownerRef)
 		},
 	}
@@ -219,7 +218,7 @@ func (n *networkPolicy) discoverAPIServerIPs(ctx context.Context) ([]string, err
 			ips = append(ips, endpoint.Addresses...)
 		}
 	}
-	sort.Strings(ips)
+	slices.Sort(ips)
 	return ips, nil
 }
 
@@ -227,11 +226,11 @@ func (n *networkPolicy) discoverAPIServerIPs(ctx context.Context) ([]string, err
 func ipsEqual(a, b []string) bool {
 	sortedA := make([]string, len(a))
 	copy(sortedA, a)
-	sort.Strings(sortedA)
+	slices.Sort(sortedA)
 
 	sortedB := make([]string, len(b))
 	copy(sortedB, b)
-	sort.Strings(sortedB)
+	slices.Sort(sortedB)
 
 	return slices.Equal(sortedA, sortedB)
 }

--- a/internal/operatornetworkpolicy/operatornetworkpolicy.go
+++ b/internal/operatornetworkpolicy/operatornetworkpolicy.go
@@ -6,22 +6,34 @@ package operatornetworkpolicy
 import (
 	"context"
 	"fmt"
+	"slices"
+	"sort"
 
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const (
+	networkPolicyName  = "opentelemetry-operator"
+	endpointSliceLabel = "kubernetes.io/service-name=kubernetes"
 )
 
 type networkPolicy struct {
 	clientset kubernetes.Interface
 	scheme    *runtime.Scheme
+	logger    logr.Logger
 
 	operatorNamespace          string
 	operatorPodName            string
@@ -31,6 +43,8 @@ type networkPolicy struct {
 	metricsPort                int32
 	apiServerPodSelector       *metav1.LabelSelector
 	apiServerNamespaceSelector *metav1.LabelSelector
+
+	podSelector metav1.LabelSelector
 }
 
 var (
@@ -42,6 +56,7 @@ func NewOperatorNetworkPolicy(clientset kubernetes.Interface, scheme *runtime.Sc
 	n := &networkPolicy{
 		clientset: clientset,
 		scheme:    scheme,
+		logger:    logr.Discard(),
 	}
 
 	for _, opt := range options {
@@ -51,6 +66,13 @@ func NewOperatorNetworkPolicy(clientset kubernetes.Interface, scheme *runtime.Sc
 }
 
 type Option func(policy *networkPolicy)
+
+// WithLogger sets the logger for the network policy reconciler.
+func WithLogger(logger logr.Logger) Option {
+	return func(s *networkPolicy) {
+		s.logger = logger
+	}
+}
 
 // WithOperatorNamespace sets the namespace of the operator and enables it in the network policy.
 func WithOperatorNamespace(operatorNamespace string) Option {
@@ -111,19 +133,136 @@ func WithAPISererNamespaceLabelSelector(selector *metav1.LabelSelector) Option {
 }
 
 func (n *networkPolicy) Start(ctx context.Context) error {
-	operatorDep, err := n.operatorDeployment(ctx)
+	ownerRef, err := n.getOwnerReference(ctx)
 	if err != nil {
 		return err
 	}
 
+	if err := n.createOrUpdateNetworkPolicy(ctx, ownerRef); err != nil {
+		return err
+	}
+
+	n.logger.Info("Starting EndpointSlice watcher for API server IP changes")
+	return n.watchEndpointSlices(ctx, ownerRef)
+}
+
+// watchEndpointSlices sets up an informer on EndpointSlices in the default namespace
+// filtered by the kubernetes service label. When IPs change, it updates the NetworkPolicy.
+func (n *networkPolicy) watchEndpointSlices(ctx context.Context, ownerRef []metav1.OwnerReference) error {
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		n.clientset,
+		0,
+		informers.WithNamespace("default"),
+		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.LabelSelector = endpointSliceLabel
+		}),
+	)
+
+	informer := factory.Discovery().V1().EndpointSlices().Informer()
+
+	handler := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			n.handleEndpointSliceEvent(ctx, ownerRef)
+		},
+		UpdateFunc: func(_, _ interface{}) {
+			n.handleEndpointSliceEvent(ctx, ownerRef)
+		},
+		DeleteFunc: func(obj interface{}) {
+			n.handleEndpointSliceEvent(ctx, ownerRef)
+		},
+	}
+
+	if _, err := informer.AddEventHandler(handler); err != nil {
+		return err
+	}
+
+	informer.Run(ctx.Done())
+	return nil
+}
+
+// handleEndpointSliceEvent is called on any EndpointSlice event. It re-reads all matching
+// EndpointSlices, extracts the current API server IPs, and updates the NetworkPolicy if changed.
+func (n *networkPolicy) handleEndpointSliceEvent(ctx context.Context, ownerRef []metav1.OwnerReference) {
+	newIPs, err := n.discoverAPIServerIPs(ctx)
+	if err != nil {
+		n.logger.Error(err, "Failed to discover API server IPs from EndpointSlices")
+		return
+	}
+
+	if ipsEqual(n.apiServerIPs, newIPs) {
+		return
+	}
+
+	n.logger.Info("API server IPs changed, updating NetworkPolicy", "oldIPs", n.apiServerIPs, "newIPs", newIPs)
+	n.apiServerIPs = newIPs
+
+	if err := n.createOrUpdateNetworkPolicy(ctx, ownerRef); err != nil {
+		n.logger.Error(err, "Failed to update NetworkPolicy after IP change")
+	}
+}
+
+// discoverAPIServerIPs lists EndpointSlices for the kubernetes service and extracts endpoint IPs.
+func (n *networkPolicy) discoverAPIServerIPs(ctx context.Context) ([]string, error) {
+	endpointSlices, err := n.clientset.DiscoveryV1().EndpointSlices("default").List(ctx, metav1.ListOptions{
+		LabelSelector: endpointSliceLabel,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var ips []string
+	for _, es := range endpointSlices.Items {
+		for _, endpoint := range es.Endpoints {
+			ips = append(ips, endpoint.Addresses...)
+		}
+	}
+	sort.Strings(ips)
+	return ips, nil
+}
+
+// ipsEqual compares two IP slices for equality, ignoring order.
+func ipsEqual(a, b []string) bool {
+	sortedA := make([]string, len(a))
+	copy(sortedA, a)
+	sort.Strings(sortedA)
+
+	sortedB := make([]string, len(b))
+	copy(sortedB, b)
+	sort.Strings(sortedB)
+
+	return slices.Equal(sortedA, sortedB)
+}
+
+// getOwnerReference resolves the operator deployment, caches its pod selector,
+// and returns the owner reference for the NetworkPolicy.
+func (n *networkPolicy) getOwnerReference(ctx context.Context) ([]metav1.OwnerReference, error) {
+	operatorDep, err := n.operatorDeployment(ctx)
+	if err != nil {
+		return nil, err
+	}
+	n.podSelector = *operatorDep.Spec.Selector
+
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkPolicyName,
+			Namespace: n.operatorNamespace,
+		},
+	}
+	if err := controllerutil.SetControllerReference(operatorDep, np, n.scheme); err != nil {
+		return nil, err
+	}
+	return np.OwnerReferences, nil
+}
+
+// buildNetworkPolicy constructs the desired NetworkPolicy object from the current state.
+func (n *networkPolicy) buildNetworkPolicy(ownerRef []metav1.OwnerReference) *networkingv1.NetworkPolicy {
 	tcp := corev1.ProtocolTCP
 	apiServerPort := intstr.FromInt32(n.apiServerPort)
 
-	var apiSeverIPs []networkingv1.NetworkPolicyPeer
-	// Add IPBlock rules for API server IPs
+	var apiServerPeers []networkingv1.NetworkPolicyPeer
 	for _, ip := range n.apiServerIPs {
 		cidr := ip + "/32"
-		apiSeverIPs = append(apiSeverIPs, networkingv1.NetworkPolicyPeer{
+		apiServerPeers = append(apiServerPeers, networkingv1.NetworkPolicyPeer{
 			IPBlock: &networkingv1.IPBlock{
 				CIDR: cidr,
 			},
@@ -132,11 +271,12 @@ func (n *networkPolicy) Start(ctx context.Context) error {
 
 	np := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "opentelemetry-operator",
-			Namespace: n.operatorNamespace,
+			Name:            networkPolicyName,
+			Namespace:       n.operatorNamespace,
+			OwnerReferences: ownerRef,
 		},
 		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: *operatorDep.Spec.Selector,
+			PodSelector: n.podSelector,
 			Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
 			Egress: []networkingv1.NetworkPolicyEgressRule{
 				{
@@ -146,7 +286,7 @@ func (n *networkPolicy) Start(ctx context.Context) error {
 							Port:     &apiServerPort,
 						},
 					},
-					To: apiSeverIPs,
+					To: apiServerPeers,
 				},
 			},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
@@ -184,18 +324,34 @@ func (n *networkPolicy) Start(ctx context.Context) error {
 		})
 	}
 
-	// set owner reference to the operator deployment
-	err = controllerutil.SetControllerReference(operatorDep, np, n.scheme)
+	return np
+}
+
+// createOrUpdateNetworkPolicy creates the NetworkPolicy if it doesn't exist, or updates it if it does.
+func (n *networkPolicy) createOrUpdateNetworkPolicy(ctx context.Context, ownerRef []metav1.OwnerReference) error {
+	desired := n.buildNetworkPolicy(ownerRef)
+
+	_, err := n.clientset.NetworkingV1().NetworkPolicies(n.operatorNamespace).Create(ctx, desired, metav1.CreateOptions{})
+	if err == nil {
+		n.logger.Info("Created NetworkPolicy", "name", networkPolicyName, "namespace", n.operatorNamespace)
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	existing, err := n.clientset.NetworkingV1().NetworkPolicies(n.operatorNamespace).Get(ctx, networkPolicyName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 
-	_, err = n.clientset.NetworkingV1().NetworkPolicies(n.operatorNamespace).Create(ctx, np, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	existing.Spec = desired.Spec
+	existing.OwnerReferences = desired.OwnerReferences
+	_, err = n.clientset.NetworkingV1().NetworkPolicies(n.operatorNamespace).Update(ctx, existing, metav1.UpdateOptions{})
+	if err != nil {
 		return err
 	}
-
-	<-ctx.Done()
+	n.logger.Info("Updated NetworkPolicy", "name", networkPolicyName, "namespace", n.operatorNamespace)
 	return nil
 }
 
@@ -229,6 +385,19 @@ func (n *networkPolicy) operatorDeployment(ctx context.Context) (*appsv1.Deploym
 		return nil, fmt.Errorf("failed to get operator Deployment %q: %w", depRef.Name, err)
 	}
 	return dep, nil
+}
+
+// extractIPsFromEndpointSlice extracts endpoint addresses from an EndpointSlice.
+func extractIPsFromEndpointSlice(obj interface{}) []string {
+	es, ok := obj.(*discoveryv1.EndpointSlice)
+	if !ok {
+		return nil
+	}
+	var ips []string
+	for _, endpoint := range es.Endpoints {
+		ips = append(ips, endpoint.Addresses...)
+	}
+	return ips
 }
 
 func (*networkPolicy) NeedLeaderElection() bool {

--- a/internal/operatornetworkpolicy/operatornetworkpolicy_test.go
+++ b/internal/operatornetworkpolicy/operatornetworkpolicy_test.go
@@ -6,11 +6,14 @@ package operatornetworkpolicy
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -25,6 +28,7 @@ func newTestScheme() *runtime.Scheme {
 	_ = appsv1.AddToScheme(s)
 	_ = networkingv1.AddToScheme(s)
 	_ = corev1.AddToScheme(s)
+	_ = discoveryv1.AddToScheme(s)
 	return s
 }
 
@@ -83,6 +87,32 @@ func operatorObjects(namespace string) []runtime.Object {
 	return []runtime.Object{dep, rs, pod}
 }
 
+func ownerRef() []metav1.OwnerReference {
+	trueVal := true
+	return []metav1.OwnerReference{
+		{
+			APIVersion:         "apps/v1",
+			Kind:               "Deployment",
+			Name:               operatorDeploymentName,
+			UID:                types.UID("test-uid"),
+			Controller:         &trueVal,
+			BlockOwnerDeletion: &trueVal,
+		},
+	}
+}
+
+// buildAndCapture creates a networkPolicy with the given options and returns the built NetworkPolicy.
+func buildAndCapture(t *testing.T, clientset *fake.Clientset, scheme *runtime.Scheme, opts ...Option) *networkingv1.NetworkPolicy {
+	t.Helper()
+
+	n := NewOperatorNetworkPolicy(clientset, scheme, opts...).(*networkPolicy)
+	ctx := context.Background()
+
+	ref, err := n.getOwnerReference(ctx)
+	require.NoError(t, err)
+	return n.buildNetworkPolicy(ref)
+}
+
 // startAndCapture runs Start() and captures the created NetworkPolicy
 // by using a reactor that cancels the context after creation.
 func startAndCapture(t *testing.T, clientset *fake.Clientset, scheme *runtime.Scheme, opts ...Option) *networkingv1.NetworkPolicy {
@@ -106,25 +136,11 @@ func startAndCapture(t *testing.T, clientset *fake.Clientset, scheme *runtime.Sc
 	return captured
 }
 
-func ownerRef() []metav1.OwnerReference {
-	trueVal := true
-	return []metav1.OwnerReference{
-		{
-			APIVersion:         "apps/v1",
-			Kind:               "Deployment",
-			Name:               operatorDeploymentName,
-			UID:                types.UID("test-uid"),
-			Controller:         &trueVal,
-			BlockOwnerDeletion: &trueVal,
-		},
-	}
-}
-
-func TestStart_IPBlockPeersOnly(t *testing.T) {
+func TestBuild_IPBlockPeersOnly(t *testing.T) {
 	const namespace = "test-ns"
 	clientset := fake.NewClientset(operatorObjects(namespace)...)
 
-	np := startAndCapture(t, clientset, newTestScheme(),
+	np := buildAndCapture(t, clientset, newTestScheme(),
 		WithOperatorNamespace(namespace),
 		WithOperatorPodName(testPodName),
 		WithAPIServerPort(6443),
@@ -160,7 +176,7 @@ func TestStart_IPBlockPeersOnly(t *testing.T) {
 	assert.Equal(t, expected, np)
 }
 
-func TestStart_SelectorPeersOnly(t *testing.T) {
+func TestBuild_SelectorPeersOnly(t *testing.T) {
 	const namespace = "test-ns"
 	clientset := fake.NewClientset(operatorObjects(namespace)...)
 
@@ -171,7 +187,7 @@ func TestStart_SelectorPeersOnly(t *testing.T) {
 		MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-kube-apiserver"},
 	}
 
-	np := startAndCapture(t, clientset, newTestScheme(),
+	np := buildAndCapture(t, clientset, newTestScheme(),
 		WithOperatorNamespace(namespace),
 		WithOperatorPodName(testPodName),
 		WithAPIServerPort(6443),
@@ -210,7 +226,7 @@ func TestStart_SelectorPeersOnly(t *testing.T) {
 	assert.Equal(t, expected, np)
 }
 
-func TestStart_CombinedIPBlockAndSelectors(t *testing.T) {
+func TestBuild_CombinedIPBlockAndSelectors(t *testing.T) {
 	const namespace = "openshift-opentelemetry-operator"
 	clientset := fake.NewClientset(operatorObjects(namespace)...)
 
@@ -221,7 +237,7 @@ func TestStart_CombinedIPBlockAndSelectors(t *testing.T) {
 		MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-kube-apiserver"},
 	}
 
-	np := startAndCapture(t, clientset, newTestScheme(),
+	np := buildAndCapture(t, clientset, newTestScheme(),
 		WithOperatorNamespace(namespace),
 		WithOperatorPodName(testPodName),
 		WithAPIServerPort(6443),
@@ -260,11 +276,11 @@ func TestStart_CombinedIPBlockAndSelectors(t *testing.T) {
 	assert.Equal(t, expected, np)
 }
 
-func TestStart_WithIngressPorts(t *testing.T) {
+func TestBuild_WithIngressPorts(t *testing.T) {
 	const namespace = "test-ns"
 	clientset := fake.NewClientset(operatorObjects(namespace)...)
 
-	np := startAndCapture(t, clientset, newTestScheme(),
+	np := buildAndCapture(t, clientset, newTestScheme(),
 		WithOperatorNamespace(namespace),
 		WithOperatorPodName(testPodName),
 		WithAPIServerPort(6443),
@@ -308,7 +324,7 @@ func TestStart_WithIngressPorts(t *testing.T) {
 	assert.Equal(t, expected, np)
 }
 
-func TestStart_FullOpenShiftConfig(t *testing.T) {
+func TestBuild_FullOpenShiftConfig(t *testing.T) {
 	const namespace = "openshift-opentelemetry-operator"
 	clientset := fake.NewClientset(operatorObjects(namespace)...)
 
@@ -319,7 +335,7 @@ func TestStart_FullOpenShiftConfig(t *testing.T) {
 		MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-kube-apiserver"},
 	}
 
-	np := startAndCapture(t, clientset, newTestScheme(),
+	np := buildAndCapture(t, clientset, newTestScheme(),
 		WithOperatorNamespace(namespace),
 		WithOperatorPodName(testPodName),
 		WithAPIServerPort(6443),
@@ -462,4 +478,300 @@ func TestStart_DeploymentNotFound(t *testing.T) {
 func TestNeedLeaderElection(t *testing.T) {
 	n := &networkPolicy{}
 	assert.True(t, n.NeedLeaderElection())
+}
+
+func TestCreateOrUpdate_CreatesWhenNotExist(t *testing.T) {
+	const namespace = "test-ns"
+	clientset := fake.NewClientset(operatorObjects(namespace)...)
+
+	n := NewOperatorNetworkPolicy(clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
+		WithAPIServerPort(6443),
+		WithAPIServerIPs([]string{"10.0.0.1"}),
+		WithLogger(logr.Discard()),
+	).(*networkPolicy)
+
+	ctx := context.Background()
+	ref, err := n.getOwnerReference(ctx)
+	require.NoError(t, err)
+
+	err = n.createOrUpdateNetworkPolicy(ctx, ref)
+	require.NoError(t, err)
+
+	np, err := clientset.NetworkingV1().NetworkPolicies(namespace).Get(ctx, networkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, networkPolicyName, np.Name)
+	assert.Len(t, np.Spec.Egress[0].To, 1)
+	assert.Equal(t, "10.0.0.1/32", np.Spec.Egress[0].To[0].IPBlock.CIDR)
+}
+
+func TestCreateOrUpdate_UpdatesExistingPolicy(t *testing.T) {
+	const namespace = "test-ns"
+
+	tcp := corev1.ProtocolTCP
+	oldPort := intstr.FromInt32(6443)
+	existingNP := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkPolicyName,
+			Namespace: namespace,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/name": "opentelemetry-operator"},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{{Protocol: &tcp, Port: &oldPort}},
+					To: []networkingv1.NetworkPolicyPeer{
+						{IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.99/32"}},
+					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+		},
+	}
+
+	clientset := fake.NewClientset(append(operatorObjects(namespace), existingNP)...)
+
+	n := NewOperatorNetworkPolicy(clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
+		WithAPIServerPort(6443),
+		WithAPIServerIPs([]string{"10.0.0.1", "10.0.0.2"}),
+		WithLogger(logr.Discard()),
+	).(*networkPolicy)
+
+	ctx := context.Background()
+	ref, err := n.getOwnerReference(ctx)
+	require.NoError(t, err)
+
+	err = n.createOrUpdateNetworkPolicy(ctx, ref)
+	require.NoError(t, err)
+
+	np, err := clientset.NetworkingV1().NetworkPolicies(namespace).Get(ctx, networkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	require.Len(t, np.Spec.Egress, 1)
+	require.Len(t, np.Spec.Egress[0].To, 2)
+	assert.Equal(t, "10.0.0.1/32", np.Spec.Egress[0].To[0].IPBlock.CIDR)
+	assert.Equal(t, "10.0.0.2/32", np.Spec.Egress[0].To[1].IPBlock.CIDR)
+}
+
+func TestIpsEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a, b     []string
+		expected bool
+	}{
+		{
+			name:     "equal same order",
+			a:        []string{"10.0.0.1", "10.0.0.2"},
+			b:        []string{"10.0.0.1", "10.0.0.2"},
+			expected: true,
+		},
+		{
+			name:     "equal different order",
+			a:        []string{"10.0.0.2", "10.0.0.1"},
+			b:        []string{"10.0.0.1", "10.0.0.2"},
+			expected: true,
+		},
+		{
+			name:     "not equal different IPs",
+			a:        []string{"10.0.0.1"},
+			b:        []string{"10.0.0.2"},
+			expected: false,
+		},
+		{
+			name:     "not equal different lengths",
+			a:        []string{"10.0.0.1", "10.0.0.2"},
+			b:        []string{"10.0.0.1"},
+			expected: false,
+		},
+		{
+			name:     "both empty",
+			a:        nil,
+			b:        nil,
+			expected: true,
+		},
+		{
+			name:     "one empty one not",
+			a:        []string{"10.0.0.1"},
+			b:        nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ipsEqual(tt.a, tt.b))
+		})
+	}
+}
+
+func TestHandleEndpointSliceEvent_UpdatesOnIPChange(t *testing.T) {
+	const namespace = "test-ns"
+
+	httpsPort := int32(6443)
+	portName := "https"
+	endpointSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubernetes",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kubernetes.io/service-name": "kubernetes",
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Name: &portName,
+				Port: &httpsPort,
+			},
+		},
+		Endpoints: []discoveryv1.Endpoint{
+			{Addresses: []string{"10.0.0.5", "10.0.0.6"}},
+		},
+	}
+
+	clientset := fake.NewClientset(append(operatorObjects(namespace), endpointSlice)...)
+
+	n := NewOperatorNetworkPolicy(clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
+		WithAPIServerPort(6443),
+		WithAPIServerIPs([]string{"10.0.0.1", "10.0.0.2"}),
+		WithLogger(logr.Discard()),
+	).(*networkPolicy)
+
+	ctx := context.Background()
+	ref, err := n.getOwnerReference(ctx)
+	require.NoError(t, err)
+
+	err = n.createOrUpdateNetworkPolicy(ctx, ref)
+	require.NoError(t, err)
+
+	n.handleEndpointSliceEvent(ctx, ref)
+
+	assert.Equal(t, []string{"10.0.0.5", "10.0.0.6"}, n.apiServerIPs)
+
+	np, err := clientset.NetworkingV1().NetworkPolicies(namespace).Get(ctx, networkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, np.Spec.Egress, 1)
+	require.Len(t, np.Spec.Egress[0].To, 2)
+	assert.Equal(t, "10.0.0.5/32", np.Spec.Egress[0].To[0].IPBlock.CIDR)
+	assert.Equal(t, "10.0.0.6/32", np.Spec.Egress[0].To[1].IPBlock.CIDR)
+}
+
+func TestHandleEndpointSliceEvent_NoUpdateWhenIPsSame(t *testing.T) {
+	const namespace = "test-ns"
+
+	httpsPort := int32(6443)
+	portName := "https"
+	endpointSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubernetes",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kubernetes.io/service-name": "kubernetes",
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Name: &portName,
+				Port: &httpsPort,
+			},
+		},
+		Endpoints: []discoveryv1.Endpoint{
+			{Addresses: []string{"10.0.0.1", "10.0.0.2"}},
+		},
+	}
+
+	clientset := fake.NewClientset(append(operatorObjects(namespace), endpointSlice)...)
+
+	n := NewOperatorNetworkPolicy(clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
+		WithAPIServerPort(6443),
+		WithAPIServerIPs([]string{"10.0.0.1", "10.0.0.2"}),
+		WithLogger(logr.Discard()),
+	).(*networkPolicy)
+
+	ctx := context.Background()
+	ref, err := n.getOwnerReference(ctx)
+	require.NoError(t, err)
+
+	err = n.createOrUpdateNetworkPolicy(ctx, ref)
+	require.NoError(t, err)
+
+	np1, err := clientset.NetworkingV1().NetworkPolicies(namespace).Get(ctx, networkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err)
+	rv1 := np1.ResourceVersion
+
+	n.handleEndpointSliceEvent(ctx, ref)
+
+	np2, err := clientset.NetworkingV1().NetworkPolicies(namespace).Get(ctx, networkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, rv1, np2.ResourceVersion, "NetworkPolicy should not have been updated when IPs haven't changed")
+}
+
+func TestStart_CreatesAndWatches(t *testing.T) {
+	const namespace = "test-ns"
+
+	httpsPort := int32(6443)
+	portName := "https"
+	endpointSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubernetes",
+			Namespace: "default",
+			Labels: map[string]string{
+				"kubernetes.io/service-name": "kubernetes",
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Name: &portName,
+				Port: &httpsPort,
+			},
+		},
+		Endpoints: []discoveryv1.Endpoint{
+			{Addresses: []string{"10.0.0.1"}},
+		},
+	}
+
+	clientset := fake.NewClientset(append(operatorObjects(namespace), endpointSlice)...)
+
+	n := NewOperatorNetworkPolicy(clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
+		WithAPIServerPort(6443),
+		WithAPIServerIPs([]string{"10.0.0.1"}),
+		WithLogger(logr.Discard()),
+	).(*networkPolicy)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- n.Start(ctx)
+	}()
+
+	// Give the informer time to start
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify the NetworkPolicy was created
+	np, err := clientset.NetworkingV1().NetworkPolicies(namespace).Get(ctx, networkPolicyName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, networkPolicyName, np.Name)
+
+	cancel()
+
+	err = <-startDone
+	assert.NoError(t, err)
+}
+
+func TestWithLogger(t *testing.T) {
+	n := &networkPolicy{}
+	logger := logr.Discard()
+	WithLogger(logger)(n)
+	assert.Equal(t, logger, n.logger)
 }


### PR DESCRIPTION
## Description

Fixes #5558
Fixes https://github.com/open-telemetry/opentelemetry-operator/issues/5551 

The operator `NetworkPolicy` (created when the `operator.networkpolicy` feature gate is enabled) was built once at startup with hardcoded API server IPs and never updated. When control plane nodes are replaced and their IPs change, the policy becomes stale — the operator pod can no longer reach the API server and enters `CrashLoopBackOff`.

This PR adds an EndpointSlice informer inside the existing `manager.Runnable` so that the `NetworkPolicy` is automatically reconciled whenever the `kubernetes` service endpoints change.

## Changes

### `internal/operatornetworkpolicy/operatornetworkpolicy.go`

- **`buildNetworkPolicy()`** — Extracted the NetworkPolicy spec-building logic into a reusable helper method.
- **`createOrUpdateNetworkPolicy()`** — Replaces the one-shot `Create` + silent `AlreadyExists` ignore. Now does `Create`, and if the policy already exists, does `Get` + `Update` to overwrite stale entries.
- **`watchEndpointSlices()`** — Sets up a `SharedInformerFactory` watching EndpointSlices in the `default` namespace filtered by label `kubernetes.io/service-name=kubernetes`.
- **`handleEndpointSliceEvent()`** — On any Add/Update/Delete event, re-discovers API server IPs via `discoverAPIServerIPs()`, compares with the current set using order-independent comparison, and updates the NetworkPolicy only if IPs have actually changed.
- **`ipsEqual()`** — Order-independent IP slice comparison to avoid spurious updates.
- **`WithLogger()` option** — Adds structured logging for IP change events and errors.
- **Refactored `Start()`** — Now: get owner ref → create/update policy → start EndpointSlice watcher (blocks until `ctx.Done()`).

### `internal/controllers/opentelemetrycollector_controller.go`

- Added `watch` verb to the EndpointSlice RBAC marker (`get;list` → `get;list;watch`), required for the informer.

### `cmd/operator/operator.go`

- Passes a named logger (`operator-networkpolicy`) via the new `WithLogger` option.

## Testing

All 13 tests pass, covering:

| Test | What it verifies |
|------|-----------------|
| `TestBuild_IPBlockPeersOnly` | Build with IP-only egress peers |
| `TestBuild_SelectorPeersOnly` | Build with pod/namespace selector peers |
| `TestBuild_CombinedIPBlockAndSelectors` | Build with both IP and selector peers |
| `TestBuild_WithIngressPorts` | Build with webhook + metrics ingress ports |
| `TestBuild_FullOpenShiftConfig` | Full OpenShift config (IPs + selectors + ports) |
| `TestNeedLeaderElection` | Leader election requirement |
| `TestCreateOrUpdate_CreatesWhenNotExist` | Create path for new NetworkPolicy |
| `TestCreateOrUpdate_UpdatesExistingPolicy` | Update path overwrites stale IPs (`10.0.0.99` → `10.0.0.1, 10.0.0.2`) |
| `TestIpsEqual` | 6 sub-tests: same order, different order, different IPs, different lengths, both empty, one empty |
| `TestHandleEndpointSliceEvent_UpdatesOnIPChange` | Full reconciliation flow: old IPs → new IPs from EndpointSlice |
| `TestHandleEndpointSliceEvent_NoUpdateWhenIPsSame` | No spurious update (ResourceVersion unchanged) |
| `TestStart_CreatesAndWatches` | Integration: Start creates policy and runs informer |
| `TestWithLogger` | Logger option wiring |

## Design Decisions

- **Informer over polling**: Event-driven via client-go informer — instant, efficient, and idiomatic Kubernetes.
- **Kept as a Runnable**: The operator network policy is fundamentally different from operand policies (not CR-driven). Converting to a full controller-runtime reconciler would be over-engineering for this use case.
- **Order-independent IP comparison**: Sorted before comparing to avoid false positives from EndpointSlice ordering differences.

## How to test manually

1. Enable the feature gate: `--feature-gates=+operator.networkpolicy`
2. Deploy the operator and verify the `opentelemetry-operator` NetworkPolicy exists with correct API server IPs
3. Simulate a control plane IP change (e.g. scale/replace a control plane node)
4. Verify the NetworkPolicy is automatically updated with the new IPs (check `kubectl get networkpolicy opentelemetry-operator -o yaml`)

Made with [Cursor](https://cursor.com)