### PR TITLE
Resolve operator Deployment via pod owner references in NetworkPolicy

### DIFF
--- a/.chloggen/fix_operator-networkpolicy-identity.yaml
+++ b/.chloggen/fix_operator-networkpolicy-identity.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: operator
+note: "Resolve the operator's own Deployment through pod owner references instead of a hardcoded name, so the operator NetworkPolicy no longer crashes the operator or selects no pods when installed with custom names (e.g. via the Helm chart)."
+issues: [5493]
+subtext:

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -335,12 +335,20 @@ func enableOperatorNetworkPolicy(cfg config.Config, clientset kubernetes.Interfa
 		return errors.New("NAMESPACE environment variable is not set, it is required for the Operator Network Policy to work")
 	}
 
+	// The pod hostname defaults to the pod name; it is used to resolve the
+	// operator's own Deployment without assuming its name.
+	operatorPodName, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("failed to determine the operator pod name from the hostname: %w", err)
+	}
+
 	if cfg.Internal.KubeAPIServerPort == 0 || len(cfg.Internal.KubeAPIServerIPs) == 0 {
 		return errors.New("Kubernetes API server info not discovered from EndpointSlice") //nolint:staticcheck // ST1005
 	}
 
 	var policyOpts []operatornetworkpolicy.Option
 	policyOpts = append(policyOpts, operatornetworkpolicy.WithOperatorNamespace(operatorNamespace))
+	policyOpts = append(policyOpts, operatornetworkpolicy.WithOperatorPodName(operatorPodName))
 	policyOpts = append(policyOpts, operatornetworkpolicy.WithAPIServerPort(cfg.Internal.KubeAPIServerPort))
 	policyOpts = append(policyOpts, operatornetworkpolicy.WithAPIServerIPs(cfg.Internal.KubeAPIServerIPs))
 

