### PR TITLE
Surface TargetAllocator lookup and build errors on the collector CR

### DIFF
--- a/.chloggen/collector-surface-params-build-errors.yaml
+++ b/.chloggen/collector-surface-params-build-errors.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: collector
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Report a `Ready=False` status condition and a Warning event on the OpenTelemetryCollector when the referenced TargetAllocator cannot be fetched or the collector manifests cannot be built, instead of only logging the error in the operator.
+
+# One or more tracking issues related to the change
+issues: [4296]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/controllers/opentelemetrycollector_controller.go
+++ b/internal/controllers/opentelemetrycollector_controller.go
@@ -300,7 +300,7 @@ func (r *OpenTelemetryCollectorReconciler) Reconcile(ctx context.Context, req ct
 	params, err := r.GetParams(ctx, instance)
 	if err != nil {
 		log.Error(err, "Failed to create manifest.Params")
-		return ctrl.Result{}, err
+		return collectorStatus.HandleReconcileStatus(ctx, log, params, instance, err)
 	}
 
 	// We have a deletion, short circuit and let the deletion happen
@@ -335,7 +335,7 @@ func (r *OpenTelemetryCollectorReconciler) Reconcile(ctx context.Context, req ct
 
 	desiredObjects, buildErr := BuildCollector(params)
 	if buildErr != nil {
-		return ctrl.Result{}, buildErr
+		return collectorStatus.HandleReconcileStatus(ctx, log, params, instance, buildErr)
 	}
 
 	ownedObjects, err := r.findOtelOwnedObjects(ctx, params)

--- a/internal/controllers/opentelemetrycollector_reconciler_test.go
+++ b/internal/controllers/opentelemetrycollector_reconciler_test.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,18 +16,24 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
 
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1alpha1"
 	"github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	"github.com/open-telemetry/opentelemetry-operator/internal/autodetect/rbac"
 	"github.com/open-telemetry/opentelemetry-operator/internal/config"
 	"github.com/open-telemetry/opentelemetry-operator/internal/manifests"
+	"github.com/open-telemetry/opentelemetry-operator/pkg/constants"
 )
 
 var reconcilerTestScheme *runtime.Scheme
@@ -265,6 +272,102 @@ func TestRemoveFinalizer(t *testing.T) {
 				assert.False(t, controllerutil.ContainsFinalizer(instance, collectorFinalizer),
 					"expected finalizer to be removed")
 			}
+		})
+	}
+}
+
+func TestReconcileReportsParamsAndBuildErrors(t *testing.T) {
+	const configYAML = `
+receivers:
+  otlp:
+    protocols:
+      grpc: {}
+exporters:
+  debug: {}
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]
+`
+	testCases := []struct {
+		name       string
+		collector  func() *v1beta1.OpenTelemetryCollector
+		wantErrMsg string
+	}{
+		{
+			name: "target allocator referenced by label does not exist",
+			collector: func() *v1beta1.OpenTelemetryCollector {
+				return &v1beta1.OpenTelemetryCollector{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-collector",
+						Namespace: "default",
+						Labels:    map[string]string{constants.LabelTargetAllocator: "missing-ta"},
+					},
+				}
+			},
+			wantErrMsg: `"missing-ta" not found`,
+		},
+		{
+			name: "target allocator enabled without prometheus receiver",
+			collector: func() *v1beta1.OpenTelemetryCollector {
+				var cfg v1beta1.Config
+				require.NoError(t, yaml.Unmarshal([]byte(configYAML), &cfg))
+				return &v1beta1.OpenTelemetryCollector{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-collector",
+						Namespace: "default",
+					},
+					Spec: v1beta1.OpenTelemetryCollectorSpec{
+						Mode:            v1beta1.ModeStatefulSet,
+						TargetAllocator: v1beta1.TargetAllocatorEmbedded{Enabled: true},
+						Config:          cfg,
+					},
+				}
+			},
+			wantErrMsg: "no prometheus available as part of the configuration",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			instance := tc.collector()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(reconcilerTestScheme).
+				WithObjects(instance).
+				WithStatusSubresource(instance).
+				Build()
+			recorder := events.NewFakeRecorder(10)
+			reconciler := NewReconciler(Params{
+				Client:   fakeClient,
+				Recorder: recorder,
+				Scheme:   reconcilerTestScheme,
+				Log:      logr.Discard(),
+				Config: config.Config{
+					CollectorConfigMapEntry:       "collector.yaml",
+					TargetAllocatorConfigMapEntry: "targetallocator.yaml",
+				},
+			})
+			nsn := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
+
+			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: nsn})
+			require.ErrorContains(t, err, tc.wantErrMsg)
+
+			select {
+			case event := <-recorder.Events:
+				assert.Contains(t, event, corev1.EventTypeWarning)
+				assert.Contains(t, event, tc.wantErrMsg)
+			default:
+				t.Errorf("expected a %s event containing %q, got none", corev1.EventTypeWarning, tc.wantErrMsg)
+			}
+
+			updated := &v1beta1.OpenTelemetryCollector{}
+			require.NoError(t, fakeClient.Get(context.Background(), nsn, updated))
+			ready := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+			require.NotNil(t, ready, "expected a Ready condition on the collector status")
+			assert.Equal(t, metav1.ConditionFalse, ready.Status)
+			assert.Equal(t, "ReconcileError", ready.Reason)
+			assert.True(t, strings.Contains(ready.Message, tc.wantErrMsg), "condition message %q should contain %q", ready.Message, tc.wantErrMsg)
 		})
 	}
 }

