### PR TITLE
chore: Add `+listType=atomic` to slice fields missing it

### DIFF
--- a/.chloggen/add-listtype-atomic-markers.yaml
+++ b/.chloggen/add-listtype-atomic-markers.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: api
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Add `+listType=atomic` markers to slice field that were missing it, matches fields in the same structs."
+note: "Explicitly declare `+listType` on slice fields across the CRDs that were missing it, for consistency with sibling fields in the same structs."
 
 # One or more tracking issues related to the change
 issues: []
@@ -13,4 +13,5 @@ issues: []
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: "This fields had no merge key, declaring them ensures correct server-side apply and strategic-merge-patch semantics (replace-whole-list)."
+subtext: |
+  For CRDs, an unset list type already defaults to atomic under server-side apply, and strategic merge patch does not apply to custom resources, so the `atomic` additions have no functional effect on merge behavior they only make the existing implicit behavior explicit.

--- a/.chloggen/add-listtype-atomic-markers.yaml
+++ b/.chloggen/add-listtype-atomic-markers.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. collector, target allocator, auto-instrumentation, opamp, github action)
+component: api
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `+listType=atomic` markers to slice field that were missing it, matches fields in the same structs."
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "This fields had no merge key, declaring them ensures correct server-side apply and strategic-merge-patch semantics (replace-whole-list)."