--- a/internal/operatornetworkpolicy/operatornetworkpolicy.go
+++ b/internal/operatornetworkpolicy/operatornetworkpolicy.go
@@ -5,7 +5,9 @@ package operatornetworkpolicy
 
 import (
 	"context"
+	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,15 +19,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-const (
-	operatorName = "opentelemetry-operator-controller-manager"
-)
-
 type networkPolicy struct {
 	clientset kubernetes.Interface
 	scheme    *runtime.Scheme
 
 	operatorNamespace          string
+	operatorPodName            string
 	apiServerPort              int32
 	apiServerIPs               []string
 	webhookPort                int32
@@ -57,6 +56,15 @@ type Option func(policy *networkPolicy)
 func WithOperatorNamespace(operatorNamespace string) Option {
 	return func(s *networkPolicy) {
 		s.operatorNamespace = operatorNamespace
+	}
+}
+
+// WithOperatorPodName sets the name of the pod the operator runs in. It is
+// used to resolve the operator's own Deployment, whose name depends on how
+// the operator was installed (kustomize, Helm chart, OLM).
+func WithOperatorPodName(podName string) Option {
+	return func(s *networkPolicy) {
+		s.operatorPodName = podName
 	}
 }
 
@@ -103,6 +111,11 @@ func WithAPISererNamespaceLabelSelector(selector *metav1.LabelSelector) Option {
 }
 
 func (n *networkPolicy) Start(ctx context.Context) error {
+	operatorDep, err := n.operatorDeployment(ctx)
+	if err != nil {
+		return err
+	}
+
 	tcp := corev1.ProtocolTCP
 	apiServerPort := intstr.FromInt32(n.apiServerPort)
 
@@ -123,12 +136,8 @@ func (n *networkPolicy) Start(ctx context.Context) error {
 			Namespace: n.operatorNamespace,
 		},
 		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app.kubernetes.io/name": "opentelemetry-operator",
-				},
-			},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{{}},
+			PodSelector: *operatorDep.Spec.Selector,
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
 			Egress: []networkingv1.NetworkPolicyEgressRule{
 				{
 					Ports: []networkingv1.NetworkPolicyPort{
@@ -175,11 +184,6 @@ func (n *networkPolicy) Start(ctx context.Context) error {
 		})
 	}
 
-	operatorDep, err := n.clientset.AppsV1().Deployments(n.operatorNamespace).Get(ctx, operatorName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
 	// set owner reference to the operator deployment
 	err = controllerutil.SetControllerReference(operatorDep, np, n.scheme)
 	if err != nil {
@@ -193,6 +197,38 @@ func (n *networkPolicy) Start(ctx context.Context) error {
 
 	<-ctx.Done()
 	return nil
+}
+
+// operatorDeployment resolves the Deployment the operator runs in by walking
+// the owner references of its own pod. The deployment name cannot be assumed:
+// it depends on the installation method (kustomize, Helm chart with name
+// overrides, OLM).
+func (n *networkPolicy) operatorDeployment(ctx context.Context) (*appsv1.Deployment, error) {
+	pod, err := n.clientset.CoreV1().Pods(n.operatorNamespace).Get(ctx, n.operatorPodName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operator pod %q: %w", n.operatorPodName, err)
+	}
+
+	rsRef := metav1.GetControllerOf(pod)
+	if rsRef == nil || rsRef.Kind != "ReplicaSet" {
+		return nil, fmt.Errorf("operator pod %q is not owned by a ReplicaSet", pod.Name)
+	}
+
+	rs, err := n.clientset.AppsV1().ReplicaSets(n.operatorNamespace).Get(ctx, rsRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operator ReplicaSet %q: %w", rsRef.Name, err)
+	}
+
+	depRef := metav1.GetControllerOf(rs)
+	if depRef == nil || depRef.Kind != "Deployment" {
+		return nil, fmt.Errorf("operator ReplicaSet %q is not owned by a Deployment", rs.Name)
+	}
+
+	dep, err := n.clientset.AppsV1().Deployments(n.operatorNamespace).Get(ctx, depRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operator Deployment %q: %w", depRef.Name, err)
+	}
+	return dep, nil
 }
 
 func (*networkPolicy) NeedLeaderElection() bool {

--- a/internal/operatornetworkpolicy/operatornetworkpolicy_test.go
+++ b/internal/operatornetworkpolicy/operatornetworkpolicy_test.go
@@ -28,10 +28,21 @@ func newTestScheme() *runtime.Scheme {
 	return s
 }
 
-func operatorDeployment(namespace string) *appsv1.Deployment {
-	return &appsv1.Deployment{
+// A Helm-style deployment name proves nothing depends on the kustomize name
+// opentelemetry-operator-controller-manager anymore.
+const (
+	operatorDeploymentName = "my-release-opentelemetry-operator"
+	testReplicaSetName     = operatorDeploymentName + "-6b9f7c"
+	testPodName            = testReplicaSetName + "-x2x9z"
+)
+
+// operatorObjects returns the pod → ReplicaSet → Deployment ownership chain
+// Start() walks to resolve the operator's own deployment.
+func operatorObjects(namespace string) []runtime.Object {
+	trueVal := true
+	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      operatorName,
+			Name:      operatorDeploymentName,
 			Namespace: namespace,
 			UID:       "test-uid",
 		},
@@ -49,6 +60,27 @@ func operatorDeployment(namespace string) *appsv1.Deployment {
 			},
 		},
 	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testReplicaSetName,
+			Namespace: namespace,
+			UID:       "rs-uid",
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "apps/v1", Kind: "Deployment", Name: operatorDeploymentName, UID: "test-uid", Controller: &trueVal},
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: namespace,
+			UID:       "pod-uid",
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: testReplicaSetName, UID: "rs-uid", Controller: &trueVal},
+			},
+		},
+	}
+	return []runtime.Object{dep, rs, pod}
 }
 
 // startAndCapture runs Start() and captures the created NetworkPolicy