--- a/internal/controllers/opentelemetrycollector_reconciler_test.go
+++ b/internal/controllers/opentelemetrycollector_reconciler_test.go
@@ -350,7 +350,7 @@ service:
 			})
 			nsn := types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}
 
-			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: nsn})
+			_, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: nsn})
 			require.ErrorContains(t, err, tc.wantErrMsg)
 
 			select {
@@ -362,7 +362,7 @@ service:
 			}
 
 			updated := &v1beta1.OpenTelemetryCollector{}
-			require.NoError(t, fakeClient.Get(context.Background(), nsn, updated))
+			require.NoError(t, fakeClient.Get(t.Context(), nsn, updated))
 			ready := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
 			require.NotNil(t, ready, "expected a Ready condition on the collector status")
 			assert.Equal(t, metav1.ConditionFalse, ready.Status)

--- a/tests/e2e-targetallocator-cr/targetallocator-missing/00-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-missing/00-assert.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: ta-missing
+status:
+  conditions:
+  - type: Ready
+    status: "False"
+    reason: ReconcileError
+    (contains(message, 'not found')): true

--- a/tests/e2e-targetallocator-cr/targetallocator-missing/00-error.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-missing/00-error.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ta-missing-collector

--- a/tests/e2e-targetallocator-cr/targetallocator-missing/00-install.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-missing/00-install.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: ta-missing
+  labels:
+    opentelemetry.io/target-allocator: ta-missing
+spec:
+  mode: statefulset
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: 'otel-collector'
+              scrape_interval: 10s
+              static_configs:
+                - targets: [ '0.0.0.0:8888' ]
+    exporters:
+      debug: {}
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          exporters: [debug]

--- a/tests/e2e-targetallocator-cr/targetallocator-missing/01-assert.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-missing/01-assert.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: ta-missing
+status:
+  conditions:
+  - type: Ready
+    status: "True"
+    reason: Reconciled
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: ta-missing-collector
+data:
+  collector.yaml:
+    ( contains(@, 'ta-missing-targetallocator') ): true
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ta-missing-collector

--- a/tests/e2e-targetallocator-cr/targetallocator-missing/01-install.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-missing/01-install.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: opentelemetry.io/v1alpha1
+kind: TargetAllocator
+metadata:
+  name: ta-missing
+spec:
+  filterStrategy: none

--- a/tests/e2e-targetallocator-cr/targetallocator-missing/chainsaw-test.yaml
+++ b/tests/e2e-targetallocator-cr/targetallocator-missing/chainsaw-test.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: targetallocator-missing
+spec:
+  steps:
+  - name: step-00
+    description: A collector labelled with a TargetAllocator that does not exist reports Ready=False on its status and gets no workload.
+    try:
+    - apply:
+        file: 00-install.yaml
+    - assert:
+        file: 00-assert.yaml
+    - error:
+        file: 00-error.yaml
+    catch:
+    - podLogs:
+        selector: app.kubernetes.io/name=opentelemetry-operator
+  - name: step-01
+    description: Creating the referenced TargetAllocator lets the collector reconcile and become Ready.
+    try:
+    - apply:
+        file: 01-install.yaml
+    - assert:
+        file: 01-assert.yaml
+    catch:
+    - podLogs:
+        selector: app.kubernetes.io/name=opentelemetry-operator


### PR DESCRIPTION
**Description:** Fixing a bug - when the `OpenTelemetryCollector` reconciler fails while resolving the referenced `TargetAllocator` or while building the collector manifests, the error is now written to the CR's `Ready` status condition and emitted as a Warning event instead of only appearing in the operator log.