--- a/apis/v1alpha1/instrumentation_types.go
+++ b/apis/v1alpha1/instrumentation_types.go
@@ -23,6 +23,7 @@ type InstrumentationSpec struct {
 	// Values in this list will be set in the OTEL_PROPAGATORS env var.
 	// Enum=tracecontext;baggage;b3;b3multi;jaeger;xray;ottrace;none
 	// +optional
+	// +listType=atomic
 	Propagators []Propagator `json:"propagators,omitempty"`
 
 	// Sampler defines sampling configuration.
@@ -36,6 +37,7 @@ type InstrumentationSpec struct {
 	// the precedence order is: `original container env vars` > `language specific env vars` > `common env vars` > `instrument spec configs' vars`.
 	// If the former var had been defined, then the other vars would be ignored.
 	// +optional
+	// +listType=atomic
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// Java defines configuration for java auto-instrumentation.
@@ -181,6 +183,7 @@ type Java struct {
 	// the precedence order is: `original container env vars` > `language specific env vars` > `common env vars` > `instrument spec configs' vars`.
 	// If the former var had been defined, then the other vars would be ignored.
 	// +optional
+	// +listType=atomic
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// Resources describes the compute resource requirements.
@@ -190,6 +193,7 @@ type Java struct {
 	// Extensions defines java specific extensions.
 	// All extensions are copied to a single directory; if a JAR with the same name exists, it will be overwritten.
 	// +optional
+	// +listType=atomic
 	Extensions []Extensions `json:"extensions,omitempty"`
 }
 
@@ -221,6 +225,7 @@ type NodeJS struct {
 	// the precedence order is: `original container env vars` > `language specific env vars` > `common env vars` > `instrument spec configs' vars`.
 	// If the former var had been defined, then the other vars would be ignored.
 	// +optional
+	// +listType=atomic
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// Resources describes the compute resource requirements.
@@ -248,6 +253,7 @@ type Python struct {
 	// the precedence order is: `original container env vars` > `language specific env vars` > `common env vars` > `instrument spec configs' vars`.
 	// If the former var had been defined, then the other vars would be ignored.
 	// +optional
+	// +listType=atomic
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// Resources describes the compute resource requirements.
@@ -275,6 +281,7 @@ type DotNet struct {
 	// the precedence order is: `original container env vars` > `language specific env vars` > `common env vars` > `instrument spec configs' vars`.
 	// If the former var had been defined, then the other vars would be ignored.
 	// +optional
+	// +listType=atomic
 	Env []corev1.EnvVar `json:"env,omitempty"`
 	// Resources describes the compute resource requirements.
 	// +optional
@@ -300,6 +307,7 @@ type Go struct {
 	// the precedence order is: `original container env vars` > `language specific env vars` > `common env vars` > `instrument spec configs' vars`.
 	// If the former var had been defined, then the other vars would be ignored.
 	// +optional
+	// +listType=atomic
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// Resources describes the compute resource requirements.
@@ -334,12 +342,14 @@ type ApacheHttpd struct {
 	// the precedence order is: `original container env vars` > `language specific env vars` > `common env vars` > `instrument spec configs' vars`.
 	// If the former var had been defined, then the other vars would be ignored.
 	// +optional
+	// +listType=atomic
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// Attrs defines Apache HTTPD agent specific attributes. The precedence is:
 	// `agent default attributes` > `instrument spec attributes` .
 	// Attributes are documented at https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module
 	// +optional
+	// +listType=atomic
 	Attrs []corev1.EnvVar `json:"attrs,omitempty"`
 
 	// Apache HTTPD server version. One of 2.4 or 2.2. Default is 2.4
@@ -378,12 +388,14 @@ type Nginx struct {
 	// the precedence order is: `original container env vars` > `language specific env vars` > `common env vars` > `instrument spec configs' vars`.
 	// If the former var had been defined, then the other vars would be ignored.
 	// +optional
+	// +listType=atomic
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// Attrs defines Nginx agent specific attributes. The precedence order is:
 	// `agent default attributes` > `instrument spec attributes` .
 	// Attributes are documented at https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module
 	// +optional
+	// +listType=atomic
 	Attrs []corev1.EnvVar `json:"attrs,omitempty"`
 
 	// Location of Nginx configuration file.

--- a/apis/v1alpha1/opampbridge_types.go
+++ b/apis/v1alpha1/opampbridge_types.go
@@ -75,9 +75,11 @@ type OpAMPBridgeSpec struct {
 	Ports []v1.ServicePort `json:"ports,omitempty"`
 	// ENV vars to set on the OpAMPBridge Pods.
 	// +optional
+	// +listType=atomic
 	Env []v1.EnvVar `json:"env,omitempty"`
 	// List of sources to populate environment variables on the OpAMPBridge Pods.
 	// +optional
+	// +listType=atomic
 	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
 	// Toleration to schedule OpAMPBridge pods.
 	// +optional
@@ -110,6 +112,7 @@ type OpAMPBridgeSpec struct {
 	// IPFamily represents the IP Family (IPv4 or IPv6). This type is used
 	// to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
 	// +optional
+	// +listType=atomic
 	IpFamilies []v1.IPFamily `json:"ipFamilies,omitempty"`
 	// IPFamilyPolicy represents the dual-stack-ness requested or required by a Service
 	IpFamilyPolicy *v1.IPFamilyPolicy `json:"ipFamilyPolicy,omitempty"`

--- a/apis/v1alpha1/opampbridge_types.go
+++ b/apis/v1alpha1/opampbridge_types.go
@@ -81,6 +81,7 @@ type OpAMPBridgeSpec struct {
 	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
 	// Toleration to schedule OpAMPBridge pods.
 	// +optional
+	// +listType=atomic
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// Volumes represents which volumes to use in the underlying OpAMPBridge deployment(s).
 	// +optional
@@ -102,6 +103,7 @@ type OpAMPBridgeSpec struct {
 	// such as regions, zones, nodes, and other user-defined topology domains
 	// https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 	// +optional
+	// +listType=atomic
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	// PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.
 	PodDNSConfig v1.PodDNSConfig `json:"podDnsConfig,omitempty"`

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -196,6 +196,7 @@ type OpenTelemetryCollectorSpec struct {
 	// Toleration to schedule OpenTelemetry Collector pods.
 	// This is only relevant to daemonset, statefulset, and deployment mode
 	// +optional
+	// +listType=atomic
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// Volumes represents which volumes to use in the underlying collector deployment(s).
 	// +optional
@@ -277,6 +278,7 @@ type OpenTelemetryCollectorSpec struct {
 	// https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 	// This is only relevant to statefulset, and deployment mode
 	// +optional
+	// +listType=atomic
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 
 	// ConfigMaps is a list of ConfigMaps in the same namespace as the OpenTelemetryCollector
@@ -361,10 +363,12 @@ type OpenTelemetryTargetAllocator struct {
 	// such as regions, zones, nodes, and other user-defined topology domains
 	// https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 	// +optional
+	// +listType=atomic
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	// Toleration embedded kubernetes pod configuration option,
 	// controls how pods can be scheduled with matching taints
 	// +optional
+	// +listType=atomic
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// ENV vars to set on the OpenTelemetry TargetAllocator's Pods. These can then in certain cases be
 	// consumed in the config file for the TargetAllocator.

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -61,6 +61,7 @@ type Ingress struct {
 
 	// TLS configuration.
 	// +optional
+	// +listType=atomic
 	TLS []networkingv1.IngressTLS `json:"tls,omitempty"`
 
 	// IngressClassName is the name of an IngressClass cluster resource. Ingress
@@ -184,10 +185,12 @@ type OpenTelemetryCollectorSpec struct {
 	// ENV vars to set on the OpenTelemetry Collector's Pods. These can then in certain cases be
 	// consumed in the config file for the Collector.
 	// +optional
+	// +listType=atomic
 	Env []v1.EnvVar `json:"env,omitempty"`
 	// List of sources to populate environment variables on the OpenTelemetry Collector's Pods.
 	// These can then in certain cases be consumed in the config file for the Collector.
 	// +optional
+	// +listType=atomic
 	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
 	// VolumeClaimTemplates will provide stable storage using PersistentVolumes. Only available when the mode=statefulset.
 	// +optional
@@ -237,6 +240,7 @@ type OpenTelemetryCollectorSpec struct {
 	// an initContainer will lead to a restart of the Pod. More info:
 	// https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 	// +optional
+	// +listType=atomic
 	InitContainers []v1.Container `json:"initContainers,omitempty"`
 
 	// ServiceName is the name of the Service to be used.
@@ -263,6 +267,7 @@ type OpenTelemetryCollectorSpec struct {
 	// doing so, you wil accept the risk of it breaking things.
 	//
 	// +optional
+	// +listType=atomic
 	AdditionalContainers []v1.Container `json:"additionalContainers,omitempty"`
 
 	// ObservabilitySpec defines how telemetry data gets handled.
@@ -284,6 +289,7 @@ type OpenTelemetryCollectorSpec struct {
 	// ConfigMaps is a list of ConfigMaps in the same namespace as the OpenTelemetryCollector
 	// object, which shall be mounted into the Collector Pods.
 	// Each ConfigMap will be added to the Collector's Deployments as a volume named `configmap-<configmap-name>`.
+	// +listType=atomic
 	ConfigMaps []ConfigMapsSpec `json:"configmaps,omitempty"`
 	// UpdateStrategy represents the strategy the operator will take replacing existing DaemonSet pods with new pods
 	// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec
@@ -373,6 +379,7 @@ type OpenTelemetryTargetAllocator struct {
 	// ENV vars to set on the OpenTelemetry TargetAllocator's Pods. These can then in certain cases be
 	// consumed in the config file for the TargetAllocator.
 	// +optional
+	// +listType=atomic
 	Env []v1.EnvVar `json:"env,omitempty"`
 	// ObservabilitySpec defines how telemetry data gets handled.
 	//
@@ -523,6 +530,7 @@ type AutoscalerSpec struct {
 	// currently the only supported custom metrics is type=Pod.
 	// Use TargetCPUUtilization or TargetMemoryUtilization instead if scaling on these common resource metrics.
 	// +optional
+	// +listType=atomic
 	Metrics []MetricSpec `json:"metrics,omitempty"`
 	// TargetCPUUtilization sets the target average CPU used across all replicas.
 	// If average CPU exceeds this value, the HPA will scale up. Defaults to 90 percent.

--- a/apis/v1beta1/common.go
+++ b/apis/v1beta1/common.go
@@ -49,6 +49,7 @@ type AutoscalerSpec struct {
 	// currently the only supported custom metrics is type=Pod.
 	// Use TargetCPUUtilization or TargetMemoryUtilization instead if scaling on these common resource metrics.
 	// +optional
+	// +listType=atomic
 	Metrics []MetricSpec `json:"metrics,omitempty"`
 	// TargetCPUUtilization sets the target average CPU used across all replicas.
 	// If average CPU exceeds this value, the HPA will scale up. Defaults to 90 percent.
@@ -166,13 +167,16 @@ type OpenTelemetryCommonFields struct {
 	Ports []PortsSpec `json:"ports,omitempty"`
 	// Environment variables to set on the generated pods.
 	// +optional
+	// +listType=atomic
 	Env []v1.EnvVar `json:"env,omitempty"`
 	// List of sources to populate environment variables on the generated pods.
 	// +optional
+	// +listType=atomic
 	EnvFrom []v1.EnvFromSource `json:"envFrom,omitempty"`
 	// Toleration to schedule the generated pods.
 	// This only works with the following OpenTelemetryCollector mode's: daemonset, statefulset, and deployment.
 	// +optional
+	// +listType=atomic
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// Volumes represents which volumes to use in the underlying deployment(s).
 	// +optional
@@ -193,6 +197,7 @@ type OpenTelemetryCommonFields struct {
 	// https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 	// This only works with the following OpenTelemetryCollector mode's: statefulset, and deployment.
 	// +optional
+	// +listType=atomic
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	// HostNetwork indicates if the pod should run in the host networking namespace.
 	// +optional
@@ -217,6 +222,7 @@ type OpenTelemetryCommonFields struct {
 	// an initContainer will lead to a restart of the Pod. More info:
 	// https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 	// +optional
+	// +listType=atomic
 	InitContainers []v1.Container `json:"initContainers,omitempty"`
 	// AdditionalContainers allows injecting additional containers into the generated pod definition.
 	// These sidecar containers can be used for authentication proxies, log shipping sidecars, agents for shipping
@@ -230,12 +236,14 @@ type OpenTelemetryCommonFields struct {
 	// doing so, you wil accept the risk of it breaking things.
 	//
 	// +optional
+	// +listType=atomic
 	AdditionalContainers []v1.Container `json:"additionalContainers,omitempty"`
 	// PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.
 	PodDNSConfig v1.PodDNSConfig `json:"podDnsConfig,omitempty"`
 	// IPFamily represents the IP Family (IPv4 or IPv6). This type is used
 	// to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
 	// +optional
+	// +listType=atomic
 	IpFamilies []v1.IPFamily `json:"ipFamilies,omitempty"`
 	// IPFamilyPolicy represents the dual-stack-ness requested or required by a Service
 	// +kubebuilder:default:=SingleStack

--- a/apis/v1beta1/config.go
+++ b/apis/v1beta1/config.go
@@ -95,9 +95,12 @@ func (c *AnyConfig) MarshalJSON() ([]byte, error) {
 
 // Pipeline is a struct of component type to a list of component IDs.
 type Pipeline struct {
-	Exporters  []string `json:"exporters" yaml:"exporters"`
+	// +listType=atomic
+	Exporters []string `json:"exporters" yaml:"exporters"`
+	// +listType=atomic
 	Processors []string `json:"processors,omitempty" yaml:"processors,omitempty"`
-	Receivers  []string `json:"receivers" yaml:"receivers"`
+	// +listType=atomic
+	Receivers []string `json:"receivers" yaml:"receivers"`
 }
 
 // Config encapsulates collector config.
@@ -126,6 +129,7 @@ func (c *Config) Yaml() (string, error) {
 }
 
 type Service struct {
+	// +listType=atomic
 	Extensions []string `json:"extensions,omitempty" yaml:"extensions,omitempty"`
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Telemetry *AnyConfig `json:"telemetry,omitempty" yaml:"telemetry,omitempty"`

--- a/apis/v1beta1/httpRoute.go
+++ b/apis/v1beta1/httpRoute.go
@@ -18,5 +18,6 @@ type HttpRouteConfig struct {
 	// Hostnames specifies the hostnames for the HTTP route.
 	// Multiple hostnames can be specified to match requests with any of the given hostnames.
 	// If empty, the route matches requests with any hostname.
+	// +listType=atomic
 	Hostnames []string `json:"hostnames,omitempty" yaml:"hostnames,omitempty"`
 }

--- a/apis/v1beta1/ingress.go
+++ b/apis/v1beta1/ingress.go
@@ -85,6 +85,7 @@ type Ingress struct {
 
 	// TLS configuration.
 	// +optional
+	// +listType=atomic
 	TLS []networkingv1.IngressTLS `json:"tls,omitempty"`
 
 	// IngressClassName is the name of an IngressClass cluster resource. Ingress

--- a/apis/v1beta1/instrumentation_types.go
+++ b/apis/v1beta1/instrumentation_types.go
@@ -23,6 +23,7 @@ type InstrumentationSpec struct {
 	// Env defines common env vars injected into all instrumented containers.
 	// Precedence: original pod env > spec.<language>.env > spec.env > operator-generated env.
 	// +optional
+	// +listType=atomic
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// Java defines configuration for Java auto-instrumentation.
@@ -70,6 +71,7 @@ type EnvConfig struct {
 
 	// Propagators defines inter-process context propagation configuration.
 	// +optional
+	// +listType=atomic
 	Propagators []Propagator `json:"propagators,omitempty"`
 
 	// Sampler defines sampling configuration.
@@ -78,6 +80,7 @@ type EnvConfig struct {
 
 	// Env defines common env vars to typically configure OpenTelemetry SDK or instrumentation.
 	// +optional
+	// +listType=atomic
 	Env []corev1.EnvVar `json:"env,omitempty"`
 }
 
@@ -192,6 +195,7 @@ type CommonLanguageSpec struct {
 	// Env defines language-specific env vars injected into containers instrumented with this language.
 	// Precedence: original pod env > spec.<language>.env > spec.env > operator-generated env.
 	// +optional
+	// +listType=atomic
 	Env []corev1.EnvVar `json:"env,omitempty"`
 
 	// Resources describes the compute resource requirements.
@@ -206,6 +210,7 @@ type Java struct {
 	// Extensions defines java specific extensions.
 	// All extensions are copied to a single directory; if a JAR with the same name exists, it will be overwritten.
 	// +optional
+	// +listType=atomic
 	Extensions []Extensions `json:"extensions,omitempty"`
 }
 

--- a/apis/v1beta1/opentelemetrycollector_types.go
+++ b/apis/v1beta1/opentelemetrycollector_types.go
@@ -215,10 +215,12 @@ type TargetAllocatorEmbedded struct {
 	// such as regions, zones, nodes, and other user-defined topology domains
 	// https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 	// +optional
+	// +listType=atomic
 	TopologySpreadConstraints []v1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 	// Toleration embedded kubernetes pod configuration option,
 	// controls how pods can be scheduled with matching taints
 	// +optional
+	// +listType=atomic
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// ENV vars to set on the OpenTelemetry TargetAllocator's Pods. These can then in certain cases be
 	// consumed in the config file for the TargetAllocator.
@@ -440,6 +442,7 @@ type TelemetryConfig struct {
 type MetricsConfig struct {
 	// Readers configures one or more metric readers following the OTel declarative configuration spec.
 	// +optional
+	// +listType=atomic
 	Readers []MetricReader `json:"readers,omitempty"`
 }
 
@@ -480,6 +483,7 @@ type OTLPCommonConfig struct {
 	Endpoint string `json:"endpoint"`
 	// Headers are additional key/value pairs sent with every export request.
 	// +optional
+	// +listType=atomic
 	Headers []NameValuePair `json:"headers,omitempty"`
 	// TemporalityPreference sets aggregation temporality: "cumulative" (default), "delta", or "low_memory".
 	// +optional

--- a/apis/v1beta1/opentelemetrycollector_types.go
+++ b/apis/v1beta1/opentelemetrycollector_types.go
@@ -64,6 +64,8 @@ type OpenTelemetryCollectorStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// Conditions represents the latest available observations of the OpenTelemetryCollector's current state.
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
@@ -138,6 +140,7 @@ type OpenTelemetryCollectorSpec struct {
 	// ConfigMaps is a list of ConfigMaps in the same namespace as the OpenTelemetryCollector
 	// object, which shall be mounted into the Collector Pods.
 	// Each ConfigMap will be added to the Collector's Deployments as a volume named `configmap-<configmap-name>`.
+	// +listType=atomic
 	ConfigMaps []ConfigMapsSpec `json:"configmaps,omitempty"`
 	// UpdateStrategy represents the strategy the operator will take replacing existing DaemonSet pods with new pods
 	// https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec
@@ -225,6 +228,7 @@ type TargetAllocatorEmbedded struct {
 	// ENV vars to set on the OpenTelemetry TargetAllocator's Pods. These can then in certain cases be
 	// consumed in the config file for the TargetAllocator.
 	// +optional
+	// +listType=atomic
 	Env []v1.EnvVar `json:"env,omitempty"`
 	// ObservabilitySpec defines how telemetry data gets handled.
 	//

--- a/apis/v1beta1/targetallocator_types.go
+++ b/apis/v1beta1/targetallocator_types.go
@@ -14,13 +14,16 @@ type TargetAllocatorPrometheusCR struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// AllowNamespaces Namespaces to scope the interaction of the Target Allocator and the apiserver (allow list). This is mutually exclusive with DenyNamespaces.
 	// +optional
+	// +listType=atomic
 	AllowNamespaces []string `json:"allowNamespaces,omitempty"`
 	// DenyNamespaces Namespaces to scope the interaction of the Target Allocator and the apiserver (deny list). This is mutually exclusive with AllowNamespaces.
 	// +optional
+	// +listType=atomic
 	DenyNamespaces []string `json:"denyNamespaces,omitempty"`
 	// SecretNamespaces Namespaces to scope the watching of secrets for the Target Allocator.
 	// If not configured, defaults to the target allocator's own namespace.
 	// +optional
+	// +listType=atomic
 	SecretNamespaces []string `json:"secretNamespaces,omitempty"`
 	// DenyFSAccessThroughSMs causes the Target Allocator to drop ServiceMonitor and
 	// PodMonitor endpoints that reference arbitrary files on the file system. When
@@ -48,6 +51,7 @@ type TargetAllocatorPrometheusCR struct {
 	// ScrapeProtocols define the protocols to negotiate during a scrape. It tells clients the
 	// protocols supported by Prometheus in order of preference (from most to least preferred).
 	// +optional
+	// +listType=atomic
 	ScrapeProtocols []string `json:"scrapeProtocols,omitempty"`
 	// ScrapeClasses to be referenced by PodMonitors and ServiceMonitors to include common configuration.
 	// If specified, expects an array of ScrapeClass objects as specified by https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.ScrapeClass.

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-09-10T09:50:57Z"
+    createdAt: "2026-09-11T10:19:01Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/community/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-09-11T10:19:01Z"
+    createdAt: "2026-09-11T12:16:36Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/community/manifests/opentelemetry.io_instrumentations.yaml
+++ b/bundle/community/manifests/opentelemetry.io_instrumentations.yaml
@@ -129,6 +129,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   configPath:
                     maxLength: 256
                     pattern: ^[A-Za-z0-9._/-]*$
@@ -216,6 +217,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -462,6 +464,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -699,6 +702,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               exporter:
                 properties:
                   endpoint:
@@ -802,6 +806,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -1187,6 +1192,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   extensions:
                     items:
                       properties:
@@ -1199,6 +1205,7 @@ spec:
                       - image
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resources:
@@ -1438,6 +1445,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   configFile:
                     maxLength: 256
                     pattern: ^[A-Za-z0-9._/-]*$
@@ -1525,6 +1533,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -1764,6 +1773,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -1931,6 +1941,7 @@ spec:
                   - none
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               python:
                 properties:
                   env:
@@ -2016,6 +2027,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:

--- a/bundle/community/manifests/opentelemetry.io_opampbridges.yaml
+++ b/bundle/community/manifests/opentelemetry.io_opampbridges.yaml
@@ -904,6 +904,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -958,6 +959,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               upgradeStrategy:
                 enum:
                 - automatic

--- a/bundle/community/manifests/opentelemetry.io_opampbridges.yaml
+++ b/bundle/community/manifests/opentelemetry.io_opampbridges.yaml
@@ -582,6 +582,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -607,6 +608,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               headers:
                 additionalProperties:
                   type: string
@@ -621,6 +623,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilyPolicy:
                 type: string
               nodeSelector:

--- a/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -3558,6 +3558,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   topologySpreadConstraints:
                     items:
                       properties:
@@ -3612,6 +3613,7 @@ spec:
                       - whenUnsatisfiable
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
               terminationGracePeriodSeconds:
                 format: int64
@@ -3632,6 +3634,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -3686,6 +3689,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               trafficDistribution:
                 type: string
               updateStrategy:
@@ -8971,6 +8975,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             temporalityPreference:
                                               enum:
                                               - cumulative
@@ -9001,6 +9006,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             temporalityPreference:
                                               enum:
                                               - cumulative
@@ -9020,6 +9026,7 @@ spec:
                                   type: object
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                         type: object
                     type: object
                   tolerations:
@@ -9038,6 +9045,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   topologySpreadConstraints:
                     items:
                       properties:
@@ -9092,6 +9100,7 @@ spec:
                       - whenUnsatisfiable
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
               terminationGracePeriodSeconds:
                 format: int64

--- a/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/community/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -811,6 +811,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               affinity:
                 properties:
                   nodeAffinity:
@@ -1396,6 +1397,7 @@ spec:
                       - type
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   minReplicas:
                     format: int32
                     type: integer
@@ -1420,6 +1422,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               deploymentUpdateStrategy:
                 properties:
                   rollingUpdate:
@@ -1521,6 +1524,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -1546,6 +1550,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               hostNetwork:
                 type: boolean
               image:
@@ -1589,6 +1594,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   type:
                     enum:
                     - ingress
@@ -2338,6 +2344,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               lifecycle:
                 properties:
                   postStart:
@@ -3296,6 +3303,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   filterStrategy:
                     default: relabel-config
                     type: string
@@ -5634,6 +5642,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               affinity:
                 properties:
                   nodeAffinity:
@@ -6220,6 +6229,7 @@ spec:
                       - type
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   minReplicas:
                     format: int32
                     minimum: 1
@@ -6262,6 +6272,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       pipelines:
                         additionalProperties:
                           properties:
@@ -6269,14 +6280,17 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             processors:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             receivers:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                           - exporters
                           - receivers
@@ -6311,6 +6325,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               daemonSetUpdateStrategy:
                 properties:
                   rollingUpdate:
@@ -6432,6 +6447,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -6457,6 +6473,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               hostAliases:
                 items:
                   properties:
@@ -6490,6 +6507,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                 required:
                 - enabled
                 - gateway
@@ -6535,6 +6553,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   type:
                     enum:
                     - ingress
@@ -7284,10 +7303,12 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilies:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilyPolicy:
                 default: SingleStack
                 type: string
@@ -8383,6 +8404,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   filterStrategy:
                     default: relabel-config
                     enum:
@@ -8595,12 +8617,14 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       denyFSAccessThroughSMs:
                         type: boolean
                       denyNamespaces:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       enabled:
                         type: boolean
                       evaluationInterval:
@@ -8780,10 +8804,12 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       secretNamespaces:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       serviceMonitorNamespaceSelector:
                         default: {}
                         properties:
@@ -9121,6 +9147,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -9175,6 +9202,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               trafficDistribution:
                 type: string
               upgradeStrategy:
@@ -10343,6 +10371,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               image:
                 type: string
               observedGeneration:

--- a/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
@@ -3118,6 +3118,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         temporalityPreference:
                                           enum:
                                           - cumulative
@@ -3148,6 +3149,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         temporalityPreference:
                                           enum:
                                           - cumulative
@@ -3167,6 +3169,7 @@ spec:
                               type: object
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                     type: object
                 type: object
               terminationGracePeriodSeconds:

--- a/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/community/manifests/opentelemetry.io_targetallocators.yaml
@@ -782,6 +782,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               affinity:
                 properties:
                   nodeAffinity:
@@ -1323,6 +1324,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -1348,6 +1350,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               filterStrategy:
                 default: relabel-config
                 enum:
@@ -2125,10 +2128,12 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilies:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilyPolicy:
                 default: SingleStack
                 type: string
@@ -2620,12 +2625,14 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   denyFSAccessThroughSMs:
                     type: boolean
                   denyNamespaces:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   enabled:
                     type: boolean
                   evaluationInterval:
@@ -2805,10 +2812,12 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   secretNamespaces:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   serviceMonitorNamespaceSelector:
                     default: {}
                     properties:
@@ -3191,6 +3200,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -3245,6 +3255,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               trafficDistribution:
                 type: string
               volumeMounts:

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-09-11T10:19:01Z"
+    createdAt: "2026-09-11T12:16:37Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
+++ b/bundle/openshift/manifests/opentelemetry-operator.clusterserviceversion.yaml
@@ -99,7 +99,7 @@ metadata:
     categories: Logging & Tracing,Monitoring,Observability
     certified: "false"
     containerImage: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-    createdAt: "2026-09-10T09:50:57Z"
+    createdAt: "2026-09-11T10:19:01Z"
     description: Provides the OpenTelemetry components, including the Collector
     operators.operatorframework.io/builder: operator-sdk-v1.29.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/openshift/manifests/opentelemetry.io_instrumentations.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_instrumentations.yaml
@@ -129,6 +129,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   configPath:
                     maxLength: 256
                     pattern: ^[A-Za-z0-9._/-]*$
@@ -216,6 +217,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -462,6 +464,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -699,6 +702,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               exporter:
                 properties:
                   endpoint:
@@ -802,6 +806,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -1187,6 +1192,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   extensions:
                     items:
                       properties:
@@ -1199,6 +1205,7 @@ spec:
                       - image
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resources:
@@ -1438,6 +1445,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   configFile:
                     maxLength: 256
                     pattern: ^[A-Za-z0-9._/-]*$
@@ -1525,6 +1533,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -1764,6 +1773,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -1931,6 +1941,7 @@ spec:
                   - none
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               python:
                 properties:
                   env:
@@ -2016,6 +2027,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:

--- a/bundle/openshift/manifests/opentelemetry.io_opampbridges.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opampbridges.yaml
@@ -904,6 +904,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -958,6 +959,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               upgradeStrategy:
                 enum:
                 - automatic

--- a/bundle/openshift/manifests/opentelemetry.io_opampbridges.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opampbridges.yaml
@@ -582,6 +582,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -607,6 +608,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               headers:
                 additionalProperties:
                   type: string
@@ -621,6 +623,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilyPolicy:
                 type: string
               nodeSelector:

--- a/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -810,6 +810,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               affinity:
                 properties:
                   nodeAffinity:
@@ -1395,6 +1396,7 @@ spec:
                       - type
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   minReplicas:
                     format: int32
                     type: integer
@@ -1419,6 +1421,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               deploymentUpdateStrategy:
                 properties:
                   rollingUpdate:
@@ -1520,6 +1523,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -1545,6 +1549,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               hostNetwork:
                 type: boolean
               image:
@@ -1588,6 +1593,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   type:
                     enum:
                     - ingress
@@ -2337,6 +2343,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               lifecycle:
                 properties:
                   postStart:
@@ -3295,6 +3302,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   filterStrategy:
                     default: relabel-config
                     type: string
@@ -5633,6 +5641,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               affinity:
                 properties:
                   nodeAffinity:
@@ -6219,6 +6228,7 @@ spec:
                       - type
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   minReplicas:
                     format: int32
                     minimum: 1
@@ -6261,6 +6271,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       pipelines:
                         additionalProperties:
                           properties:
@@ -6268,14 +6279,17 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             processors:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             receivers:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                           - exporters
                           - receivers
@@ -6310,6 +6324,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               daemonSetUpdateStrategy:
                 properties:
                   rollingUpdate:
@@ -6431,6 +6446,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -6456,6 +6472,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               hostAliases:
                 items:
                   properties:
@@ -6489,6 +6506,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                 required:
                 - enabled
                 - gateway
@@ -6534,6 +6552,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   type:
                     enum:
                     - ingress
@@ -7283,10 +7302,12 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilies:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilyPolicy:
                 default: SingleStack
                 type: string
@@ -8382,6 +8403,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   filterStrategy:
                     default: relabel-config
                     enum:
@@ -8594,12 +8616,14 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       denyFSAccessThroughSMs:
                         type: boolean
                       denyNamespaces:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       enabled:
                         type: boolean
                       evaluationInterval:
@@ -8779,10 +8803,12 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       secretNamespaces:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       serviceMonitorNamespaceSelector:
                         default: {}
                         properties:
@@ -9120,6 +9146,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -9174,6 +9201,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               trafficDistribution:
                 type: string
               upgradeStrategy:
@@ -10342,6 +10370,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               image:
                 type: string
               observedGeneration:

--- a/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -3557,6 +3557,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   topologySpreadConstraints:
                     items:
                       properties:
@@ -3611,6 +3612,7 @@ spec:
                       - whenUnsatisfiable
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
               terminationGracePeriodSeconds:
                 format: int64
@@ -3631,6 +3633,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -3685,6 +3688,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               trafficDistribution:
                 type: string
               updateStrategy:
@@ -8970,6 +8974,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             temporalityPreference:
                                               enum:
                                               - cumulative
@@ -9000,6 +9005,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             temporalityPreference:
                                               enum:
                                               - cumulative
@@ -9019,6 +9025,7 @@ spec:
                                   type: object
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                         type: object
                     type: object
                   tolerations:
@@ -9037,6 +9044,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   topologySpreadConstraints:
                     items:
                       properties:
@@ -9091,6 +9099,7 @@ spec:
                       - whenUnsatisfiable
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
               terminationGracePeriodSeconds:
                 format: int64

--- a/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
@@ -3118,6 +3118,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         temporalityPreference:
                                           enum:
                                           - cumulative
@@ -3148,6 +3149,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         temporalityPreference:
                                           enum:
                                           - cumulative
@@ -3167,6 +3169,7 @@ spec:
                               type: object
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                     type: object
                 type: object
               terminationGracePeriodSeconds:

--- a/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
+++ b/bundle/openshift/manifests/opentelemetry.io_targetallocators.yaml
@@ -782,6 +782,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               affinity:
                 properties:
                   nodeAffinity:
@@ -1323,6 +1324,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -1348,6 +1350,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               filterStrategy:
                 default: relabel-config
                 enum:
@@ -2125,10 +2128,12 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilies:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilyPolicy:
                 default: SingleStack
                 type: string
@@ -2620,12 +2625,14 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   denyFSAccessThroughSMs:
                     type: boolean
                   denyNamespaces:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   enabled:
                     type: boolean
                   evaluationInterval:
@@ -2805,10 +2812,12 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   secretNamespaces:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   serviceMonitorNamespaceSelector:
                     default: {}
                     properties:
@@ -3191,6 +3200,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -3245,6 +3255,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               trafficDistribution:
                 type: string
               volumeMounts:

--- a/config/crd/bases/opentelemetry.io_instrumentations.yaml
+++ b/config/crd/bases/opentelemetry.io_instrumentations.yaml
@@ -127,6 +127,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   configPath:
                     maxLength: 256
                     pattern: ^[A-Za-z0-9._/-]*$
@@ -214,6 +215,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -460,6 +462,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -697,6 +700,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               exporter:
                 properties:
                   endpoint:
@@ -800,6 +804,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -1185,6 +1190,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   extensions:
                     items:
                       properties:
@@ -1197,6 +1203,7 @@ spec:
                       - image
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resources:
@@ -1436,6 +1443,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   configFile:
                     maxLength: 256
                     pattern: ^[A-Za-z0-9._/-]*$
@@ -1523,6 +1531,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -1762,6 +1771,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:
@@ -1929,6 +1939,7 @@ spec:
                   - none
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               python:
                 properties:
                   env:
@@ -2014,6 +2025,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   image:
                     type: string
                   resourceRequirements:

--- a/config/crd/bases/opentelemetry.io_opampbridges.yaml
+++ b/config/crd/bases/opentelemetry.io_opampbridges.yaml
@@ -902,6 +902,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -956,6 +957,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               upgradeStrategy:
                 enum:
                 - automatic

--- a/config/crd/bases/opentelemetry.io_opampbridges.yaml
+++ b/config/crd/bases/opentelemetry.io_opampbridges.yaml
@@ -580,6 +580,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -605,6 +606,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               headers:
                 additionalProperties:
                   type: string
@@ -619,6 +621,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilyPolicy:
                 type: string
               nodeSelector:

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -3544,6 +3544,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   topologySpreadConstraints:
                     items:
                       properties:
@@ -3598,6 +3599,7 @@ spec:
                       - whenUnsatisfiable
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
               terminationGracePeriodSeconds:
                 format: int64
@@ -3618,6 +3620,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -3672,6 +3675,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               trafficDistribution:
                 type: string
               updateStrategy:
@@ -8957,6 +8961,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             temporalityPreference:
                                               enum:
                                               - cumulative
@@ -8987,6 +8992,7 @@ spec:
                                                 - value
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             temporalityPreference:
                                               enum:
                                               - cumulative
@@ -9006,6 +9012,7 @@ spec:
                                   type: object
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                         type: object
                     type: object
                   tolerations:
@@ -9024,6 +9031,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   topologySpreadConstraints:
                     items:
                       properties:
@@ -9078,6 +9086,7 @@ spec:
                       - whenUnsatisfiable
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
               terminationGracePeriodSeconds:
                 format: int64

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -797,6 +797,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               affinity:
                 properties:
                   nodeAffinity:
@@ -1382,6 +1383,7 @@ spec:
                       - type
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   minReplicas:
                     format: int32
                     type: integer
@@ -1406,6 +1408,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               deploymentUpdateStrategy:
                 properties:
                   rollingUpdate:
@@ -1507,6 +1510,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -1532,6 +1536,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               hostNetwork:
                 type: boolean
               image:
@@ -1575,6 +1580,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   type:
                     enum:
                     - ingress
@@ -2324,6 +2330,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               lifecycle:
                 properties:
                   postStart:
@@ -3282,6 +3289,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   filterStrategy:
                     default: relabel-config
                     type: string
@@ -5620,6 +5628,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               affinity:
                 properties:
                   nodeAffinity:
@@ -6206,6 +6215,7 @@ spec:
                       - type
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   minReplicas:
                     format: int32
                     minimum: 1
@@ -6248,6 +6258,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       pipelines:
                         additionalProperties:
                           properties:
@@ -6255,14 +6266,17 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             processors:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             receivers:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                           - exporters
                           - receivers
@@ -6297,6 +6311,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               daemonSetUpdateStrategy:
                 properties:
                   rollingUpdate:
@@ -6418,6 +6433,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -6443,6 +6459,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               hostAliases:
                 items:
                   properties:
@@ -6476,6 +6493,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                 required:
                 - enabled
                 - gateway
@@ -6521,6 +6539,7 @@ spec:
                           type: string
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   type:
                     enum:
                     - ingress
@@ -7270,10 +7289,12 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilies:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilyPolicy:
                 default: SingleStack
                 type: string
@@ -8369,6 +8390,7 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   filterStrategy:
                     default: relabel-config
                     enum:
@@ -8581,12 +8603,14 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       denyFSAccessThroughSMs:
                         type: boolean
                       denyNamespaces:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       enabled:
                         type: boolean
                       evaluationInterval:
@@ -8766,10 +8790,12 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       secretNamespaces:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       serviceMonitorNamespaceSelector:
                         default: {}
                         properties:
@@ -9107,6 +9133,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -9161,6 +9188,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               trafficDistribution:
                 type: string
               upgradeStrategy:
@@ -10329,6 +10357,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               image:
                 type: string
               observedGeneration:

--- a/config/crd/bases/opentelemetry.io_targetallocators.yaml
+++ b/config/crd/bases/opentelemetry.io_targetallocators.yaml
@@ -780,6 +780,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               affinity:
                 properties:
                   nodeAffinity:
@@ -1321,6 +1322,7 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               envFrom:
                 items:
                   properties:
@@ -1346,6 +1348,7 @@ spec:
                       x-kubernetes-map-type: atomic
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               filterStrategy:
                 default: relabel-config
                 enum:
@@ -2123,10 +2126,12 @@ spec:
                   - name
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilies:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               ipFamilyPolicy:
                 default: SingleStack
                 type: string
@@ -2618,12 +2623,14 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   denyFSAccessThroughSMs:
                     type: boolean
                   denyNamespaces:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   enabled:
                     type: boolean
                   evaluationInterval:
@@ -2803,10 +2810,12 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   secretNamespaces:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   serviceMonitorNamespaceSelector:
                     default: {}
                     properties:
@@ -3189,6 +3198,7 @@ spec:
                       type: string
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               topologySpreadConstraints:
                 items:
                   properties:
@@ -3243,6 +3253,7 @@ spec:
                   - whenUnsatisfiable
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
               trafficDistribution:
                 type: string
               volumeMounts:

--- a/config/crd/bases/opentelemetry.io_targetallocators.yaml
+++ b/config/crd/bases/opentelemetry.io_targetallocators.yaml
@@ -3116,6 +3116,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         temporalityPreference:
                                           enum:
                                           - cumulative
@@ -3146,6 +3147,7 @@ spec:
                                             - value
                                             type: object
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         temporalityPreference:
                                           enum:
                                           - cumulative
@@ -3165,6 +3167,7 @@ spec:
                               type: object
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                     type: object
                 type: object
               terminationGracePeriodSeconds:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Noticed a couple of slice fields where missing the kubebuilder validation  +listType=atomic, added to keep consistent with the rest of existing structs.

**Link to tracking Issue(s):** <Issue number if applicable>

- Resolves: #issue-number

**Testing:** 
Run the recommended checks on CONTRIBUTING.md.

**Documentation:** <Describe the documentation added.>