@@ -80,7 +112,7 @@ func ownerRef() []metav1.OwnerReference {
 		{
 			APIVersion:         "apps/v1",
 			Kind:               "Deployment",
-			Name:               operatorName,
+			Name:               operatorDeploymentName,
 			UID:                types.UID("test-uid"),
 			Controller:         &trueVal,
 			BlockOwnerDeletion: &trueVal,
@@ -90,10 +122,11 @@ func ownerRef() []metav1.OwnerReference {
 
 func TestStart_IPBlockPeersOnly(t *testing.T) {
 	const namespace = "test-ns"
-	clientset := fake.NewClientset(operatorDeployment(namespace))
+	clientset := fake.NewClientset(operatorObjects(namespace)...)
 
 	np := startAndCapture(t, clientset, newTestScheme(),
 		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
 		WithAPIServerPort(6443),
 		WithAPIServerIPs([]string{"10.0.0.1", "10.0.0.2"}),
 	)
@@ -129,7 +162,7 @@ func TestStart_IPBlockPeersOnly(t *testing.T) {
 
 func TestStart_SelectorPeersOnly(t *testing.T) {
 	const namespace = "test-ns"
-	clientset := fake.NewClientset(operatorDeployment(namespace))
+	clientset := fake.NewClientset(operatorObjects(namespace)...)
 
 	podSelector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{"apiserver": "true"},
@@ -140,6 +173,7 @@ func TestStart_SelectorPeersOnly(t *testing.T) {
 
 	np := startAndCapture(t, clientset, newTestScheme(),
 		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
 		WithAPIServerPort(6443),
 		WithAPISererPodLabelSelector(podSelector),
 		WithAPISererNamespaceLabelSelector(nsSelector),
@@ -178,7 +212,7 @@ func TestStart_SelectorPeersOnly(t *testing.T) {
 
 func TestStart_CombinedIPBlockAndSelectors(t *testing.T) {
 	const namespace = "openshift-opentelemetry-operator"
-	clientset := fake.NewClientset(operatorDeployment(namespace))
+	clientset := fake.NewClientset(operatorObjects(namespace)...)
 
 	podSelector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{"apiserver": "true"},
@@ -189,6 +223,7 @@ func TestStart_CombinedIPBlockAndSelectors(t *testing.T) {
 
 	np := startAndCapture(t, clientset, newTestScheme(),
 		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
 		WithAPIServerPort(6443),
 		WithAPIServerIPs([]string{"10.0.0.1"}),
 		WithAPISererPodLabelSelector(podSelector),
@@ -227,10 +262,11 @@ func TestStart_CombinedIPBlockAndSelectors(t *testing.T) {
 
 func TestStart_WithIngressPorts(t *testing.T) {
 	const namespace = "test-ns"
-	clientset := fake.NewClientset(operatorDeployment(namespace))
+	clientset := fake.NewClientset(operatorObjects(namespace)...)
 
 	np := startAndCapture(t, clientset, newTestScheme(),
 		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
 		WithAPIServerPort(6443),
 		WithAPIServerIPs([]string{"10.0.0.1"}),
 		WithWebhookPort(9443),
@@ -274,7 +310,7 @@ func TestStart_WithIngressPorts(t *testing.T) {
 
 func TestStart_FullOpenShiftConfig(t *testing.T) {
 	const namespace = "openshift-opentelemetry-operator"
-	clientset := fake.NewClientset(operatorDeployment(namespace))
+	clientset := fake.NewClientset(operatorObjects(namespace)...)
 
 	podSelector := &metav1.LabelSelector{
 		MatchLabels: map[string]string{"apiserver": "true"},
@@ -285,6 +321,7 @@ func TestStart_FullOpenShiftConfig(t *testing.T) {
 
 	np := startAndCapture(t, clientset, newTestScheme(),
 		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
 		WithAPIServerPort(6443),
 		WithAPIServerIPs([]string{"10.0.0.1", "10.0.0.2"}),
 		WithAPISererPodLabelSelector(podSelector),
@@ -333,6 +370,53 @@ func TestStart_FullOpenShiftConfig(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, np)
+}
+
+func TestStart_PodSelectorFromDeployment(t *testing.T) {
+	const namespace = "test-ns"
+	customSelector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"app.kubernetes.io/name": "custom-operator",
+			"control-plane":          "controller-manager",
+		},
+	}
+	objects := operatorObjects(namespace)
+	objects[0].(*appsv1.Deployment).Spec.Selector = customSelector
+	clientset := fake.NewClientset(objects...)
+
+	np := startAndCapture(t, clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
+		WithAPIServerPort(6443),
+		WithAPIServerIPs([]string{"10.0.0.1"}),
+	)
+
+	assert.Equal(t, *customSelector, np.Spec.PodSelector)
+}
+
+func TestStart_PodNotFound(t *testing.T) {
+	clientset := fake.NewClientset()
+
+	n := NewOperatorNetworkPolicy(clientset, newTestScheme(),
+		WithOperatorNamespace("test-ns"),
+		WithOperatorPodName("missing-pod"),
+	)
+	err := n.(*networkPolicy).Start(context.Background())
+	require.ErrorContains(t, err, `failed to get operator pod "missing-pod"`)
+}
+
+func TestStart_PodWithoutReplicaSetOwner(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "bare-pod", Namespace: "test-ns"},
+	}
+	clientset := fake.NewClientset(pod)
+
+	n := NewOperatorNetworkPolicy(clientset, newTestScheme(),
+		WithOperatorNamespace("test-ns"),
+		WithOperatorPodName("bare-pod"),
+	)
+	err := n.(*networkPolicy).Start(context.Background())
+	require.ErrorContains(t, err, "not owned by a ReplicaSet")
 }
 
 func TestNeedLeaderElection(t *testing.T) {

--- a/internal/operatornetworkpolicy/operatornetworkpolicy_test.go
+++ b/internal/operatornetworkpolicy/operatornetworkpolicy_test.go
@@ -419,6 +419,46 @@ func TestStart_PodWithoutReplicaSetOwner(t *testing.T) {
 	require.ErrorContains(t, err, "not owned by a ReplicaSet")
 }
 
+func TestStart_ReplicaSetNotFound(t *testing.T) {
+	const namespace = "test-ns"
+	pod := operatorObjects(namespace)[2]
+	clientset := fake.NewClientset(pod)
+
+	n := NewOperatorNetworkPolicy(clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
+	)
+	err := n.(*networkPolicy).Start(context.Background())
+	require.ErrorContains(t, err, "failed to get operator ReplicaSet")
+}
+
+func TestStart_ReplicaSetWithoutDeploymentOwner(t *testing.T) {
+	const namespace = "test-ns"
+	objects := operatorObjects(namespace)
+	objects[1].(*appsv1.ReplicaSet).OwnerReferences = nil
+	clientset := fake.NewClientset(objects[1], objects[2])
+
+	n := NewOperatorNetworkPolicy(clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
+	)
+	err := n.(*networkPolicy).Start(context.Background())
+	require.ErrorContains(t, err, "not owned by a Deployment")
+}
+
+func TestStart_DeploymentNotFound(t *testing.T) {
+	const namespace = "test-ns"
+	objects := operatorObjects(namespace)
+	clientset := fake.NewClientset(objects[1], objects[2])
+
+	n := NewOperatorNetworkPolicy(clientset, newTestScheme(),
+		WithOperatorNamespace(namespace),
+		WithOperatorPodName(testPodName),
+	)
+	err := n.(*networkPolicy).Start(context.Background())
+	require.ErrorContains(t, err, "failed to get operator Deployment")
+}
+
 func TestNeedLeaderElection(t *testing.T) {
 	n := &networkPolicy{}
 	assert.True(t, n.NeedLeaderElection())

--- a/tests/e2e/operator-restart/00-assert-operator-network-policy.yaml
+++ b/tests/e2e/operator-restart/00-assert-operator-network-policy.yaml
@@ -19,6 +19,7 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/name: opentelemetry-operator
+      control-plane: controller-manager
   policyTypes:
     - Ingress
     - Egress


### PR DESCRIPTION
**Description:** The operator NetworkPolicy looked up the operator Deployment by the hardcoded kustomize name and selected pods by hardcoded labels, crashing the operator on Helm installations that name the deployment differently. Walk the pod -> ReplicaSet -> Deployment owner references instead and reuse the Deployment's selector for the policy's podSelector.

**Link to tracking Issue(s):**  #5493 (items 1, 4 and 6)

**Testing:** Rewrote the unit test fixture as a pod -> ReplicaSet -> Deployment chain with a Helm-style deployment name, added tests for selector propagation and lookup failures, and updated the operator-restart e2e assertion to the full selector. `make precommit` passes

**Documentation:**  Changelog entry.