## Problem

An `OpenTelemetryCollector` labelled `opentelemetry.io/target-allocator=<name>` where that `TargetAllocator` does not exist never gets its StatefulSet/DaemonSet/Deployment, but `kubectl describe` shows `Events: <none>` and no status condition. The only trace of the failure is a `Reconciler error` line in the operator log, which most users cannot see. The same happens when `spec.targetAllocator.enabled: true` is set but the config has no `prometheus` receiver, so the collector manifests cannot be built.

## Root cause

`internal/controllers/opentelemetrycollector_controller.go`:

- `getTargetAllocator()` (line 229) returns the `NotFound` error from `r.Get`, which `GetParams()` propagates.
- `Reconcile()` returns `ctrl.Result{}, err` directly after `GetParams` (line 303) and after `BuildCollector` (line 338).
- Both returns happen before `collectorStatus.HandleReconcileStatus` (line 347), which is the only place that sets the `Ready` condition and records the Warning event, so neither the status nor the event recorder is touched on these paths.

## Fix

Route both early error returns through `collectorStatus.HandleReconcileStatus(ctx, log, params, instance, err)`. That helper already patches `status.conditions` with `Ready=False`, reason `ReconcileError`, and the error message, records a `Warning` event on the CR, and returns the original error so controller-runtime still requeues with backoff. The `params` value returned by `GetParams` on error already carries the client and recorder, so no additional plumbing is needed. No behaviour change on the success path.

A `.chloggen` entry is included.

## How tested

Added `TestReconcileReportsParamsAndBuildErrors` in `internal/controllers/opentelemetrycollector_reconciler_test.go`. It uses a fake controller-runtime client and `events.NewFakeRecorder`, reconciles (a) a collector labelled with a non-existent TargetAllocator and (b) a collector with the embedded target allocator enabled and no `prometheus` receiver, and asserts that an error is returned, a Warning event containing the error is recorded, and a `Ready=False` / `ReconcileError` condition is set on the CR.

Before the fix (`go test ./internal/controllers/ -run TestReconcileReportsParamsAndBuildErrors`):

```
--- FAIL: TestReconcileReportsParamsAndBuildErrors (0.08s)
    --- FAIL: TestReconcileReportsParamsAndBuildErrors/target_allocator_referenced_by_label_does_not_exist (0.08s)
        opentelemetrycollector_reconciler_test.go:361: expected a Warning event containing "\"missing-ta\" not found", got none
        opentelemetrycollector_reconciler_test.go:367: Expected value not to be nil.
            Messages:   expected a Ready condition on the collector status
    --- FAIL: TestReconcileReportsParamsAndBuildErrors/target_allocator_enabled_without_prometheus_receiver (0.00s)
        opentelemetrycollector_reconciler_test.go:361: expected a Warning event containing "no prometheus available as part of the configuration", got none
        opentelemetrycollector_reconciler_test.go:367: Expected value not to be nil.
            Messages:   expected a Ready condition on the collector status
FAIL
```

After the fix:

```
--- PASS: TestReconcileReportsParamsAndBuildErrors (0.07s)
    --- PASS: TestReconcileReportsParamsAndBuildErrors/target_allocator_referenced_by_label_does_not_exist (0.07s)
    --- PASS: TestReconcileReportsParamsAndBuildErrors/target_allocator_enabled_without_prometheus_receiver (0.00s)
ok  	github.com/open-telemetry/opentelemetry-operator/internal/controllers	4.312s
```

Also ran `go test ./internal/controllers/... ./internal/status/...` (all pass, including the envtest-based suite), `go build ./...`, `go vet`, `golangci-lint run ./internal/controllers/...` (0 issues) and `chloggen validate`.

**Link to tracking Issue(s):**

- Resolves: #4296

Horiodino self-assigned #4296 in June; if there is work in progress on that side I am happy to close this in favour of it or rebase onto it.

**Testing:** New unit test described above, plus a chainsaw e2e test in `tests/e2e-targetallocator-cr/targetallocator-missing` (collector referencing a missing TargetAllocator reports `Ready=False`/`ReconcileError` and gets no StatefulSet; creating the TargetAllocator makes it `Ready=True`). Existing controller and status test suites pass.

**Documentation:** None needed; behaviour is surfaced through the existing `Ready` condition and Kubernetes events. Changelog entry added under `.chloggen/`.

## Links

- https://github.com/open-telemetry/opentelemetry-operator/issues/4296

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.


